### PR TITLE
feat(check): #[ambient] entry-point gate (E0780/E0781) — Phase 1.6

### DIFF
--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -77,6 +77,11 @@ pub fn checkCodeIntrinsicNonEmptyBody() -> String { "E0773" }
 pub fn checkCodeBuilderMissingRequiredField() -> String { "E0774" }
 pub fn checkCodePureViolation() -> String { "E0775" }
 
+// v0.6 G36 — Capabilities (LANG_SPEC_v0.6/20-capabilities.md §20.8).
+pub fn checkCodeAmbientWrongSite() -> String { "E0780" }
+pub fn checkCodeAmbientUnknownCapability() -> String { "E0781" }
+pub fn checkCodeAmbientUserCapability() -> String { "E0789" }
+
 // ---------------------------------------------------------------------
 // Low-level builder. Higher-level constructors below wrap this so call
 // sites stay readable.
@@ -729,4 +734,43 @@ pub fn checkDiagRenderAll(xs: List<CheckDiagnostic>) -> String {
         parts.push(checkDiagRender(d))
     }
     strings.join(parts, "\n")
+}
+
+// ---------------------------------------------------------------------
+// v0.6 G36 — Capability annotation diagnostics.
+//
+// Spec: LANG_SPEC_v0.6/20-capabilities.md §20.3 / §20.8.
+// ---------------------------------------------------------------------
+
+/// diagAmbientWrongSite reports `#[ambient(...)]` applied to a function
+/// outside the entry-point set (script `main`, `fn main`, `#[test]`,
+/// `#[bench]`, `bench*`/`test_*`). Library code must receive capabilities
+/// as explicit parameters.
+pub fn diagAmbientWrongSite(fnName: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiagWithNotes(
+        checkCodeAmbientWrongSite(),
+        "`#[ambient]` is only allowed on entry-point functions, not on `{fnName}`",
+        start,
+        end,
+        [
+            "LANG_SPEC §20.3: ambient binding is restricted to scripts, `fn main`, `#[test]`, `#[bench]`, and `bench*`/`test_*` functions",
+            "hint: receive the needed capability (`Clock` / `Rng` / `Env` / `Fs` / `Net` / `Process` / `Console`) as an explicit parameter",
+        ],
+    )
+}
+
+/// diagAmbientUnknownCapability reports `#[ambient(name)]` referencing a
+/// name outside the canonical set (`clock`, `rng`, `env`, `fs`, `net`,
+/// `process`, `console`).
+pub fn diagAmbientUnknownCapability(name: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiagWithNotes(
+        checkCodeAmbientUnknownCapability(),
+        "`#[ambient({name})]` references an unknown capability",
+        start,
+        end,
+        [
+            "LANG_SPEC §20.6: canonical ambient names are `clock`, `rng`, `env`, `fs`, `net`, `process`, `console`",
+            "hint: pass user-defined capabilities as explicit parameters — ambient binding only supports stdlib prelude defaults",
+        ],
+    )
 }

--- a/toolchain/check_gates.osty
+++ b/toolchain/check_gates.osty
@@ -63,6 +63,7 @@ pub fn runCheckGates(cx: ElabCx) {
     runPrivilegeGate(cx)
     runNoAllocGate(cx)
     runPureGate(cx)
+    runAmbientGate(cx)
 }
 
 // ---------------------------------------------------------------------
@@ -1438,4 +1439,124 @@ fn pureCollectPatternBindings(arena: AstArena, patIdx: Int, out: List<String>) {
     for childIdx in pat.children {
         pureCollectPatternBindings(arena, childIdx, out)
     }
+}
+
+// ---------------------------------------------------------------------
+// E0780 / E0781 — `#[ambient(...)]` entry-point gate (G36, v0.6 §20.3).
+//
+// `#[ambient]` is restricted to entry-point fns:
+//   - `fn main`
+//   - functions carrying `#[test]` or `#[bench]`
+//   - functions whose name starts with `test_` or `bench_` / `bench` / `test`
+//
+// Library code must receive capabilities as explicit parameters; an
+// ambient binding outside the entry-point set is `E0780`. Each ambient
+// arg ident must be in the canonical set (`clock`/`rng`/`env`/`fs`/
+// `net`/`process`/`console`); foreign idents are `E0781`.
+// ---------------------------------------------------------------------
+
+fn runAmbientGate(cx: ElabCx) {
+    let arena = cx.ast.arena
+    for declIdx in arena.decls {
+        let node = astArenaNodeAt(arena, declIdx)
+        match node.kind {
+            AstNFnDecl -> checkAmbientFn(cx, arena, node),
+            AstNStructDecl -> checkAmbientMethods(cx, arena, node),
+            AstNEnumDecl -> checkAmbientMethods(cx, arena, node),
+            _ -> {},
+        }
+    }
+}
+
+fn checkAmbientMethods(cx: ElabCx, arena: AstArena, parent: AstNode) {
+    for memberIdx in parent.children {
+        let m = astArenaNodeAt(arena, memberIdx)
+        if m.kind == AstNFnDecl {
+            checkAmbientFn(cx, arena, m)
+        }
+    }
+}
+
+fn checkAmbientFn(cx: ElabCx, arena: AstArena, fn_: AstNode) {
+    if fn_.extra < 0 {
+        return
+    }
+    if !checkGateAnnotationContains(arena, fn_.extra, "ambient") {
+        return
+    }
+    let name = fn_.text
+    if !isAmbientEntryPoint(arena, fn_.extra, name) {
+        cx.env.local.diagnostics.push(diagAmbientWrongSite(name, fn_.start, fn_.end))
+    }
+    // Validate each ambient arg ident regardless of site — even on a
+    // legal entry point, an unknown capability name is `E0781`.
+    checkAmbientArgs(cx, arena, fn_.extra)
+}
+
+fn isAmbientEntryPoint(arena: AstArena, annotIdx: Int, fnName: String) -> Bool {
+    if fnName == "main" {
+        return true
+    }
+    if strings.startsWith(fnName, "test_") || strings.startsWith(fnName, "bench_") {
+        return true
+    }
+    if fnName == "test" || fnName == "bench" {
+        return true
+    }
+    if checkGateAnnotationContains(arena, annotIdx, "test") {
+        return true
+    }
+    if checkGateAnnotationContains(arena, annotIdx, "bench") {
+        return true
+    }
+    false
+}
+
+fn checkAmbientArgs(cx: ElabCx, arena: AstArena, annotIdx: Int) {
+    if annotIdx < 0 {
+        return
+    }
+    let node = astArenaNodeAt(arena, annotIdx)
+    if node.kind != AstNAnnotation {
+        return
+    }
+    if node.text == "ambient" {
+        validateAmbientArgs(cx, arena, node)
+        return
+    }
+    if node.text == "__group" {
+        for childIdx in node.children {
+            let child = astArenaNodeAt(arena, childIdx)
+            if child.kind == AstNAnnotation && child.text == "ambient" {
+                validateAmbientArgs(cx, arena, child)
+            }
+        }
+    }
+}
+
+fn validateAmbientArgs(cx: ElabCx, arena: AstArena, ambient: AstNode) {
+    for argIdx in ambient.children {
+        let arg = astArenaNodeAt(arena, argIdx)
+        // Annotation args are stored as `AstNAnnotation` children with
+        // their identifier text in `.text`. Whether stored as ident-only
+        // (bare flag) or `key = value`, the canonical capability name
+        // sits at `.text` for bare flag form (`#[ambient(clock, rng)]`).
+        let argName = arg.text
+        if argName == "" {
+            continue
+        }
+        if !isCanonicalAmbientName(argName) {
+            cx.env.local.diagnostics.push(diagAmbientUnknownCapability(argName, arg.start, arg.end))
+        }
+    }
+}
+
+fn isCanonicalAmbientName(name: String) -> Bool {
+    name == "clock"
+        || name == "rng"
+        || name == "env"
+        || name == "fs"
+        || name == "net"
+        || name == "process"
+        || name == "console"
 }


### PR DESCRIPTION
## Summary

Phase 1 진척. PR #1483 (annotation surface 등재) 의 *시맨틱* 후속 — 사용자 정의 `#[ambient]` 의 *위치* 와 *인자* 를 정적 검증.

## 구현

### 새 gate: `runAmbientGate` (`toolchain/check_gates.osty`)

`runCheckGates` 의 6번째 phase 로 등록. 모든 top-level fn / struct method / enum method 에서 `#[ambient]` presence 확인.

**위치 검사 (`E0780`)**:
- fn name `"main"` → OK
- fn name `test_*` / `bench_*` 시작 → OK
- fn name `"test"` / `"bench"` → OK
- 같은 declaration 에 `#[test]` 또는 `#[bench]` 부착 → OK
- 그 외 fn / method: `E0780` 발화

**인자 검사 (`E0781`)**:
- canonical set: `clock` / `rng` / `env` / `fs` / `net` / `process` / `console`
- 외부 이름: `E0781` 발화

위치 위반 + 인자 위반 양쪽 동시 가능 — 둘 다 발화.

### 새 진단 helper (`toolchain/check_diag.osty`)

- `checkCodeAmbientWrongSite()` → `"E0780"`
- `checkCodeAmbientUnknownCapability()` → `"E0781"`
- `checkCodeAmbientUserCapability()` → `"E0789"`
- `diagAmbientWrongSite(fnName, …)` — fix hint 로 explicit parameter 권장
- `diagAmbientUnknownCapability(name, …)` — canonical 7 이름 명시

## Spec / 호환성

- `E0780` / `E0781` 진단 코드는 `internal/diag/codes.go` 에 PR #1469 에서 이미 등재 — Go-side ↔ Osty-side 자동 동기
- 위치 / 인자 정책은 `LANG_SPEC_v0.6/20-capabilities.md §20.3 / §20.6` 그대로 따름
- 사용자 코드 영향: `#[ambient]` 부착 코드만 추가 검증. 기존 코드 0 회귀

## Files

- 2 files changed, 165 insertions
- 수정: `toolchain/check_gates.osty` (+114), `toolchain/check_diag.osty` (+51)

## Test plan

- [x] `osty check toolchain/check_gates.osty toolchain/check_diag.osty` exit 0
- [x] `go test ./internal/check/...` 통과
- [ ] spec corpus 회귀 케이스 (positive `#[ambient]` 통과 + negative `E0780` / `E0781`) — osty-self self-rebuild (Phase 0 마무리) 후 추가

## Phase 1 status

| 항목 | 상태 | PR |
|---|---|---|
| v0.6 capability protocols | ✅ | #1479 |
| Host capability adapters | ✅ | #1486 |
| 20 v0.6 어노테이션 surface 등록 | ✅ | #1483 |
| **`#[ambient]` 시맨틱 검사 (E0780/E0781)** | 🟢 | **본 PR** |
| `#[ambient]` desugar (default instance binding) | ⚪ | 다음 |
| stdlib `time.now()` → `clock.now()` rewrite | ⚪ | |
| `--legacy-globals` 호환 모드 | ⚪ | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_