### PR TITLE
docs: restructure 90 markdown files for AI-friendly format

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture
 
+- **Scope**: Compiler pipeline design — pass-level architecture, error recovery, diagnostic flow
+- **Type**: Design doc
 High-level map of the Osty front-end. For spec decisions see
 `OSTY_GRAMMAR_v0.5.md`; this document covers **implementation** layout.
 

--- a/CHANGELOG_v0.5.md
+++ b/CHANGELOG_v0.5.md
@@ -1,5 +1,7 @@
 # CHANGELOG — v0.5
 
+- **Scope**: v0.5 edition changes — new surface, wired features, regen status
+- **Type**: Changelog
 Tracks the user-visible slice of the v0.5 spec (`LANG_SPEC_v0.5/`) that
 has landed in the compiler today, separate from the spec itself. The
 spec is the authority on what v0.5 *will* be; this file is the

--- a/LANG_SPEC_v0.5/01-lexical-structure.md
+++ b/LANG_SPEC_v0.5/01-lexical-structure.md
@@ -1,5 +1,7 @@
 ## 1. Lexical Structure
 
+- **Scope**: Osty language spec — 1. Lexical Structure
+- **Type**: Language specification
 ### 1.1 Source Files
 
 - File extension: `.osty`

--- a/LANG_SPEC_v0.5/02-type-system.md
+++ b/LANG_SPEC_v0.5/02-type-system.md
@@ -1,5 +1,7 @@
 ## 2. Type System
 
+- **Scope**: Osty language spec — 2. Type System
+- **Type**: Language specification
 ### 2.1 Primitive Types
 
 ```

--- a/LANG_SPEC_v0.5/02a-type-inference.md
+++ b/LANG_SPEC_v0.5/02a-type-inference.md
@@ -1,5 +1,7 @@
 ## 2a. Type Inference Algorithm
 
+- **Scope**: Osty language spec — 2a. Type Inference Algorithm
+- **Type**: Language specification
 This section specifies the algorithm that assigns a type to every
 expression, binding, and declaration. It complements §2 (type system)
 and §3 (declarations): §2 tells you *what* types exist, §3 tells you

--- a/LANG_SPEC_v0.5/03-declarations.md
+++ b/LANG_SPEC_v0.5/03-declarations.md
@@ -1,5 +1,7 @@
 ## 3. Declarations
 
+- **Scope**: Osty language spec — 3. Declarations
+- **Type**: Language specification
 ### 3.1 Functions
 
 ```osty

--- a/LANG_SPEC_v0.5/04-expressions.md
+++ b/LANG_SPEC_v0.5/04-expressions.md
@@ -1,5 +1,7 @@
 ## 4. Expressions
 
+- **Scope**: Osty language spec — 4. Expressions
+- **Type**: Language specification
 ### 4.1 Block Expressions
 
 ```osty

--- a/LANG_SPEC_v0.5/05-modules-and-packages.md
+++ b/LANG_SPEC_v0.5/05-modules-and-packages.md
@@ -1,5 +1,7 @@
 ## 5. Modules and Packages
 
+- **Scope**: Osty language spec — 5. Modules and Packages
+- **Type**: Language specification
 ### 5.1 Package = Directory
 
 A directory is a package. All `.osty` files in a directory belong to the

--- a/LANG_SPEC_v0.5/06-scripts.md
+++ b/LANG_SPEC_v0.5/06-scripts.md
@@ -1,5 +1,7 @@
 ## 6. Scripts
 
+- **Scope**: Osty language spec — 6. Scripts
+- **Type**: Language specification
 A file is a **script file** if it contains top-level statements outside
 any function or type declaration. A file with only declarations is a
 **module file**.

--- a/LANG_SPEC_v0.5/07-the-error-interface.md
+++ b/LANG_SPEC_v0.5/07-the-error-interface.md
@@ -1,5 +1,7 @@
 ## 7. The Error Interface
 
+- **Scope**: Osty language spec — 7. The Error Interface
+- **Type**: Language specification
 ### 7.1 Definition
 
 `Error` is an interface defined in `std.error` and re-exported by the

--- a/LANG_SPEC_v0.5/08-concurrency.md
+++ b/LANG_SPEC_v0.5/08-concurrency.md
@@ -1,5 +1,7 @@
 ## 8. Concurrency
 
+- **Scope**: Osty language spec — 8. Concurrency
+- **Type**: Language specification
 ### 8.0 Scheduler Model
 
 Osty specifies an **M:N scheduler**. Task-level units (`g.spawn(...)`, the

--- a/LANG_SPEC_v0.5/09-memory-management.md
+++ b/LANG_SPEC_v0.5/09-memory-management.md
@@ -1,5 +1,7 @@
 ## 9. Memory Management
 
+- **Scope**: Osty language spec — 9. Memory Management
+- **Type**: Language specification
 Osty is garbage collected. There are no explicit memory primitives:
 no `new`, no `delete`, no destructors.
 

--- a/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
+++ b/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
@@ -1,5 +1,7 @@
 ### 10.1 Tier 1 (Core)
 
+- **Scope**: Osty stdlib spec — 10.1 Tier 1 (Core)
+- **Type**: Standard library specification
 - `std.io` — `print`, `println`, `eprint`, `eprintln`, `readLine`, the
   `Reader`/`Writer` protocol, in-memory `BytesReader`/`Buffer`, and core
   stream helpers such as `readAll`, `readExact`, `copy`, `writeString`

--- a/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
+++ b/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
@@ -1,5 +1,7 @@
 ### 10.2 Tier 2 (Production essentials)
 
+- **Scope**: Osty stdlib spec — 10.2 Tier 2 (Production essentials)
+- **Type**: Standard library specification
 - `std.json` — JSON encode/decode (reflection-based)
 - `std.http` — HTTP client and server
 - `std.time` — instants, durations, formatting, parsing, timezones

--- a/LANG_SPEC_v0.5/10-standard-library/03-excluded-from-stdlib.md
+++ b/LANG_SPEC_v0.5/10-standard-library/03-excluded-from-stdlib.md
@@ -1,5 +1,7 @@
 ### 10.3 Excluded from stdlib
 
+- **Scope**: Osty stdlib spec — 10.3 Excluded from stdlib
+- **Type**: Standard library specification
 Asymmetric cryptography (RSA, Ed25519, etc.), compression formats other
 than gzip (zstd, brotli, lz4), OS-specific APIs (systemd, Windows
 registry, etc.; portable credential storage is exposed through

--- a/LANG_SPEC_v0.5/10-standard-library/04-prelude.md
+++ b/LANG_SPEC_v0.5/10-standard-library/04-prelude.md
@@ -1,5 +1,7 @@
 ### 10.4 Prelude
 
+- **Scope**: Osty stdlib spec — 10.4 Prelude
+- **Type**: Standard library specification
 Auto-imported in every file:
 
 - Types: all primitives, `Option`, `Result`, `Error`, `List`, `Map`,

--- a/LANG_SPEC_v0.5/10-standard-library/05-standard-numeric-methods.md
+++ b/LANG_SPEC_v0.5/10-standard-library/05-standard-numeric-methods.md
@@ -1,5 +1,7 @@
 ### 10.5 Standard Numeric Methods
 
+- **Scope**: Osty stdlib spec — 10.5 Standard Numeric Methods
+- **Type**: Standard library specification
 **Common to every integer type `T` (`Int`, `Int8..Int64`, `UInt8..UInt64`, `Byte`):**
 
 ```

--- a/LANG_SPEC_v0.5/10-standard-library/06-collection-methods.md
+++ b/LANG_SPEC_v0.5/10-standard-library/06-collection-methods.md
@@ -1,5 +1,7 @@
 ### 10.6 Collection Methods
 
+- **Scope**: Osty stdlib spec — 10.6 Collection Methods
+- **Type**: Standard library specification
 All standard collections satisfy `Iterable<T>` (§15) and may be used
 directly with `for x in xs`.
 

--- a/LANG_SPEC_v0.5/10-standard-library/07-lazy-iterators.md
+++ b/LANG_SPEC_v0.5/10-standard-library/07-lazy-iterators.md
@@ -1,5 +1,7 @@
 ### 10.7 Lazy Iterators (`std.iter`)
 
+- **Scope**: Osty stdlib spec — 10.7 Lazy Iterators (`std.iter`)
+- **Type**: Standard library specification
 For pipeline-style transformations over sequences:
 
 ```osty

--- a/LANG_SPEC_v0.5/10-standard-library/08-json.md
+++ b/LANG_SPEC_v0.5/10-standard-library/08-json.md
@@ -1,5 +1,7 @@
 ### 10.8 JSON (`std.json`)
 
+- **Scope**: Osty stdlib spec — 10.8 JSON (`std.json`)
+- **Type**: Standard library specification
 Reflection-based encode/decode for primitives, `struct`, and `enum`:
 
 ```osty

--- a/LANG_SPEC_v0.5/10-standard-library/09-regular-expressions.md
+++ b/LANG_SPEC_v0.5/10-standard-library/09-regular-expressions.md
@@ -1,5 +1,7 @@
 ### 10.9 Regular Expressions (`std.regex`)
 
+- **Scope**: Osty stdlib spec — 10.9 Regular Expressions (`std.regex`)
+- **Type**: Standard library specification
 RE2-based regular expressions. Linear-time matching; no catastrophic
 backtracking, no ReDoS. Does not support backreferences or lookaround
 (RE2 limitations).

--- a/LANG_SPEC_v0.5/10-standard-library/10-logging.md
+++ b/LANG_SPEC_v0.5/10-standard-library/10-logging.md
@@ -1,5 +1,7 @@
 ### 10.10 Logging (`std.log`)
 
+- **Scope**: Osty stdlib spec — 10.10 Logging (`std.log`)
+- **Type**: Standard library specification
 Structured logging with levels and pluggable handlers. Inspired by
 Go's `slog`.
 

--- a/LANG_SPEC_v0.5/10-standard-library/11-encoding.md
+++ b/LANG_SPEC_v0.5/10-standard-library/11-encoding.md
@@ -1,5 +1,7 @@
 ### 10.11 Encoding (`std.encoding`)
 
+- **Scope**: Osty stdlib spec — 10.11 Encoding (`std.encoding`)
+- **Type**: Standard library specification
 Binary-to-text encodings.
 
 ```osty

--- a/LANG_SPEC_v0.5/10-standard-library/12-cryptography.md
+++ b/LANG_SPEC_v0.5/10-standard-library/12-cryptography.md
@@ -1,5 +1,7 @@
 ### 10.12 Cryptography (`std.crypto`)
 
+- **Scope**: Osty stdlib spec — 10.12 Cryptography (`std.crypto`)
+- **Type**: Standard library specification
 Hashing, message authentication, and cryptographically secure random
 bytes. Asymmetric cryptography (RSA, Ed25519) is out of scope.
 

--- a/LANG_SPEC_v0.5/10-standard-library/13-uuid.md
+++ b/LANG_SPEC_v0.5/10-standard-library/13-uuid.md
@@ -1,5 +1,7 @@
 ### 10.13 UUID (`std.uuid`)
 
+- **Scope**: Osty stdlib spec — 10.13 UUID (`std.uuid`)
+- **Type**: Standard library specification
 ```osty
 use std.uuid
 

--- a/LANG_SPEC_v0.5/10-standard-library/14-random.md
+++ b/LANG_SPEC_v0.5/10-standard-library/14-random.md
@@ -1,5 +1,7 @@
 ### 10.14 Random (`std.random`)
 
+- **Scope**: Osty stdlib spec — 10.14 Random (`std.random`)
+- **Type**: Standard library specification
 Non-cryptographic pseudorandom numbers.
 
 ```osty

--- a/LANG_SPEC_v0.5/10-standard-library/15-operating-system.md
+++ b/LANG_SPEC_v0.5/10-standard-library/15-operating-system.md
@@ -1,5 +1,7 @@
 ### 10.15 Operating System (`std.os`)
 
+- **Scope**: Osty stdlib spec — 10.15 Operating System (`std.os`)
+- **Type**: Standard library specification
 Paths, process control, and signal handling. File I/O is in `std.fs`;
 environment variables and arguments are in `std.env`.
 

--- a/LANG_SPEC_v0.5/10-standard-library/16-url.md
+++ b/LANG_SPEC_v0.5/10-standard-library/16-url.md
@@ -1,5 +1,7 @@
 ### 10.16 URL (`std.url`)
 
+- **Scope**: Osty stdlib spec — 10.16 URL (`std.url`)
+- **Type**: Standard library specification
 URL parsing and building.
 
 ```osty

--- a/LANG_SPEC_v0.5/10-standard-library/17-math.md
+++ b/LANG_SPEC_v0.5/10-standard-library/17-math.md
@@ -1,5 +1,7 @@
 ### 10.17 Math (`std.math`)
 
+- **Scope**: Osty stdlib spec — 10.17 Math (`std.math`)
+- **Type**: Standard library specification
 Mathematical functions and constants.
 
 ```osty

--- a/LANG_SPEC_v0.5/10-standard-library/18-csv.md
+++ b/LANG_SPEC_v0.5/10-standard-library/18-csv.md
@@ -1,5 +1,7 @@
 ### 10.18 CSV (`std.csv`)
 
+- **Scope**: Osty stdlib spec — 10.18 CSV (`std.csv`)
+- **Type**: Standard library specification
 RFC 4180-compliant CSV.
 
 ```osty

--- a/LANG_SPEC_v0.5/10-standard-library/19-compression.md
+++ b/LANG_SPEC_v0.5/10-standard-library/19-compression.md
@@ -1,5 +1,7 @@
 ### 10.19 Compression (`std.compress`)
 
+- **Scope**: Osty stdlib spec — 10.19 Compression (`std.compress`)
+- **Type**: Standard library specification
 gzip compression. Other formats (zstd, brotli, lz4) are available as
 community packages.
 

--- a/LANG_SPEC_v0.5/10-standard-library/20-time-extensions.md
+++ b/LANG_SPEC_v0.5/10-standard-library/20-time-extensions.md
@@ -1,5 +1,7 @@
 ### 10.20 Time Extensions (`std.time`)
 
+- **Scope**: Osty stdlib spec — 10.20 Time Extensions (`std.time`)
+- **Type**: Standard library specification
 Beyond basic instants and durations, `std.time` provides formatting,
 parsing, and timezone handling.
 

--- a/LANG_SPEC_v0.5/10-standard-library/21-bytes.md
+++ b/LANG_SPEC_v0.5/10-standard-library/21-bytes.md
@@ -1,5 +1,7 @@
 ### 10.21 Bytes (`std.bytes`)
 
+- **Scope**: Osty stdlib spec — 10.21 Bytes (`std.bytes`)
+- **Type**: Standard library specification
 Byte-sequence manipulation, mirroring `std.strings` for `Bytes` values.
 `Bytes` is an immutable byte sequence (§2.4.1); all operations return new
 values and never mutate in place.

--- a/LANG_SPEC_v0.5/10-standard-library/22-fmt.md
+++ b/LANG_SPEC_v0.5/10-standard-library/22-fmt.md
@@ -1,5 +1,7 @@
 ### 10.22 Formatting (`std.fmt`)
 
+- **Scope**: Osty stdlib spec — 10.22 Formatting (`std.fmt`)
+- **Type**: Standard library specification
 String formatting utilities beyond `{}` interpolation: number base
 conversion, padding and alignment, fixed-precision printing, escaped
 string rendering, compact human-readable numbers, and composite value

--- a/LANG_SPEC_v0.5/10-standard-library/23-net.md
+++ b/LANG_SPEC_v0.5/10-standard-library/23-net.md
@@ -1,5 +1,7 @@
 ### 10.23 Network (`std.net`)
 
+- **Scope**: Osty stdlib spec — 10.23 Network (`std.net`)
+- **Type**: Standard library specification
 Low-level TCP and UDP networking. Higher-level HTTP is in `std.http`
 (§10.24). All blocking operations are cancellation-aware (§8.4.2).
 

--- a/LANG_SPEC_v0.5/10-standard-library/24-http.md
+++ b/LANG_SPEC_v0.5/10-standard-library/24-http.md
@@ -1,5 +1,7 @@
 ### 10.24 HTTP (`std.http`)
 
+- **Scope**: Osty stdlib spec — 10.24 HTTP (`std.http`)
+- **Type**: Standard library specification
 HTTP client/server ergonomics built on top of three runtime-owned
 transport primitives:
 

--- a/LANG_SPEC_v0.5/10-standard-library/25-term.md
+++ b/LANG_SPEC_v0.5/10-standard-library/25-term.md
@@ -1,5 +1,7 @@
 ### 10.25 Terminal (`std.term`)
 
+- **Scope**: Osty stdlib spec — 10.25 Terminal (`std.term`)
+- **Type**: Standard library specification
 `std.term` is the low-level terminal boundary used by text UIs and simple
 terminal games.
 

--- a/LANG_SPEC_v0.5/10-standard-library/26-tui.md
+++ b/LANG_SPEC_v0.5/10-standard-library/26-tui.md
@@ -1,5 +1,7 @@
 ### 10.26 Text UI (`std.tui`)
 
+- **Scope**: Osty stdlib spec — 10.26 Text UI (`std.tui`)
+- **Type**: Standard library specification
 `std.tui` provides retained frame buffers for terminal UI code. A `Frame`
 contains fixed-size `Cell` values, each with text and style. Rendering can
 emit a whole frame or only the cells that changed compared with a previous

--- a/LANG_SPEC_v0.5/10-standard-library/27-grid.md
+++ b/LANG_SPEC_v0.5/10-standard-library/27-grid.md
@@ -1,5 +1,7 @@
 ### 10.27 Grid (`std.grid`)
 
+- **Scope**: Osty stdlib spec — 10.27 Grid (`std.grid`)
+- **Type**: Standard library specification
 `std.grid` contains small spatial types shared by text UIs, board games,
 roguelikes, simulations, and pathfinding libraries.
 

--- a/LANG_SPEC_v0.5/10-standard-library/28-sql.md
+++ b/LANG_SPEC_v0.5/10-standard-library/28-sql.md
@@ -1,5 +1,7 @@
 ### 10.28 SQL (`std.sql`)
 
+- **Scope**: Osty stdlib spec — 10.28 SQL (`std.sql`)
+- **Type**: Standard library specification
 `std.sql` provides safe SQL fragment and statement builders. It does not
 open database connections or execute queries; drivers such as SQLite or
 Postgres should accept the `Query` value produced by this module.

--- a/LANG_SPEC_v0.5/10-standard-library/29-db.md
+++ b/LANG_SPEC_v0.5/10-standard-library/29-db.md
@@ -1,5 +1,7 @@
 ### 10.29 DB (`std.db`)
 
+- **Scope**: Osty stdlib spec — 10.29 DB (`std.db`)
+- **Type**: Standard library specification
 `std.db` contains the database pieces that can be implemented without a
 runtime driver: connection configuration, DSN rendering, pool and transaction
 options, row/result containers, and migration planning helpers.

--- a/LANG_SPEC_v0.5/10-standard-library/30-smtp.md
+++ b/LANG_SPEC_v0.5/10-standard-library/30-smtp.md
@@ -1,5 +1,7 @@
 ### 10.30 SMTP (`std.smtp`)
 
+- **Scope**: Osty stdlib spec — 10.30 SMTP (`std.smtp`)
+- **Type**: Standard library specification
 `std.smtp` builds SMTP protocol commands and parses server replies. It uses
 `std.email.Envelope` for message data, but does not claim TLS/socket execution
 until the runtime grows that transport layer.

--- a/LANG_SPEC_v0.5/10-standard-library/31-zip.md
+++ b/LANG_SPEC_v0.5/10-standard-library/31-zip.md
@@ -1,5 +1,7 @@
 ### 10.31 ZIP (`std.zip`)
 
+- **Scope**: Osty stdlib spec — 10.31 ZIP (`std.zip`)
+- **Type**: Standard library specification
 `std.zip` creates and reads ZIP archives using the standard "store" method.
 This needs no deflate runtime and produces interoperable ZIP files with local
 headers, central directory records, EOCD, and CRC32 checks.

--- a/LANG_SPEC_v0.5/10-standard-library/32-image.md
+++ b/LANG_SPEC_v0.5/10-standard-library/32-image.md
@@ -1,5 +1,7 @@
 ### 10.32 Image (`std.image`)
 
+- **Scope**: Osty stdlib spec — 10.32 Image (`std.image`)
+- **Type**: Standard library specification
 `std.image` detects common image formats and parses header metadata. Full
 pixel decoding is intentionally left for a future runtime-backed codec layer.
 

--- a/LANG_SPEC_v0.5/10-standard-library/33-aiagents.md
+++ b/LANG_SPEC_v0.5/10-standard-library/33-aiagents.md
@@ -1,5 +1,7 @@
 ### 10.33 AI Agents (`std.aiagents`)
 
+- **Scope**: Osty stdlib spec — 10.33 AI Agents (`std.aiagents`)
+- **Type**: Standard library specification
 `std.aiagents` contains dependency-light primitives for building agent
 applications. It deliberately starts with the parts that can be implemented as
 pure Osty data shapes and helper logic: message/session models, tool presets,

--- a/LANG_SPEC_v0.5/10-standard-library/34-deneb-utilities.md
+++ b/LANG_SPEC_v0.5/10-standard-library/34-deneb-utilities.md
@@ -1,5 +1,7 @@
 ### 10.34 Deneb-Derived Utilities
 
+- **Scope**: Osty stdlib spec — 10.34 Deneb-Derived Utilities
+- **Type**: Standard library specification
 These modules port Deneb subsystems that were intentionally implemented
 without external dependencies. The goal is not a thin wrapper around Deneb
 names; each module preserves the behavior that made the original useful.

--- a/LANG_SPEC_v0.5/10-standard-library/35-table.md
+++ b/LANG_SPEC_v0.5/10-standard-library/35-table.md
@@ -1,5 +1,7 @@
 ### 10.35 Tables (`std.table`)
 
+- **Scope**: Osty stdlib spec — 10.35 Tables (`std.table`)
+- **Type**: Standard library specification
 `std.table` is a small dataframe layer for command-line tools and data
 cleanup jobs. It keeps cells as strings for lossless CSV/TSV round-trips,
 then layers typed access and column inference on top.

--- a/LANG_SPEC_v0.5/10-standard-library/36-ai.md
+++ b/LANG_SPEC_v0.5/10-standard-library/36-ai.md
@@ -1,5 +1,7 @@
 ### 10.36 AI API (`std.ai`)
 
+- **Scope**: Osty stdlib spec — 10.36 AI API (`std.ai`)
+- **Type**: Standard library specification
 `std.ai` provides the provider-neutral API layer for model calls. It is not a
 model SDK and it does not store credentials. Instead, it turns common chat,
 model-listing, and embedding shapes into `std.http.Request` values, then parses

--- a/LANG_SPEC_v0.5/10-standard-library/37-scan.md
+++ b/LANG_SPEC_v0.5/10-standard-library/37-scan.md
@@ -1,5 +1,7 @@
 ### 10.37 Scanner Automation (`std.scan`)
 
+- **Scope**: Osty stdlib spec — 10.37 Scanner Automation (`std.scan`)
+- **Type**: Standard library specification
 `std.scan` provides a typed automation layer for document scanners. Scanner
 drivers remain host-specific, so the module plans and runs host commands rather
 than embedding a driver stack. The built-in backend targets SANE `scanimage`;

--- a/LANG_SPEC_v0.5/10-standard-library/38-print.md
+++ b/LANG_SPEC_v0.5/10-standard-library/38-print.md
@@ -1,5 +1,7 @@
 ### 10.38 Print (`std.print`)
 
+- **Scope**: Osty stdlib spec — 10.38 Print (`std.print`)
+- **Type**: Standard library specification
 `std.print` sends existing PDF and image files to the host print spooler. It
 does not implement page rendering in the language runtime; applications should
 produce a PDF or image first, then ask the host printer stack to print it.

--- a/LANG_SPEC_v0.5/10-standard-library/39-clipboard.md
+++ b/LANG_SPEC_v0.5/10-standard-library/39-clipboard.md
@@ -1,5 +1,7 @@
 ### 10.39 Clipboard (`std.clipboard`)
 
+- **Scope**: Osty stdlib spec — 10.39 Clipboard (`std.clipboard`)
+- **Type**: Standard library specification
 `std.clipboard` provides small-tool clipboard text I/O. It is intentionally
 text-only; binary clipboard formats, MIME negotiation, and platform-native
 pasteboard metadata remain host/runtime concerns.

--- a/LANG_SPEC_v0.5/10-standard-library/40-xlsx.md
+++ b/LANG_SPEC_v0.5/10-standard-library/40-xlsx.md
@@ -1,5 +1,7 @@
 ### 10.40 XLSX (`std.xlsx`)
 
+- **Scope**: Osty stdlib spec — 10.40 XLSX (`std.xlsx`)
+- **Type**: Standard library specification
 `std.xlsx` builds simple Excel-compatible `.xlsx` workbooks on top of
 stored ZIP packaging and `std.table` row adapters.
 

--- a/LANG_SPEC_v0.5/10-standard-library/41-keychain-secrets.md
+++ b/LANG_SPEC_v0.5/10-standard-library/41-keychain-secrets.md
@@ -1,5 +1,7 @@
 ### 10.41 Keychain / Secrets (`std.keychain`, `std.secrets`)
 
+- **Scope**: Osty stdlib spec — 10.41 Keychain / Secrets (`std.keychain`, `std.secrets`)
+- **Type**: Standard library specification
 `std.keychain` is the portable credential-store facade for API keys, tokens,
 and other small application secrets. It stores secrets by `(service, account)`
 in the OS credential store instead of in project files.

--- a/LANG_SPEC_v0.5/10-standard-library/42-pdf.md
+++ b/LANG_SPEC_v0.5/10-standard-library/42-pdf.md
@@ -1,5 +1,7 @@
 ### 10.42 PDF (`std.pdf`)
 
+- **Scope**: Osty stdlib spec — 10.42 PDF (`std.pdf`)
+- **Type**: Standard library specification
 `std.pdf` provides dependency-free PDF inspection helpers. It does not render
 pages or decode compressed streams; those require host/runtime-backed PDF
 engines. The stdlib surface focuses on portable checks that are useful in CLI

--- a/LANG_SPEC_v0.5/10-standard-library/43-supabase.md
+++ b/LANG_SPEC_v0.5/10-standard-library/43-supabase.md
@@ -1,5 +1,7 @@
 ### 10.43 Supabase (`std.supabase`)
 
+- **Scope**: Osty stdlib spec — 10.43 Supabase (`std.supabase`)
+- **Type**: Standard library specification
 `std.supabase` is a lightweight Supabase API layer on top of `std.http`. It
 does not embed a database driver or storage client runtime. Instead, it builds
 ready-to-send HTTP requests for Supabase's stable gateway paths:

--- a/LANG_SPEC_v0.5/10-standard-library/44-github.md
+++ b/LANG_SPEC_v0.5/10-standard-library/44-github.md
@@ -1,5 +1,7 @@
 ### 10.44 GitHub (`std.github`)
 
+- **Scope**: Osty stdlib spec — 10.44 GitHub (`std.github`)
+- **Type**: Standard library specification
 `std.github` is a GitHub automation layer over `std.http`, `std.json`, and
 `std.crypto`. It builds ready-to-send REST requests for day-to-day developer
 automation and verifies GitHub webhook signatures without taking ownership of

--- a/LANG_SPEC_v0.5/10-standard-library/45-webhook.md
+++ b/LANG_SPEC_v0.5/10-standard-library/45-webhook.md
@@ -1,5 +1,7 @@
 ### 10.45 Webhooks (`std.webhook`)
 
+- **Scope**: Osty stdlib spec — 10.45 Webhooks (`std.webhook`)
+- **Type**: Standard library specification
 `std.webhook` is the safe intake layer for HTTP callbacks from external
 systems. It composes with `std.http`, `std.crypto`, `std.encoding`,
 `std.json`, and `std.time` instead of owning a server runtime. The module

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -1,5 +1,7 @@
 ## 10. Standard Library
 
+- **Scope**: Osty stdlib spec — 10. Standard Library
+- **Type**: Standard library specification
 This chapter is split into one file per subsection for easier navigation. The introduction below states the structuring principles; each `std.*` package then lives in its own file.
 
 ## 10. Standard Library

--- a/LANG_SPEC_v0.5/11-testing.md
+++ b/LANG_SPEC_v0.5/11-testing.md
@@ -1,5 +1,7 @@
 ## 11. Testing
 
+- **Scope**: Osty language spec — 11. Testing
+- **Type**: Language specification
 Test files use the `_test.osty` suffix and live alongside code in the
 same package. Functions whose names begin with lowercase `test` and
 take no arguments are discovered and run by `osty test`.

--- a/LANG_SPEC_v0.5/12-foreign-function-interface.md
+++ b/LANG_SPEC_v0.5/12-foreign-function-interface.md
@@ -1,5 +1,7 @@
 ## 12. Foreign Function Interface
 
+- **Scope**: Osty language spec — 12. Foreign Function Interface
+- **Type**: Language specification
 ### 12.1 Importing Go Packages
 
 ```osty

--- a/LANG_SPEC_v0.5/13-tooling.md
+++ b/LANG_SPEC_v0.5/13-tooling.md
@@ -1,5 +1,7 @@
 ## 13. Tooling
 
+- **Scope**: Osty language spec — 13. Tooling
+- **Type**: Language specification
 ### 13.1 CLI
 
 ```

--- a/LANG_SPEC_v0.5/14-excluded-features.md
+++ b/LANG_SPEC_v0.5/14-excluded-features.md
@@ -1,5 +1,7 @@
 ## 14. Excluded Features
 
+- **Scope**: Osty language spec — 14. Excluded Features
+- **Type**: Language specification
 The items below are excluded from v0.5. Items are grouped by reason so
 readers can see the argument without consulting the change history.
 Re-opening any of them requires a design proposal, a new minor or major

--- a/LANG_SPEC_v0.5/15-iteration-protocol.md
+++ b/LANG_SPEC_v0.5/15-iteration-protocol.md
@@ -1,5 +1,7 @@
 ## 15. Iteration Protocol
 
+- **Scope**: Osty language spec — 15. Iteration Protocol
+- **Type**: Language specification
 `for x in xs { ... }` is defined in terms of two interfaces:
 
 ```osty

--- a/LANG_SPEC_v0.5/16-io-protocol.md
+++ b/LANG_SPEC_v0.5/16-io-protocol.md
@@ -1,5 +1,7 @@
 ## 16. I/O Protocol
 
+- **Scope**: Osty language spec — 16. I/O Protocol
+- **Type**: Language specification
 The `Reader` and `Writer` interfaces define the streaming I/O contract
 shared across `std.io`, stream-oriented standard-library modules, and
 FFI byte-stream bridges. `std.fs` currently exposes whole-file and

--- a/LANG_SPEC_v0.5/17-display-and-format-protocol.md
+++ b/LANG_SPEC_v0.5/17-display-and-format-protocol.md
@@ -1,5 +1,7 @@
 ## 17. Display and Format Protocol
 
+- **Scope**: Osty language spec — 17. Display and Format Protocol
+- **Type**: Language specification
 String interpolation and the `print*` family are defined in terms of a
 single interface:
 

--- a/LANG_SPEC_v0.5/18-change-history.md
+++ b/LANG_SPEC_v0.5/18-change-history.md
@@ -1,5 +1,7 @@
 ## 18. Change History
 
+- **Scope**: Osty language spec — 18. Change History
+- **Type**: Language specification
 This chapter records the evolution of the specification across released
 versions. The latest release is at the top.
 

--- a/LANG_SPEC_v0.5/19-runtime-primitives.md
+++ b/LANG_SPEC_v0.5/19-runtime-primitives.md
@@ -1,5 +1,7 @@
 ## 19. Runtime Primitives
 
+- **Scope**: Osty language spec — 19. Runtime Primitives
+- **Type**: Language specification
 This chapter specifies the **runtime sublanguage** — a small, package-gated
 surface that lets the Osty toolchain implement the GC, allocator, and other
 runtime services in Osty itself. None of this surface is reachable from

--- a/LANG_SPEC_v0.5/ABRIDGED.md
+++ b/LANG_SPEC_v0.5/ABRIDGED.md
@@ -1,5 +1,7 @@
 # Osty v0.5 Agent Quick Spec
 
+- **Scope**: Osty language spec appendix — Osty v0.5 Agent Quick Spec
+- **Type**: Language specification
 AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위한 규칙 카드.
 예제는 싣지 않는다. 충돌 시 `LANG_SPEC_v0.5/`와 `OSTY_GRAMMAR_v0.5.md`가
 우선한다.

--- a/LANG_SPEC_v0.5/README.md
+++ b/LANG_SPEC_v0.5/README.md
@@ -1,5 +1,7 @@
 # Osty Language Specification v0.5
 
+- **Scope**: Osty language spec v0.5 — table of contents and overview
+- **Type**: Language specification
 Osty is a general-purpose, statically-typed, garbage-collected programming language.
 This directory holds the specification, split into per-section files for easier navigation and editing.
 

--- a/LLVM_ARTIFACT_LAYOUT.md
+++ b/LLVM_ARTIFACT_LAYOUT.md
@@ -1,5 +1,7 @@
 # LLVM Artifact Layout
 
+- **Scope**: Backend-aware output/cache layout — .osty/ directory structure, fingerprinting
+- **Type**: Spec
 이 문서는 LLVM 이주 25-step Phase 4의 산출물이다. 목적은 Go backend와 LLVM
 backend가 같은 project/profile/target에서 동시에 동작해도 생성물이 서로
 덮어쓰지 않도록 artifact layout을 확정하는 것이다.

--- a/LLVM_BACKEND_CORPUS.md
+++ b/LLVM_BACKEND_CORPUS.md
@@ -1,5 +1,7 @@
 # LLVM Backend Corpus
 
+- **Scope**: Backend parity fixture classes and smoke test set
+- **Type**: Reference
 이 문서는 LLVM 이주 Phase 2의 산출물이다. 목적은 backend parity에 사용할
 fixture를 명시적으로 분류해서, Go backend의 현재 동작과 LLVM backend의 목표
 범위를 섞지 않도록 하는 것이다.

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -1,5 +1,7 @@
 # LLVM Migration Plan
 
+- **Scope**: Native LLVM backend migration history and plan
+- **Type**: Plan
 > **Status (2026-04-29): Historical with current sync notes.** 공개 백엔드는 이미 LLVM 하나뿐이며,
 > 기존 Osty→Go 부트스트랩 트랜스파일러는 제거되었다 — `internal/selfhost/generated.go`
 > 는 커밋된 시드 산출물로 동결되어 있다. 이 문서는 이주 과정의 기록이며, phase

--- a/LLVM_PHASE1_BASELINE.md
+++ b/LLVM_PHASE1_BASELINE.md
@@ -1,5 +1,7 @@
 # LLVM Phase 1 Baseline
 
+- **Scope**: Legacy Go-backend baseline metrics for LLVM migration comparison
+- **Type**: Reference
 기준일: 2026-04-16 Asia/Seoul
 기준 commit: `0eb6ea1`
 목적: LLVM backend 이주 초기에 기록한 historical baseline 이다. 당시 Go

--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -1,5 +1,7 @@
 # MIR emitter selfhost port
 
+- **Scope**: LLVM IR emitter porting status — Go→Osty self-host tracking
+- **Type**: Porting matrix
 > **Phase 1 (LLVM-text builder library): COMPLETE (2026-04-27).**
 >
 > The §1–§17 builder library at `toolchain/mir_generator.osty`

--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -1,1290 +1,1439 @@
 # ONB 설계 — Osty Native Backend
 
-> **Status: Phase 0 scaffold started (2026-04-30); dev-loop integration
-> (Slice A1) landed (2026-05-01).** 33개 설계 결정 통합.
-> `internal/onb` + `--backend onb` 등록까지 착수했고, `fn main() {}`의 MIR를
-> ONB Program으로 낮춘 뒤 첫 aarch64 LIR (`mov w0, #0`; `ret`)까지 생성하는
-> Phase 1.0 slice가 구현됐다. ONB assembly text artifact (`main.s`) 렌더링과
-> 최소 Mach-O relocatable object (`main.o`) emission이 가능하다. Binary emit은
-> ONB object를 host linker에 넘겨 실행 파일을 만들며, darwin/aarch64
-> `fn main() {}` smoke는 exit 0까지 확인됐다. 다음 slice로
-> `println("literal")` MIR intrinsic을 ONB LIR + assembly text까지 낮추며
-> `_puts` 호출과 `__cstring` 섹션을 렌더링하고, Mach-O `PAGE21` / `PAGEOFF12`
-> / `BR26` relocation을 포함한 object emission까지 확장했다. 이어서
-> `println(123)` 같은 정수 리터럴 출력도 `_printf("%lld\n", value)` 경로로
-> lowering/object/binary smoke까지 통과한다.
->
-> **Slice A1 (dev-loop integration)** — 실제 개발자가 `osty run --backend onb`
-> 를 켜둔 채 작업할 수 있도록 두 축이 추가됐다. (1) `internal/onb`가 미지원
-> MIR shape를 만나면 `ErrUnsupportedShape` sentinel을 반환하고, `ONBBackend`
-> 가 `EmitObject` / `EmitBinary` 모드에서 자동으로 LLVM 백엔드에 위임한다
-> (`--emit asm`은 사용자가 ONB asm을 명시적으로 원했다고 보고 hard-fail
-> 유지). 결과 binary는 `.osty/out/llvm/`에 떨어지며 `osty run`이 그대로
-> 실행한다. (2) `OSTY_ONB_TIMING=1`이면 stderr에 한 줄 요약을 찍는다 —
-> `onb: emit 312ms [native: aarch64-apple-darwin]` 또는
-> `onb: emit 1.82s [fallback to llvm: instruction *mir.CallInstr is outside phase 1]`.
-> Cross-validation 흐름은 `OSTY_ONB_STRICT=1`로 fallback을 끄면 raw 거부
-> 에러를 받을 수 있다.
->
-> **Slice A2 Week 1 (Int 산술 + locals, 2026-05-02)** — ONB native path의 첫
-> 의미 있는 커버리지 확장. 패턴: `let mut n = 1; n = n + 5; println(n)`,
-> `let x = 10; let y = 32; println(x + y)`, `let a = 10; let b = 3; println(a - b * 2)`
-> 모두 native path로 통과 (각 50–150ms wall-clock, LLVM 대비 5–10×).
-> 추가된 LIR opcode: `Load64Stack`, `MovRegReg`, `AddReg` / `SubReg` / `MulReg`.
-> 모델: **stack-everything** — RA 없이 모든 read 대상 local에 고정 stack slot
-> 할당, 모든 operand가 x9/x10 scratch register를 거침. 프레임 layout:
-> `[sp+0..16] vararg slot (printf int용) → [sp+V..V+8N] locals → [sp+frameSize-16] FP/LR`.
-> dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
-> 후속 의제로 유예.
->
-> **Slice A2 Week 31 (ONB self-host port — Mach-O wire writer
-> Slices B+C, 2026-05-03)** — Mach-O 직렬화 layer 착륙. 신규 4
-> 파일 (constants 78 + writer 265 + symtab 127 + test 181) +
-> Go parity 125 = ~776줄. Header / segment / section / symtab /
-> dysymtab / reloc / nlist64 / strtab 모두 mirror. Go macho.go
-> wire-format 부분 100% 미러 달성.
->
-> **Slice A2 Week 30 (ONB self-host port — Phase 6.3 DWARF info
-> section + string table, 2026-05-03)** — DWARF series 마무리.
-> `__debug_str` 테이블 + `__debug_info` section emitter (CU DIE +
-> base type / pointer type / structure type / subprogram / variable
-> DIEs) 모두 Osty 측 착륙. Go-side `dwarf.go`의 100% logical mirror
-> 달성. 신규: `onb_dwarf_strings.osty` (55), `onb_dwarf_info.osty`
-> (389), 5 새 Osty 테스트, 2 새 Go parity 테스트
-> (`TestDwarfInfoParityVsOstyTable` 외).
->
-> **Slice A2 Week 29 (ONB self-host port — Phase 6.1 + 6.2 LEB128 +
-> DWARF abbrev + line program, 2026-05-03)** — DWARF 이미터 진입.
-> 1k 라인 슬라이스로 LEB128 byte-stream 인코더, DWARF 4 상수 (tags /
-> attrs / forms / opcodes / ATE / DW_OP / abbrev codes), 7개 abbrev
-> 코드 (CU / subprogram / variable / base type / pointer type /
-> structure type / member) 의 abbreviation 테이블, 그리고 완전한 line
-> program 인코더 (header + body 상태 머신 + extended opcodes) 가
-> Osty 측에 착륙.
->
-> 신규 Osty 파일:
->
-> - `toolchain/onb_leb128.osty` (89줄): `onbWriteULEB128`,
->   `onbWriteSLEB128`, `onbWriteULEB128Pair`. Osty의 `for ... in
->   range`로 16-iteration 고정 chunking 구현 (osty엔 `break`/
->   `continue`가 expression-position에서 깔끔하지 않으므로
->   `done` flag로 skip-rest invariant)
->
-> - `toolchain/onb_dwarf_constants.osty` (128줄): `onbDwarfVersion`,
->   `onbDwarfTagCompileUnit`, `onbDwarfAtName`, `onbDwarfFormStrp`,
->   `onbDwarfATESigned`, `onbDwarfOpFbreg`, `onbDwarfAbbrevSubprogram`
->   등 ~50개 상수를 `pub fn () -> Int`로 노출
->
-> - `toolchain/onb_dwarf_abbrev.osty` (123줄): `onbEmitDwarfAbbrev()
->   -> List<Int>` — 7 abbreviation entries + table terminator를
->   ULEB128 인코딩으로 byte stream 생성
->
-> - `toolchain/onb_dwarf_line.osty` (318줄):
->   - `OnbDwarfLineFile` / `OnbDwarfLineRow` / `OnbDwarfLineProgram`
->     데이터 타입
->   - `onbWriteU8/U16LE/U32LE/U64LE` byte writers (Osty의 `List<Int>`
->     누적 패턴, Go의 `bytes.Buffer + binary.Write` 미러)
->   - `onbWriteCString` (NUL-terminated)
->   - `onbDwarfStdOpcodeLengths` 12바이트 standard opcode 길이 테이블
->   - `writeDwarfExtended{SetAddress, EndSequence}` extended op 헬퍼
->   - `onbEncodeDwarfLineHeader(prog)` — DWARF 4 §6.2.4 헤더 layout
->   - `onbEncodeDwarfLineBody(prog)` — 행 스테이트 머신 워클 (file
->     /line/column/PC 변경 시 적절한 standard op + ULEB128/SLEB128
->     인자 emit). 첫 행은 extended set_address로 PC 초기화. 행이
->     PC 순서 어긋나면 `outcome.ok = false`. 마지막에 textSize까지
->     advance + extended end_sequence
->   - `onbEmitDwarfLine(prog)` — unit_length + version +
->     header_length + header + body 합성. `setAddressOffset` 반환
->     (Mach-O reloc target)
->
-> - `toolchain/onb_dwarf_test.osty` (181줄): ULEB128 단일/다중 바이트
->   경계, SLEB128 양수/음수 경계, abbreviation 첫 3바이트 +
->   end-of-table 마커, line program 빈 행 well-formed 검증, 헤더
->   metadata block 6바이트 일치
->
-> - `internal/onb/onb_dwarf_parity_test.go` (131줄):
->   - `TestDwarfLEB128ParityVsOstyTable` — ULEB/SLEB 12 케이스
->   - `TestDwarfLineParityVsOstyTable` — line section header 메타데이터
->     6바이트 (minInstLen / maxOpsPerInst / defaultIsStmt /
->     lineBaseByte / lineRange / opcodeBase) + version 일치
->   - `TestDwarfAbbrevParityVsOstyTable` — abbreviation 테이블 첫
->     3바이트 (compile-unit code + tag + has-children) + 표 종료자
->     + 최소 사이즈
->
-> 검증:
-> - `osty check toolchain` exit 0
-> - `go test ./internal/onb -run TestDwarf` — 4 case 모두 통과
-> - `go test ./internal/onb ./internal/backend -short` — 0 회귀
->
-> Phase 6 시리즈 진행도:
-> - 6.1 (LEB128) ✅
-> - 6.2 (line program) ✅ (이번 슬라이스)
-> - 6.3 (CU DIE + subprogram DIE + base type / pointer type /
->   structure type DIE 이미터) — 다음 슬라이스
->
-> 누적 Osty self-host LOC: 3,774 (이전 2,804 + 970 이번 슬라이스).
->
-> **다음 phase 후보**:
-> - Phase 6.3 — `__debug_info` section emitter, `__debug_str` 테이블,
->   per-function subprogram DIE + variable DIE generation. DWARF
->   시리즈 마무리. ~700줄 예상.
-> - Phase 3a — MIR Type 의존 ABI predicates 첫 진입. 새로운 표면
->   (toolchain/mir.osty의 Type enum 소비) — 별도 디자인 필요.
->
-> **Slice A2 Week 28 (ONB self-host port — Phase 2c + 2e symbol
-> reloc + container types + function emitter, 2026-05-03)** — 1k+
-> 줄 슬라이스. adrp+add + bl 심볼 reloc 모델 + Function/Block/Program
-> 컨테이너 타입 + per-function 워커가 한 번에 착륙. **Phase 2 시리즈
-> 마무리**: Osty 측이 단일 instr부터 완전한 함수 emit (워드 + 분기
-> fixup + 심볼 reloc + 블록 오프셋 + 라인 스팬) 까지 표현.
->
-> 추가 Osty 파일:
->
-> - `toolchain/onb_relocs.osty` (84줄, 신규):
->   - `OnbRelocKind` enum (Branch26 / Page21 / PageOff12)
->   - `OnbReloc { codeOffset, symbol, pcrel, kind }` 레코드
->   - `onbRelocKindMachoTyp(kind)` — Mach-O 와이어 type 바이트 매핑
->   - 편의 builder: `onbRelocPage21/PageOff12/Branch26`
->
-> - `toolchain/onb_program.osty` (250줄, 신규):
->   - `OnbLineSpan` (line + column)
->   - `OnbDebugStructField`, `OnbDebugLocal`, `OnbDebugLocalStruct`
->     constructor
->   - `OnbBlock` (label / originalIndex / instrs / lineSpans)
->   - `OnbFunction` (name / blocks / frameSize / debugLocals)
->   - `OnbCStringLiteral`, `OnbProgram`
->   - `OnbEmittedFunction { words, fixups, relocs, blockOffsets,
->     blockLineSpans }` + `onbEmitFunction(func)` walker — 블록을
->     순회하며 PC 바이트 오프셋 추적, 모든 emit 산출물 (워드+fixup+
->     reloc+offset) 을 collect
->   - `onbEmitFunctionResolved(func)` — emit + branch fixup 패스를
->     하나로 묶음. `OnbResolvedFunction { words, relocs,
->     blockOffsets, blockLineSpans, ok }` 반환
->
-> - `toolchain/onb_program_test.osty` (152줄, 신규):
->   - 4 round-trip 케이스: leaf ret, conditional fall-through,
->     println-style (adrp+add+bl+mov+ret with 3 relocs), multi-word
->     op + branch (block 경계가 movz/movk chain 길이로 변하는 경우)
->
-> - `toolchain/onb_encoding.osty` 확장:
->   - `onbEncodeAdrpPlaceholder(dst)` — `adrp Xd, 0`
->   - `onbEncodeAddPageOffPlaceholder(dst)` — `add Xd, Xd, #0`
->   - `onbEncodeBlPlaceholder()` — `bl 0`
->
-> - `toolchain/onb_lir.osty` 확장:
->   - 3 새 opcode (`OnbInstrLoadCStringAddress`,
->     `OnbInstrLoadSymbolAddress`, `OnbInstrBranchLink`)
->   - `OnbInstr`에 `symbol`, `label` 두 필드 추가
->   - 3 새 constructor + emit helpers (`onbEmitAdrpAddPair`,
->     `onbEmitBranchLinkPlaceholder`)
->   - `OnbBranchEmit`에 `relocs: List<OnbReloc>` 필드 추가 — emit
->     결과의 통합 surface
->   - `onbEncodeInstr` switch에 3 새 None 가지 (multi-step opcode
->     표시)
->
-> - `internal/onb/onb_lir_parity_test.go` 확장:
->   - `TestLirSymbolReferenceParityVsOstyTable` — adrp/add/bl
->     placeholder 비트 패턴 검증 (x0/x9 / 0/9 두 슬롯)
->
-> 검증:
-> - `osty check toolchain` exit 0 (총 2,804줄 Osty source +
->   Go-side parity)
-> - 5개 parity 테스트 모두 통과 (Encoder, LirOpcode, LirMultiWord,
->   LirBranch, LirSymbolReference)
-> - `go test ./internal/onb ./internal/backend -short` — 0 회귀
->
-> Phase 2 시리즈 LOC 누적 (Osty + Go-side):
->
-> | 파일 | 라인 |
-> |------|---:|
-> | `onb_encoding.osty` | 653 |
-> | `onb_encoding_test.osty` | 103 |
-> | `onb_fixups.osty` | 114 |
-> | `onb_fixups_test.osty` | 180 |
-> | `onb_layouts.osty` | 81 |
-> | `onb_lir.osty` | 494 |
-> | `onb_lir_test.osty` | 191 |
-> | `onb_program.osty` | 250 |
-> | `onb_program_test.osty` | 152 |
-> | `onb_relocs.osty` | 84 |
-> | `onb_runtime_symbols.osty` | 158 |
-> | `onb_lir_parity_test.go` | 257 |
-> | `onb_osty_parity_test.go` | 87 |
-> | **합계** | **2,804** |
->
-> **다음 phase 후보**: Phase 3a — MIR Type 의존 ABI predicates
-> (`isABIScalarType`, `abiKindFor`, `abiRegSlots`). 첫 MIR 진입.
-> 또는 Phase 6 (DWARF 라인 프로그램 + 변수 DIE emit). DWARF는
-> Phase 2e의 `blockLineSpans`/`debugLocals` 필드를 소비하므로
-> 자연스러운 다음 슬라이스.
->
-> **Slice A2 Week 27 (ONB self-host port — Phase 2d branch family +
-> fixup pass, 2026-05-03)** — Block-relative 분기 encoder + placeholder
-> + fixup resolve pass 일체. Branch instruction의 알고리즘적 핵심
-> (placeholder 작성 → 블록 byte offset 계산 → displacement 패치) 가
-> 한 슬라이스에 묶임. `b` / `b.cond` / `cbnz` 모두 커버.
->
-> 추가:
->
-> - `toolchain/onb_encoding.osty` 확장:
->   - `onbEncodeBranchDisplacement(disp) -> Int?` — `b imm26`,
->     signed 26-bit (range ±2^25 words)
->   - `onbEncodeBranchCondDisplacement(cond, disp) -> Int?` —
->     `b.cond imm19`, signed 19-bit
->   - `onbEncodeCbnzDisplacement(src, disp) -> Int?` — `cbnz Xt, imm19`
->   - `onbEncodeBranchPlaceholder/CondPlaceholder/CbnzPlaceholder` —
->     emit-time placeholder (imm = 0)
->   - `onbPatchBranchUnconditional/Cond/Cbnz(placeholder, disp)` —
->     fixup pass의 패치 헬퍼
->   - `onbBranchImm26Min/Max`, `onbBranchImm19Min/Max` 상수
->
-> - `toolchain/onb_fixups.osty` (새 파일):
->   - `OnbBranchFixupKind` enum (Uncond / Cond / Cbnz)
->   - `OnbBranchFixup` struct (codeOffset / targetBlock / kind)
->   - `OnbResolveOutcome` struct (words + ok flag)
->   - `onbResolveBranchFixups(words, fixups, blockOffsets)` —
->     fixup 리스트를 walk, 각 fixup의 displacement 계산, placeholder
->     워드를 patched 워드로 교체
->   - `onbPatchBranchByKind` — kind별 dispatch
->
-> - `toolchain/onb_lir.osty` 확장:
->   - `OnbInstrKind`에 `OnbInstrBranch`, `OnbInstrBranchCond`,
->     `OnbInstrBranchCondNotZero` 추가
->   - `OnbInstr.targetBlock: Int` 필드 (-1 default for non-branch)
->   - constructors: `onbInstrBranch`, `onbInstrBranchCond`,
->     `onbInstrBranchCondNotZero`
->   - `OnbBranchEmit` struct (words + fixups)
->   - `onbEmitInstr(instr, codeOffset) -> OnbBranchEmit` — 모든
->     opcode를 통합한 emitter. 분기는 placeholder + fixup record를
->     반환, non-branch는 빈 fixups 리스트
->   - `onbEncodeInstr` 분기 가지: 분기는 None 반환 (multi-step path
->     표시; 단일 워드 fast path 유지)
->
-> - `toolchain/onb_fixups_test.osty` (새 파일):
->   - 5 round-trip 케이스: forward branch (b +4), backward loop
->     (b -4), conditional (b.eq +8), cbnz (+4), 그리고 out-of-range
->     blockId 실패 케이스
->   - `emitBlocks(blocks)` 헬퍼 — block 리스트를 walk해 word stream +
->     fixups + blockOffsets 만듦 (byte 단위)
->   - 각 case: emit → resolve → expected hex 비교
->
-> - `internal/onb/onb_lir_parity_test.go` 확장:
->   - `TestLirBranchParityVsOstyTable` — Go의 `patchMachOBranch`가
->     b/+4, b/-4, b.eq/+8, cbnz/+4 4 케이스에서 Osty 테스트가
->     주장하는 동일한 hex 워드를 produce하는지 검증
->
-> 검증:
-> - `osty check toolchain` exit 0
-> - 4개 parity 테스트 (Encoder + LirOpcode + LirMultiWord + LirBranch)
->   모두 통과
-> - `go test ./internal/onb -short` 0 회귀
->
-> 한계 (Phase 2c+로 분리):
-> - **BranchLink (`bl symbol`)** — 분기 displacement가 아닌 Mach-O
->   reloc 표 의존. Phase 2c가 adrp+add와 함께 처리
-> - **Block walker / Function emitter** — 현재 emit 헬퍼는 단일 instr
->   레벨. 전체 함수를 emit하는 walker (line span tracking, prologue/
->   epilogue placement, reloc collection 포함) 는 Phase 2e와 함께
-> - **Branch optimization** — fall-through 후속 블록으로의 무조건
->   분기 elide, mutual rewriting (b → b.cond) 같은 최적화는 lowering
->   레이어 (Phase 4-5) 의 책임
->
-> **다음 phase 후보**: Phase 2c (BranchLink + adrp+add + Mach-O reloc
-> 표 model), Phase 2e (Function/Block/Program container types), 또는
-> Phase 3a (MIR Type 의존 ABI predicates).
->
-> **Slice A2 Week 26 (ONB self-host port — Phase 2b multi-word
-> constant materialisation, 2026-05-03)** — Variable-length
-> encoding 도입. `MovImm64`가 1–4개의 32-bit word를 produce하는
-> movz/movk chain으로 lower되며, `onbEncodeInstrWords` dispatcher가
-> single-word / multi-word를 통합한 `List<Int>` 출력으로 노출.
->
-> 추가:
->
-> - `toolchain/onb_encoding.osty` 확장:
->   - `onbEncodeMovz(dst, hw, imm16)` — 64-bit MOVZ
->   - `onbEncodeMovk(dst, hw, imm16)` — 64-bit MOVK
->   - `onbEncodeMovzW(dst, hw, imm16)` — W-register MOVZ + 내부
->     `onbWToXAlias` (w0..w7 → x0..x7 인덱스 공유)
->   - `onbEncodeMovImm64Words(dst, imm) -> List<Int>` — 4개 hw
->     position을 unconditional iteration으로 walk, 첫 chunk는
->     MOVZ로 강제 (다른 비트 zero 화), 이후 chunk가 0이면 MOVK 생략
->   - `onbEncodeMovImm32Word(dst, imm) -> Int?` — `mov w0, #0`
->     스타일의 단일 word
->
-> - `toolchain/onb_lir.osty`:
->   - `OnbInstrKind`에 `OnbInstrMovImm32`, `OnbInstrMovImm64` 추가
->   - 대응 constructors `onbInstrMovImm32`, `onbInstrMovImm64`
->   - `onbEncodeInstr` dispatcher가 MovImm32 단일 word 처리,
->     MovImm64는 None (multi-word path 표시)
->   - 새 `onbEncodeInstrWords(instr) -> List<Int>` — 모든 opcode 통합.
->     단일 word는 1-element list로 wrap, MovImm64는 chain 그대로
->
-> - `toolchain/onb_lir_test.osty` 확장:
->   - `assertOnbInstrWordsEq` helper — word count + per-position 비교
->   - mov x0/x9 #0 / #100 / #65535 / #0x12345678 케이스 (1-2 word
->     chains)
->
-> - `internal/onb/onb_lir_parity_test.go` 확장:
->   - `TestLirMultiWordParityVsOstyTable` — Go `encodeMachOMovImm64`
->     출력을 Osty 테이블과 word-by-word 비교
->
-> 한계 (Phase 2c+로 분리):
-> - **adrp + add 페어** (`LoadCStringAddress`, `LoadSymbolAddress`)
->   는 reloc 표 의존이라 Mach-O writer 진입까지 미룸
-> - **Branch family** (`Branch`, `BranchCond`, `BranchCondNotZero`,
->   `BranchLink`) — link-time fixup pass 필요. Phase 2d
-> - **Container types** — Phase 2e
->
-> 검증:
-> - `osty check toolchain` exit 0
-> - `go test ./internal/onb -run TestLirMultiWordParity` — 4
->   MovImm64 케이스가 word-by-word 일치
-> - `go test ./internal/onb -short` — 0 회귀
->
-> **다음 phase 후보**: Phase 2c (adrp+add skeletons, Mach-O reloc
-> hooks), Phase 2d (branch fixups), 또는 Phase 3a (MIR Type 의존성
-> 도입).
->
-> **Slice A2 Week 25 (ONB self-host port — Phase 2a single-word LIR
-> mirror, 2026-05-03)** — LIR opcode 21종을 Osty 측 enum + flat
-> struct + per-opcode constructor + dispatch encoder로 미러. Phase 1
-> 의 인코딩 헬퍼들이 이제 Osty-side LIR record로 driving 되며,
-> `OnbInstr → Int?` 디스패처가 Go의 `*<Opcode>` switch를 직접 미러.
->
-> 신규 Osty 파일:
->
-> 1. `toolchain/onb_lir.osty` — 단일-word LIR opcode 미러
->    - `OnbCond` enum (Eq/Ne/Ge/Lt/Gt/Le) + `onbCondToCode` 매퍼
->    - `OnbDebugTypeKind` enum (5개 + Struct)
->    - `OnbInstrKind` enum (21개 단일-word opcode)
->    - `OnbInstr` flat struct (kind + dst/src/lhs/rhs/base/imm/offset/cond)
->    - per-opcode constructors (`onbInstrAddReg(...)`, `onbInstrCmp(...)` ...)
->    - `onbEncodeInstr(instr) -> Int?` — Phase 1 인코더로 디스패치
->
-> 2. `toolchain/onb_lir_test.osty` — 21개 round-trip 케이스 (constructor →
->    encoder → expected hex)
->
-> 3. `toolchain/onb_encoding.osty` 확장 — 5개 인코더 추가
->    (`onbEncodeArithReg`, `onbEncodeMulReg`, `onbEncodeCmp`,
->    `onbEncodeCset`, `onbEncodeStackLoad/Store`, `onbEncodeAddImm`)
->
-> 4. `internal/onb/onb_lir_parity_test.go` — Go-side parity gate.
->    Phase 1 gate에 더해 ADD/SUB/MUL/CMP/CSET/stack 트래픽까지
->    Go encoder 출력 vs Osty 테이블 비교
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - **Multi-word opcodes** — `MovImm64` (1-4 movz/movk),
->   `LoadCStringAddress` (adrp+add), `LoadSymbolAddress` (adrp+add)는
->   variable-length 출력이 필요해 Phase 2b. 그 phase는 fixup pass
->   (블록 ID → byte offset 매핑) + 외부 심볼 reloc 표 만들기까지 묶음.
-> - **Branch family** — `Branch` / `BranchCond` / `BranchCondNotZero` /
->   `BranchLink`도 link-time fixup이 필요해 Phase 2b
-> - **Instr이 아닌 LIR 데이터 타입** (`Function`, `Block`,
->   `Program`, `LineSpan`, `CStringLiteral`, `DebugLocal`,
->   `DebugStructField`)은 Phase 2c
->
-> 검증:
-> - `osty check toolchain` exit 0 (`onb_lir.osty`,
->   `onb_lir_test.osty`, 확장된 `onb_encoding.osty` 모두 통과)
-> - `go test ./internal/onb -run TestLirOpcodeParityVsOstyTable` —
->   21개 expected hex 값이 Go encoder와 일치
-> - `go test ./internal/onb -short` — 0 회귀
->
-> **다음 phase 후보**: Phase 2b (multi-word + branch fixups), 또는
-> Phase 3a (ABI predicates `isABIScalarType` / `abiKindFor`로 진입,
-> MIR Type 의존성 도입).
->
-> **Slice A2 Week 24 (ONB self-host port — Phase 1 leaf modules,
-> 2026-05-02)** — ONB Go 구현의 Osty 포팅 첫 슬라이스. **Tier 1 native
-> 기능 확장은 일단락**, 이제부터 `internal/onb/`의 Go 코드를
-> `toolchain/onb_*.osty`로 옮기는 self-host 포팅 트랙으로 전환.
->
-> 패턴 (lir_proto.osty 선례 따름):
-> - Osty source = future-canonical 단일 소스
-> - Go 구현 = 현재 production (LLVM self-host LLVMgen이 ONB를 컴파일할
->   수 있을 때까지)
-> - Go-side 페어리티 테스트가 두 표현이 byte-for-byte 일치하도록 잠금
-> - `generated.go` 재생성 경로는 #854 이후 frozen이라 Osty 코드는
->   현재 dev-time runtime에 직접 닿지 않음 — `osty check toolchain` smoke
->   가 syntactic/typecheck만 검증
->
-> Phase 1 (이번 슬라이스, MIR/LIR 의존성 없는 leaf 모듈 3개):
->
-> 1. `toolchain/onb_encoding.osty` — pure aarch64 instruction encoders
->    - `onbXRegisterNumber` / `onbDRegisterNumber` — 레지스터명 → 0..31 인코딩
->    - `onbEncodeBrk` (UnreachableTerm trap)
->    - `onbEncodeFmovDFromX` / `onbEncodeFmovXFromD` (FP↔Int 비트캐스트)
->    - `onbEncodeFPArith(base, ...)` (fadd/fsub/fmul/fdiv 공통)
->    - `onbEncodeBlr` (closure indirect call)
->    - `onbEncodeRet`
->    - `onbEncodeFPStack(base, reg, off)` (str/ldr d, [sp])
->    - `onbEncodeLoadStoreReg(base, t, n, off)` (str/ldr x, [reg])
->    - `onbEncodeMovRegReg`
->
-> 2. `toolchain/onb_runtime_symbols.osty` — 런타임 심볼 테이블
->    - `onbAbiKind*` 5종 상수 + `onbAbiKindFor`-슈도 헬퍼
->    - `onbRuntimeSym*` String/List/Map/Closure 심볼 상수
->    - `onbListPushSymbolForKind` / `onbListGetSymbolForKind`
->    - `onbMapInsert/Get/Contains/RemoveSymbolForKeyKind` (5개 dispatch table)
->
-> 3. `toolchain/onb_layouts.osty` — 슬롯/객체 layout 헬퍼
->    - `onbClosureEnvCapturesOffset()` (= 24, 런타임 헤더 크기)
->    - `onbClosureEnvFieldByteOffset(index)` — index 0 → 0 (fn ptr),
->      index N≥1 → 24 + (N-1)*8 (capture N-1)
->    - `onbEnumPayloadOffset(fieldIdx)` / `onbEnumDiscriminantOffset()`
->    - `onbStructFieldByteOffset(index)`
->    - `onbAbiSmallStructRegLimit()` / `onbAbiIndirectStructFieldLimit()`
->      / `onbAbiPointerRegSlotBytes()`
->
-> 4. `toolchain/onb_encoding_test.osty` — Osty-side parity 테이블 (14 케이스)
->
-> 5. `internal/onb/onb_osty_parity_test.go` — Go-side parity gate. Go
->    encoder가 produce하는 32-bit word를 Osty 테스트의 expected hex와
->    한 줄씩 비교. 두 표현 사이 drift는 PR 리뷰에서 양쪽 expected
->    column 수정으로 surface.
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - **runtime wire 없음** — Osty 함수는 dead code 상태. 실제 production은
->   여전히 `internal/onb/{lower,macho,asm,dwarf}.go`. LLVM self-host
->   LLVMgen이 ONB를 컴파일할 수 있게 되면 그때 `selfhost.ONBRunner` 같은
->   인터페이스로 wire (lir_proto_runner.go 패턴 참조).
-> - MIR/LIR 타입 의존하는 함수 (abiRegSlots, lookupStructLayout, lower*Assign)
->   는 Phase 2+. 먼저 LIR opcode + Reg를 Osty enum으로 미러해야 함.
-> - DWARF 인코더 / 라인 프로그램 / Mach-O 헤더는 Phase 6+ 별도 슬라이스.
->
-> 검증:
-> - `go run ./cmd/osty check ./toolchain` — exit 0 (4 새 파일 syntactic
->   + typecheck 통과)
-> - `go test ./internal/onb -run TestEncoderParityVsOstyTable` — Go encoder
->   가 Osty 테이블의 14개 expected hex값과 byte-for-byte 일치
->
-> **다음 phase 후보**: LIR Opcode + Reg를 Osty enum으로 (Phase 2),
-> 또는 ABI 헬퍼 (`abiRegSlots` 등)를 MIR Type 의존 minimal subset으로
-> 시작 (Phase 3a).
->
-> **Slice A2 Week 23 (Map<K,V> — get / containsKey / remove, 2026-05-02)** —
-> Map의 핵심 lookup 3종을 native lowering. Week 22의 new/insert/len과
-> 결합하면 Map 일상 사용 (캐시, 인덱스, 빈도 카운트)이 fallback 없이
-> 통과.
->
-> 작동:
->
-> ```osty
-> let mut m: Map<String, Int> = {:}
-> m.insert("k", 42)
-> match m.get("k") {                  // V? 반환 — Some(42)
->     Some(x) -> println(x),
->     None -> println(-1),
-> }
-> println(m.containsKey("k"))         // 1 (Bool, true)
-> m.remove("k")                        // Bool 반환 (찾았는지)
-> println(m.len())                     // 0
-> ```
->
-> 추가:
-> - 새 런타임 심볼: `runtimeSymMapGet/Contains/Remove` × 5 key kinds
->   (i64/i1/f64/ptr/string)
-> - `lowerMapGet` — Week 22 scratch 슬롯을 `out_value`로 재사용 →
->   런타임 호출 → x0 (None=0/Some=1 디스크리미넌트) → dest+0,
->   scratch 값 → dest+8 (None일 땐 stale이지만 디스크리미넌트로 차단)
-> - `lowerMapContains` / `lowerMapRemove` — `lowerMapBoolReturn` 헬퍼로
->   공유. 런타임이 bool을 x0로 반환, dest slot에 직접 capture
-> - `mapGet/Contains/RemoveSymbolForKeyKind` 디스패치 테이블
-> - `functionUsesMapValueScratch`이 `IntrinsicMapGet`도 감지해
->   scratch 슬롯 예약
->
-> 검증:
-> - E2E binary smoke 4개 (`TestONBBackendBinaryRunsMapGetContainsRemoveOnDarwinARM64`):
->   map_get_hit / map_get_miss (Some/None 분기), map_contains_int_keys
->   (Int 키), map_remove_shrinks_len (insert→remove→len)
-> - 기존 fallback 테스트 4개의 sentinel을 `taskGroup(|g| g.spawn(|| 42))`
->   로 변경 (Map.get은 이제 native라 더 이상 fallback 사유 아님)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - `m.update(k, |v| ...)` — 클로저 + Map.get + Map.set 조합. front
->   end가 어떻게 lowering하는지에 따라 추가 작업 필요할 수 있음
-> - `m.getOr(k, default)` — IntrinsicMapGetOr 별도
-> - `m.keys()` / `m.values()` — `List<K>` 반환, 미구현
-> - `for (k, v) in m` — Map iterator 미구현
-> - GC pointer_bitmap 정확도는 Week 22 그대로 — pointer-typed values
->   는 GC false-retain 위험
->
-> **Tier 1 마무리 상태**: ONB가 일반적인 Osty 코드 패턴의 대부분을
-> native path로 처리. 클로저 (Week 20), 제네릭 함수 (Week 21),
-> Map<K,V> CRUD + len + lookup (Week 22 + 23), 메서드 디스패치 (intrinsic
-> 경유, Week 22), String .len/.isEmpty + Option .isSome/.isNone +
-> List .isEmpty (Week 21) 모두 통과. 남은 Tier 1 잔여물은 작은 String
-> 메서드 (.split/.contains/.compare) 정도로 follow-up.
->
-> **Slice A2 Week 22 (Map<K,V> — new + insert + len, 2026-05-02)** —
-> Map가 native path로 들어옴. 가장 흔한 패턴 `Map<String, Int>`,
-> `Map<Int, Int>` 의 생성·삽입·길이 쿼리가 fallback 없이 통과.
->
-> 작동:
->
-> ```osty
-> let mut m: Map<String, Int> = {:}
-> m.insert("a", 1)
-> m.insert("b", 2)
-> println(m.len())                 // 2
-> ```
->
-> 추가:
-> - 새 런타임 심볼: `runtimeSymMapNew/Len` + key kind별 insert
->   (`_i64`, `_i1`, `_f64`, `_ptr`, `_string`)
-> - `abiKindI64/I1/F64/Ptr/String` 상수 + `abiKindFor(t)` — 런타임의
->   `OSTY_RT_ABI_*` 태그 enum과 동일
-> - **Per-function map scratch slot** — `osty_rt_map_insert_*`은 value를
->   포인터로 받기 때문에 8B 스택 공간이 필요. `functionUsesMapValueScratch`
->   가 `IntrinsicMapSet`을 감지하면 vararg 슬롯과 user locals 사이에
->   8B 예약. `mapScratchOffset` 필드로 각 map_set 호출이 같은 슬롯 재사용
-> - `lowerMapNew` — `(key_kind, value_kind, 8, NULL)` 4-인자 호출,
->   결과 ptr를 dest slot에 capture
-> - `lowerMapSet` — 값을 scratch에 stamp → `LoadStackAddress`로
->   `&scratch`를 x2에 → key kind에 따라 insert 심볼 디스패치
-> - `lowerMapLen` — 단순 런타임 호출
-> - `mapKeyValueTypes(t)` helper — `Map<K,V>` NamedType에서 K, V 추출
-> - `mapInsertSymbolForKeyKind(kind)` — kind → 런타임 심볼 매핑
->
-> 검증:
-> - E2E binary smoke 3개 (`TestONBBackendBinaryRunsMapNewInsertLenOnDarwinARM64`):
->   map_string_int_three_keys (3 insert → len 3),
->   map_int_int_two_keys (Int 키), map_string_int_overwrite (같은 키
->   재삽입 → len 1)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - `m.get(k) -> V?` — 런타임이 ptr-out 컨벤션 (`out_value` 인자)을
->   사용하므로 별도 stack slot + Option<V> 구성 필요. **fallback 테스트
->   가 이 패턴 사용** (`m.get("a").isSome()`)
-> - `m.contains(k) -> Bool`, `m.remove(k) -> Bool` — 마찬가지 ptr-out
-> - `m.update(k, |v| ...)` — 클로저 + map_get 결합
-> - `m.keys()` / `m.values()` / `for (k, v) in m` — iterator 별도
-> - struct/enum value 타입 (8B 초과) — `value_size`가 8 hardcoded
-> - GC trace fn pointer는 NULL — pointer 값 (String, List 등)이 map에
->   들어가면 GC가 참조 못 잡을 위험. 정확한 trace 함수는 follow-up
->
-> 다음 슬라이스 후보: Map.get / Map.contains, 추가 String/Option/List
-> 메서드, Float 비교 / 캐스트, 클로저 GC bitmap.
->
-> **Slice A2 Week 21 (stdlib intrinsics + builtin pointer ABI, 2026-05-02)** —
-> 작은 lift, 큰 unlock. Builtin generic 컨테이너 (List/Map/Set/Channel
-> /Bytes/Handle)가 ABI에서 1-reg 포인터로 분류되도록 확장 + String /
-> List / Option의 `.len()` / `.isEmpty()` / `.isSome()` / `.isNone()`
-> 인트린식 lowering 추가. 결과적으로 **제네릭 함수가 fallback 없이
-> 통과** — 모노모피제이션은 이미 front end가 처리하고 있어서 ONB는
-> 그저 `List<T>` 인자를 받아주기만 하면 됨.
->
-> 작동:
->
-> ```osty
-> fn first<T>(xs: List<T>) -> T? {
->     if xs.len() == 0 { None } else { Some(xs[0]) }
-> }
-> fn main() {
->     let mut xs: List<Int> = []
->     xs.push(42)
->     let r = first(xs)               // List<Int>가 x0로 통과
->     match r {
->         Some(x) -> println(x),       // 42
->         None -> println(-1),
->     }
-> }
-> ```
->
-> 추가:
-> - `isBuiltinPointerType(t)` — `NamedType{Builtin: true}` 중 `List` /
->   `Map` / `Set` / `Channel` / `Bytes` / `Handle`을 1-reg 포인터로 인식
-> - `isABIScalarType`이 위 predicate를 포함하도록 확장 → `abiRegSlots`
->   가 `List<Int>` / `Map<K,V>` 같은 타입을 fn arg/return으로 받음
-> - `runtimeSymStringByteLen = "osty_rt_strings_ByteLen"` — String
->   .len()의 런타임 심볼
-> - `lowerStringLen` — `osty_rt_strings_ByteLen` 직접 호출
-> - `lowerStringIsEmpty` / `lowerListIsEmpty` — len 호출 + `cmp + cset eq`
-> - `lowerOptionIsSome` / `lowerOptionIsNone` — disc 슬롯 (옵션 슬롯 + 0)
->   읽고 1과 비교 (`Some` 태그 = 1)
-> - `lowerOptionDiscriminantCompare` 헬퍼 — isSome/isNone 공유 본체
->
-> 검증:
-> - E2E binary smoke 5개 (`TestONBBackendBinaryRunsStdlibIntrinsicsOnDarwinARM64`):
->   string_len ("hello".len() → 5), string_is_empty ("".isEmpty() → 1),
->   list_is_empty (push 전후), option_is_some_none (Some(7) + None
->   각각의 isSome/isNone), generic_fn_first (first<T> 호출 → 42)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - **Map intrinsics** 여전히 fallback — `osty_rt_map_new`은 `(key_kind,
->   value_kind, value_size, trace_fn)` 4 인자가 필요하고 set/get은 value
->   를 포인터로 전달 (스택 scratch 슬롯 필요). 별도 슬라이스로 보류
-> - String 메서드: `.split` / `.contains` / `.compare` / 슬라이싱 등 미구현
-> - Option 메서드: `.unwrap()` / `.unwrapOr(d)` 미구현
-> - List 메서드: `.pop()` / `.contains()` / `.indexOf()` 미구현
-> - Bool println은 여전히 0/1로 출력 (`%lld` 포맷). 사용자가 `true` /
->   `false` 문자열을 원하면 명시적 toString 필요
-> - GC pointer_bitmap 정확도 (Week 20 그대로)
->
-> 다음 슬라이스 후보: Map<K,V> 인트린식, 추가 String/Option/List 메서드,
-> Float 비교 / 캐스트.
->
-> **Slice A2 Week 20 (closures — value + indirect call, 2026-05-02)** —
-> ONB가 처음으로 클로저를 native lowering. `let f = |x| x + n`,
-> `xs.filter(|x| x > 0)` 같은 패턴이 fallback 없이 통과 (filter 자체는
-> 메서드 디스패치 별도). Tier 1의 단일-최대 unlock — Osty stdlib API의
-> 대부분이 클로저를 받기 때문.
->
-> 작동:
->
-> ```osty
-> fn main() {
->     let n = 100
->     let f = |x: Int| x + n           // env 할당, n을 capture[0]에 stamp
->     println(f(10))                    // x0 = env, x1 = 10, blr [env+0] → 110
-> }
-> ```
->
-> 추가:
-> - `runtimeSymClosureEnvAllocV2 = "osty.rt.closure_env_alloc_v2"` —
->   런타임이 `__asm__("osty.rt....")`로 export한 dotted symbol
-> - `closureEnvCapturesOffset = 24` — 런타임 env 헤더 (`fn_ptr` 8B +
->   `capture_count` 8B + `pointer_bitmap` 8B) 다음부터 captures 시작
-> - 새 LIR opcodes:
->   - `BranchLinkReg{Reg}` — `blr Xn` 간접 호출
->   - `LoadSymbolAddress{Dst, Symbol}` — `adrp + add` 함수/데이터 심볼
->     주소 materialise (LoadCStringAddress의 일반화)
-> - `isClosureScalarType(t)` — `*ir.FnType` + `NamedType{ClosureEnv,
->   Builtin}` 둘 다 1-reg 포인터로 분류
-> - `lowerClosureLiteralAssign` — alloc_v2 호출 → x10에 env stash →
->   fn pointer를 [env+0]에 store → 각 capture를 [env+24+i*8]에 store →
->   env pointer를 dest slot에 store
-> - `lowerIndirectCall` — closure local → x0, user args → x1.., d0..,
->   `ldr x9, [x0, #0]` (fn ptr load) → `blr x9` → 반환 캡처
-> - `loadEnvProjection` — `_env.*.{i}` MIR 패턴 lowering. Field 0 →
->   offset 0 (fn pointer), Field N (N≥1) → 24 + (N-1)*8 (capture N-1).
->   FieldProj와 TupleProj 둘 다 받음 (front end가 capture에 대해
->   TupleProj 사용)
-> - `collectReadLocals`이 `IndirectCall.Callee`를 walk해 closure local이
->   slot을 받도록 보장
->
-> 검증:
-> - E2E binary smoke 3개 (`TestONBBackendBinaryRunsClosuresOnDarwinARM64`):
->   no_capture (`|x| x + 1` 두 번 호출), single_capture (`|x| x + n`
->   with n=100), two_captures (`|x| x + a + b` with a=10, b=20)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - **pointer_bitmap = 0 고정** — GC가 capture를 모두 ptr로 trace하지
->   못해 false retention 가능. LLVM 백엔드는 capture 타입을 보고 정확한
->   bitmap을 계산. ONB는 dev path이므로 trade-off는 수용 가능하나,
->   GC stress 테스트가 false root를 잡아내면 작업 필요
-> - **Float capture** — 코드 경로는 있지만 e2e 검증 안 함
-> - **String/List/struct/enum capture** — pointer 1-reg에 들어가지만
->   정확한 GC tracing 미구현
-> - **고차 함수의 클로저 리턴** (`fn make_adder(n: Int) -> fn(Int) -> Int`)
->   — 동작해야 하지만 미검증
-> - **클로저를 인자로 다른 클로저에 전달** — 미검증
->
-> 다음 슬라이스 후보: Map<K,V> intrinsics, 메서드 디스패치, String
-> 메서드, 제네릭 함수 검증.
->
-> **Slice A2 Week 19 (struct >16B sret-style indirect passing, 2026-05-02)** —
-> ONB가 16B 초과 (3-4 필드) all-scalar struct를 AAPCS64 indirect ABI로
-> 처리. `make() -> V3` 같은 함수가 fallback 없이 통과.
->
-> 작동:
->
-> ```osty
-> struct V3 { x: Int, y: Int, z: Int }     // 24B
-> fn make() -> V3 { V3 { 10, 20, 30 } }    // sret via x8
-> fn sum(v: V3) -> Int { v.x + v.y + v.z } // indirect arg via x0
-> fn main() {
->     let v = make()                       // x8 = &v_slot, callee writes through it
->     println(sum(v))                       // x0 = &v_slot, callee copies into local
-> }
-> ```
->
-> ABI:
-> - **반환** (sret): caller가 dest slot 할당 → `add x8, sp, #destSlot`
->   → `bl _callee` → callee가 x8 통해 결과 stamp → caller는 capture 안 함
-> - **인자** (indirect): caller가 `add Xn, sp, #srcSlot` → `bl _callee`
->   → callee의 prologue가 `[Xn + i*8] → [sp + slot + i*8]`로 필드별 복사
->
-> 추가:
-> - `abiUsesIndirectStruct(t)` predicate — 3-4 필드 all-scalar struct
->   에서 true
-> - `abiRegSlots`이 indirect struct에 대해 1을 반환 (포인터 1 reg)
-> - `abiIndirectStructFieldLimit = 4` — 5+ 필드는 여전히 fallback
-> - 새 LIR opcodes: `LoadStackAddress` (`add Xt, sp, #imm`),
->   `LoadFromReg` (`ldr Xt, [Xn, #imm]`), `StoreToReg` (`str Xt, [Xn, #imm]`)
-> - `paramShuffle` indirect 분기 — argReg를 포인터로 보고 x9 경유 복사
-> - `lowerCall` sret/indirect 분기 — destSlot 자동 할당 + x8 / argReg 세팅
-> - `epilogue` sret 분기 — local $ret slot을 `[x8 + offset]`로 복사
-> - `regX8` 상수 + `xRegisterNumber`이 x8 인식
-> - 새 Mach-O encoder: `encodeLoadStoreReg`
->
-> 검증:
-> - E2E binary smoke 4개 (`TestONBBackendBinaryRunsLargeStructSretOnDarwinARM64`):
->   make_v3 (24B sret return), sum_v3 (indirect arg), roundtrip_v3
->   (make→sum 결합 — caller dest slot이 sret 버퍼 + indirect arg
->   소스로 양쪽 역할), make_v4 (32B 4-필드 상한 케이스)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - 5+ 필드 / 32B 초과 struct — `abiIndirectStructFieldLimit` 캡
-> - struct payload를 가진 enum (Some(V3) 같은) — payload 자체가 indirect
-> - sret 함수 body가 중간에 다른 함수를 호출하는 경우 — x8 save/restore
->   미구현 (`make()` 같은 leaf 패턴에는 해당 없음)
-> - struct/enum의 indirect 필드 (외부 struct 안에 큰 struct 중첩)
-> - DWARF struct DIE for >16B struct — 작동은 하지만 lldb로
->   `frame variable v` 출력은 검증 안 함 (small struct 경로와 동일
->   layout이라 likely OK이지만 회귀 테스트 미작성)
->
-> 다음 슬라이스 후보: list_set_* (`xs[i] = v`), Float 비교 / 캐스트
-> (fcmpe / fcvtzs / scvtf), 또는 callee-side x8 save/restore.
->
-> **Slice A2 Week 18 (struct field mutation, 2026-05-02)** —
-> ONB가 `p.x = 5` 같은 projection-as-Dest 어사인을 native lowering.
-> Week 12에서 `p.x` read는 통과했지만 write는 fallback 사유였음. 이번
-> 슬라이스로 `let mut p = Point { x: 3, y: 4 }; p.x = 100;
-> p.y = p.y + 1` 패턴이 fallback 없이 통과.
->
-> 추가:
-> - `lowerAssignToProjection` — Dest의 projection chain (FieldProj /
->   VariantProj)을 byte offset으로 변환해 slot+offset에 store
-> - `projectionEndType` helper — projection chain 끝의 MIR 타입 반환
->   (Float field write는 d8 경유, 그 외는 x9 경유)
-> - 기존 가드 `if instr.Dest.HasProjections()` 제거 — 새 경로로 라우팅
->
-> 검증:
-> - E2E binary smoke 2개 (`TestONBBackendBinaryRunsStructFieldMutationOnDarwinARM64`):
->   simple_assign (`p.x = 100; println p.x = 100, p.y = 4`),
->   read_modify_write (`p.y = p.y + 10; p.x = p.x * 2`)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - `xs[i] = v` (IndexProj-as-Dest) — runtime list_set_* 디스패치 필요
-> - `Some(p).x = ...` 같은 nested projection 후 write — 흔치 않음
-> - struct/enum 타입의 field write (e.g. `outer.inner = Point {...}`) —
->   multi-slot store 미구현
->
-> 다음 슬라이스 후보: struct >16B sret-style passing, 또는 list_set_*
-> 디스패치 (xs[i] = v).
->
-> **Slice A2 Week 17 (`for x in list` native lowering, 2026-05-02)** —
-> ONB가 `for x in list` 루프를 native lowering. 이전에는 List 인덱스
-> read가 fallback 사유였는데, `LenRV` + `IndexProj` 두 vocab item을
-> 추가해서 모든 element type (Int/Bool/Float64/String) 의 list가 통과.
->
-> 작동:
->
-> ```osty
-> let mut v: List<Int> = []
-> v.push(10); v.push(20); v.push(30)
-> let mut sum = 0
-> for x in v {
->     sum = sum + x
-> }
-> println(sum)                 // 60
->
-> for i in 0..10 { sum = sum + i }    // Range는 카운터 루프로
->                                      // lowering — Week 1부터 통과
-> ```
->
-> Front end MIR 셰이프 (counter + bounded loop):
->
-> ```
-> _len = len _iter           // LenRV → osty_rt_list_len
-> _idx = const 0
-> bb1: cond = _idx < _len
-> branch cond -> [bb2 (body), bb4 (exit)]
-> bb2: _elem = use _iter[_idx]   // IndexProj → osty_rt_list_get_*
->      sum = sum + _elem
-> bb3: _idx = _idx + 1
->      goto bb1
-> ```
->
-> 추가:
-> - 새 runtime symbol 상수: `runtimeSymListGetI64` / `_I1` / `_F64` /
->   `_String`
-> - `lowerLenAssign` (LenRV → osty_rt_list_len + capture x0)
-> - `loadIndexedPlaceIntoIntReg` / `loadIndexedPlaceIntoFloatReg` —
->   IndexProj 감지 시 list_get_* 디스패치 (element type 기준)
-> - `indexCallPrefix` helper — list pointer → x0, index → x1
-> - `listGetSymbol(elem)` — Int/Bool/String/Float dispatch
-> - `materialiseOperand` / `materialiseFloatOperand`이 IndexProj가
->   있으면 indexed-load 경로로 우회
-> - `collectRValueLocals`이 LenRV.Place를 read로 표시
-> - `collectOperandLocals`이 IndexProj.Index 안의 locals도 수집
->   (인덱스 local이 slot을 못 받는 회귀 방지)
->
-> 검증:
-> - E2E binary smoke 3개 (`TestONBBackendBinaryRunsForInLoopOnDarwinARM64`):
->   range_sum (0..10 sum=45), list_int_sum (10+20+30=60),
->   list_string_count (4 strings → 4)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - `list[i] = v` write — IndexProj as Dest 미구현
-> - `list.pop()` — runtime symbol 다양 (Option<T> 반환), 미구현
-> - struct/enum element type을 가진 List — push/get_bytes 경로 필요
-> - `for (k, v) in map` — Map iterator 별도
-> - `for x in iter()` — 사용자 정의 Iterable 프로토콜 미구현
->
-> 다음 슬라이스 후보: struct field mutation (`p.x = 5`) → struct >16B
-> sret-style passing.
->
-> **Slice A2 Week 16 (List<T> 일반화 — Bool/Float64/String, 2026-05-02)** —
-> ONB가 List<Int> 외의 element type에 대해 push/len을 native lowering.
-> 런타임은 이미 `osty_rt_list_push_i64` 외에 `_i1`/`_f64`/`_string`을
-> 노출하고 있어서 dispatch만 추가하면 됨.
->
-> 작동:
->
-> ```osty
-> let mut bools: List<Bool> = []
-> bools.push(true)             // osty_rt_list_push_i1
->
-> let mut floats: List<Float64> = []
-> floats.push(3.14)            // osty_rt_list_push_f64 — value in d0
->
-> let mut strs: List<String> = []
-> strs.push("hi")              // osty_rt_list_push_string
-> ```
->
-> 추가:
-> - 새 runtime symbol 상수: `runtimeSymListPushI1`, `runtimeSymListPushF64`,
->   `runtimeSymListPushString`
-> - `lowerListPush`이 `value.Type()`로 디스패치 — Int/Bool/String은
->   x1, Float은 d0 (AAPCS64 FP arg cursor)
->
-> 검증:
-> - E2E binary smoke 3개 (`TestONBBackendBinaryRunsListGenericsOnDarwinARM64`):
->   list_bool (3 push → len 3), list_float (2 push → len 2),
->   list_string (4 push → len 4)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - `list[i]` 인덱스 read/write — `osty_rt_list_get_*` / `_set_*`
->   디스패치 미구현
-> - `list_pop()` — runtime symbol 다양함, 미구현
-> - 비-empty list literal `[1, 2, 3]` — `AggregateRV(list)` non-empty
->   case 미구현 (현재 빈 리스트만)
-> - `for x in list` — iterator protocol 미구현
-> - struct/enum element type — `osty_rt_list_push_bytes` 경로 필요
->
-> 다음 슬라이스 후보: for-in 루프 native lowering (List<T> + 인덱스 read
-> 결합), 또는 struct field mutation.
->
-> **Slice A2 Week 15 (Float64 + IEEE 산술 + AAPCS64 FP ABI, 2026-05-02)** —
-> ONB가 처음으로 Float64를 native lowering. `let x: Float64 = 3.14` /
-> `(a + b) * 3.0` / `fn double(x: Float64) -> Float64` 같은 코드가
-> fallback 없이 통과.
->
-> 작동:
->
-> ```osty
-> fn double(x: Float64) -> Float64 { x * 2.0 }       // d0 in / d0 out
-> fn add(n: Int, f: Float64) -> Float64 { f + 1.0 }  // n in x0, f in d0
-> fn main() {
->     let a: Float64 = 1.5
->     let b: Float64 = 2.5
->     let c = (a + b) * 3.0
->     println(c)                                      // %g format
->     println(double(3.5))
->     println(add(10, 2.5))
-> }
-> ```
->
-> 모델: scalar-everything 모델 유지 + d-register 클래스 추가. d8/d9를
-> FP scratch (mirroring x9/x10), d0-d7을 AAPCS64 FP-arg cursor로 사용.
-> Float64 const는 `movz/movk x9 + fmov d, x9` 시퀀스로 materialise.
-> Mixed Int+Float fn signature은 두 개의 독립 cursor (regCursor +
-> fpCursor)로 처리 — `fn(n: Int, f: Float64)`는 n→x0, f→d0 (자주
-> 잘못 매핑되는 x0/x1이 아님).
->
-> 추가:
-> - 새 LIR opcodes: `LoadFloat64Stack`, `StoreFloat64Stack`,
->   `FmovDFromX` / `FmovXFromD`, `FaddReg` / `FsubReg` / `FmulReg` /
->   `FdivReg`, d0–d9 register names
-> - `isFloatABIType(t)` predicate (Float / Float64), `isABIScalarType`
->   가 이를 포함하도록 확장
-> - `materialiseFloatOperand` — FloatConst 또는 Float local → d 레지스터
->   (FloatConst는 `floatConstInstrs` helper로 movz/movk + fmov 시퀀스)
-> - `lowerFloatBinaryAssign` — d8/d9 페어로 fadd/fsub/fmul/fdiv
-> - `lowerUseAssign` Float 분기 — Float local 복사는 d 레지스터 경유
-> - `lowerPrintln`이 Float 인자에 `%g\n` + fmov x1, d9 + str x1, [sp]
->   (darwin 변동인자 ABI는 모든 vararg가 stack)
-> - `paramShuffle` / `lowerCall` / `epilogue`가 fpCursor로 d0-d7 사용
-> - 새 Mach-O encoders: `dRegisterNumber`, `encodeFPStack` (str/ldr d),
->   `encodeFmovDFromX` / `encodeFmovXFromD`, `encodeFPArith` (fadd 외)
-> - 자동 surface: `DebugTypeFloat`은 dwarf.go에 이미 있었던 dead path
->   였는데 이번 슬라이스에서 첫 사용자 등장
->
-> 검증:
-> - 단위 테스트 2개 (`internal/onb/onb_test.go`) — 1.5 + 2.5 패턴이
->   FmovDFromX + FaddReg + StoreFloat64Stack + FmovXFromD를 모두 emit
->   하는지, Float local이 DWARF DebugLocal로 surface되는지
-> - E2E binary smoke 4개 (`TestONBBackendBinaryRunsFloat64OnDarwinARM64`):
->   const_print (3.14), arith ((1.5+2.5)*3.0=12), fn_param_ret
->   (double(3.5)=7), mixed_int_float_args (add(10,2.5)=3.5 — Int/Float
->   cursor 분리 회귀 테스트)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - Float 비교 연산 (`a < b`, `a == b`) — fcmpe + cset / b.cond 미구현
-> - Float32 — 모든 경로가 d 레지스터 (Float64) 가정
-> - Int↔Float 변환 (`n.toFloat64()`, `f.toInt()`) — fcvtzs / scvtf 미구현
-> - Float을 struct/enum payload로 — abiRegSlots는 1-reg로 분류하지만
->   field write/read 코드 경로는 d 레지스터를 인식 못 함
-> - Float DWARF (`frame variable c` 시 값 표시) — DebugTypeFloat은
->   surface되나 lldb 통합 테스트는 별도 슬라이스
->
-> 다음 슬라이스 후보: List<T> 일반화 (`List<Bool>` / `List<Float64>` /
->  `List<String>` 런타임 디스패치) → for-in 루프 native.
->
-> **Slice A2 Week 14 (Enum lowering v1 — Color / Option / Result + `?`,
-> 2026-05-02)** — ONB가 처음으로 enum을 native lowering. Option/Result가
-> prelude라 거의 모든 의미 있는 Osty 코드가 fallback에서 풀려나옴.
->
-> 작동 (canonical 예제):
->
-> ```osty
-> enum Color { Red, Green, Blue }                // no-payload enum
-> fn pick() -> Color { Color.Green }
->
-> fn first(n: Int) -> Int? {                      // Option<scalar>
->     if n > 0 { Some(n) } else { None }
-> }
->
-> enum MyError { Empty, BadInt }
-> fn parseSign(n: Int) -> Result<Int, MyError> {  // Result + ? operator
->     if n == 0 { Err(MyError.Empty) } else { Ok(n) }
-> }
-> fn parseAndDouble(n: Int) -> Result<Int, MyError> {
->     let v = parseSign(n)?
->     Ok(v * 2)
-> }
-> ```
->
-> 슬롯 레이아웃: `[disc 8B][payload N×8B]`, 16B로 캡 (1 disc reg +
-> 1 payload reg, AAPCS64 small-struct ABI 재사용). no-payload enum은
-> 8바이트, Option<scalar>·Result<scalar, scalar>·Result<scalar, no-payload-enum>
-> 은 16바이트.
->
-> 추가:
-> - `lookupEnumLayout(t)` — user enum (`mod.Layouts.Enums[name]`) +
->   합성 레이아웃 (`OptionalType`, `NamedType{Option/Maybe/Result, Builtin}`)
-> - `syntheticOptionLayout` (None=0/Some=1) + `syntheticResultLayout`
->   (Err=0/Ok=1) — 컨벤션은 `internal/llvmgen` + `mir/lower.go`와 동일
-> - `enumSlotSize(layout)` / `enumPayloadOffset(fieldIdx)` /
->   `enumDiscriminantValue(layout, idx)` 헬퍼
-> - `payloadAllScalar`이 `isABIWordType`로 일반화 — scalar OR
->   1-register-slot 타입 (no-payload enum 같은) 허용 → `Result<Int,
->   MyError>` 가능
-> - `lowerAggregateAssign`이 `AggEnumVariant` 처리 — discriminant를
->   slot+0에, payload를 slot+8+i*8에 stamp
-> - 새 rvalue lowering: `*mir.NullaryRV` (None tag write),
->   `*mir.DiscriminantRV` (slot+0 → dest slot)
-> - `placeProjectionOffset`이 `*mir.VariantProj` 처리 — payload는
->   slot+8 부터 (FieldIdx=-1은 "전체 payload tuple" → slot+8 시작)
-> - `collectRValueLocals`가 `AggregateRV.Fields` + `DiscriminantRV.Place`
->   를 스캔해 enum scrutinee local이 slot을 받도록 보장
-> - `lowerUseAssignMulti` — multi-slot copy (`_q = use _result`처럼
->   `?` 연산자가 fallback 분기에서 전체 enum을 복사할 때 필요).
->   destination type이 2-reg일 때 자동 선택; 1-byte clipping 회피
-> - 새 LIR opcode `Brk{Imm}` + Mach-O 인코딩 (`brk #1`) — match
->   exhaustiveness가 추가하는 `mir.UnreachableTerm`을 안전하게 trap
->
-> 검증:
-> - 단위 테스트 3개 (`internal/onb/onb_test.go`) — Color enum 태그
->   write, UnreachableTerm → Brk lowering, Option<Int> Some 분기의
->   tag+payload 8B 간격
-> - E2E binary smoke 7개 (`TestONBBackendBinaryRunsEnumPatternsOnDarwinARM64`,
->   darwin/arm64): no-payload enum, Option Some, Option None, Result
->   Ok, Result Err, `?` Ok 전파, `?` Err 전파 — 모두 native path 통과
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - struct payload를 가진 enum variant — payload 1-reg 캡 때문에
->   `Some(Point)` 같은 형태는 fallback (Point가 2-reg)
-> - 2개 이상 payload field를 가진 variant — `Some((a, b))` 같은 튜플 페이로드
-> - `match` arm에서 `_4@Some.0` 같은 nested projection 외 (struct
->   payload + field projection 조합)
-> - enum DWARF DIE — `frame variable` 출력에는 여전히 안 잡힘
->   (B.5 abbrev infra는 이미 있음, lower→encoder 와이어링은 별도 슬라이스)
->
-> 다음 슬라이스 후보: Float64 + IEEE 산술 (Week 15) → List<T>
-> 일반화 → for-in 루프 native lowering.
->
-> **Slice A2 Week 13 (AAPCS64 small-struct passing + DWARF struct
-> wiring, 2026-05-02)** — ONB가 처음으로 struct를 함수 경계에서 사용 가능.
-> `≤16B` 모든-스칼라 struct가 AAPCS64 small-struct ABI로 2-reg pair에 실려
-> 전달되며, lldb의 `frame variable`이 struct 필드를 풀어서 보여준다.
->
-> 작동 (canonical 예제):
->
-> ```osty
-> struct Point { x: Int, y: Int }
-> fn make() -> Point { Point { x: 5, y: 6 } }
-> fn px(p: Point) -> Int { p.x }
-> fn main() {
->     let p = make()           // {x0, x1} → slot+0 / slot+8
->     println(px(p))           // slot+0 / slot+8 → {x0, x1}
-> }
-> ```
->
-> 추가:
-> - `abiRegSlots(t)` / `isABIPassableType(t)` — ABI 슬롯 카운트 (스칼라 1,
->   ≤16B all-scalar struct N=ceil(size/8), 그 외 0/false)
-> - `paramShuffle`이 register-cursor 모델로 multi-reg struct param을 처리:
->   regs[i..i+N) → slot+0 / slot+8 / …
-> - `lowerCall`이 struct 인자를 `materialiseStructOperand`로 슬롯에서 N개의
->   인자 레지스터에 적재; 반환 값이 struct이면 x0, x1을 dest+0 / dest+8에 캡처
-> - `epilogue`가 struct 반환 시 `_return` 슬롯에서 x0/x1을 로드
-> - `assignLocalSlots`가 struct 반환 함수에서 `$ret`를 강제로 read 셋에
->   추가 (스칼라/Unit는 기존대로 x0 직통)
-> - `lowerFunction` ABI guard가 struct 파라미터 / 반환을 허용 (>16B 또는
->   composite 필드는 여전히 fallback)
-> - DWARF: `DebugTypeStruct` enum 값과 `DebugLocal.{StructName, StructFields}`
->   추가; `macho.go`의 `collectStructTypeInputs`가 distinct struct 타입을
->   첫-등장 순서로 수집해 `dwarfStructTypeInput` 리스트로 `emitDwarfInfo`에
->   전달; 변수 DIE는 `StructTypeIndex`로 struct DIE를 가리킴
->
-> 검증:
-> - 단위 테스트 4개 (`TestLowerMIRStruct*`, `TestEmitObjectIncludesStructDIE*`)
->   — paramShuffle multi-reg, epilogue multi-reg, call site materialise +
->   capture, DebugLocal에 struct 필드 노출, `__debug_info`에 struct/member DIE
-> - E2E binary smoke (`TestONBBackendBinaryRunsStructParamAndReturnOnDarwinARM64`)
->   — `make() -> Point` + `px(p)` / `py(p)` 호출 체인이 darwin/arm64에서
->   `5\n6\n` 출력
-> - LLDB integration (`TestONBBackendLldbFrameVariableShowsStructOnDarwinARM64`)
->   — `frame variable`이 `(Point) p = (x = 7, y = 11)` 표시
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - >16B struct (3+ scalar 필드) — indirect/sret-style passing 미구현
-> - 비-스칼라 필드를 가진 struct (List/String 포함) — HFA / 복합 분류 필요
-> - struct 필드 mutation (`p.x = 5`) — projection-as-write 미지원, 여전히
->   fallback
-> - 중첩 struct
-> - struct 생성을 인자로 직접 (`px(Point { x: 1, y: 2 })`) — Aggregate-as-arg
->   는 fallback
->
-> 다음 슬라이스 후보: enum lowering v1 (struct payload 없는 단순 enum
-> variant), 또는 list element 일반화 (List<Bool> / List<Float64>).
->
-> **Slice A2 Week 12 (struct lowering v1 — literals + field reads, 2026-05-02)** —
-> ONB가 처음으로 struct를 lower. `struct Point { x: Int, y: Int }` 같은
-> 모든-스칼라 struct 한정. 작동:
-> - `let p = Point { x: 3, y: 4 }` → 16바이트 슬롯 (필드별 8바이트) 할당,
->   각 필드를 slot+offset에 write
-> - `p.x` → `Copy(local projs=[FieldProj{Index:0}])` → `Load64Stack` at
->   slot + `Index * 8`
-> - `println(p.x)` 정상 동작
->
-> 추가:
-> - `lowerState.mod` 필드 — 모듈-범위 layout 조회용
-> - `localTypeSize`: 가변 슬롯 크기 (Unit 0, scalar 8, struct N×8, builtin
->   pointer 기본 8)
-> - `lookupStructLayout` / `fieldByteOffset` / `placeProjectionOffset`
->   helpers — Type → layout → 바이트 offset 변환
-> - `lowerStructLiteralAssign`: `AggregateRV(struct)` 처리, 각 필드를
->   slot+i*8에 store
-> - `loadPlaceIntoReg`가 projection을 받아 slot+offset에서 load
-> - `assignLocalSlots`가 `localTypeSize` 사용 (이전 hardcoded 8)
->
-> 한계 (이번 슬라이스에서 명시적으로 보류):
-> - struct fn param / return (AAPCS64 small-struct passing 2-reg / indirect)
-> - DWARF struct 변수 인스펙션 (`frame variable p`) — B.5 infra는 깔려
->   있으나 lower→encoder 와이어링은 별도 슬라이스
-> - struct 필드 mutation (`p.x = 5`) — projection-as-write 미지원
-> - 중첩 struct
->
-> 다음 슬라이스 후보: AAPCS64 small-struct passing → struct를 fn 경계에서
-> 사용 가능 → DWARF 변수 인스펙션과 묶어서 진행.
->
-> **Slice A2 Week 11 (DWARF B.5 infra — struct/member DIEs, 2026-05-02)** —
-> 인코더 인프라만 추가. ONB가 struct를 lower하지 않으므로 dead code지만,
-> 향후 struct lowering 슬라이스가 들어올 때 DWARF 측은 더 이상 막히지 않음.
-> 구체적으로:
-> - `DW_TAG_structure_type` (abbrev 6, has children) + `DW_TAG_member`
->   (abbrev 7) 추가
-> - `DW_AT_data_member_location` 속성 + `DW_FORM_udata` form
-> - `dwarfStructTypeInput` / `dwarfStructMemberInput` 입력 타입
-> - `emitDwarfInfo`가 `structs []dwarfStructTypeInput` 인자 추가 (callers
->   pass nil 으로 변동 없음)
-> - 구조체 멤버가 base 타입을 참조하면 같은 CU의 base_type DIE를 공유
->   (`collectUsedTypeKinds`가 멤버까지 union)
-> - `dwarfVariableInput.StructTypeIndex int` (–1 = base type 사용,
->   ≥0 = struct list 인덱스 — `variableTypeOffset` helper로 분기)
->
-> 검증: 단위 테스트 3개 — abbrev 테이블에 struct/member 코드 존재,
-> 인코더가 struct 입력을 받으면 DIE 바이트가 늘어남, variable이
-> StructTypeIndex로 struct DIE를 가리킬 수 있음.
->
-> 한계: dwarfdump round-trip은 macho.go가 struct를 받지 않아 ScaleHole.
-> 실제 사용은 lowering 들어올 때 (struct AggregateRV + place projection
-> + AAPCS64 small-struct passing).
->
-> **Slice A2 Week 10 (DWARF B.4 — Bool/String var inspection, 2026-05-02)** —
-> Phase B.3의 variable inspection을 Int 외 ABI-scalar 두 종류로 확장. Bool은
-> `byte_size 1` + `DW_ATE_boolean` (lldb는 byte_size 8 + boolean을 거부하고
-> "void"로 표시), String은 `DW_TAG_pointer_type` → `DW_TAG_base_type "char"`
-> 체인 (lldb가 pointee를 C 문자열로 표시).
->
-> 검증: `fn first(a: Int, b: Bool, c: String) -> Int { a }` 함수 진입 시점에
-> `frame variable`이 다음을 표시:
-> - `(long) a = 42`
-> - `(bool) b = true`
-> - `(char *) c = 0x... "hi"`
->
-> 추가:
-> - `DebugTypeBool` / `DebugTypeString` / `DebugTypeFloat` enum entries
->   (Float은 ONB lowering이 D-reg 미지원이라 dead code, future-ready)
-> - `dwarfBaseTypeBool` / `Float` / `String` + `dwarfAbbrevPointerType`
-> - `collectUsedTypeKinds`로 변수에서 참조된 타입만 emit (CU dead 타입 X)
-> - `emitDwarfInfo`가 String일 때 char base_type + pointer_type 두 DIE
-> - `mirTypeToDebugKind` helper로 MIR type → debug kind 단일 source
-> - **Param 슬롯이 read 여부와 무관하게 항상 할당** — unused param도
->   `frame variable`에 표시되도록 (이전엔 unused면 슬롯 없어 invisible)
->
-> 한계: Float은 ONB native가 아직 처리 못 함 (Float 인자/반환 → fallback to
-> LLVM). struct/list/Map composite 타입은 후속 슬라이스.
->
-> **Slice A2 Week 9 (DWARF B.3 — variable inspection, 2026-05-02)** —
-> lldb `frame variable` 가 ONB 빌드 결과에서 named Int local의 현재 값을
-> 보여줌. 추가:
-> - `DW_TAG_base_type` DIE for Int (byte_size 8, encoding DW_ATE_signed)
-> - `DW_TAG_variable` DIE per named Int local: `DW_AT_name` + `DW_AT_type`
->   (ref4 to base_type) + `DW_AT_location` (DW_OP_fbreg sleb128(slot))
-> - Subprogram DIE에 `DW_AT_frame_base = DW_OP_breg31 0` (sp-relative)
-> - Abbrev table 4 entries: CU, subprogram(children), variable, base_type
-> - LIR Function에 `DebugLocals []DebugLocal` 필드 — 이름·slot·type 캐리
-> - lower.go가 named Int local만 (`_return` / 익명 temp 제외) 추출
-> - **Param shuffle instrs는 LineSpan zero**: shuffle PC가 source line으로
->   매핑되면 lldb가 prologue 끝/shuffle 시작 사이에 stop해서 uninitialised
->   슬롯을 읽는 문제 — line program이 shuffle 행을 skip하도록 수정
->
-> 검증: `lldb -o "br set -f main.osty -l 1" ./app` → `frame variable`
-> → `(long) a = 10`, `(long) b = 32`. 변수 이름·값 모두 정확.
->
-> 한계: 현재는 Int만 (DW_ATE_signed). String/Bool/Float/List 등은
-> DebugTypeKind 확장 + 대응 base_type/pointer_type DIE 추가가 필요.
->
-> **Slice A2 Week 8 (DWARF B.2 — lldb integration, 2026-05-02)** — DWARF
-> 파이프라인이 lldb 자동 인식까지 도달. `dsymutil`이 .o의 DWARF를 .dSYM으로
-> 번들링하고, `lldb`가 `br set -f main.osty -l 4` 같은 source-level breakpoint
-> 를 PC로 해상하며 source view까지 표시한다. 추가:
-> - `DW_TAG_subprogram` DIE per user function (CU의 child DIE; CU는
->   `DW_CHILDREN_yes`로 변경) — dsymutil이 child 없는 CU를 빈 것으로 처리하던
->   문제 해결
-> - `__debug_info` + `__debug_line` 섹션에 **non-extern UNSIGNED 릴로케이션**
->   (extern=false, symbolnum=__text section number) — clang의 패턴과 동일.
->   extern symbol-rel 릴로케이션은 dsymutil이 silently 거부함
-> - `dwarfInfoEncoded.LowPCOffsets` / `dwarfLineEncoded.SetAddressOffset`로
->   인코더가 reloc 위치를 호출자에게 전달
-> - Mach-O writer가 `__text` reloc 다음에 DWARF section reloc들을 배치
->   (highest-address-first 정렬)
-> - `ltmp0` local symbol (당시엔 reloc target으로 의도했으나 결국 section-rel
->   reloc으로 갔으므로 unused; 향후 cleanup 가능)
->
-> 검증: `lldb -o "br set -f main.osty -l 4" ./app` 실행 시
-> `Breakpoint 1: where = app\`main + 56 at main.osty:4:9` + source 5라인 표시.
->
-> **Slice A2 Week 7 (DWARF B.1 — CU DIE, 2026-05-02)** — `__debug_info` +
-> `__debug_abbrev` + `__debug_str` 세 섹션이 추가되어 DWARF 인프라 완비.
-> CU DIE는 `DW_TAG_compile_unit` 1개에 7개 attribute (producer, language=C99,
-> name, comp_dir, low_pc, high_pc, stmt_list). DW_AT_stmt_list가 line program을
-> 가리키므로 DWARF 파서가 컴파일 유닛 → 라인 프로그램 traversal 가능.
-> `dwarfdump --debug-info / --debug-abbrev / --debug-str` 모두 zero-warning.
->
-> 추가:
->   - DWARF tag/attr/form 상수 (DW_TAG_compile_unit, DW_AT_producer 등)
->   - `dwarfStringTable`: dedup string storage with stable byte offsets
->   - `emitDwarfAbbrev`: abbrev table 1개 entry (compile_unit + 7 attrs)
->   - `emitDwarfInfo`: CU header + DIE encoder
->   - Mach-O writer가 `__DWARF` 세그먼트에 4 sections (line/info/abbrev/str)
->   - 새 section name 상수 (`machoSectnameInfo` / `Abbrev` / `Str`)
->
-> 한계 — lldb 자동 인식은 아직: dsymutil이 .o의 Mach-O Stab debug symbols
-> (N_OSO/N_FUN/N_BNSYM) 을 walk해서 .dSYM 번들을 만드는데, 우리는 아직 Stabs를
-> emit 안 함. dwarfdump는 DWARF 섹션을 직접 읽어 모두 검증되지만, lldb가
-> `bt`에서 `main.osty:42` 표시하려면 Phase B.2 (Stabs)이 추가로 필요.
->
-> **Slice A2 Week 6 (String concat + List<Int>, 2026-05-02)** — ONB native
-> path가 처음으로 런타임 호출 경로를 사용. `osty_runtime.c` 가 link 단계에
-> 같이 들어오며 다음 패턴이 native로 통과:
->
->   - `let name = "world"; println("hello, " + name)` (String concat with local)
->   - `fn greet(name: String) -> String { "hello, " + name }` (String param/return)
->   - `let mut v: List<Int> = []; v.push(10); println(v.len())` (list ops)
->   - `for i in 0..5 { v.push(i) }` (list build via loop)
->
-> 추가:
->   - 런타임 심볼: `osty_rt_strings_Concat`, `osty_rt_list_new`,
->     `osty_rt_list_push_i64`, `osty_rt_list_len` — 모두 `BranchLink`로 호출
->   - `materialiseOperand`가 `StringConst` → `LoadCStringAddress` 경로 추가
->   - `lowerStringConcatAssign`: `BinaryAdd` + `T == TString` → 두 args를
->     x0/x1에 띄우고 runtime concat 호출, 결과 ptr를 dest slot에 저장
->   - `lowerAggregateAssign`: 빈 list literal → `osty_rt_list_new`
->   - `lowerListPush` / `lowerListLen`: 새 intrinsic dispatch
->   - `lowerPrintln`이 String local도 처리 (`puts(string ptr)` 경로)
->   - `LoadCStringAddress`가 임의 X register dst 지원 (이전엔 x0 only)
->   - `isABIScalarType` helper로 user fn param/return을 Int/Bool/String 모두 허용
->   - Backend가 매 빌드에 `EnsureRuntimeObject` 호출해서 runtime.o를 link 인자로 추가
->
-> 부수 (직전 Week 5 cleanup): `_ = fnStart` / `_ = dwarfSegmentSections` 제거,
-> `functionPrologueWords`를 lir.go로 이동 (single source of truth),
-> Mach-O 세그먼트/섹션 이름 상수화.
->
-> **Slice A2 Week 5 (DWARF .debug_line, 2026-05-02)** — ONB가 처음으로 디버그
-> 메타데이터를 emit. `__debug_line` 섹션이 Mach-O `__DWARF` 세그먼트로 들어감.
-> `dwarfdump --debug-line foo.o`가 정상 파싱하며 PC→source `<file>:<line>:<col>`
-> 매핑이 모든 실행 경로에서 정확. 추가:
-> - DWARF 4 line-program 인코더 (`internal/onb/dwarf.go`): leb128/uleb128 +
->   prologue + state machine. Special opcode는 안 쓰고 `set_address +
->   advance_pc + advance_line + copy + end_sequence` 시퀀스로 단순화
-> - `Block.LineSpans` 필드 + `lowerBlock`이 각 LIR 명령마다 source position 부착.
->   Dead-store / 중복 행은 `appendLineRow`가 코얼레스
-> - Mach-O writer가 `__DWARF` + `__LINKEDIT` 세그먼트 추가. 파일 레이아웃은
->   `text → cstring → debug_line → relocs → symtab → strtab` 순서로 segment
->   range overlap 없이 배치. ld64가 multi-segment .o를 받아들이려면 LINKEDIT가
->   필수 (이전엔 단일 __TEXT 세그먼트라 LINKEDIT 없어도 통과)
-> - `Request.SourcePath` / `PackageName`이 `Program`까지 흐르면서 file table에
->   소스 경로가 채워짐
->
-> 후속: `__debug_info` + `__debug_abbrev` + `__debug_str`이 들어와야 lldb가
-> 자동 인식. dsymutil 통합도 추가 슬라이스로 분리.
->
-> **Slice A2 Week 4 (loops + match, 2026-05-02)** — `while` / `for ... in 0..N`
-> / 중첩 루프 / `match`(non-const scrutinee 포함)이 모두 native path로 통과.
-> 핵심 발견: while/for/단순 match는 Week 3 multi-block + branch fixup
-> 인프라로 이미 동작 — 별도 lowering 없이도 native. 추가된 것은
-> SwitchIntTerm 한 가지 (non-const scrutinee가 있는 일반 match가 사용):
-> - `BranchCond { Cond, Target }` LIR opcode + Mach-O fixup (`b.cond imm19`)
-> - `lowerSwitchIntTerm`: scrutinee를 x9에 load, 각 case는 `mov x10, #imm;
->   cmp x9, x10; b.eq case_target`, 마지막에 `b default`
-> - `collectTerminatorReads`가 `SwitchIntTerm.Scrutinee`도 walk
-> 부수: `_ = fnStart` 미사용 변수 정리 (simplify 리뷰 피드백).
->
-> **Slice A2 Week 3 (control flow, 2026-05-02)** — `if/else` + 6개 비교
-> 연산자 (`==`, `!=`, `<`, `<=`, `>`, `>=`) 분기 코드가 native path로 통과.
-> 패턴 `let x = K; if x > 0 { println(1) } else { println(0) }` 모두 OSTY_ONB_STRICT
-> 으로 동작 (80–180ms). 추가:
-> - `Cmp` / `Cset` opcode + 6개 `Cond` 상수 (CondEq/Ne/Lt/Le/Gt/Ge)
-> - `Branch` (unconditional) + `BranchCondNotZero` (cbnz) — block index를
->   target으로 들고, 인코더가 fixup pass에서 PC-relative imm26 / imm19로 패치
-> - Multi-block 함수 지원: `Block.OriginalIndex`로 MIR BlockID를 보존,
->   entry block first 정책으로 emit slot 0이 항상 entry
-> - `BoolConst` materialisation (`mov #0` / `#1`)
-> - `collectTerminatorReads`로 BranchTerm.Cond 같은 terminator-level 읽기를
->   slot allocation에 반영
->
-> **Slice A2 Week 2 (사용자 함수 호출, 2026-05-02)** — 단일 모듈 내 helper
-> 함수 + AAPCS64 호출 규약 추가. 패턴 `fn add(a: Int, b: Int) -> Int { a + b };
-> fn main() { println(add(40, 2)) }`이 native path로 통과. 모든 Int 파라미터
-> 지원 (최대 8개, x0..x7). 변경:
-> - `LowerMIR`이 모든 함수를 순회 (main 외 helper 포함). main이 항상 첫 번째
-> - 함수 진입 시 prologue가 AAPCS64 인자 register를 stack slot으로 shuffle
-> - 비-main 함수의 `ReturnTerm`은 `_return` slot을 x0에 load 후 ret
-> - `CallInstr` (FnRef 한정) lowering: 인자를 x0..x7에 배치 → `bl <symbol>`
->   → 결과 register x0를 dest slot에 저장
-> - Mach-O encoder가 multi-function: 각 함수가 자기 symbol entry + text
->   offset, `bl _add` 같은 local fn 호출은 local symtab slot으로 reloc해서
->   `_add`가 defined와 undefined로 중복 등장하는 문제 방지
->
-> 본 문서는 결정 lock-in이며, 후속 의제(예: aarch64 LIR opcode 카탈로그,
-> cross-validation harness, simple inliner 도입 검토)는 별도 문서로 분기한다.
+- **Status**: In active development (self-host port Phase 2-6)
+- **Last Updated**: 2026-05-03
+- **Scope**: Osty Native Backend — dev/debug backend design + implementation log
+- **Decisions**: 33 integrated
+
+---
+
+## Progress Log
+
+**Status: Phase 0 scaffold started (2026-04-30); dev-loop integration
+(Slice A1) landed (2026-05-01).** 33개 설계 결정 통합.
+`internal/onb` + `--backend onb` 등록까지 착수했고, `fn main() {}`의 MIR를
+ONB Program으로 낮춘 뒤 첫 aarch64 LIR (`mov w0, #0`; `ret`)까지 생성하는
+Phase 1.0 slice가 구현됐다. ONB assembly text artifact (`main.s`) 렌더링과
+최소 Mach-O relocatable object (`main.o`) emission이 가능하다. Binary emit은
+ONB object를 host linker에 넘겨 실행 파일을 만들며, darwin/aarch64
+`fn main() {}` smoke는 exit 0까지 확인됐다. 다음 slice로
+`println("literal")` MIR intrinsic을 ONB LIR + assembly text까지 낮추며
+`_puts` 호출과 `__cstring` 섹션을 렌더링하고, Mach-O `PAGE21` / `PAGEOFF12`
+/ `BR26` relocation을 포함한 object emission까지 확장했다. 이어서
+`println(123)` 같은 정수 리터럴 출력도 `_printf("%lld\n", value)` 경로로
+lowering/object/binary smoke까지 통과한다.
+
+
+---
+
+### Slice A1 (dev-loop integration)
+
+실제 개발자가 `osty run --backend onb`
+를 켜둔 채 작업할 수 있도록 두 축이 추가됐다. (1) `internal/onb`가 미지원
+MIR shape를 만나면 `ErrUnsupportedShape` sentinel을 반환하고, `ONBBackend`
+가 `EmitObject` / `EmitBinary` 모드에서 자동으로 LLVM 백엔드에 위임한다
+(`--emit asm`은 사용자가 ONB asm을 명시적으로 원했다고 보고 hard-fail
+유지). 결과 binary는 `.osty/out/llvm/`에 떨어지며 `osty run`이 그대로
+실행한다. (2) `OSTY_ONB_TIMING=1`이면 stderr에 한 줄 요약을 찍는다 —
+`onb: emit 312ms [native: aarch64-apple-darwin]` 또는
+`onb: emit 1.82s [fallback to llvm: instruction *mir.CallInstr is outside phase 1]`.
+Cross-validation 흐름은 `OSTY_ONB_STRICT=1`로 fallback을 끄면 raw 거부
+에러를 받을 수 있다.
+
+
+---
+
+### Slice A2 Week 1 (Int 산술 + locals, 2026-05-02)
+
+ONB native path의 첫
+의미 있는 커버리지 확장. 패턴: `let mut n = 1; n = n + 5; println(n)`,
+`let x = 10; let y = 32; println(x + y)`, `let a = 10; let b = 3; println(a - b * 2)`
+모두 native path로 통과 (각 50–150ms wall-clock, LLVM 대비 5–10×).
+추가된 LIR opcode: `Load64Stack`, `MovRegReg`, `AddReg` / `SubReg` / `MulReg`.
+모델: **stack-everything** — RA 없이 모든 read 대상 local에 고정 stack slot
+할당, 모든 operand가 x9/x10 scratch register를 거침. 프레임 layout:
+`[sp+0..16] vararg slot (printf int용) → [sp+V..V+8N] locals → [sp+frameSize-16] FP/LR`.
+dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
+후속 의제로 유예.
+
+
+---
+
+### Slice A2 Week 31 (ONB self-host port — Mach-O wire writer Slices B+C, 2026-05-03)
+
+Mach-O 직렬화 layer 착륙. 신규 4
+파일 (constants 78 + writer 265 + symtab 127 + test 181) +
+Go parity 125 = ~776줄. Header / segment / section / symtab /
+dysymtab / reloc / nlist64 / strtab 모두 mirror. Go macho.go
+wire-format 부분 100% 미러 달성.
+
+
+---
+
+### Slice A2 Week 30 (ONB self-host port — Phase 6.3 DWARF info section + string table, 2026-05-03)
+
+DWARF series 마무리.
+`__debug_str` 테이블 + `__debug_info` section emitter (CU DIE +
+base type / pointer type / structure type / subprogram / variable
+DIEs) 모두 Osty 측 착륙. Go-side `dwarf.go`의 100% logical mirror
+달성. 신규: `onb_dwarf_strings.osty` (55), `onb_dwarf_info.osty`
+(389), 5 새 Osty 테스트, 2 새 Go parity 테스트
+(`TestDwarfInfoParityVsOstyTable` 외).
+
+
+---
+
+### Slice A2 Week 29 (ONB self-host port — Phase 6.1 + 6.2 LEB128 + DWARF abbrev + line program, 2026-05-03)
+
+DWARF 이미터 진입.
+1k 라인 슬라이스로 LEB128 byte-stream 인코더, DWARF 4 상수 (tags /
+attrs / forms / opcodes / ATE / DW_OP / abbrev codes), 7개 abbrev
+코드 (CU / subprogram / variable / base type / pointer type /
+structure type / member) 의 abbreviation 테이블, 그리고 완전한 line
+program 인코더 (header + body 상태 머신 + extended opcodes) 가
+Osty 측에 착륙.
+
+신규 Osty 파일:
+
+- `toolchain/onb_leb128.osty` (89줄): `onbWriteULEB128`,
+  `onbWriteSLEB128`, `onbWriteULEB128Pair`. Osty의 `for ... in
+  range`로 16-iteration 고정 chunking 구현 (osty엔 `break`/
+  `continue`가 expression-position에서 깔끔하지 않으므로
+  `done` flag로 skip-rest invariant)
+
+- `toolchain/onb_dwarf_constants.osty` (128줄): `onbDwarfVersion`,
+  `onbDwarfTagCompileUnit`, `onbDwarfAtName`, `onbDwarfFormStrp`,
+  `onbDwarfATESigned`, `onbDwarfOpFbreg`, `onbDwarfAbbrevSubprogram`
+  등 ~50개 상수를 `pub fn () -> Int`로 노출
+
+- `toolchain/onb_dwarf_abbrev.osty` (123줄): `onbEmitDwarfAbbrev()
+  -> List<Int>` — 7 abbreviation entries + table terminator를
+  ULEB128 인코딩으로 byte stream 생성
+
+- `toolchain/onb_dwarf_line.osty` (318줄):
+  - `OnbDwarfLineFile` / `OnbDwarfLineRow` / `OnbDwarfLineProgram`
+    데이터 타입
+  - `onbWriteU8/U16LE/U32LE/U64LE` byte writers (Osty의 `List<Int>`
+    누적 패턴, Go의 `bytes.Buffer + binary.Write` 미러)
+  - `onbWriteCString` (NUL-terminated)
+  - `onbDwarfStdOpcodeLengths` 12바이트 standard opcode 길이 테이블
+  - `writeDwarfExtended{SetAddress, EndSequence}` extended op 헬퍼
+  - `onbEncodeDwarfLineHeader(prog)` — DWARF 4 §6.2.4 헤더 layout
+  - `onbEncodeDwarfLineBody(prog)` — 행 스테이트 머신 워클 (file
+    /line/column/PC 변경 시 적절한 standard op + ULEB128/SLEB128
+    인자 emit). 첫 행은 extended set_address로 PC 초기화. 행이
+    PC 순서 어긋나면 `outcome.ok = false`. 마지막에 textSize까지
+    advance + extended end_sequence
+  - `onbEmitDwarfLine(prog)` — unit_length + version +
+    header_length + header + body 합성. `setAddressOffset` 반환
+    (Mach-O reloc target)
+
+- `toolchain/onb_dwarf_test.osty` (181줄): ULEB128 단일/다중 바이트
+  경계, SLEB128 양수/음수 경계, abbreviation 첫 3바이트 +
+  end-of-table 마커, line program 빈 행 well-formed 검증, 헤더
+  metadata block 6바이트 일치
+
+- `internal/onb/onb_dwarf_parity_test.go` (131줄):
+  - `TestDwarfLEB128ParityVsOstyTable` — ULEB/SLEB 12 케이스
+  - `TestDwarfLineParityVsOstyTable` — line section header 메타데이터
+    6바이트 (minInstLen / maxOpsPerInst / defaultIsStmt /
+    lineBaseByte / lineRange / opcodeBase) + version 일치
+  - `TestDwarfAbbrevParityVsOstyTable` — abbreviation 테이블 첫
+    3바이트 (compile-unit code + tag + has-children) + 표 종료자
+    + 최소 사이즈
+
+검증:
+- `osty check toolchain` exit 0
+- `go test ./internal/onb -run TestDwarf` — 4 case 모두 통과
+- `go test ./internal/onb ./internal/backend -short` — 0 회귀
+
+Phase 6 시리즈 진행도:
+- 6.1 (LEB128) ✅
+- 6.2 (line program) ✅ (이번 슬라이스)
+- 6.3 (CU DIE + subprogram DIE + base type / pointer type /
+  structure type DIE 이미터) — 다음 슬라이스
+
+누적 Osty self-host LOC: 3,774 (이전 2,804 + 970 이번 슬라이스).
+
+**다음 phase 후보**:
+- Phase 6.3 — `__debug_info` section emitter, `__debug_str` 테이블,
+  per-function subprogram DIE + variable DIE generation. DWARF
+  시리즈 마무리. ~700줄 예상.
+- Phase 3a — MIR Type 의존 ABI predicates 첫 진입. 새로운 표면
+  (toolchain/mir.osty의 Type enum 소비) — 별도 디자인 필요.
+
+
+---
+
+### Slice A2 Week 28 (ONB self-host port — Phase 2c + 2e symbol reloc + container types + function emitter, 2026-05-03)
+
+1k+
+줄 슬라이스. adrp+add + bl 심볼 reloc 모델 + Function/Block/Program
+컨테이너 타입 + per-function 워커가 한 번에 착륙. **Phase 2 시리즈
+마무리**: Osty 측이 단일 instr부터 완전한 함수 emit (워드 + 분기
+fixup + 심볼 reloc + 블록 오프셋 + 라인 스팬) 까지 표현.
+
+추가 Osty 파일:
+
+- `toolchain/onb_relocs.osty` (84줄, 신규):
+  - `OnbRelocKind` enum (Branch26 / Page21 / PageOff12)
+  - `OnbReloc { codeOffset, symbol, pcrel, kind }` 레코드
+  - `onbRelocKindMachoTyp(kind)` — Mach-O 와이어 type 바이트 매핑
+  - 편의 builder: `onbRelocPage21/PageOff12/Branch26`
+
+- `toolchain/onb_program.osty` (250줄, 신규):
+  - `OnbLineSpan` (line + column)
+  - `OnbDebugStructField`, `OnbDebugLocal`, `OnbDebugLocalStruct`
+    constructor
+  - `OnbBlock` (label / originalIndex / instrs / lineSpans)
+  - `OnbFunction` (name / blocks / frameSize / debugLocals)
+  - `OnbCStringLiteral`, `OnbProgram`
+  - `OnbEmittedFunction { words, fixups, relocs, blockOffsets,
+    blockLineSpans }` + `onbEmitFunction(func)` walker — 블록을
+    순회하며 PC 바이트 오프셋 추적, 모든 emit 산출물 (워드+fixup+
+    reloc+offset) 을 collect
+  - `onbEmitFunctionResolved(func)` — emit + branch fixup 패스를
+    하나로 묶음. `OnbResolvedFunction { words, relocs,
+    blockOffsets, blockLineSpans, ok }` 반환
+
+- `toolchain/onb_program_test.osty` (152줄, 신규):
+  - 4 round-trip 케이스: leaf ret, conditional fall-through,
+    println-style (adrp+add+bl+mov+ret with 3 relocs), multi-word
+    op + branch (block 경계가 movz/movk chain 길이로 변하는 경우)
+
+- `toolchain/onb_encoding.osty` 확장:
+  - `onbEncodeAdrpPlaceholder(dst)` — `adrp Xd, 0`
+  - `onbEncodeAddPageOffPlaceholder(dst)` — `add Xd, Xd, #0`
+  - `onbEncodeBlPlaceholder()` — `bl 0`
+
+- `toolchain/onb_lir.osty` 확장:
+  - 3 새 opcode (`OnbInstrLoadCStringAddress`,
+    `OnbInstrLoadSymbolAddress`, `OnbInstrBranchLink`)
+  - `OnbInstr`에 `symbol`, `label` 두 필드 추가
+  - 3 새 constructor + emit helpers (`onbEmitAdrpAddPair`,
+    `onbEmitBranchLinkPlaceholder`)
+  - `OnbBranchEmit`에 `relocs: List<OnbReloc>` 필드 추가 — emit
+    결과의 통합 surface
+  - `onbEncodeInstr` switch에 3 새 None 가지 (multi-step opcode
+    표시)
+
+- `internal/onb/onb_lir_parity_test.go` 확장:
+  - `TestLirSymbolReferenceParityVsOstyTable` — adrp/add/bl
+    placeholder 비트 패턴 검증 (x0/x9 / 0/9 두 슬롯)
+
+검증:
+- `osty check toolchain` exit 0 (총 2,804줄 Osty source +
+  Go-side parity)
+- 5개 parity 테스트 모두 통과 (Encoder, LirOpcode, LirMultiWord,
+  LirBranch, LirSymbolReference)
+- `go test ./internal/onb ./internal/backend -short` — 0 회귀
+
+Phase 2 시리즈 LOC 누적 (Osty + Go-side):
+
+| 파일 | 라인 |
+|------|---:|
+| `onb_encoding.osty` | 653 |
+| `onb_encoding_test.osty` | 103 |
+| `onb_fixups.osty` | 114 |
+| `onb_fixups_test.osty` | 180 |
+| `onb_layouts.osty` | 81 |
+| `onb_lir.osty` | 494 |
+| `onb_lir_test.osty` | 191 |
+| `onb_program.osty` | 250 |
+| `onb_program_test.osty` | 152 |
+| `onb_relocs.osty` | 84 |
+| `onb_runtime_symbols.osty` | 158 |
+| `onb_lir_parity_test.go` | 257 |
+| `onb_osty_parity_test.go` | 87 |
+| **합계** | **2,804** |
+
+**다음 phase 후보**: Phase 3a — MIR Type 의존 ABI predicates
+(`isABIScalarType`, `abiKindFor`, `abiRegSlots`). 첫 MIR 진입.
+또는 Phase 6 (DWARF 라인 프로그램 + 변수 DIE emit). DWARF는
+Phase 2e의 `blockLineSpans`/`debugLocals` 필드를 소비하므로
+자연스러운 다음 슬라이스.
+
+
+---
+
+### Slice A2 Week 27 (ONB self-host port — Phase 2d branch family + fixup pass, 2026-05-03)
+
+Block-relative 분기 encoder + placeholder
++ fixup resolve pass 일체. Branch instruction의 알고리즘적 핵심
+(placeholder 작성 → 블록 byte offset 계산 → displacement 패치) 가
+한 슬라이스에 묶임. `b` / `b.cond` / `cbnz` 모두 커버.
+
+추가:
+
+- `toolchain/onb_encoding.osty` 확장:
+  - `onbEncodeBranchDisplacement(disp) -> Int?` — `b imm26`,
+    signed 26-bit (range ±2^25 words)
+  - `onbEncodeBranchCondDisplacement(cond, disp) -> Int?` —
+    `b.cond imm19`, signed 19-bit
+  - `onbEncodeCbnzDisplacement(src, disp) -> Int?` — `cbnz Xt, imm19`
+  - `onbEncodeBranchPlaceholder/CondPlaceholder/CbnzPlaceholder` —
+    emit-time placeholder (imm = 0)
+  - `onbPatchBranchUnconditional/Cond/Cbnz(placeholder, disp)` —
+    fixup pass의 패치 헬퍼
+  - `onbBranchImm26Min/Max`, `onbBranchImm19Min/Max` 상수
+
+- `toolchain/onb_fixups.osty` (새 파일):
+  - `OnbBranchFixupKind` enum (Uncond / Cond / Cbnz)
+  - `OnbBranchFixup` struct (codeOffset / targetBlock / kind)
+  - `OnbResolveOutcome` struct (words + ok flag)
+  - `onbResolveBranchFixups(words, fixups, blockOffsets)` —
+    fixup 리스트를 walk, 각 fixup의 displacement 계산, placeholder
+    워드를 patched 워드로 교체
+  - `onbPatchBranchByKind` — kind별 dispatch
+
+- `toolchain/onb_lir.osty` 확장:
+  - `OnbInstrKind`에 `OnbInstrBranch`, `OnbInstrBranchCond`,
+    `OnbInstrBranchCondNotZero` 추가
+  - `OnbInstr.targetBlock: Int` 필드 (-1 default for non-branch)
+  - constructors: `onbInstrBranch`, `onbInstrBranchCond`,
+    `onbInstrBranchCondNotZero`
+  - `OnbBranchEmit` struct (words + fixups)
+  - `onbEmitInstr(instr, codeOffset) -> OnbBranchEmit` — 모든
+    opcode를 통합한 emitter. 분기는 placeholder + fixup record를
+    반환, non-branch는 빈 fixups 리스트
+  - `onbEncodeInstr` 분기 가지: 분기는 None 반환 (multi-step path
+    표시; 단일 워드 fast path 유지)
+
+- `toolchain/onb_fixups_test.osty` (새 파일):
+  - 5 round-trip 케이스: forward branch (b +4), backward loop
+    (b -4), conditional (b.eq +8), cbnz (+4), 그리고 out-of-range
+    blockId 실패 케이스
+  - `emitBlocks(blocks)` 헬퍼 — block 리스트를 walk해 word stream +
+    fixups + blockOffsets 만듦 (byte 단위)
+  - 각 case: emit → resolve → expected hex 비교
+
+- `internal/onb/onb_lir_parity_test.go` 확장:
+  - `TestLirBranchParityVsOstyTable` — Go의 `patchMachOBranch`가
+    b/+4, b/-4, b.eq/+8, cbnz/+4 4 케이스에서 Osty 테스트가
+    주장하는 동일한 hex 워드를 produce하는지 검증
+
+검증:
+- `osty check toolchain` exit 0
+- 4개 parity 테스트 (Encoder + LirOpcode + LirMultiWord + LirBranch)
+  모두 통과
+- `go test ./internal/onb -short` 0 회귀
+
+한계 (Phase 2c+로 분리):
+- **BranchLink (`bl symbol`)** — 분기 displacement가 아닌 Mach-O
+  reloc 표 의존. Phase 2c가 adrp+add와 함께 처리
+- **Block walker / Function emitter** — 현재 emit 헬퍼는 단일 instr
+  레벨. 전체 함수를 emit하는 walker (line span tracking, prologue/
+  epilogue placement, reloc collection 포함) 는 Phase 2e와 함께
+- **Branch optimization** — fall-through 후속 블록으로의 무조건
+  분기 elide, mutual rewriting (b → b.cond) 같은 최적화는 lowering
+  레이어 (Phase 4-5) 의 책임
+
+**다음 phase 후보**: Phase 2c (BranchLink + adrp+add + Mach-O reloc
+표 model), Phase 2e (Function/Block/Program container types), 또는
+Phase 3a (MIR Type 의존 ABI predicates).
+
+
+---
+
+### Slice A2 Week 26 (ONB self-host port — Phase 2b multi-word constant materialisation, 2026-05-03)
+
+Variable-length
+encoding 도입. `MovImm64`가 1–4개의 32-bit word를 produce하는
+movz/movk chain으로 lower되며, `onbEncodeInstrWords` dispatcher가
+single-word / multi-word를 통합한 `List<Int>` 출력으로 노출.
+
+추가:
+
+- `toolchain/onb_encoding.osty` 확장:
+  - `onbEncodeMovz(dst, hw, imm16)` — 64-bit MOVZ
+  - `onbEncodeMovk(dst, hw, imm16)` — 64-bit MOVK
+  - `onbEncodeMovzW(dst, hw, imm16)` — W-register MOVZ + 내부
+    `onbWToXAlias` (w0..w7 → x0..x7 인덱스 공유)
+  - `onbEncodeMovImm64Words(dst, imm) -> List<Int>` — 4개 hw
+    position을 unconditional iteration으로 walk, 첫 chunk는
+    MOVZ로 강제 (다른 비트 zero 화), 이후 chunk가 0이면 MOVK 생략
+  - `onbEncodeMovImm32Word(dst, imm) -> Int?` — `mov w0, #0`
+    스타일의 단일 word
+
+- `toolchain/onb_lir.osty`:
+  - `OnbInstrKind`에 `OnbInstrMovImm32`, `OnbInstrMovImm64` 추가
+  - 대응 constructors `onbInstrMovImm32`, `onbInstrMovImm64`
+  - `onbEncodeInstr` dispatcher가 MovImm32 단일 word 처리,
+    MovImm64는 None (multi-word path 표시)
+  - 새 `onbEncodeInstrWords(instr) -> List<Int>` — 모든 opcode 통합.
+    단일 word는 1-element list로 wrap, MovImm64는 chain 그대로
+
+- `toolchain/onb_lir_test.osty` 확장:
+  - `assertOnbInstrWordsEq` helper — word count + per-position 비교
+  - mov x0/x9 #0 / #100 / #65535 / #0x12345678 케이스 (1-2 word
+    chains)
+
+- `internal/onb/onb_lir_parity_test.go` 확장:
+  - `TestLirMultiWordParityVsOstyTable` — Go `encodeMachOMovImm64`
+    출력을 Osty 테이블과 word-by-word 비교
+
+한계 (Phase 2c+로 분리):
+- **adrp + add 페어** (`LoadCStringAddress`, `LoadSymbolAddress`)
+  는 reloc 표 의존이라 Mach-O writer 진입까지 미룸
+- **Branch family** (`Branch`, `BranchCond`, `BranchCondNotZero`,
+  `BranchLink`) — link-time fixup pass 필요. Phase 2d
+- **Container types** — Phase 2e
+
+검증:
+- `osty check toolchain` exit 0
+- `go test ./internal/onb -run TestLirMultiWordParity` — 4
+  MovImm64 케이스가 word-by-word 일치
+- `go test ./internal/onb -short` — 0 회귀
+
+**다음 phase 후보**: Phase 2c (adrp+add skeletons, Mach-O reloc
+hooks), Phase 2d (branch fixups), 또는 Phase 3a (MIR Type 의존성
+도입).
+
+
+---
+
+### Slice A2 Week 25 (ONB self-host port — Phase 2a single-word LIR mirror, 2026-05-03)
+
+LIR opcode 21종을 Osty 측 enum + flat
+struct + per-opcode constructor + dispatch encoder로 미러. Phase 1
+의 인코딩 헬퍼들이 이제 Osty-side LIR record로 driving 되며,
+`OnbInstr → Int?` 디스패처가 Go의 `*<Opcode>` switch를 직접 미러.
+
+신규 Osty 파일:
+
+1. `toolchain/onb_lir.osty` — 단일-word LIR opcode 미러
+   - `OnbCond` enum (Eq/Ne/Ge/Lt/Gt/Le) + `onbCondToCode` 매퍼
+   - `OnbDebugTypeKind` enum (5개 + Struct)
+   - `OnbInstrKind` enum (21개 단일-word opcode)
+   - `OnbInstr` flat struct (kind + dst/src/lhs/rhs/base/imm/offset/cond)
+   - per-opcode constructors (`onbInstrAddReg(...)`, `onbInstrCmp(...)` ...)
+   - `onbEncodeInstr(instr) -> Int?` — Phase 1 인코더로 디스패치
+
+2. `toolchain/onb_lir_test.osty` — 21개 round-trip 케이스 (constructor →
+   encoder → expected hex)
+
+3. `toolchain/onb_encoding.osty` 확장 — 5개 인코더 추가
+   (`onbEncodeArithReg`, `onbEncodeMulReg`, `onbEncodeCmp`,
+   `onbEncodeCset`, `onbEncodeStackLoad/Store`, `onbEncodeAddImm`)
+
+4. `internal/onb/onb_lir_parity_test.go` — Go-side parity gate.
+   Phase 1 gate에 더해 ADD/SUB/MUL/CMP/CSET/stack 트래픽까지
+   Go encoder 출력 vs Osty 테이블 비교
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- **Multi-word opcodes** — `MovImm64` (1-4 movz/movk),
+  `LoadCStringAddress` (adrp+add), `LoadSymbolAddress` (adrp+add)는
+  variable-length 출력이 필요해 Phase 2b. 그 phase는 fixup pass
+  (블록 ID → byte offset 매핑) + 외부 심볼 reloc 표 만들기까지 묶음.
+- **Branch family** — `Branch` / `BranchCond` / `BranchCondNotZero` /
+  `BranchLink`도 link-time fixup이 필요해 Phase 2b
+- **Instr이 아닌 LIR 데이터 타입** (`Function`, `Block`,
+  `Program`, `LineSpan`, `CStringLiteral`, `DebugLocal`,
+  `DebugStructField`)은 Phase 2c
+
+검증:
+- `osty check toolchain` exit 0 (`onb_lir.osty`,
+  `onb_lir_test.osty`, 확장된 `onb_encoding.osty` 모두 통과)
+- `go test ./internal/onb -run TestLirOpcodeParityVsOstyTable` —
+  21개 expected hex 값이 Go encoder와 일치
+- `go test ./internal/onb -short` — 0 회귀
+
+**다음 phase 후보**: Phase 2b (multi-word + branch fixups), 또는
+Phase 3a (ABI predicates `isABIScalarType` / `abiKindFor`로 진입,
+MIR Type 의존성 도입).
+
+
+---
+
+### Slice A2 Week 24 (ONB self-host port — Phase 1 leaf modules, 2026-05-02)
+
+ONB Go 구현의 Osty 포팅 첫 슬라이스. **Tier 1 native
+기능 확장은 일단락**, 이제부터 `internal/onb/`의 Go 코드를
+`toolchain/onb_*.osty`로 옮기는 self-host 포팅 트랙으로 전환.
+
+패턴 (lir_proto.osty 선례 따름):
+- Osty source = future-canonical 단일 소스
+- Go 구현 = 현재 production (LLVM self-host LLVMgen이 ONB를 컴파일할
+  수 있을 때까지)
+- Go-side 페어리티 테스트가 두 표현이 byte-for-byte 일치하도록 잠금
+- `generated.go` 재생성 경로는 #854 이후 frozen이라 Osty 코드는
+  현재 dev-time runtime에 직접 닿지 않음 — `osty check toolchain` smoke
+  가 syntactic/typecheck만 검증
+
+Phase 1 (이번 슬라이스, MIR/LIR 의존성 없는 leaf 모듈 3개):
+
+1. `toolchain/onb_encoding.osty` — pure aarch64 instruction encoders
+   - `onbXRegisterNumber` / `onbDRegisterNumber` — 레지스터명 → 0..31 인코딩
+   - `onbEncodeBrk` (UnreachableTerm trap)
+   - `onbEncodeFmovDFromX` / `onbEncodeFmovXFromD` (FP↔Int 비트캐스트)
+   - `onbEncodeFPArith(base, ...)` (fadd/fsub/fmul/fdiv 공통)
+   - `onbEncodeBlr` (closure indirect call)
+   - `onbEncodeRet`
+   - `onbEncodeFPStack(base, reg, off)` (str/ldr d, [sp])
+   - `onbEncodeLoadStoreReg(base, t, n, off)` (str/ldr x, [reg])
+   - `onbEncodeMovRegReg`
+
+2. `toolchain/onb_runtime_symbols.osty` — 런타임 심볼 테이블
+   - `onbAbiKind*` 5종 상수 + `onbAbiKindFor`-슈도 헬퍼
+   - `onbRuntimeSym*` String/List/Map/Closure 심볼 상수
+   - `onbListPushSymbolForKind` / `onbListGetSymbolForKind`
+   - `onbMapInsert/Get/Contains/RemoveSymbolForKeyKind` (5개 dispatch table)
+
+3. `toolchain/onb_layouts.osty` — 슬롯/객체 layout 헬퍼
+   - `onbClosureEnvCapturesOffset()` (= 24, 런타임 헤더 크기)
+   - `onbClosureEnvFieldByteOffset(index)` — index 0 → 0 (fn ptr),
+     index N≥1 → 24 + (N-1)*8 (capture N-1)
+   - `onbEnumPayloadOffset(fieldIdx)` / `onbEnumDiscriminantOffset()`
+   - `onbStructFieldByteOffset(index)`
+   - `onbAbiSmallStructRegLimit()` / `onbAbiIndirectStructFieldLimit()`
+     / `onbAbiPointerRegSlotBytes()`
+
+4. `toolchain/onb_encoding_test.osty` — Osty-side parity 테이블 (14 케이스)
+
+5. `internal/onb/onb_osty_parity_test.go` — Go-side parity gate. Go
+   encoder가 produce하는 32-bit word를 Osty 테스트의 expected hex와
+   한 줄씩 비교. 두 표현 사이 drift는 PR 리뷰에서 양쪽 expected
+   column 수정으로 surface.
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- **runtime wire 없음** — Osty 함수는 dead code 상태. 실제 production은
+  여전히 `internal/onb/{lower,macho,asm,dwarf}.go`. LLVM self-host
+  LLVMgen이 ONB를 컴파일할 수 있게 되면 그때 `selfhost.ONBRunner` 같은
+  인터페이스로 wire (lir_proto_runner.go 패턴 참조).
+- MIR/LIR 타입 의존하는 함수 (abiRegSlots, lookupStructLayout, lower*Assign)
+  는 Phase 2+. 먼저 LIR opcode + Reg를 Osty enum으로 미러해야 함.
+- DWARF 인코더 / 라인 프로그램 / Mach-O 헤더는 Phase 6+ 별도 슬라이스.
+
+검증:
+- `go run ./cmd/osty check ./toolchain` — exit 0 (4 새 파일 syntactic
+  + typecheck 통과)
+- `go test ./internal/onb -run TestEncoderParityVsOstyTable` — Go encoder
+  가 Osty 테이블의 14개 expected hex값과 byte-for-byte 일치
+
+**다음 phase 후보**: LIR Opcode + Reg를 Osty enum으로 (Phase 2),
+또는 ABI 헬퍼 (`abiRegSlots` 등)를 MIR Type 의존 minimal subset으로
+시작 (Phase 3a).
+
+
+---
+
+### Slice A2 Week 23 (Map<K,V> — get / containsKey / remove, 2026-05-02)
+
+Map의 핵심 lookup 3종을 native lowering. Week 22의 new/insert/len과
+결합하면 Map 일상 사용 (캐시, 인덱스, 빈도 카운트)이 fallback 없이
+통과.
+
+작동:
+
+```osty
+let mut m: Map<String, Int> = {:}
+m.insert("k", 42)
+match m.get("k") {                  // V? 반환 — Some(42)
+    Some(x) -> println(x),
+    None -> println(-1),
+}
+println(m.containsKey("k"))         // 1 (Bool, true)
+m.remove("k")                        // Bool 반환 (찾았는지)
+println(m.len())                     // 0
+```
+
+추가:
+- 새 런타임 심볼: `runtimeSymMapGet/Contains/Remove` × 5 key kinds
+  (i64/i1/f64/ptr/string)
+- `lowerMapGet` — Week 22 scratch 슬롯을 `out_value`로 재사용 →
+  런타임 호출 → x0 (None=0/Some=1 디스크리미넌트) → dest+0,
+  scratch 값 → dest+8 (None일 땐 stale이지만 디스크리미넌트로 차단)
+- `lowerMapContains` / `lowerMapRemove` — `lowerMapBoolReturn` 헬퍼로
+  공유. 런타임이 bool을 x0로 반환, dest slot에 직접 capture
+- `mapGet/Contains/RemoveSymbolForKeyKind` 디스패치 테이블
+- `functionUsesMapValueScratch`이 `IntrinsicMapGet`도 감지해
+  scratch 슬롯 예약
+
+검증:
+- E2E binary smoke 4개 (`TestONBBackendBinaryRunsMapGetContainsRemoveOnDarwinARM64`):
+  map_get_hit / map_get_miss (Some/None 분기), map_contains_int_keys
+  (Int 키), map_remove_shrinks_len (insert→remove→len)
+- 기존 fallback 테스트 4개의 sentinel을 `taskGroup(|g| g.spawn(|| 42))`
+  로 변경 (Map.get은 이제 native라 더 이상 fallback 사유 아님)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- `m.update(k, |v| ...)` — 클로저 + Map.get + Map.set 조합. front
+  end가 어떻게 lowering하는지에 따라 추가 작업 필요할 수 있음
+- `m.getOr(k, default)` — IntrinsicMapGetOr 별도
+- `m.keys()` / `m.values()` — `List<K>` 반환, 미구현
+- `for (k, v) in m` — Map iterator 미구현
+- GC pointer_bitmap 정확도는 Week 22 그대로 — pointer-typed values
+  는 GC false-retain 위험
+
+**Tier 1 마무리 상태**: ONB가 일반적인 Osty 코드 패턴의 대부분을
+native path로 처리. 클로저 (Week 20), 제네릭 함수 (Week 21),
+Map<K,V> CRUD + len + lookup (Week 22 + 23), 메서드 디스패치 (intrinsic
+경유, Week 22), String .len/.isEmpty + Option .isSome/.isNone +
+List .isEmpty (Week 21) 모두 통과. 남은 Tier 1 잔여물은 작은 String
+메서드 (.split/.contains/.compare) 정도로 follow-up.
+
+
+---
+
+### Slice A2 Week 22 (Map<K,V> — new + insert + len, 2026-05-02)
+
+Map가 native path로 들어옴. 가장 흔한 패턴 `Map<String, Int>`,
+`Map<Int, Int>` 의 생성·삽입·길이 쿼리가 fallback 없이 통과.
+
+작동:
+
+```osty
+let mut m: Map<String, Int> = {:}
+m.insert("a", 1)
+m.insert("b", 2)
+println(m.len())                 // 2
+```
+
+추가:
+- 새 런타임 심볼: `runtimeSymMapNew/Len` + key kind별 insert
+  (`_i64`, `_i1`, `_f64`, `_ptr`, `_string`)
+- `abiKindI64/I1/F64/Ptr/String` 상수 + `abiKindFor(t)` — 런타임의
+  `OSTY_RT_ABI_*` 태그 enum과 동일
+- **Per-function map scratch slot** — `osty_rt_map_insert_*`은 value를
+  포인터로 받기 때문에 8B 스택 공간이 필요. `functionUsesMapValueScratch`
+  가 `IntrinsicMapSet`을 감지하면 vararg 슬롯과 user locals 사이에
+  8B 예약. `mapScratchOffset` 필드로 각 map_set 호출이 같은 슬롯 재사용
+- `lowerMapNew` — `(key_kind, value_kind, 8, NULL)` 4-인자 호출,
+  결과 ptr를 dest slot에 capture
+- `lowerMapSet` — 값을 scratch에 stamp → `LoadStackAddress`로
+  `&scratch`를 x2에 → key kind에 따라 insert 심볼 디스패치
+- `lowerMapLen` — 단순 런타임 호출
+- `mapKeyValueTypes(t)` helper — `Map<K,V>` NamedType에서 K, V 추출
+- `mapInsertSymbolForKeyKind(kind)` — kind → 런타임 심볼 매핑
+
+검증:
+- E2E binary smoke 3개 (`TestONBBackendBinaryRunsMapNewInsertLenOnDarwinARM64`):
+  map_string_int_three_keys (3 insert → len 3),
+  map_int_int_two_keys (Int 키), map_string_int_overwrite (같은 키
+  재삽입 → len 1)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- `m.get(k) -> V?` — 런타임이 ptr-out 컨벤션 (`out_value` 인자)을
+  사용하므로 별도 stack slot + Option<V> 구성 필요. **fallback 테스트
+  가 이 패턴 사용** (`m.get("a").isSome()`)
+- `m.contains(k) -> Bool`, `m.remove(k) -> Bool` — 마찬가지 ptr-out
+- `m.update(k, |v| ...)` — 클로저 + map_get 결합
+- `m.keys()` / `m.values()` / `for (k, v) in m` — iterator 별도
+- struct/enum value 타입 (8B 초과) — `value_size`가 8 hardcoded
+- GC trace fn pointer는 NULL — pointer 값 (String, List 등)이 map에
+  들어가면 GC가 참조 못 잡을 위험. 정확한 trace 함수는 follow-up
+
+다음 슬라이스 후보: Map.get / Map.contains, 추가 String/Option/List
+메서드, Float 비교 / 캐스트, 클로저 GC bitmap.
+
+
+---
+
+### Slice A2 Week 21 (stdlib intrinsics + builtin pointer ABI, 2026-05-02)
+
+작은 lift, 큰 unlock. Builtin generic 컨테이너 (List/Map/Set/Channel
+/Bytes/Handle)가 ABI에서 1-reg 포인터로 분류되도록 확장 + String /
+List / Option의 `.len()` / `.isEmpty()` / `.isSome()` / `.isNone()`
+인트린식 lowering 추가. 결과적으로 **제네릭 함수가 fallback 없이
+통과** — 모노모피제이션은 이미 front end가 처리하고 있어서 ONB는
+그저 `List<T>` 인자를 받아주기만 하면 됨.
+
+작동:
+
+```osty
+fn first<T>(xs: List<T>) -> T? {
+    if xs.len() == 0 { None } else { Some(xs[0]) }
+}
+fn main() {
+    let mut xs: List<Int> = []
+    xs.push(42)
+    let r = first(xs)               // List<Int>가 x0로 통과
+    match r {
+        Some(x) -> println(x),       // 42
+        None -> println(-1),
+    }
+}
+```
+
+추가:
+- `isBuiltinPointerType(t)` — `NamedType{Builtin: true}` 중 `List` /
+  `Map` / `Set` / `Channel` / `Bytes` / `Handle`을 1-reg 포인터로 인식
+- `isABIScalarType`이 위 predicate를 포함하도록 확장 → `abiRegSlots`
+  가 `List<Int>` / `Map<K,V>` 같은 타입을 fn arg/return으로 받음
+- `runtimeSymStringByteLen = "osty_rt_strings_ByteLen"` — String
+  .len()의 런타임 심볼
+- `lowerStringLen` — `osty_rt_strings_ByteLen` 직접 호출
+- `lowerStringIsEmpty` / `lowerListIsEmpty` — len 호출 + `cmp + cset eq`
+- `lowerOptionIsSome` / `lowerOptionIsNone` — disc 슬롯 (옵션 슬롯 + 0)
+  읽고 1과 비교 (`Some` 태그 = 1)
+- `lowerOptionDiscriminantCompare` 헬퍼 — isSome/isNone 공유 본체
+
+검증:
+- E2E binary smoke 5개 (`TestONBBackendBinaryRunsStdlibIntrinsicsOnDarwinARM64`):
+  string_len ("hello".len() → 5), string_is_empty ("".isEmpty() → 1),
+  list_is_empty (push 전후), option_is_some_none (Some(7) + None
+  각각의 isSome/isNone), generic_fn_first (first<T> 호출 → 42)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- **Map intrinsics** 여전히 fallback — `osty_rt_map_new`은 `(key_kind,
+  value_kind, value_size, trace_fn)` 4 인자가 필요하고 set/get은 value
+  를 포인터로 전달 (스택 scratch 슬롯 필요). 별도 슬라이스로 보류
+- String 메서드: `.split` / `.contains` / `.compare` / 슬라이싱 등 미구현
+- Option 메서드: `.unwrap()` / `.unwrapOr(d)` 미구현
+- List 메서드: `.pop()` / `.contains()` / `.indexOf()` 미구현
+- Bool println은 여전히 0/1로 출력 (`%lld` 포맷). 사용자가 `true` /
+  `false` 문자열을 원하면 명시적 toString 필요
+- GC pointer_bitmap 정확도 (Week 20 그대로)
+
+다음 슬라이스 후보: Map<K,V> 인트린식, 추가 String/Option/List 메서드,
+Float 비교 / 캐스트.
+
+
+---
+
+### Slice A2 Week 20 (closures — value + indirect call, 2026-05-02)
+
+ONB가 처음으로 클로저를 native lowering. `let f = |x| x + n`,
+`xs.filter(|x| x > 0)` 같은 패턴이 fallback 없이 통과 (filter 자체는
+메서드 디스패치 별도). Tier 1의 단일-최대 unlock — Osty stdlib API의
+대부분이 클로저를 받기 때문.
+
+작동:
+
+```osty
+fn main() {
+    let n = 100
+    let f = |x: Int| x + n           // env 할당, n을 capture[0]에 stamp
+    println(f(10))                    // x0 = env, x1 = 10, blr [env+0] → 110
+}
+```
+
+추가:
+- `runtimeSymClosureEnvAllocV2 = "osty.rt.closure_env_alloc_v2"` —
+  런타임이 `__asm__("osty.rt....")`로 export한 dotted symbol
+- `closureEnvCapturesOffset = 24` — 런타임 env 헤더 (`fn_ptr` 8B +
+  `capture_count` 8B + `pointer_bitmap` 8B) 다음부터 captures 시작
+- 새 LIR opcodes:
+  - `BranchLinkReg{Reg}` — `blr Xn` 간접 호출
+  - `LoadSymbolAddress{Dst, Symbol}` — `adrp + add` 함수/데이터 심볼
+    주소 materialise (LoadCStringAddress의 일반화)
+- `isClosureScalarType(t)` — `*ir.FnType` + `NamedType{ClosureEnv,
+  Builtin}` 둘 다 1-reg 포인터로 분류
+- `lowerClosureLiteralAssign` — alloc_v2 호출 → x10에 env stash →
+  fn pointer를 [env+0]에 store → 각 capture를 [env+24+i*8]에 store →
+  env pointer를 dest slot에 store
+- `lowerIndirectCall` — closure local → x0, user args → x1.., d0..,
+  `ldr x9, [x0, #0]` (fn ptr load) → `blr x9` → 반환 캡처
+- `loadEnvProjection` — `_env.*.{i}` MIR 패턴 lowering. Field 0 →
+  offset 0 (fn pointer), Field N (N≥1) → 24 + (N-1)*8 (capture N-1).
+  FieldProj와 TupleProj 둘 다 받음 (front end가 capture에 대해
+  TupleProj 사용)
+- `collectReadLocals`이 `IndirectCall.Callee`를 walk해 closure local이
+  slot을 받도록 보장
+
+검증:
+- E2E binary smoke 3개 (`TestONBBackendBinaryRunsClosuresOnDarwinARM64`):
+  no_capture (`|x| x + 1` 두 번 호출), single_capture (`|x| x + n`
+  with n=100), two_captures (`|x| x + a + b` with a=10, b=20)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- **pointer_bitmap = 0 고정** — GC가 capture를 모두 ptr로 trace하지
+  못해 false retention 가능. LLVM 백엔드는 capture 타입을 보고 정확한
+  bitmap을 계산. ONB는 dev path이므로 trade-off는 수용 가능하나,
+  GC stress 테스트가 false root를 잡아내면 작업 필요
+- **Float capture** — 코드 경로는 있지만 e2e 검증 안 함
+- **String/List/struct/enum capture** — pointer 1-reg에 들어가지만
+  정확한 GC tracing 미구현
+- **고차 함수의 클로저 리턴** (`fn make_adder(n: Int) -> fn(Int) -> Int`)
+  — 동작해야 하지만 미검증
+- **클로저를 인자로 다른 클로저에 전달** — 미검증
+
+다음 슬라이스 후보: Map<K,V> intrinsics, 메서드 디스패치, String
+메서드, 제네릭 함수 검증.
+
+
+---
+
+### Slice A2 Week 19 (struct >16B sret-style indirect passing, 2026-05-02)
+
+ONB가 16B 초과 (3-4 필드) all-scalar struct를 AAPCS64 indirect ABI로
+처리. `make() -> V3` 같은 함수가 fallback 없이 통과.
+
+작동:
+
+```osty
+struct V3 { x: Int, y: Int, z: Int }     // 24B
+fn make() -> V3 { V3 { 10, 20, 30 } }    // sret via x8
+fn sum(v: V3) -> Int { v.x + v.y + v.z } // indirect arg via x0
+fn main() {
+    let v = make()                       // x8 = &v_slot, callee writes through it
+    println(sum(v))                       // x0 = &v_slot, callee copies into local
+}
+```
+
+ABI:
+- **반환** (sret): caller가 dest slot 할당 → `add x8, sp, #destSlot`
+  → `bl _callee` → callee가 x8 통해 결과 stamp → caller는 capture 안 함
+- **인자** (indirect): caller가 `add Xn, sp, #srcSlot` → `bl _callee`
+  → callee의 prologue가 `[Xn + i*8] → [sp + slot + i*8]`로 필드별 복사
+
+추가:
+- `abiUsesIndirectStruct(t)` predicate — 3-4 필드 all-scalar struct
+  에서 true
+- `abiRegSlots`이 indirect struct에 대해 1을 반환 (포인터 1 reg)
+- `abiIndirectStructFieldLimit = 4` — 5+ 필드는 여전히 fallback
+- 새 LIR opcodes: `LoadStackAddress` (`add Xt, sp, #imm`),
+  `LoadFromReg` (`ldr Xt, [Xn, #imm]`), `StoreToReg` (`str Xt, [Xn, #imm]`)
+- `paramShuffle` indirect 분기 — argReg를 포인터로 보고 x9 경유 복사
+- `lowerCall` sret/indirect 분기 — destSlot 자동 할당 + x8 / argReg 세팅
+- `epilogue` sret 분기 — local $ret slot을 `[x8 + offset]`로 복사
+- `regX8` 상수 + `xRegisterNumber`이 x8 인식
+- 새 Mach-O encoder: `encodeLoadStoreReg`
+
+검증:
+- E2E binary smoke 4개 (`TestONBBackendBinaryRunsLargeStructSretOnDarwinARM64`):
+  make_v3 (24B sret return), sum_v3 (indirect arg), roundtrip_v3
+  (make→sum 결합 — caller dest slot이 sret 버퍼 + indirect arg
+  소스로 양쪽 역할), make_v4 (32B 4-필드 상한 케이스)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- 5+ 필드 / 32B 초과 struct — `abiIndirectStructFieldLimit` 캡
+- struct payload를 가진 enum (Some(V3) 같은) — payload 자체가 indirect
+- sret 함수 body가 중간에 다른 함수를 호출하는 경우 — x8 save/restore
+  미구현 (`make()` 같은 leaf 패턴에는 해당 없음)
+- struct/enum의 indirect 필드 (외부 struct 안에 큰 struct 중첩)
+- DWARF struct DIE for >16B struct — 작동은 하지만 lldb로
+  `frame variable v` 출력은 검증 안 함 (small struct 경로와 동일
+  layout이라 likely OK이지만 회귀 테스트 미작성)
+
+다음 슬라이스 후보: list_set_* (`xs[i] = v`), Float 비교 / 캐스트
+(fcmpe / fcvtzs / scvtf), 또는 callee-side x8 save/restore.
+
+
+---
+
+### Slice A2 Week 18 (struct field mutation, 2026-05-02)
+
+ONB가 `p.x = 5` 같은 projection-as-Dest 어사인을 native lowering.
+Week 12에서 `p.x` read는 통과했지만 write는 fallback 사유였음. 이번
+슬라이스로 `let mut p = Point { x: 3, y: 4 }; p.x = 100;
+p.y = p.y + 1` 패턴이 fallback 없이 통과.
+
+추가:
+- `lowerAssignToProjection` — Dest의 projection chain (FieldProj /
+  VariantProj)을 byte offset으로 변환해 slot+offset에 store
+- `projectionEndType` helper — projection chain 끝의 MIR 타입 반환
+  (Float field write는 d8 경유, 그 외는 x9 경유)
+- 기존 가드 `if instr.Dest.HasProjections()` 제거 — 새 경로로 라우팅
+
+검증:
+- E2E binary smoke 2개 (`TestONBBackendBinaryRunsStructFieldMutationOnDarwinARM64`):
+  simple_assign (`p.x = 100; println p.x = 100, p.y = 4`),
+  read_modify_write (`p.y = p.y + 10; p.x = p.x * 2`)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- `xs[i] = v` (IndexProj-as-Dest) — runtime list_set_* 디스패치 필요
+- `Some(p).x = ...` 같은 nested projection 후 write — 흔치 않음
+- struct/enum 타입의 field write (e.g. `outer.inner = Point {...}`) —
+  multi-slot store 미구현
+
+다음 슬라이스 후보: struct >16B sret-style passing, 또는 list_set_*
+디스패치 (xs[i] = v).
+
+
+---
+
+### Slice A2 Week 17 (`for x in list` native lowering, 2026-05-02)
+
+ONB가 `for x in list` 루프를 native lowering. 이전에는 List 인덱스
+read가 fallback 사유였는데, `LenRV` + `IndexProj` 두 vocab item을
+추가해서 모든 element type (Int/Bool/Float64/String) 의 list가 통과.
+
+작동:
+
+```osty
+let mut v: List<Int> = []
+v.push(10); v.push(20); v.push(30)
+let mut sum = 0
+for x in v {
+    sum = sum + x
+}
+println(sum)                 // 60
+
+for i in 0..10 { sum = sum + i }    // Range는 카운터 루프로
+                                     // lowering — Week 1부터 통과
+```
+
+Front end MIR 셰이프 (counter + bounded loop):
+
+```
+_len = len _iter           // LenRV → osty_rt_list_len
+_idx = const 0
+bb1: cond = _idx < _len
+branch cond -> [bb2 (body), bb4 (exit)]
+bb2: _elem = use _iter[_idx]   // IndexProj → osty_rt_list_get_*
+     sum = sum + _elem
+bb3: _idx = _idx + 1
+     goto bb1
+```
+
+추가:
+- 새 runtime symbol 상수: `runtimeSymListGetI64` / `_I1` / `_F64` /
+  `_String`
+- `lowerLenAssign` (LenRV → osty_rt_list_len + capture x0)
+- `loadIndexedPlaceIntoIntReg` / `loadIndexedPlaceIntoFloatReg` —
+  IndexProj 감지 시 list_get_* 디스패치 (element type 기준)
+- `indexCallPrefix` helper — list pointer → x0, index → x1
+- `listGetSymbol(elem)` — Int/Bool/String/Float dispatch
+- `materialiseOperand` / `materialiseFloatOperand`이 IndexProj가
+  있으면 indexed-load 경로로 우회
+- `collectRValueLocals`이 LenRV.Place를 read로 표시
+- `collectOperandLocals`이 IndexProj.Index 안의 locals도 수집
+  (인덱스 local이 slot을 못 받는 회귀 방지)
+
+검증:
+- E2E binary smoke 3개 (`TestONBBackendBinaryRunsForInLoopOnDarwinARM64`):
+  range_sum (0..10 sum=45), list_int_sum (10+20+30=60),
+  list_string_count (4 strings → 4)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- `list[i] = v` write — IndexProj as Dest 미구현
+- `list.pop()` — runtime symbol 다양 (Option<T> 반환), 미구현
+- struct/enum element type을 가진 List — push/get_bytes 경로 필요
+- `for (k, v) in map` — Map iterator 별도
+- `for x in iter()` — 사용자 정의 Iterable 프로토콜 미구현
+
+다음 슬라이스 후보: struct field mutation (`p.x = 5`) → struct >16B
+sret-style passing.
+
+
+---
+
+### Slice A2 Week 16 (List<T> 일반화 — Bool/Float64/String, 2026-05-02)
+
+ONB가 List<Int> 외의 element type에 대해 push/len을 native lowering.
+런타임은 이미 `osty_rt_list_push_i64` 외에 `_i1`/`_f64`/`_string`을
+노출하고 있어서 dispatch만 추가하면 됨.
+
+작동:
+
+```osty
+let mut bools: List<Bool> = []
+bools.push(true)             // osty_rt_list_push_i1
+
+let mut floats: List<Float64> = []
+floats.push(3.14)            // osty_rt_list_push_f64 — value in d0
+
+let mut strs: List<String> = []
+strs.push("hi")              // osty_rt_list_push_string
+```
+
+추가:
+- 새 runtime symbol 상수: `runtimeSymListPushI1`, `runtimeSymListPushF64`,
+  `runtimeSymListPushString`
+- `lowerListPush`이 `value.Type()`로 디스패치 — Int/Bool/String은
+  x1, Float은 d0 (AAPCS64 FP arg cursor)
+
+검증:
+- E2E binary smoke 3개 (`TestONBBackendBinaryRunsListGenericsOnDarwinARM64`):
+  list_bool (3 push → len 3), list_float (2 push → len 2),
+  list_string (4 push → len 4)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- `list[i]` 인덱스 read/write — `osty_rt_list_get_*` / `_set_*`
+  디스패치 미구현
+- `list_pop()` — runtime symbol 다양함, 미구현
+- 비-empty list literal `[1, 2, 3]` — `AggregateRV(list)` non-empty
+  case 미구현 (현재 빈 리스트만)
+- `for x in list` — iterator protocol 미구현
+- struct/enum element type — `osty_rt_list_push_bytes` 경로 필요
+
+다음 슬라이스 후보: for-in 루프 native lowering (List<T> + 인덱스 read
+결합), 또는 struct field mutation.
+
+
+---
+
+### Slice A2 Week 15 (Float64 + IEEE 산술 + AAPCS64 FP ABI, 2026-05-02)
+
+ONB가 처음으로 Float64를 native lowering. `let x: Float64 = 3.14` /
+`(a + b) * 3.0` / `fn double(x: Float64) -> Float64` 같은 코드가
+fallback 없이 통과.
+
+작동:
+
+```osty
+fn double(x: Float64) -> Float64 { x * 2.0 }       // d0 in / d0 out
+fn add(n: Int, f: Float64) -> Float64 { f + 1.0 }  // n in x0, f in d0
+fn main() {
+    let a: Float64 = 1.5
+    let b: Float64 = 2.5
+    let c = (a + b) * 3.0
+    println(c)                                      // %g format
+    println(double(3.5))
+    println(add(10, 2.5))
+}
+```
+
+모델: scalar-everything 모델 유지 + d-register 클래스 추가. d8/d9를
+FP scratch (mirroring x9/x10), d0-d7을 AAPCS64 FP-arg cursor로 사용.
+Float64 const는 `movz/movk x9 + fmov d, x9` 시퀀스로 materialise.
+Mixed Int+Float fn signature은 두 개의 독립 cursor (regCursor +
+fpCursor)로 처리 — `fn(n: Int, f: Float64)`는 n→x0, f→d0 (자주
+잘못 매핑되는 x0/x1이 아님).
+
+추가:
+- 새 LIR opcodes: `LoadFloat64Stack`, `StoreFloat64Stack`,
+  `FmovDFromX` / `FmovXFromD`, `FaddReg` / `FsubReg` / `FmulReg` /
+  `FdivReg`, d0–d9 register names
+- `isFloatABIType(t)` predicate (Float / Float64), `isABIScalarType`
+  가 이를 포함하도록 확장
+- `materialiseFloatOperand` — FloatConst 또는 Float local → d 레지스터
+  (FloatConst는 `floatConstInstrs` helper로 movz/movk + fmov 시퀀스)
+- `lowerFloatBinaryAssign` — d8/d9 페어로 fadd/fsub/fmul/fdiv
+- `lowerUseAssign` Float 분기 — Float local 복사는 d 레지스터 경유
+- `lowerPrintln`이 Float 인자에 `%g\n` + fmov x1, d9 + str x1, [sp]
+  (darwin 변동인자 ABI는 모든 vararg가 stack)
+- `paramShuffle` / `lowerCall` / `epilogue`가 fpCursor로 d0-d7 사용
+- 새 Mach-O encoders: `dRegisterNumber`, `encodeFPStack` (str/ldr d),
+  `encodeFmovDFromX` / `encodeFmovXFromD`, `encodeFPArith` (fadd 외)
+- 자동 surface: `DebugTypeFloat`은 dwarf.go에 이미 있었던 dead path
+  였는데 이번 슬라이스에서 첫 사용자 등장
+
+검증:
+- 단위 테스트 2개 (`internal/onb/onb_test.go`) — 1.5 + 2.5 패턴이
+  FmovDFromX + FaddReg + StoreFloat64Stack + FmovXFromD를 모두 emit
+  하는지, Float local이 DWARF DebugLocal로 surface되는지
+- E2E binary smoke 4개 (`TestONBBackendBinaryRunsFloat64OnDarwinARM64`):
+  const_print (3.14), arith ((1.5+2.5)*3.0=12), fn_param_ret
+  (double(3.5)=7), mixed_int_float_args (add(10,2.5)=3.5 — Int/Float
+  cursor 분리 회귀 테스트)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- Float 비교 연산 (`a < b`, `a == b`) — fcmpe + cset / b.cond 미구현
+- Float32 — 모든 경로가 d 레지스터 (Float64) 가정
+- Int↔Float 변환 (`n.toFloat64()`, `f.toInt()`) — fcvtzs / scvtf 미구현
+- Float을 struct/enum payload로 — abiRegSlots는 1-reg로 분류하지만
+  field write/read 코드 경로는 d 레지스터를 인식 못 함
+- Float DWARF (`frame variable c` 시 값 표시) — DebugTypeFloat은
+  surface되나 lldb 통합 테스트는 별도 슬라이스
+
+다음 슬라이스 후보: List<T> 일반화 (`List<Bool>` / `List<Float64>` /
+ `List<String>` 런타임 디스패치) → for-in 루프 native.
+
+
+---
+
+### Slice A2 Week 14 (Enum lowering v1 — Color / Option / Result + `?`, 2026-05-02)
+
+ONB가 처음으로 enum을 native lowering. Option/Result가
+prelude라 거의 모든 의미 있는 Osty 코드가 fallback에서 풀려나옴.
+
+작동 (canonical 예제):
+
+```osty
+enum Color { Red, Green, Blue }                // no-payload enum
+fn pick() -> Color { Color.Green }
+
+fn first(n: Int) -> Int? {                      // Option<scalar>
+    if n > 0 { Some(n) } else { None }
+}
+
+enum MyError { Empty, BadInt }
+fn parseSign(n: Int) -> Result<Int, MyError> {  // Result + ? operator
+    if n == 0 { Err(MyError.Empty) } else { Ok(n) }
+}
+fn parseAndDouble(n: Int) -> Result<Int, MyError> {
+    let v = parseSign(n)?
+    Ok(v * 2)
+}
+```
+
+슬롯 레이아웃: `[disc 8B][payload N×8B]`, 16B로 캡 (1 disc reg +
+1 payload reg, AAPCS64 small-struct ABI 재사용). no-payload enum은
+8바이트, Option<scalar>·Result<scalar, scalar>·Result<scalar, no-payload-enum>
+은 16바이트.
+
+추가:
+- `lookupEnumLayout(t)` — user enum (`mod.Layouts.Enums[name]`) +
+  합성 레이아웃 (`OptionalType`, `NamedType{Option/Maybe/Result, Builtin}`)
+- `syntheticOptionLayout` (None=0/Some=1) + `syntheticResultLayout`
+  (Err=0/Ok=1) — 컨벤션은 `internal/llvmgen` + `mir/lower.go`와 동일
+- `enumSlotSize(layout)` / `enumPayloadOffset(fieldIdx)` /
+  `enumDiscriminantValue(layout, idx)` 헬퍼
+- `payloadAllScalar`이 `isABIWordType`로 일반화 — scalar OR
+  1-register-slot 타입 (no-payload enum 같은) 허용 → `Result<Int,
+  MyError>` 가능
+- `lowerAggregateAssign`이 `AggEnumVariant` 처리 — discriminant를
+  slot+0에, payload를 slot+8+i*8에 stamp
+- 새 rvalue lowering: `*mir.NullaryRV` (None tag write),
+  `*mir.DiscriminantRV` (slot+0 → dest slot)
+- `placeProjectionOffset`이 `*mir.VariantProj` 처리 — payload는
+  slot+8 부터 (FieldIdx=-1은 "전체 payload tuple" → slot+8 시작)
+- `collectRValueLocals`가 `AggregateRV.Fields` + `DiscriminantRV.Place`
+  를 스캔해 enum scrutinee local이 slot을 받도록 보장
+- `lowerUseAssignMulti` — multi-slot copy (`_q = use _result`처럼
+  `?` 연산자가 fallback 분기에서 전체 enum을 복사할 때 필요).
+  destination type이 2-reg일 때 자동 선택; 1-byte clipping 회피
+- 새 LIR opcode `Brk{Imm}` + Mach-O 인코딩 (`brk #1`) — match
+  exhaustiveness가 추가하는 `mir.UnreachableTerm`을 안전하게 trap
+
+검증:
+- 단위 테스트 3개 (`internal/onb/onb_test.go`) — Color enum 태그
+  write, UnreachableTerm → Brk lowering, Option<Int> Some 분기의
+  tag+payload 8B 간격
+- E2E binary smoke 7개 (`TestONBBackendBinaryRunsEnumPatternsOnDarwinARM64`,
+  darwin/arm64): no-payload enum, Option Some, Option None, Result
+  Ok, Result Err, `?` Ok 전파, `?` Err 전파 — 모두 native path 통과
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- struct payload를 가진 enum variant — payload 1-reg 캡 때문에
+  `Some(Point)` 같은 형태는 fallback (Point가 2-reg)
+- 2개 이상 payload field를 가진 variant — `Some((a, b))` 같은 튜플 페이로드
+- `match` arm에서 `_4@Some.0` 같은 nested projection 외 (struct
+  payload + field projection 조합)
+- enum DWARF DIE — `frame variable` 출력에는 여전히 안 잡힘
+  (B.5 abbrev infra는 이미 있음, lower→encoder 와이어링은 별도 슬라이스)
+
+다음 슬라이스 후보: Float64 + IEEE 산술 (Week 15) → List<T>
+일반화 → for-in 루프 native lowering.
+
+
+---
+
+### Slice A2 Week 13 (AAPCS64 small-struct passing + DWARF struct wiring, 2026-05-02)
+
+ONB가 처음으로 struct를 함수 경계에서 사용 가능.
+`≤16B` 모든-스칼라 struct가 AAPCS64 small-struct ABI로 2-reg pair에 실려
+전달되며, lldb의 `frame variable`이 struct 필드를 풀어서 보여준다.
+
+작동 (canonical 예제):
+
+```osty
+struct Point { x: Int, y: Int }
+fn make() -> Point { Point { x: 5, y: 6 } }
+fn px(p: Point) -> Int { p.x }
+fn main() {
+    let p = make()           // {x0, x1} → slot+0 / slot+8
+    println(px(p))           // slot+0 / slot+8 → {x0, x1}
+}
+```
+
+추가:
+- `abiRegSlots(t)` / `isABIPassableType(t)` — ABI 슬롯 카운트 (스칼라 1,
+  ≤16B all-scalar struct N=ceil(size/8), 그 외 0/false)
+- `paramShuffle`이 register-cursor 모델로 multi-reg struct param을 처리:
+  regs[i..i+N) → slot+0 / slot+8 / …
+- `lowerCall`이 struct 인자를 `materialiseStructOperand`로 슬롯에서 N개의
+  인자 레지스터에 적재; 반환 값이 struct이면 x0, x1을 dest+0 / dest+8에 캡처
+- `epilogue`가 struct 반환 시 `_return` 슬롯에서 x0/x1을 로드
+- `assignLocalSlots`가 struct 반환 함수에서 `$ret`를 강제로 read 셋에
+  추가 (스칼라/Unit는 기존대로 x0 직통)
+- `lowerFunction` ABI guard가 struct 파라미터 / 반환을 허용 (>16B 또는
+  composite 필드는 여전히 fallback)
+- DWARF: `DebugTypeStruct` enum 값과 `DebugLocal.{StructName, StructFields}`
+  추가; `macho.go`의 `collectStructTypeInputs`가 distinct struct 타입을
+  첫-등장 순서로 수집해 `dwarfStructTypeInput` 리스트로 `emitDwarfInfo`에
+  전달; 변수 DIE는 `StructTypeIndex`로 struct DIE를 가리킴
+
+검증:
+- 단위 테스트 4개 (`TestLowerMIRStruct*`, `TestEmitObjectIncludesStructDIE*`)
+  — paramShuffle multi-reg, epilogue multi-reg, call site materialise +
+  capture, DebugLocal에 struct 필드 노출, `__debug_info`에 struct/member DIE
+- E2E binary smoke (`TestONBBackendBinaryRunsStructParamAndReturnOnDarwinARM64`)
+  — `make() -> Point` + `px(p)` / `py(p)` 호출 체인이 darwin/arm64에서
+  `5\n6\n` 출력
+- LLDB integration (`TestONBBackendLldbFrameVariableShowsStructOnDarwinARM64`)
+  — `frame variable`이 `(Point) p = (x = 7, y = 11)` 표시
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- >16B struct (3+ scalar 필드) — indirect/sret-style passing 미구현
+- 비-스칼라 필드를 가진 struct (List/String 포함) — HFA / 복합 분류 필요
+- struct 필드 mutation (`p.x = 5`) — projection-as-write 미지원, 여전히
+  fallback
+- 중첩 struct
+- struct 생성을 인자로 직접 (`px(Point { x: 1, y: 2 })`) — Aggregate-as-arg
+  는 fallback
+
+다음 슬라이스 후보: enum lowering v1 (struct payload 없는 단순 enum
+variant), 또는 list element 일반화 (List<Bool> / List<Float64>).
+
+
+---
+
+### Slice A2 Week 12 (struct lowering v1 — literals + field reads, 2026-05-02)
+
+ONB가 처음으로 struct를 lower. `struct Point { x: Int, y: Int }` 같은
+모든-스칼라 struct 한정. 작동:
+- `let p = Point { x: 3, y: 4 }` → 16바이트 슬롯 (필드별 8바이트) 할당,
+  각 필드를 slot+offset에 write
+- `p.x` → `Copy(local projs=[FieldProj{Index:0}])` → `Load64Stack` at
+  slot + `Index * 8`
+- `println(p.x)` 정상 동작
+
+추가:
+- `lowerState.mod` 필드 — 모듈-범위 layout 조회용
+- `localTypeSize`: 가변 슬롯 크기 (Unit 0, scalar 8, struct N×8, builtin
+  pointer 기본 8)
+- `lookupStructLayout` / `fieldByteOffset` / `placeProjectionOffset`
+  helpers — Type → layout → 바이트 offset 변환
+- `lowerStructLiteralAssign`: `AggregateRV(struct)` 처리, 각 필드를
+  slot+i*8에 store
+- `loadPlaceIntoReg`가 projection을 받아 slot+offset에서 load
+- `assignLocalSlots`가 `localTypeSize` 사용 (이전 hardcoded 8)
+
+한계 (이번 슬라이스에서 명시적으로 보류):
+- struct fn param / return (AAPCS64 small-struct passing 2-reg / indirect)
+- DWARF struct 변수 인스펙션 (`frame variable p`) — B.5 infra는 깔려
+  있으나 lower→encoder 와이어링은 별도 슬라이스
+- struct 필드 mutation (`p.x = 5`) — projection-as-write 미지원
+- 중첩 struct
+
+다음 슬라이스 후보: AAPCS64 small-struct passing → struct를 fn 경계에서
+사용 가능 → DWARF 변수 인스펙션과 묶어서 진행.
+
+
+---
+
+### Slice A2 Week 11 (DWARF B.5 infra — struct/member DIEs, 2026-05-02)
+
+인코더 인프라만 추가. ONB가 struct를 lower하지 않으므로 dead code지만,
+향후 struct lowering 슬라이스가 들어올 때 DWARF 측은 더 이상 막히지 않음.
+구체적으로:
+- `DW_TAG_structure_type` (abbrev 6, has children) + `DW_TAG_member`
+  (abbrev 7) 추가
+- `DW_AT_data_member_location` 속성 + `DW_FORM_udata` form
+- `dwarfStructTypeInput` / `dwarfStructMemberInput` 입력 타입
+- `emitDwarfInfo`가 `structs []dwarfStructTypeInput` 인자 추가 (callers
+  pass nil 으로 변동 없음)
+- 구조체 멤버가 base 타입을 참조하면 같은 CU의 base_type DIE를 공유
+  (`collectUsedTypeKinds`가 멤버까지 union)
+- `dwarfVariableInput.StructTypeIndex int` (–1 = base type 사용,
+  ≥0 = struct list 인덱스 — `variableTypeOffset` helper로 분기)
+
+검증: 단위 테스트 3개 — abbrev 테이블에 struct/member 코드 존재,
+인코더가 struct 입력을 받으면 DIE 바이트가 늘어남, variable이
+StructTypeIndex로 struct DIE를 가리킬 수 있음.
+
+한계: dwarfdump round-trip은 macho.go가 struct를 받지 않아 ScaleHole.
+실제 사용은 lowering 들어올 때 (struct AggregateRV + place projection
++ AAPCS64 small-struct passing).
+
+
+---
+
+### Slice A2 Week 10 (DWARF B.4 — Bool/String var inspection, 2026-05-02)
+
+Phase B.3의 variable inspection을 Int 외 ABI-scalar 두 종류로 확장. Bool은
+`byte_size 1` + `DW_ATE_boolean` (lldb는 byte_size 8 + boolean을 거부하고
+"void"로 표시), String은 `DW_TAG_pointer_type` → `DW_TAG_base_type "char"`
+체인 (lldb가 pointee를 C 문자열로 표시).
+
+검증: `fn first(a: Int, b: Bool, c: String) -> Int { a }` 함수 진입 시점에
+`frame variable`이 다음을 표시:
+- `(long) a = 42`
+- `(bool) b = true`
+- `(char *) c = 0x... "hi"`
+
+추가:
+- `DebugTypeBool` / `DebugTypeString` / `DebugTypeFloat` enum entries
+  (Float은 ONB lowering이 D-reg 미지원이라 dead code, future-ready)
+- `dwarfBaseTypeBool` / `Float` / `String` + `dwarfAbbrevPointerType`
+- `collectUsedTypeKinds`로 변수에서 참조된 타입만 emit (CU dead 타입 X)
+- `emitDwarfInfo`가 String일 때 char base_type + pointer_type 두 DIE
+- `mirTypeToDebugKind` helper로 MIR type → debug kind 단일 source
+- **Param 슬롯이 read 여부와 무관하게 항상 할당** — unused param도
+  `frame variable`에 표시되도록 (이전엔 unused면 슬롯 없어 invisible)
+
+한계: Float은 ONB native가 아직 처리 못 함 (Float 인자/반환 → fallback to
+LLVM). struct/list/Map composite 타입은 후속 슬라이스.
+
+
+---
+
+### Slice A2 Week 9 (DWARF B.3 — variable inspection, 2026-05-02)
+
+lldb `frame variable` 가 ONB 빌드 결과에서 named Int local의 현재 값을
+보여줌. 추가:
+- `DW_TAG_base_type` DIE for Int (byte_size 8, encoding DW_ATE_signed)
+- `DW_TAG_variable` DIE per named Int local: `DW_AT_name` + `DW_AT_type`
+  (ref4 to base_type) + `DW_AT_location` (DW_OP_fbreg sleb128(slot))
+- Subprogram DIE에 `DW_AT_frame_base = DW_OP_breg31 0` (sp-relative)
+- Abbrev table 4 entries: CU, subprogram(children), variable, base_type
+- LIR Function에 `DebugLocals []DebugLocal` 필드 — 이름·slot·type 캐리
+- lower.go가 named Int local만 (`_return` / 익명 temp 제외) 추출
+- **Param shuffle instrs는 LineSpan zero**: shuffle PC가 source line으로
+  매핑되면 lldb가 prologue 끝/shuffle 시작 사이에 stop해서 uninitialised
+  슬롯을 읽는 문제 — line program이 shuffle 행을 skip하도록 수정
+
+검증: `lldb -o "br set -f main.osty -l 1" ./app` → `frame variable`
+→ `(long) a = 10`, `(long) b = 32`. 변수 이름·값 모두 정확.
+
+한계: 현재는 Int만 (DW_ATE_signed). String/Bool/Float/List 등은
+DebugTypeKind 확장 + 대응 base_type/pointer_type DIE 추가가 필요.
+
+
+---
+
+### Slice A2 Week 8 (DWARF B.2 — lldb integration, 2026-05-02)
+
+DWARF
+파이프라인이 lldb 자동 인식까지 도달. `dsymutil`이 .o의 DWARF를 .dSYM으로
+번들링하고, `lldb`가 `br set -f main.osty -l 4` 같은 source-level breakpoint
+를 PC로 해상하며 source view까지 표시한다. 추가:
+- `DW_TAG_subprogram` DIE per user function (CU의 child DIE; CU는
+  `DW_CHILDREN_yes`로 변경) — dsymutil이 child 없는 CU를 빈 것으로 처리하던
+  문제 해결
+- `__debug_info` + `__debug_line` 섹션에 **non-extern UNSIGNED 릴로케이션**
+  (extern=false, symbolnum=__text section number) — clang의 패턴과 동일.
+  extern symbol-rel 릴로케이션은 dsymutil이 silently 거부함
+- `dwarfInfoEncoded.LowPCOffsets` / `dwarfLineEncoded.SetAddressOffset`로
+  인코더가 reloc 위치를 호출자에게 전달
+- Mach-O writer가 `__text` reloc 다음에 DWARF section reloc들을 배치
+  (highest-address-first 정렬)
+- `ltmp0` local symbol (당시엔 reloc target으로 의도했으나 결국 section-rel
+  reloc으로 갔으므로 unused; 향후 cleanup 가능)
+
+검증: `lldb -o "br set -f main.osty -l 4" ./app` 실행 시
+`Breakpoint 1: where = app\`main + 56 at main.osty:4:9` + source 5라인 표시.
+
+
+---
+
+### Slice A2 Week 7 (DWARF B.1 — CU DIE, 2026-05-02)
+
+`__debug_info` +
+`__debug_abbrev` + `__debug_str` 세 섹션이 추가되어 DWARF 인프라 완비.
+CU DIE는 `DW_TAG_compile_unit` 1개에 7개 attribute (producer, language=C99,
+name, comp_dir, low_pc, high_pc, stmt_list). DW_AT_stmt_list가 line program을
+가리키므로 DWARF 파서가 컴파일 유닛 → 라인 프로그램 traversal 가능.
+`dwarfdump --debug-info / --debug-abbrev / --debug-str` 모두 zero-warning.
+
+추가:
+  - DWARF tag/attr/form 상수 (DW_TAG_compile_unit, DW_AT_producer 등)
+  - `dwarfStringTable`: dedup string storage with stable byte offsets
+  - `emitDwarfAbbrev`: abbrev table 1개 entry (compile_unit + 7 attrs)
+  - `emitDwarfInfo`: CU header + DIE encoder
+  - Mach-O writer가 `__DWARF` 세그먼트에 4 sections (line/info/abbrev/str)
+  - 새 section name 상수 (`machoSectnameInfo` / `Abbrev` / `Str`)
+
+한계 — lldb 자동 인식은 아직: dsymutil이 .o의 Mach-O Stab debug symbols
+(N_OSO/N_FUN/N_BNSYM) 을 walk해서 .dSYM 번들을 만드는데, 우리는 아직 Stabs를
+emit 안 함. dwarfdump는 DWARF 섹션을 직접 읽어 모두 검증되지만, lldb가
+`bt`에서 `main.osty:42` 표시하려면 Phase B.2 (Stabs)이 추가로 필요.
+
+
+---
+
+### Slice A2 Week 6 (String concat + List<Int>, 2026-05-02)
+
+ONB native
+path가 처음으로 런타임 호출 경로를 사용. `osty_runtime.c` 가 link 단계에
+같이 들어오며 다음 패턴이 native로 통과:
+
+  - `let name = "world"; println("hello, " + name)` (String concat with local)
+  - `fn greet(name: String) -> String { "hello, " + name }` (String param/return)
+  - `let mut v: List<Int> = []; v.push(10); println(v.len())` (list ops)
+  - `for i in 0..5 { v.push(i) }` (list build via loop)
+
+추가:
+  - 런타임 심볼: `osty_rt_strings_Concat`, `osty_rt_list_new`,
+    `osty_rt_list_push_i64`, `osty_rt_list_len` — 모두 `BranchLink`로 호출
+  - `materialiseOperand`가 `StringConst` → `LoadCStringAddress` 경로 추가
+  - `lowerStringConcatAssign`: `BinaryAdd` + `T == TString` → 두 args를
+    x0/x1에 띄우고 runtime concat 호출, 결과 ptr를 dest slot에 저장
+  - `lowerAggregateAssign`: 빈 list literal → `osty_rt_list_new`
+  - `lowerListPush` / `lowerListLen`: 새 intrinsic dispatch
+  - `lowerPrintln`이 String local도 처리 (`puts(string ptr)` 경로)
+  - `LoadCStringAddress`가 임의 X register dst 지원 (이전엔 x0 only)
+  - `isABIScalarType` helper로 user fn param/return을 Int/Bool/String 모두 허용
+  - Backend가 매 빌드에 `EnsureRuntimeObject` 호출해서 runtime.o를 link 인자로 추가
+
+부수 (직전 Week 5 cleanup): `_ = fnStart` / `_ = dwarfSegmentSections` 제거,
+`functionPrologueWords`를 lir.go로 이동 (single source of truth),
+Mach-O 세그먼트/섹션 이름 상수화.
+
+
+---
+
+### Slice A2 Week 5 (DWARF .debug_line, 2026-05-02)
+
+ONB가 처음으로 디버그
+메타데이터를 emit. `__debug_line` 섹션이 Mach-O `__DWARF` 세그먼트로 들어감.
+`dwarfdump --debug-line foo.o`가 정상 파싱하며 PC→source `<file>:<line>:<col>`
+매핑이 모든 실행 경로에서 정확. 추가:
+- DWARF 4 line-program 인코더 (`internal/onb/dwarf.go`): leb128/uleb128 +
+  prologue + state machine. Special opcode는 안 쓰고 `set_address +
+  advance_pc + advance_line + copy + end_sequence` 시퀀스로 단순화
+- `Block.LineSpans` 필드 + `lowerBlock`이 각 LIR 명령마다 source position 부착.
+  Dead-store / 중복 행은 `appendLineRow`가 코얼레스
+- Mach-O writer가 `__DWARF` + `__LINKEDIT` 세그먼트 추가. 파일 레이아웃은
+  `text → cstring → debug_line → relocs → symtab → strtab` 순서로 segment
+  range overlap 없이 배치. ld64가 multi-segment .o를 받아들이려면 LINKEDIT가
+  필수 (이전엔 단일 __TEXT 세그먼트라 LINKEDIT 없어도 통과)
+- `Request.SourcePath` / `PackageName`이 `Program`까지 흐르면서 file table에
+  소스 경로가 채워짐
+
+후속: `__debug_info` + `__debug_abbrev` + `__debug_str`이 들어와야 lldb가
+자동 인식. dsymutil 통합도 추가 슬라이스로 분리.
+
+
+---
+
+### Slice A2 Week 4 (loops + match, 2026-05-02)
+
+`while` / `for ... in 0..N`
+/ 중첩 루프 / `match`(non-const scrutinee 포함)이 모두 native path로 통과.
+핵심 발견: while/for/단순 match는 Week 3 multi-block + branch fixup
+인프라로 이미 동작 — 별도 lowering 없이도 native. 추가된 것은
+SwitchIntTerm 한 가지 (non-const scrutinee가 있는 일반 match가 사용):
+- `BranchCond { Cond, Target }` LIR opcode + Mach-O fixup (`b.cond imm19`)
+- `lowerSwitchIntTerm`: scrutinee를 x9에 load, 각 case는 `mov x10, #imm;
+  cmp x9, x10; b.eq case_target`, 마지막에 `b default`
+- `collectTerminatorReads`가 `SwitchIntTerm.Scrutinee`도 walk
+부수: `_ = fnStart` 미사용 변수 정리 (simplify 리뷰 피드백).
+
+
+---
+
+### Slice A2 Week 3 (control flow, 2026-05-02)
+
+`if/else` + 6개 비교
+연산자 (`==`, `!=`, `<`, `<=`, `>`, `>=`) 분기 코드가 native path로 통과.
+패턴 `let x = K; if x > 0 { println(1) } else { println(0) }` 모두 OSTY_ONB_STRICT
+으로 동작 (80–180ms). 추가:
+- `Cmp` / `Cset` opcode + 6개 `Cond` 상수 (CondEq/Ne/Lt/Le/Gt/Ge)
+- `Branch` (unconditional) + `BranchCondNotZero` (cbnz) — block index를
+  target으로 들고, 인코더가 fixup pass에서 PC-relative imm26 / imm19로 패치
+- Multi-block 함수 지원: `Block.OriginalIndex`로 MIR BlockID를 보존,
+  entry block first 정책으로 emit slot 0이 항상 entry
+- `BoolConst` materialisation (`mov #0` / `#1`)
+- `collectTerminatorReads`로 BranchTerm.Cond 같은 terminator-level 읽기를
+  slot allocation에 반영
+
+
+---
+
+### Slice A2 Week 2 (사용자 함수 호출, 2026-05-02)
+
+단일 모듈 내 helper
+함수 + AAPCS64 호출 규약 추가. 패턴 `fn add(a: Int, b: Int) -> Int { a + b };
+fn main() { println(add(40, 2)) }`이 native path로 통과. 모든 Int 파라미터
+지원 (최대 8개, x0..x7). 변경:
+- `LowerMIR`이 모든 함수를 순회 (main 외 helper 포함). main이 항상 첫 번째
+- 함수 진입 시 prologue가 AAPCS64 인자 register를 stack slot으로 shuffle
+- 비-main 함수의 `ReturnTerm`은 `_return` slot을 x0에 load 후 ret
+- `CallInstr` (FnRef 한정) lowering: 인자를 x0..x7에 배치 → `bl <symbol>`
+  → 결과 register x0를 dest slot에 저장
+- Mach-O encoder가 multi-function: 각 함수가 자기 symbol entry + text
+  offset, `bl _add` 같은 local fn 호출은 local symtab slot으로 reloc해서
+  `_add`가 defined와 undefined로 중복 등장하는 문제 방지
+
+본 문서는 결정 lock-in이며, 후속 의제(예: aarch64 LIR opcode 카탈로그,
+cross-validation harness, simple inliner 도입 검토)는 별도 문서로 분기한다.
+
+
+---
 
 ## 한 줄 요약
 

--- a/OSTY_GRAMMAR_v0.3.md
+++ b/OSTY_GRAMMAR_v0.3.md
@@ -1,5 +1,7 @@
 # Osty Grammar — Rules & EBNF (v0.3)
 
+- **Scope**: Osty EBNF grammar v0.3 — legacy edition
+- **Type**: Grammar
 v0.1 에서 열린 이슈 O1~O7 (v0.2 에서 해결) + v0.3 에서 추가된 grammar
 확장을 반영한 최종본. R1~R26 에 O1~O7 결정 및 v0.3 변경을 통합하여
 단일 규범 문서로 재구성.

--- a/OSTY_GRAMMAR_v0.4.md
+++ b/OSTY_GRAMMAR_v0.4.md
@@ -1,5 +1,7 @@
 # Osty Grammar — Rules & EBNF (v0.4) *[Archived · superseded by v0.5]*
 
+- **Scope**: Osty EBNF grammar v0.4 — legacy edition
+- **Type**: Grammar
 > **Archival notice.** 이 문서는 v0.4 grammar 의 역사 스냅샷이다.
 > 현재 유효한 문법은 `OSTY_GRAMMAR_v0.5.md` 이다.
 > 아래 `LANG_SPEC_v0.4/` 경로 참조는 당시 컨텍스트 그대로 보존되어

--- a/OSTY_GRAMMAR_v0.5.md
+++ b/OSTY_GRAMMAR_v0.5.md
@@ -1,5 +1,7 @@
 # Osty Grammar — Rules & EBNF (v0.5)
 
+- **Scope**: Osty EBNF grammar v0.5 — current edition with decision log
+- **Type**: Grammar
 v0.1 에서 열린 이슈 O1~O7 (v0.2 에서 해결), v0.3 grammar 확장, v0.4
 edge-case 결정(G13-G18), v0.5 에서 한 번에 수용된 15 개 결정
 (G20-G34) 까지 반영한 **현행본**. 문법 surface 변경은 정식 버전 업

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Osty
 
+- **Scope**: Project overview — build status, CLI reference, layout, testing, contributing
+- **Type**: README
 A work-in-progress implementation of the **Osty** programming language — a
 general-purpose, statically-typed, GC'd language specified in
 [`LANG_SPEC_v0.5/`](./LANG_SPEC_v0.5/README.md) with grammar fixed in

--- a/RUNTIME_GC.md
+++ b/RUNTIME_GC.md
@@ -1,5 +1,7 @@
 # LLVM Runtime GC
 
+- **Scope**: Runtime GC design — shadow stack ABI, root bind/release, thread-local frame chain
+- **Type**: Design doc
 This document is the source of truth for Osty's active GC implementation path.
 
 The live implementation is the LLVM/native runtime path:

--- a/RUNTIME_GC_DELTA.md
+++ b/RUNTIME_GC_DELTA.md
@@ -1,5 +1,7 @@
 # GC Delta — Model vs Live Runtime
 
+- **Scope**: GC design deltas — changes from baseline, new decisions, regression tracking
+- **Type**: Delta log
 This document tabulates the feature gap between the GC simulation model
 (`examples/gc/`) and the live LLVM runtime (`internal/backend/runtime/osty_runtime.c`
 + `internal/llvmgen/generator.go`).

--- a/RUNTIME_SCHEDULER.md
+++ b/RUNTIME_SCHEDULER.md
@@ -1,5 +1,7 @@
 # RUNTIME_SCHEDULER.md — Osty 런타임 스케줄러 아키텍처 & 단계 로드맵
 
+- **Scope**: Runtime scheduler design — task groups, structured concurrency, cancel state
+- **Type**: Design doc
 > **Status (2026-04-22):** **Phase 2 착륙.** thread-per-task pthread 모델이 워커 풀 + 워커별 Chase-Lev work-stealing deque + linked-list FIFO 인젝트 큐로 교체됨. 워커 수는 기본 `min(CPUs, 8)` (Darwin 은 `sysctlbyname("hw.ncpu")`, 그 외 POSIX 는 `sysconf(_SC_NPROCESSORS_ONLN)`, Windows 는 `GetSystemInfo`), `OSTY_SCHED_WORKERS` 환경변수로 `[1, 256]` 오버라이드. Elastic worker는 **블로킹 cv_wait 진입 직전에만** on-demand 생성 (상한 `OSTY_SCHED_ELASTIC_MAX = 256`) — CPU-bound 워크로드는 오버섭스크립션 없이 fixed pool 로 스케일. 관찰된 speedup: 16 xorshift task × `workers=1 → 4` 에서 **3.97x**. ThreadSanitizer clean (Chase-Lev slot publication 을 release/acquire atomic 으로 게시). 공개 ABI (`osty_rt_task_spawn/group_spawn/handle_join/group/group_cancel/...`) 는 Phase 1B에서 그대로 유지 — MIR/백엔드 재컴파일 불필요. `parallel` / `race` / `collectAll` / `thread.select` (recv/send/timeout/default) 은 Phase 1B에서 추가된 형태 그대로 풀 위에서 동작하며, Phase 1B부터 남아있던 `race` / `collectAll` 의 `list trace-kind mismatch` 버그는 이 마이그레이션 중에 함께 수정. 이 문서는 `LANG_SPEC_v0.5/08-concurrency.md` §8.0과 `LANG_SPEC_v0.5/19-runtime-primitives.md` §19.1 "GC × scheduler interaction" 절에 대응하는 **구현 레퍼런스**다. 스펙은 관찰 가능한 계약만 고정하고, 이 문서는 공개 LLVM 백엔드의 참조 런타임이 어떤 단계로 그 계약을 만족하는지 기술한다.
 
 ## 배경

--- a/SELFHOST_PORT_MATRIX.md
+++ b/SELFHOST_PORT_MATRIX.md
@@ -1,5 +1,7 @@
 # SELFHOST_PORT_MATRIX.md
 
+- **Scope**: Self-host porting matrix — Osty→Go frontend/backend parity tracking
+- **Type**: Porting matrix
 Go → Osty 셀프호스팅 포팅 현황 매트릭스. 리졸버 / 체커 잔여 작업을 항목 단위로 분류.
 
 > **Scope**: `internal/resolve` ↔ `toolchain/resolve.osty`, `internal/check` ↔

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -1,5 +1,7 @@
 # Osty 스펙·Grammar 갭 트래킹
 
+- **Scope**: Resolved spec gaps — v0.4 edge-case decisions, archived by language version
+- **Type**: Decision log
 `LANG_SPEC_v0.5/` + `OSTY_GRAMMAR_v0.5.md` 기준.
 
 **v0.5 시점 open gap: 없음.** v0.4 사용 코퍼스에서 관찰된 15 개

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -1,5 +1,7 @@
 # STDLIB_MATRIX.md
 
+- **Scope**: Standard library coverage matrix — module/function/status per Osty version
+- **Type**: Coverage matrix
 Osty 표준 라이브러리 모듈별 실행 가능성 / 스펙 정합 매트릭스.
 
 > **Scope**:

--- a/STRING_INTERP_RESOLVE_GAP.md
+++ b/STRING_INTERP_RESOLVE_GAP.md
@@ -1,5 +1,7 @@
 # String Interpolation Resolver Gap — Multi-Day Plan
 
+- **Scope**: String interpolation resolve gap analysis — phase tracking and resolution plan
+- **Type**: Gap analysis
 **Status (2026-05-05):** User-facing path closed via #1361 (MIR-layer
 recovery). Canonical-side parser + resolver + applyTwice regression
 shipped via #1360 (Day 1 lexer ranges), #1364 (Day 2 parser

--- a/docs/d4_closure_capture_spec.md
+++ b/docs/d4_closure_capture_spec.md
@@ -1,5 +1,7 @@
 # D4 — Closure capture lift for self-hosted CoreModule
 
+- **Scope**: Closure capture lift spec for self-hosted CoreModule
+- **Type**: Spec
 Status: spec for a parallel PR. Depends on `toolchain/core_clone.osty` (D1) only for its walk helpers — can start as soon as D1 lands. Does **not** depend on D2 (TyArena substitution) or D3 (monomorphize).
 
 ## Goal

--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -1,5 +1,7 @@
 # LIR Proto plan
 
+- **Scope**: LIR prototype plan — isolated prototype for low-level IR
+- **Type**: Plan
 Status: isolated prototype in progress. No production wiring yet.
 Authoring direction: new LIR Proto shape is Osty-first in
 `toolchain/lir_proto.osty`; the earlier Go prototype has been ported out and

--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -1,5 +1,7 @@
 # MIR design (Osty compiler)
 
+- **Scope**: MIR design — middle-end IR for the Osty compiler
+- **Type**: Design doc
 Status: Stage 4 full-coverage backend contract landed. Backend entry now treats
 any `mir.Lower` / `mir.Validate` issue as fatal incomplete MIR coverage, and the
 LLVM dispatcher no longer retries the legacy HIR→AST bridge. The old bridge

--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -1,5 +1,7 @@
 # Toolchain × LLVM compilability — status report
 
+- **Scope**: Toolchain × LLVM compilability status report
+- **Type**: Status report
 ## 2026-04-29 sync update — checker bundle bridge excluded
 
 `internal/selfhost/ast_lower.osty` is no longer a checker-bundle input. It


### PR DESCRIPTION
## Summary
- Flatten ONB_DESIGN.md 1287-line blockquote section into 32 proper ### Slice headers
- Add Scope/Type metadata headers to 18 root docs, 4 docs/, 68 LANG_SPEC files
- No code changes

## Test plan
- [x] Docs-only change
- [ ] CI green