### PR TITLE
[codex] add v0.6 capability test fakes

### DIFF
--- a/CHANGELOG_v0.6.md
+++ b/CHANGELOG_v0.6.md
@@ -47,6 +47,7 @@ rationale.
 |---|---|---|
 | `Clock` / `Rng` / `Env` / `Fs` / `Net` / `Process` / `Console` interface | **partial** | `std.capability` 에 7 canonical protocol surface 추가. `std.random.Rng.next/nextBytes` alias와 `examples/v06_capabilities` front-end proof 포함. |
 | Host capability adapter factories | **partial** | `time.systemClock`, `random.host`, `env.host`, `fs.host`, `capability.hostNet`, `capability.hostProcess`, `io.console` 를 추가하고 `examples/v06_capability_adapters` 로 front-end/type-check proof 추가. `net.host` / `process.host` bridge factory 는 cross-module migration helper 로 제공. |
+| Deterministic capability test fakes | **partial** | `std.capability.testing` 에 `FakeClock` / `FakeRng` / `FakeEnv` / `FakeFs` / `FakeNet` / `FakeProcess` / `FakeConsole` 추가. `examples/v06_capability_fakes` 로 fake injection proof 추가. |
 | `#[ambient(...)]` annotation | **planned** | script / main / test entry 에서만 |
 | `#[reproducible_capability]` annotation | **planned** | 사용자 정의 deterministic capability |
 | `--legacy-globals` 호환 모드 | **planned** | v0.6.x 에서만, v0.7 제거 |

--- a/LANG_SPEC_v0.6/10-standard-library/README.md
+++ b/LANG_SPEC_v0.6/10-standard-library/README.md
@@ -66,3 +66,5 @@ Capability protocols (`std.capability`) are specified in
 typing and ambient injection as well as stdlib shape.
 The current stdlib also exposes host-boundary adapter factories for the
 canonical capability set; see §20 for the exact list and migration status.
+`std.capability.testing` contains deterministic fake implementations for
+capability-injected tests.

--- a/LANG_SPEC_v0.6/20-capabilities.md
+++ b/LANG_SPEC_v0.6/20-capabilities.md
@@ -75,6 +75,8 @@ pub interface Process {
 factory 는 현재 `time.systemClock()`, `random.host()`, `env.host()`, `fs.host()`,
 `capability.hostNet()`, `capability.hostProcess()`, `io.console()` 로 노출하며,
 `std.net.host()` / `std.process.host()` 는 cross-module bridge helper 로 제공한다.
+테스트용 deterministic fake set 은 `std.capability.testing` 의 `FakeClock`,
+`FakeRng`, `FakeEnv`, `FakeFs`, `FakeNet`, `FakeProcess`, `FakeConsole` 로 제공한다.
 Ambient desugar / `--legacy-globals` warning 은 별도 compiler phase 에서 닫는다.
 
 함수는 capability 를 **명시적 파라미터**로 받는다:

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -28,7 +28,7 @@ Osty 표준 라이브러리 모듈별 실행 가능성 / 스펙 정합 매트릭
 - **⭐⭐ Spec-stub**: spec 있고 declaration-only인데 **백엔드 미구현** (호출 시 LLVM emit 실패 위험)
 - **⭐ Broken / Placeholder**: 본문이 무동작이거나 spec 위반
 
-## 2. 모듈 매트릭스 (99 + 8 sub = 107 파일)
+## 2. 모듈 매트릭스 (99 + 9 sub = 108 파일)
 
 표 항목:
 - **spec**: LANG_SPEC v0.5 챕터 (없으면 `—`)
@@ -222,6 +222,7 @@ partial 모듈 3개 (crypto / option / result) 는 **호출 패턴 한정 동작
 | 모듈 | spec | LOC | 비고 |
 |---|---|---|---|
 | capability | §20 | 177 | v0.6 canonical `Clock` / `Rng` / `Env` / `Fs` / `Net` / `Process` / `Console` interface surface, migration rules, exact `HostNet` / `HostProcess` adapters. `examples/v06_capabilities` + `examples/v06_capability_adapters` front-end/type-check proof. Ambient/legacy-global compiler semantics remain Phase 1 follow-up. |
+| capability.testing | §20 | 445 | deterministic `FakeClock` / `FakeRng` / `FakeEnv` / `FakeFs` / `FakeNet` / `FakeProcess` / `FakeConsole` helpers for capability-injected tests. `examples/v06_capability_fakes` front-end/type-check proof. |
 | cmp | §10.1 | 27 | Equal / Ordered / Hashable interface 정의. 컴파일러 인지 |
 | error | §10.1 / §7 | 96 | Error interface + BasicError + WrappedError + wrap/chain/rootCause |
 | ref | §10.1 | 9 | `same<T>(a, b)` 단일 함수, declaration-only — 컴파일러 intrinsic 가정 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,8 @@ the compiler evolves.
   parameters with deterministic fakes and stdlib protocol helpers.
 - `v06_capability_adapters`: v0.6 host-boundary adapter catalog showing how
   existing global stdlib modules become explicit capability values.
+- `v06_capability_fakes`: deterministic `std.capability.testing` fakes for
+  testing APIs that accept explicit v0.6 capability parameters.
 - `stdlib-tour`: front-end checked package that demonstrates Tier 1
   standard-library imports and Result-style error flow.
 - `gui-webview2-inspector`: Windows WebView2 GUI example using

--- a/examples/v06_capability_fakes/lib.osty
+++ b/examples/v06_capability_fakes/lib.osty
@@ -1,0 +1,45 @@
+use std.capability as cap
+use std.capability.testing as fake
+use std.net
+use std.testing
+pub fn buildReport(clock: cap.Clock, rng: cap.Rng, env: cap.Env, fs: cap.Fs, console: cap.Console) -> Result<String, Error> {
+    let name = env.require("APP_NAME")?
+    let body = fs.readToString("/config/app.txt")?
+    let ticket = rng.int(100, 200)
+    let stamp = clock.monotonic().millis()
+    console.println("loaded {name}")
+    Ok("{name}:{body}:{ticket}:{stamp}")
+}
+pub fn hostSnapshot(netcap: cap.Net, process: cap.Process) -> Result<String, Error> {
+    let addrs = netcap.resolveAll("example.test")?
+    let out = process.exec("hostname", [])?
+    Ok("{addrs.len()}:{out.stdout}")
+}
+pub fn fakeRuntimeReport() -> Result<String, Error> {
+    let runtime = fake.runtime()
+    let env = runtime.env.withVar("APP_NAME", "demo")
+    let fs = runtime.fs.withFile("/config/app.txt", "ready")
+    let rng = runtime.rng.withBool(false)
+    buildReport(runtime.clock, rng, env, fs, runtime.console)
+}
+pub fn fakeHostSnapshot() -> Result<String, Error> {
+    let resolved = net.Addr
+    {host: "127.0.0.1", port: 443}
+    let netcap = fake.network().withAddr("example.test", resolved)
+    let proc = fake.process().withStdout("test-host")
+    hostSnapshot(netcap, proc)
+}
+fn testBuildReportUsesOnlyInjectedCapabilities() {
+    let clock = fake.clock(123000000, 250000000)
+    let rng = fake.rng([41])
+    let env = fake.env().withVar("APP_NAME", "demo")
+    let fs = fake.fs().withFile("/config/app.txt", "ready")
+    let console = fake.console()
+    testing.assertEq(buildReport(clock, rng, env, fs, console).unwrap(), "demo:ready:141:250")
+}
+fn testFakeHostSnapshotAvoidsRealNetworkAndProcess() {
+    testing.assertEq(fakeHostSnapshot().unwrap(), "1:test-host")
+}
+fn testFakeCatalog() {
+    testing.assertEq(fake.fakeNames().len(), 7)
+}

--- a/examples/v06_capability_fakes/osty.toml
+++ b/examples/v06_capability_fakes/osty.toml
@@ -1,0 +1,7 @@
+[package]
+name = "v06_capability_fakes"
+version = "0.1.0"
+edition = "0.5"
+description = "v0.6 deterministic capability fake example."
+
+[dependencies]

--- a/internal/stdlib/capability_testing_test.go
+++ b/internal/stdlib/capability_testing_test.go
@@ -1,0 +1,80 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCapabilityTestingModuleExposesFakes(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["capability.testing"]
+	if mod == nil {
+		t.Fatal("stdlib capability.testing module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		"pub struct FakeClock",
+		"pub struct FakeRng",
+		"pub struct FakeEnv",
+		"pub struct FakeFs",
+		"pub struct FakeNet",
+		"pub struct FakeProcess",
+		"pub struct FakeConsole",
+		"pub struct FakeRuntime",
+		"pub fn runtime() -> FakeRuntime",
+		"pub fn fakeNames() -> List<String>",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("capability.testing source missing %q", want)
+		}
+	}
+}
+
+func TestCapabilityTestingFakesExposeInterfaceMethods(t *testing.T) {
+	reg := LoadCached()
+	for _, tc := range []struct {
+		typeName string
+		methods  []string
+	}{
+		{"FakeClock", []string{"now", "monotonic", "sleep", "set", "advance", "withElapsed", "rejectSleep"}},
+		{"FakeRng", []string{"next", "nextBytes", "int", "intInclusive", "float", "bool", "bytes", "withBytes", "withFloat", "withBool"}},
+		{"FakeEnv", []string{"args", "get", "require", "set", "unset", "vars", "currentDir", "setCurrentDir", "withArg", "withVar", "withCwd"}},
+		{"FakeFs", []string{"read", "readToString", "write", "writeString", "exists", "walk", "glob", "create", "remove", "rename", "copy", "mkdir", "mkdirAll", "withFile", "withBytes", "withDir"}},
+		{"FakeNet", []string{"resolve", "resolveAll", "lookup", "lookupAddr", "connect", "connectTimeout", "listen", "withAddr", "withLookup", "withReverse"}},
+		{"FakeProcess", []string{"pid", "hostname", "command", "commandArgs", "shell", "run", "exec", "withPid", "withHostname", "withOutput", "withStdout", "withTimeout"}},
+		{"FakeConsole", []string{"print", "println", "eprint", "eprintln", "readLine", "writer", "withInput", "stdoutText", "stderrText"}},
+	} {
+		for _, method := range tc.methods {
+			if got := reg.LookupMethodDecl("capability.testing", tc.typeName, method); got == nil {
+				t.Fatalf("LookupMethodDecl(capability.testing, %s, %s) = nil", tc.typeName, method)
+			}
+		}
+	}
+}
+
+func TestCapabilityTestingFactoriesAreBodied(t *testing.T) {
+	reg := LoadCached()
+	for _, name := range []string{
+		"instant",
+		"duration",
+		"clock",
+		"clockAt",
+		"rng",
+		"defaultRng",
+		"env",
+		"fs",
+		"network",
+		"process",
+		"console",
+		"runtime",
+		"fakeNames",
+	} {
+		fn := reg.LookupFnDecl("capability.testing", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(capability.testing, %s) = nil", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("capability.testing.%s body = nil, want Osty helper body", name)
+		}
+	}
+}

--- a/internal/stdlib/modules/capability/testing.osty
+++ b/internal/stdlib/modules/capability/testing.osty
@@ -1,0 +1,445 @@
+// std.capability.testing - deterministic capability fakes for v0.6 tests.
+//
+// These helpers are intentionally pure Osty values. They let examples,
+// stdlib modules, and user packages test APIs that accept the canonical
+// v0.6 capability interfaces without touching the host clock, environment,
+// filesystem, network, process table, or console.
+use std.bytes
+use std.error
+use std.io
+use std.net
+use std.os
+use std.process as proc
+use std.strings
+use std.time
+pub struct FakeClock {
+    pub current: time.Instant,
+    pub elapsed: time.Duration,
+    pub slept: List<time.Duration> = [],
+    pub failSleep: Bool = false,
+    pub fn now(self) -> time.Instant {
+        self.current
+    }
+    pub fn monotonic(self) -> time.Duration {
+        self.elapsed
+    }
+    pub fn sleep(mut self, duration: time.Duration) -> Result<(), Error> {
+        if self.failSleep {
+            return Err(error.new("capability.testing.clock: sleep rejected"))
+        }
+        self.slept.push(duration)
+        Ok(())
+    }
+    pub fn set(mut self, instant: time.Instant) -> FakeClock {
+        self.current = instant
+        self
+    }
+    pub fn advance(mut self, duration: time.Duration) -> FakeClock {
+        self.current = self.current.add(duration)
+        self.elapsed = time.Duration
+        {nanoseconds: self.elapsed.nanoseconds + duration.nanoseconds}
+        self
+    }
+    pub fn withElapsed(mut self, duration: time.Duration) -> FakeClock {
+        self.elapsed = duration
+        self
+    }
+    pub fn rejectSleep(mut self) -> FakeClock {
+        self.failSleep = true
+        self
+    }
+}
+pub fn instant(unixNanos: Int64) -> time.Instant {
+    time.Instant
+    {unixNanos: unixNanos}
+}
+pub fn duration(nanos: Int64) -> time.Duration {
+    time.Duration
+    {nanoseconds: nanos}
+}
+pub fn clock(unixNanos: Int64, elapsedNanos: Int64) -> FakeClock {
+    FakeClock {current: instant(unixNanos), elapsed: duration(elapsedNanos)}
+}
+pub fn clockAt(unixNanos: Int64) -> FakeClock {
+    clock(unixNanos, 0)
+}
+pub struct FakeRng {
+    pub values: List<Int> = [],
+    pub cursor: Int = 0,
+    pub bytePattern: String = "x",
+    pub floatValue: Float = 0.5,
+    pub boolValue: Bool = true,
+    fn take(mut self) -> Int {
+        if self.values.isEmpty() {
+            return 0
+        }
+        let idx = self.cursor % self.values.len()
+        self.cursor = self.cursor + 1
+        self.values[idx]
+    }
+    pub fn next(mut self) -> Int {
+        self.take()
+    }
+    pub fn nextBytes(self, n: Int) -> Bytes {
+        self.bytes(n)
+    }
+    pub fn int(mut self, min: Int, max: Int) -> Int {
+        if max <= min {
+            return min
+        }
+        let span = max - min
+        let raw = self.take().abs()
+        min + (raw % span)
+    }
+    pub fn intInclusive(mut self, min: Int, max: Int) -> Int {
+        if max <= min {
+            return min
+        }
+        let span = max - min + 1
+        let raw = self.take().abs()
+        min + (raw % span)
+    }
+    pub fn float(self) -> Float {
+        self.floatValue
+    }
+    pub fn bool(self) -> Bool {
+        self.boolValue
+    }
+    pub fn bytes(self, n: Int) -> Bytes {
+        if n <= 0 || self.bytePattern.isEmpty() {
+            return bytes.fromString("")
+        }
+        bytes.repeat(bytes.fromString(self.bytePattern), n)
+    }
+    pub fn withBytes(mut self, pattern: String) -> FakeRng {
+        self.bytePattern = pattern
+        self
+    }
+    pub fn withFloat(mut self, value: Float) -> FakeRng {
+        self.floatValue = value
+        self
+    }
+    pub fn withBool(mut self, value: Bool) -> FakeRng {
+        self.boolValue = value
+        self
+    }
+}
+pub fn rng(values: List<Int>) -> FakeRng {
+    FakeRng {values: values}
+}
+pub fn defaultRng() -> FakeRng {
+    rng([])
+}
+pub struct FakeEnv {
+    pub argv: List<String> = [],
+    pub values: Map<String, String> = {:},
+    pub cwd: String = "/",
+    pub fn args(self) -> List<String> {
+        self.argv
+    }
+    pub fn get(self, name: String) -> String? {
+        self.values.get(name)
+    }
+    pub fn require(self, name: String) -> Result<String, Error> {
+        match self.get(name) {
+            Some(value) -> Ok(value),
+            None -> Err(error.new("capability.testing.env: missing {name}")),
+        }
+    }
+    pub fn set(mut self, name: String, value: String) -> Result<(), Error> {
+        self.values.insert(name, value)
+        Ok(())
+    }
+    pub fn unset(mut self, name: String) -> Result<(), Error> {
+        self.values.remove(name)
+        Ok(())
+    }
+    pub fn vars(self) -> Map<String, String> {
+        self.values
+    }
+    pub fn currentDir(self) -> Result<String, Error> {
+        Ok(self.cwd)
+    }
+    pub fn setCurrentDir(mut self, path: String) -> Result<(), Error> {
+        if path.isEmpty() {
+            return Err(error.new("capability.testing.env: cwd is empty"))
+        }
+        self.cwd = path
+        Ok(())
+    }
+    pub fn withArg(mut self, arg: String) -> FakeEnv {
+        self.argv.push(arg)
+        self
+    }
+    pub fn withVar(mut self, name: String, value: String) -> FakeEnv {
+        self.values.insert(name, value)
+        self
+    }
+    pub fn withCwd(mut self, path: String) -> FakeEnv {
+        self.cwd = path
+        self
+    }
+}
+pub fn env() -> FakeEnv {
+    FakeEnv {}
+}
+pub struct FakeFs {
+    pub files: Map<String, Bytes> = {:},
+    pub dirs: Map<String, Bool> = {:},
+    pub fn read(self, path: String) -> Result<Bytes, Error> {
+        match self.files.get(path) {
+            Some(data) -> Ok(data),
+            None -> Err(error.new("capability.testing.fs: not found: {path}")),
+        }
+    }
+    pub fn readToString(self, path: String) -> Result<String, Error> {
+        (self.read(path)?).toString()
+    }
+    pub fn write(mut self, path: String, contents: Bytes) -> Result<(), Error> {
+        if path.isEmpty() {
+            return Err(error.new("capability.testing.fs: path is empty"))
+        }
+        self.files.insert(path, contents)
+        Ok(())
+    }
+    pub fn writeString(mut self, path: String, contents: String) -> Result<(), Error> {
+        self.write(path, bytes.fromString(contents))
+    }
+    pub fn exists(self, path: String) -> Bool {
+        self.files.get(path).isSome() || (self.dirs.get(path) ?? false)
+    }
+    pub fn walk(self, root: String) -> Result<List<String>, Error> {
+        let mut out: List<String> = []
+        for dir in self.dirs.keys().sorted() {
+            if underRoot(dir, root) {
+                out.push("{dir}/")
+            }
+        }
+        for path in self.files.keys().sorted() {
+            if underRoot(path, root) {
+                out.push(path)
+            }
+        }
+        Ok(out)
+    }
+    pub fn glob(self, pattern: String) -> Result<List<String>, Error> {
+        if pattern == "*" || pattern == "**" {
+            return Ok(self.files.keys().sorted())
+        }
+        if self.exists(pattern) {
+            Ok([pattern])
+        } else {
+            Ok([])
+        }
+    }
+    pub fn create(mut self, path: String) -> Result<(), Error> {
+        self.write(path, bytes.fromString(""))
+    }
+    pub fn remove(mut self, path: String) -> Result<(), Error> {
+        self.files.remove(path)
+        self.dirs.remove(path)
+        Ok(())
+    }
+    pub fn rename(mut self, from: String, to: String) -> Result<(), Error> {
+        let data = self.read(from)?
+        self.files.remove(from)
+        self.files.insert(to, data)
+        Ok(())
+    }
+    pub fn copy(mut self, from: String, to: String) -> Result<(), Error> {
+        let data = self.read(from)?
+        self.files.insert(to, data)
+        Ok(())
+    }
+    pub fn mkdir(mut self, path: String) -> Result<(), Error> {
+        self.dirs.insert(strings.trimSuffix(path, "/"), true)
+        Ok(())
+    }
+    pub fn mkdirAll(mut self, path: String) -> Result<(), Error> {
+        self.mkdir(path)
+    }
+    pub fn withFile(mut self, path: String, contents: String) -> FakeFs {
+        self.files.insert(path, bytes.fromString(contents))
+        self
+    }
+    pub fn withBytes(mut self, path: String, contents: Bytes) -> FakeFs {
+        self.files.insert(path, contents)
+        self
+    }
+    pub fn withDir(mut self, path: String) -> FakeFs {
+        self.dirs.insert(strings.trimSuffix(path, "/"), true)
+        self
+    }
+}
+pub fn fs() -> FakeFs {
+    FakeFs {}.withDir("/")
+}
+pub struct FakeNet {
+    pub addrs: Map<String, List<net.Addr>> = {:},
+    pub lookups: Map<String, List<net.IpAddr>> = {:},
+    pub reverse: Map<String, List<String>> = {:},
+    pub fn resolve(self, addr: String) -> Result<net.Addr, Error> {
+        net.parseAddr(addr)
+    }
+    pub fn resolveAll(self, host: String) -> Result<List<net.Addr>, Error> {
+        Ok(self.addrs.get(host) ?? [])
+    }
+    pub fn lookup(self, host: String) -> Result<List<net.IpAddr>, Error> {
+        Ok(self.lookups.get(host) ?? [])
+    }
+    pub fn lookupAddr(self, ip: net.IpAddr) -> Result<List<String>, Error> {
+        Ok(self.reverse.get(ip.toString()) ?? [])
+    }
+    pub fn connect(self, addr: String) -> Result<net.TcpConn, Error> {
+        Err(error.new("capability.testing.net: connect disabled for {addr}"))
+    }
+    pub fn connectTimeout(self, addr: String, timeoutMs: Int) -> Result<net.TcpConn, Error> {
+        let _ = timeoutMs
+        self.connect(addr)
+    }
+    pub fn listen(self, addr: String) -> Result<net.TcpListener, Error> {
+        Err(error.new("capability.testing.net: listen disabled for {addr}"))
+    }
+    pub fn withAddr(mut self, host: String, addr: net.Addr) -> FakeNet {
+        let mut values = self.addrs.get(host) ?? []
+        values.push(addr)
+        self.addrs.insert(host, values)
+        self
+    }
+    pub fn withLookup(mut self, host: String, ip: net.IpAddr) -> FakeNet {
+        let mut values = self.lookups.get(host) ?? []
+        values.push(ip)
+        self.lookups.insert(host, values)
+        self
+    }
+    pub fn withReverse(mut self, ip: net.IpAddr, name: String) -> FakeNet {
+        let key = ip.toString()
+        let mut values = self.reverse.get(key) ?? []
+        values.push(name)
+        self.reverse.insert(key, values)
+        self
+    }
+}
+pub fn network() -> FakeNet {
+    FakeNet {}
+}
+pub struct FakeProcess {
+    pub pidValue: Int = 1,
+    pub hostnameValue: String = "test-host",
+    pub exitCode: Int = 0,
+    pub stdout: String = "",
+    pub stderr: String = "",
+    pub timedOut: Bool = false,
+    pub fn pid(self) -> Int {
+        self.pidValue
+    }
+    pub fn hostname(self) -> Result<String, Error> {
+        Ok(self.hostnameValue)
+    }
+    pub fn command(self, program: String) -> proc.ProcessCommand {
+        proc.command(program)
+    }
+    pub fn commandArgs(self, program: String, args: List<String>) -> proc.ProcessCommand {
+        proc.commandArgs(program, args)
+    }
+    pub fn shell(self, line: String) -> proc.ProcessCommand {
+        proc.shell(line)
+    }
+    pub fn run(self, command: proc.ProcessCommand) -> Result<proc.ProcessOutput, Error> {
+        let _ = command
+        Ok(proc.output(self.exitCode, self.stdout, self.stderr, self.timedOut))
+    }
+    pub fn exec(self, command: String, args: List<String>) -> Result<os.Output, Error> {
+        let _ = command
+        let _ = args
+        Ok(os.output(self.exitCode, self.stdout, self.stderr))
+    }
+    pub fn withPid(mut self, pid: Int) -> FakeProcess {
+        self.pidValue = pid
+        self
+    }
+    pub fn withHostname(mut self, name: String) -> FakeProcess {
+        self.hostnameValue = name
+        self
+    }
+    pub fn withOutput(mut self, stdout: String, stderr: String, exitCode: Int) -> FakeProcess {
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exitCode = exitCode
+        self.timedOut = false
+        self
+    }
+    pub fn withStdout(self, stdout: String) -> FakeProcess {
+        self.withOutput(stdout, "", 0)
+    }
+    pub fn withTimeout(mut self) -> FakeProcess {
+        self.timedOut = true
+        self
+    }
+}
+pub fn process() -> FakeProcess {
+    FakeProcess {}
+}
+pub struct FakeConsole {
+    pub stdout: List<String> = [],
+    pub stderr: List<String> = [],
+    pub input: List<String> = [],
+    pub cursor: Int = 0,
+    pub fn print(mut self, text: String) {
+        self.stdout.push(text)
+    }
+    pub fn println(mut self, text: String) {
+        self.stdout.push("{text}\n")
+    }
+    pub fn eprint(mut self, text: String) {
+        self.stderr.push(text)
+    }
+    pub fn eprintln(mut self, text: String) {
+        self.stderr.push("{text}\n")
+    }
+    pub fn readLine(mut self) -> String {
+        if self.cursor >= self.input.len() {
+            return ""
+        }
+        let line = self.input[self.cursor]
+        self.cursor = self.cursor + 1
+        line
+    }
+    pub fn writer(self) -> io.Writer {
+        io.buffer()
+    }
+    pub fn withInput(mut self, line: String) -> FakeConsole {
+        self.input.push(line)
+        self
+    }
+    pub fn stdoutText(self) -> String {
+        strings.join(self.stdout, "")
+    }
+    pub fn stderrText(self) -> String {
+        strings.join(self.stderr, "")
+    }
+}
+pub fn console() -> FakeConsole {
+    FakeConsole {}
+}
+pub struct FakeRuntime {
+    pub clock: FakeClock,
+    pub rng: FakeRng,
+    pub env: FakeEnv,
+    pub fs: FakeFs,
+    pub net: FakeNet,
+    pub process: FakeProcess,
+    pub console: FakeConsole,
+}
+pub fn runtime() -> FakeRuntime {
+    FakeRuntime {clock: clockAt(0), rng: defaultRng(), env: env(), fs: fs(), net: network(), process: process(), console: console()}
+}
+pub fn fakeNames() -> List<String> {
+    ["FakeClock", "FakeRng", "FakeEnv", "FakeFs", "FakeNet", "FakeProcess", "FakeConsole"]
+}
+fn underRoot(path: String, root: String) -> Bool {
+    if root.isEmpty() || root == "/" {
+        return true
+    }
+    path == root || strings.startsWith(path, strings.trimSuffix(root, "/") + "/")
+}

--- a/internal/stdlib/modules/os.osty
+++ b/internal/stdlib/modules/os.osty
@@ -17,6 +17,14 @@ pub struct ExecOutput {
     pub timedOut: Bool,
 }
 
+pub fn output(exitCode: Int, stdout: String, stderr: String) -> Output {
+    Output {exitCode: exitCode, stdout: stdout, stderr: stderr}
+}
+
+pub fn execOutput(exitCode: Int, stdout: String, stderr: String, timedOut: Bool) -> ExecOutput {
+    ExecOutput {exitCode: exitCode, stdout: stdout, stderr: stderr, timedOut: timedOut}
+}
+
 pub enum Signal {
     Interrupt,
     Terminate,

--- a/internal/stdlib/modules/process.osty
+++ b/internal/stdlib/modules/process.osty
@@ -70,6 +70,9 @@ pub struct ProcessOutput {
         }
     }
 }
+pub fn output(exitCode: Int, stdout: String, stderr: String, timedOut: Bool) -> ProcessOutput {
+    ProcessOutput {exitCode: exitCode, stdout: stdout, stderr: stderr, timedOut: timedOut}
+}
 pub struct ProcessCommand {
     pub program: String,
     pub args: List<String>,

--- a/internal/stdlib/os_test.go
+++ b/internal/stdlib/os_test.go
@@ -1,0 +1,16 @@
+package stdlib
+
+import "testing"
+
+func TestOsModuleExposesOutputConstructors(t *testing.T) {
+	reg := LoadCached()
+	for _, name := range []string{"output", "execOutput"} {
+		fn := reg.LookupFnDecl("os", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(os, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("os.%s body = nil, want source constructor body", name)
+		}
+	}
+}

--- a/internal/stdlib/process_test.go
+++ b/internal/stdlib/process_test.go
@@ -6,7 +6,7 @@ func TestProcessModuleExposesExecutionSurface(t *testing.T) {
 	reg := LoadCached()
 
 	for _, name := range []string{
-		"command", "commandArgs", "shell", "pipeline", "pipe", "run", "runShell", "shellEscape", "joinEscaped",
+		"output", "command", "commandArgs", "shell", "pipeline", "pipe", "run", "runShell", "shellEscape", "joinEscaped",
 	} {
 		fn := reg.LookupFnDecl("process", name)
 		if fn == nil {


### PR DESCRIPTION
## Summary
- add std.capability.testing deterministic fakes for the canonical v0.6 capability interfaces
- add std.os/std.process output constructors so fake process adapters can return stdlib output values
- add examples/v06_capability_fakes plus matrix/spec/changelog coverage

## Validation
- just build
- .bin/osty check examples/v06_capability_fakes
- .bin/osty check examples/v06_capability_fakes && .bin/osty check examples/v06_capability_adapters && .bin/osty check examples/v06_capabilities
- .bin/osty fmt --check internal/stdlib/modules/capability/testing.osty examples/v06_capability_fakes/lib.osty
- go test -count=1 -vet=off ./internal/stdlib
- go test -count=1 -vet=off ./internal/speccorpus ./internal/resolve ./internal/check ./internal/format
- just support-stdlib-fast
- git diff --check