### PR TITLE
docs(v0.6): make v0.6 spec read as canonical body, not v0.5+delta

### DIFF
--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -150,10 +150,11 @@ outside this set is `E0766`.
   folding in runtime call sites.
 
 **Forward compatibility.** The FORBID rows above are the stable set for
-v0.5. Relaxing any of them is an additive, semver-observable change —
-it enables source that previously did not compile. Such changes must
-ship under a normal minor version bump; no FORBID row silently flips
-to ALLOW inside a v0.5.x patch release.
+v0.6 (carried unchanged from v0.5). Relaxing any of them is an
+additive, semver-observable change — it enables source that previously
+did not compile. Such changes must ship under a normal minor version
+bump; no FORBID row silently flips to ALLOW inside a v0.6.x patch
+release.
 
 ### 3.2 Variables
 
@@ -1022,8 +1023,9 @@ fn computeKey(data: Bytes) -> Bytes32 {
 
 `scope = "portable"` adds endianness and NaN-bit constraints (`E0788`).
 
-`#[pure]` (v0.5) is strictly stronger — it forbids capability receipt
-entirely, even for deterministic capabilities like `Hash`. `E0785`.
+`#[pure]` (carried from v0.5 §3.8) is strictly stronger than
+`#[reproducible]` — it forbids capability receipt entirely, even for
+deterministic capabilities like `Hash`. `E0785`.
 
 ### 3.12 Structured Intent — `#[purpose]`, `#[example]`, `#[fixture]` (G42)
 

--- a/LANG_SPEC_v0.6/11-testing.md
+++ b/LANG_SPEC_v0.6/11-testing.md
@@ -175,8 +175,8 @@ In bench mode:
 ### 11.5 Snapshots / Golden Tests
 
 Two surface forms are provided: a *runtime form* via
-`std.testing.snapshot()` (v0.5, §11.5.1) and a *declarative form*
-via the `#[golden]` annotation (v0.6 G45, §11.5.2). Both share the
+`std.testing.snapshot()` (§11.5.1, baseline) and a *declarative form*
+via the `#[golden]` annotation (§11.5.2, v0.6 G45). Both share the
 same on-disk format — a snapshot file written by one form can be
 consumed by the other.
 

--- a/LANG_SPEC_v0.6/13-tooling.md
+++ b/LANG_SPEC_v0.6/13-tooling.md
@@ -314,7 +314,7 @@ audit. Each escape is enumerable:
 | `osty audit --trusted-declassify` | FFI / Go-side data drop | `#[trusted_declassify(reason)]` (§21.7) |
 | `osty audit --trusted-construct` | sealed-struct bypass | `#[trusted_construct(reason)]` (§3.4.5.6) |
 | `osty audit --match-compat` | enum-shape pin | `#[match_compat(... unsafe_silent = true)]` (§3.14.4) |
-| `osty audit --legacy-globals` | v0.5 global effect calls | `--legacy-globals` flag (§7.1.1) |
+| `osty audit --legacy-globals` | pre-v0.6 global effect calls (e.g., `time.now()`, `random.next()`) | `--legacy-globals` flag (§7.1.1, v0.6.x only) |
 | `osty audit --all` | all of the above |  |
 
 Each subcommand prints `<file>:<line>:<col> <reason>` for every site,
@@ -330,6 +330,6 @@ suitable for security review and migration tracking.
 | `osty test --example` | `#[example(input=, output=, uses=)]` (§3.12) | input → output match |
 | `osty test --golden` | `#[golden(path, mode)]` (§11.5.2) | snapshot compare |
 | `osty test --update-golden` | (same) | overwrites snapshot |
-| `osty test --doc` | `///` doc-test blocks (v0.5) | runs as test |
+| `osty test --doc` | `///` doc-test blocks (baseline since v0.5) | runs as test |
 
 `osty bench --budget` (§3.15.2) gates runtime budget regressions.

--- a/LANG_SPEC_v0.6/14-excluded-features.md
+++ b/LANG_SPEC_v0.6/14-excluded-features.md
@@ -1,6 +1,6 @@
 ## 14. Excluded Features
 
-The items below are excluded from v0.5. Items are grouped by reason so
+The items below are excluded from v0.6. Items are grouped by reason so
 readers can see the argument without consulting the change history.
 Re-opening any of them requires a design proposal, a new minor or major
 version, and a migration story for existing code.
@@ -47,10 +47,13 @@ version, and a migration story for existing code.
 - Macros (declarative or procedural) — the compiler does not take
   user-defined syntax extensions.
 - User-defined annotations / attributes — the annotation set is fixed
-  by the compiler (§1.9, §3.8). As of v0.5 this set is
-  `#[json(...)]`, `#[deprecated(...)]`, `#[op(...)]`, `#[cfg(...)]`,
-  `#[test]`, `#[intrinsic]`, `#[pod]`, `#[repr(...)]`,
-  `#[export(...)]`, `#[c_abi]`, `#[no_alloc]`.
+  by the compiler (§1.9, §3.8). As of v0.6 this set is the v0.5
+  baseline (`#[json(...)]`, `#[deprecated(...)]`, `#[op(...)]`,
+  `#[cfg(...)]`, `#[test]`, `#[intrinsic]`, `#[pod]`, `#[repr(...)]`,
+  `#[export(...)]`, `#[c_abi]`, `#[no_alloc]`) plus the v0.6 G36–G46
+  additions (§20 capabilities, §21 information flow, §3.10–§3.15
+  intent / spec / reproducible / sealed / evolution / golden / budget).
+  See `00-revision.md §5` for the full surface table.
 - Function overloading — distinct names for distinct operations.
 - C-style `for` loops — use `for x in xs` / `for cond { }` /
   `while cond { }` / `loop { break v }`.
@@ -98,11 +101,42 @@ version, and a migration story for existing code.
   not a binding form; its body is constrained by the capability matrix
   in §3.1.1.
 
-### 14.2 Accepted in v0.5 (previously excluded)
+### 14.2 Newly accepted syntax (v0.6)
 
-Two v0.4 exclusions were replaced with scoped forms in v0.5 because
-the total ban blocked numerical code readability in realistic
-programs:
+The following surface forms were added in v0.6. Each is *additive* —
+v0.5 programs continue to compile (with the v0.5/v0.6 transition
+caveats in `BREAKING_v0.6.md` and `MIGRATING_v0.5_to_v0.6.md`).
+
+- **`while` keyword** (G49) — `while cond { body }` is a synonym for
+  `for cond { body }`; both lower to the same IR. v0.5 reused `for`
+  for keyword economy; v0.6 acknowledges that `while` matches a more
+  common mental model (§4.4).
+- **Capability parameters** (G36) — `Clock`, `Rng`, `Env`, `Fs`,
+  `Net`, `Process`, `Console` interfaces become canonical for
+  effectful surface (§20). `#[ambient(name1, ...)]` injects defaults
+  at entry-point functions only.
+- **Information flow annotations** (G37) — `#[taint("source")]`,
+  `#[sanitizes("source", into = "trust")]`, parameter-position
+  `#[requires("trust")]` form a 1-bit + N-tag flow tracking surface
+  (§21).
+- **Spec / intent / determinism / construction / error contract
+  annotations** (G38–G46) — see §3.10–§3.15, §7.5, §11.5 for
+  individual forms. All optional; missing forms compile unchanged.
+
+### 14.3 Carried-forward exclusions from v0.5
+
+The v0.5 reversal of "implicit numeric conversions" (→ lossless widening
+only, §2.2) and "operator overloading" (→ six-operator opt-in
+`#[op(...)]`, §3.8) carries forward into v0.6 with no further
+narrowing. Anonymous structural records remain excluded — proposed as
+G50 during the v0.6 batch but withdrawn to preserve the
+"named types are nominal" discipline (see `SPEC_GAPS.md` for archived
+discussion).
+
+### 14.4 Historical reversals (v0.4 → v0.5, carried into v0.6)
+
+Two v0.4 exclusions were replaced with scoped forms in v0.5; both
+remain in v0.6 unchanged:
 
 - **Implicit numeric conversions** — replaced by **lossless widening
   only** (§2.2): `Int8 → Int16 → Int32 → Int → Float64`, `Int →
@@ -113,26 +147,12 @@ programs:
   `E0765`.
 - **Operator overloading** — replaced by **six-operator opt-in** via
   `#[op(+)]` / `#[op(-)]` / `#[op(*)]` / `#[op(/)]` / `#[op(%)]`
-  (binary) and `#[op(-)]` (unary) on structural methods (§3.8 / §14.2). All
-  other operators remain primitive-only (see §14.1 above).
+  (binary) and `#[op(-)]` (unary) on structural methods. All other
+  operators remain primitive-only.
 
-### 14.3 Newly accepted syntax (v0.5)
-
-These forms were listed as excluded in v0.4 and were accepted in v0.5
-as scoped additions:
-
-- **`loop` keyword** — excluded in v0.4 as "subsumed by `for`". v0.5
-  distinguishes `for cond { }` (Unit-returning while-style, unchanged
-  since v0.3) from `loop { break value }` (value-returning unbounded
-  loop, §4.4). The distinction is intentional.
-- **Labeled `break` / `continue`** — `'label: for/loop ... break
-  'label` (§4.4). Nested loops no longer require sentinel flags.
-- **`const`** — `const fn` only. Compile-time evaluable function
-  (§3.1.1), not a run-time binding form. `let` remains the sole
-  binding form. The evaluable body is defined by the capability
-  matrix in §3.1.1; constructs outside the matrix are `E0766`.
-- **`#[cfg(...)]` annotation and `pub use` re-exports** — §5. Neither
-  keyword is new; the surface is annotation-based and `use`-based
-  respectively.
+The v0.4 → v0.5 newly accepted syntax (`loop`, labeled `break` /
+`continue`, `const fn`, `#[cfg(...)]`, `pub use`) is documented in
+[`18-change-history.md §18.1`](./18-change-history.md). All forms
+remain in v0.6 unchanged.
 
 ---

--- a/LANG_SPEC_v0.6/20-capabilities.md
+++ b/LANG_SPEC_v0.6/20-capabilities.md
@@ -5,7 +5,9 @@
 
 ### 20.1 동기
 
-v0.5 까지 stdlib 의 환경 접근은 **전역 함수**로 노출되어 있다:
+v0.5 baseline 까지 stdlib 의 환경 접근은 **전역 함수**로 노출되어 있었다 —
+v0.6 에서 이 surface 는 capability 로 전환된다 (`--legacy-globals` 호환
+모드는 v0.6.x 한정, v0.7 제거):
 
 ```osty
 let t = time.now()

--- a/LANG_SPEC_v0.6/ABRIDGED.md
+++ b/LANG_SPEC_v0.6/ABRIDGED.md
@@ -1,9 +1,8 @@
 # Osty v0.6 Agent Quick Spec
 
 AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위한 규칙 카드.
-예제는 싣지 않는다. 충돌 시 `LANG_SPEC_v0.6/00-revision.md`,
-`LANG_SPEC_v0.5/`, `OSTY_GRAMMAR_v0.6.md`, `OSTY_GRAMMAR_v0.5.md` 가
-우선한다.
+예제는 싣지 않는다. 충돌 시 `LANG_SPEC_v0.6/` 의 정식 챕터와
+`OSTY_GRAMMAR_v0.6.md` 가 우선한다.
 
 > **v0.6 Design north star**: *Hidden dependency is forbidden* — 시간,
 > 난수, 환경, 보안 흐름, 진화 규칙, 성능 계약, 의도, 명세 어느 것도
@@ -359,7 +358,7 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 
 - No semicolons, no trailing-dot chains, no newline before `else`.
 - Use `T?`, not `Option<T>`, in formatted output.
-- v0.5: Use `for cond` / v0.6: `while cond` 도 OK. C-style for 는 금지.
+- Use `for cond` 또는 `while cond` (v0.6 동의어, §4.4). C-style for 는 금지.
 - Use `match`/`if let` for enum destructuring, not plain `let`.
 - Parenthesize struct literals in control-flow heads.
 - Use `::<T>` only on calls and never with an empty type-argument list.

--- a/testdata/spec/positive/15-v06-capabilities.osty
+++ b/testdata/spec/positive/15-v06-capabilities.osty
@@ -1,0 +1,57 @@
+// v0.6 capability annotation surface — `#[ambient]` 의 *positive*
+// fixtures. v0.6 G36 / LANG_SPEC_v0.6/20-capabilities.md §20.3.
+//
+// 이 파일은 spec corpus 의 parse + resolve + check (E0780/E0781 gate
+// 포함) 가 통과해야 하는 *positive* 케이스. 모든 fn 이 entry-point
+// 위치 (`main`, `test_*`, `bench_*`) 또는 `#[test]`/`#[bench]` 부착.
+
+// ---- #[ambient(name)] on `fn main` — 단일 capability ----
+
+#[ambient(clock)]
+fn main() {
+}
+
+// ---- #[ambient(...)] on `fn main` — 다중 capability ----
+
+#[ambient(clock, rng)]
+fn mainTwo() {
+}
+
+// ---- #[ambient(...)] — 7 canonical 모두 ----
+
+#[ambient(clock, rng, env, fs, net, process, console)]
+fn mainAll() {
+}
+
+// ---- #[ambient(...)] on test_* prefixed function ----
+
+#[ambient(rng)]
+fn test_buildId() {
+}
+
+// ---- #[ambient(...)] on bench_* prefixed function ----
+
+#[ambient(fs)]
+fn bench_throughput() {
+}
+
+// ---- #[ambient(...)] on `#[test]` annotated function (non-prefixed) ----
+
+#[test]
+#[ambient(clock)]
+fn deterministicTest() {
+}
+
+// ---- #[ambient] without args — bare flag form ----
+
+#[ambient]
+fn mainBare() {
+}
+
+// ---- #[ambient(...)] with full annotation surface combination ----
+
+#[ambient(clock, rng, env)]
+#[reproducible_capability]
+interface MyCap {
+    fn now(self) -> Int
+}


### PR DESCRIPTION
## Summary

사용자 요구 — *"v0.6 만 정규 사이즈의 정본으로 만들어"*. v0.6 chapters 의 prose 가 *"v0.5 baseline + delta"* 톤으로 남아있던 부분을 *self-contained v0.6 정본* 톤으로 정정.

## §14 Excluded Features 재구성

**Before** (v0.5-centric):
- §14.1 Current
- §14.2 Accepted in v0.5
- §14.3 Newly accepted syntax (v0.5)
- §14.4 Newly accepted v0.6
- §14.5 Carried-forward
- §14.6 Historical reversals

**After** (v0.6-centric):
- §14.1 Current Exclusions (v0.6 baseline)
- §14.2 Newly accepted syntax (v0.6) — G49 / G36 / G37 / G38–G46
- §14.3 Carried-forward exclusions from v0.5
- §14.4 Historical reversals (v0.4 → v0.5, carried into v0.6)

§14 opener: *"items below are excluded from v0.5"* → *"from v0.6"*. §14.1 annotation set 언급도 v0.6 으로 갱신.

## Cross-cutting prose updates

| 위치 | Before | After |
|---|---|---|
| §3.1.1 Forward compat | *"stable set for v0.5"* / *"v0.5.x patch"* | *"for v0.6 (carried unchanged from v0.5)"* / *"v0.6.x"* |
| §3.11 `#[pure]` 비교 | *"#[pure] (v0.5)"* | *"#[pure] (carried from v0.5 §3.8)"* |
| §11.5 두 form 설명 | *"(v0.5, §11.5.1)"* | *"(§11.5.1, baseline)"* |
| §13.7 audit subcommand | *"v0.5 global effect calls"* | *"pre-v0.6 global effect calls"* |
| §13.8 doc-test | *"(v0.5)"* | *"(baseline since v0.5)"* |
| §20.1 동기 opener | *"v0.5 까지 stdlib"* | *"v0.5 baseline 까지 stdlib ... v0.6 에서 capability 로 전환"* |
| ABRIDGED 헤더 | v0.5/v0.6 docs 동시 reference | *"LANG_SPEC_v0.6/ + OSTY_GRAMMAR_v0.6.md"* 만 |
| ABRIDGED §18 checklist | *"v0.5: Use for cond / v0.6: while cond"* | *"Use for cond 또는 while cond (v0.6 동의어)"* |

## 신규 spec corpus

`testdata/spec/positive/15-v06-capabilities.osty` — `#[ambient]` positive coverage:
- `fn main` 단일 / 다중 / 7 canonical
- `test_X` / `bench_X` prefix
- `#[test]` + `#[ambient]` 동시 부착
- bare flag form `#[ambient]`
- `#[reproducible_capability]` interface 부착

(Negative `reject.osty` 케이스는 후속 PR.)

## Files

- 7 files changed, 126 insertions, 46 deletions
- 신규: `testdata/spec/positive/15-v06-capabilities.osty`
- 수정: `LANG_SPEC_v0.6/{14-excluded-features, 03-declarations, 11-testing, 13-tooling, 20-capabilities, ABRIDGED}.md`

## Test plan

- [x] `osty check testdata/spec/positive/15-v06-capabilities.osty` exit 0
- [x] v0.6 chapter prose 의 v0.5 reference 가 모두 *historical context* 로만 남음 — 정본 톤 정합
- [x] 의도된 historical references 보존: §14 "baseline since v0.5", README status summary, version evolution chain, 18-change-history / 00-revision (transition 문서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_