### PR TITLE
docs(v0.6): add v0.6-native chapter-level introductions to all chapters

### DIFF
--- a/LANG_SPEC_v0.6/01-lexical-structure.md
+++ b/LANG_SPEC_v0.6/01-lexical-structure.md
@@ -1,5 +1,15 @@
 ## 1. Lexical Structure
 
+This chapter defines the lexical surface of Osty v0.6 — file encoding,
+keywords (18 reserved + 14 contextual), identifier conventions,
+literals, and the rules the lexer applies to produce a token stream
+the parser can consume. The grammar (`OSTY_GRAMMAR_v0.6.md`) and v0.6
+design north star (*hidden dependency is forbidden*) inform the rule
+set, but the *token-level* rules below are mostly stable across
+versions: the v0.6 additions are limited to the `while` reserved
+keyword (G49, §1.2) and four spec-block contextual keywords (`spec`,
+`example`, `law`, `invariant`; G43, §1.3).
+
 ### 1.1 Source Files
 
 - File extension: `.osty`

--- a/LANG_SPEC_v0.6/02-type-system.md
+++ b/LANG_SPEC_v0.6/02-type-system.md
@@ -1,5 +1,24 @@
 ## 2. Type System
 
+Osty v0.6 is a statically typed language with bidirectional type
+inference, structural interfaces, monomorphized generics, and a
+fixed-shape collection of value-semantic primitives plus
+reference-semantic composites. The type system is designed to admit
+compile-time guarantees without lifetimes or borrow analysis: the
+v0.6 *capability surface* (§20) and *information flow tags* (§21)
+ride on top of the standard type rules — capabilities appear as
+ordinary parameter types, and flow tags decorate a type without
+changing its identity.
+
+This chapter covers primitives (§2.1), numeric conversions (§2.2),
+overflow semantics (§2.3), composite types (§2.4), the optional sugar
+`T?` (§2.5), structural interfaces and built-in protocols (§2.6),
+monomorphized generics (§2.7), value vs reference semantics (§2.8),
+equality and hashing (§2.9), mutability (§2.10), and nullability
+(§2.11). All v0.5 primitives and composites carry forward unchanged;
+v0.6 adds no new type-system surface — the new annotation surfaces
+(§3.10–§3.15, §20, §21) are layered on existing types.
+
 ### 2.1 Primitive Types
 
 ```

--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -1,5 +1,24 @@
 ## 3. Declarations
 
+This chapter defines Osty v0.6 declaration forms — functions (§3.1),
+variables (§3.2), multiple assignment (§3.3), structs (§3.4) including
+the v0.6 sealed-construct rule (§3.4.5, G40), enums (§3.5), interfaces
+(§3.6), type aliases (§3.7), and annotations (§3.8). Sections §3.10
+through §3.15 specify the v0.6 *hidden-dependency-surface*
+annotations (G36–G46) — `#[spec]` for spec-link traceability,
+`#[reproducible]` for environment-independence, `#[purpose]` /
+`#[example]` / `#[fixture]` for structured intent, `spec { ... }`
+blocks for executable specification, `#[since]` / `#[stability]` /
+`#[match_compat]` for API evolution, and `#[budget]` for performance
+contracts.
+
+The v0.6 design north star (*hidden dependency is forbidden*) is
+realized in this chapter through the new annotation surface: every
+external dependency, intent, contract, or evolution rule that affects
+a declaration is now expressible at the declaration site. v0.5
+declarations carry forward unchanged; the v0.6 additions are *opt-in*
+metadata — declarations without v0.6 annotations have v0.5 semantics.
+
 ### 3.1 Functions
 
 ```osty

--- a/LANG_SPEC_v0.6/04-expressions.md
+++ b/LANG_SPEC_v0.6/04-expressions.md
@@ -1,5 +1,20 @@
 ## 4. Expressions
 
+Osty v0.6 is an expression-oriented language. Block (§4.1), `if`
+(§4.2), `match` (§4.3), and `loop` are all expressions that produce
+values when used in value position, and statements when used at
+statement position. This chapter defines expression syntax and
+semantics: blocks, conditionals, pattern matching, loops including
+the v0.6-introduced `while cond { }` synonym for `for cond { }`
+(G49, §4.4), error propagation (§4.5), optional chaining and
+nil-coalescing (§4.6), closures (§4.7), string interpolation (§4.8),
+member access (§4.9), indexing (§4.10), block scope (§4.11), `defer`
+semantics including cancellation interaction (§4.12), and assignment
+forms (§4.13).
+
+The v0.6 surface additions touch §4.4 only (the `while` synonym).
+All other expression forms carry forward from v0.5 unchanged.
+
 ### 4.1 Block Expressions
 
 ```osty

--- a/LANG_SPEC_v0.6/05-modules-and-packages.md
+++ b/LANG_SPEC_v0.6/05-modules-and-packages.md
@@ -1,5 +1,14 @@
 ## 5. Modules and Packages
 
+Osty v0.6 organizes code by directory: a directory is a package, and
+all `.osty` files in that directory share one namespace. Packages
+import each other through `use` statements. The import surface —
+including `use path::{a, b as c}` (G28), `pub use path.Sym` (G30),
+and `#[cfg(...)]`-conditional declarations (G29) — is unchanged in
+v0.6. v0.6 adds no new module-system syntax; the publishing surface
+(`osty publish` SemVer enforcement, G44) and its API-surface diff
+algorithm are described in §13.5 and §3.14.3 respectively.
+
 ### 5.1 Package = Directory
 
 A directory is a package. All `.osty` files in a directory belong to the

--- a/LANG_SPEC_v0.6/06-scripts.md
+++ b/LANG_SPEC_v0.6/06-scripts.md
@@ -1,5 +1,14 @@
 ## 6. Scripts
 
+Osty v0.6 lets a single file mix declarations and top-level statements
+to function as a *script*. The compiler synthesizes an implicit
+`main() -> Result<(), Error>` from those statements. v0.6 scripts run
+under an automatic `#[ambient(clock, rng, env, fs)]` capability binding
+(§20.3), so common effectful calls work without explicit capability
+parameters in the script body. Library code retains the discipline of
+explicit capability arguments — scripts are the boundary where ambient
+binding is acceptable.
+
 A file is a **script file** if it contains top-level statements outside
 any function or type declaration. A file with only declarations is a
 **module file**.

--- a/LANG_SPEC_v0.6/07-the-error-interface.md
+++ b/LANG_SPEC_v0.6/07-the-error-interface.md
@@ -1,5 +1,17 @@
 ## 7. The Error Interface
 
+Osty v0.6 represents errors as values, never as exceptions. The
+`Error` interface (§7.1) carries a nominal tag for runtime downcast
+(`as?` per §4 and §7.4), `BasicError` (§7.2) provides the standard
+constructor, custom error enums (§7.3) integrate via the structural
+interface rules of §2.6, and propagation uses the `?` operator
+(§7.4). The v0.6 addition is `#[error_contract]` (§7.5, G41) — a
+declaration-level annotation that catalogues which error variants
+flow out under which conditions, enabling caller-side exhaustiveness
+pruning, machine-readable failure-mode export via `osty context`
+(§13.4), and the publish-time SemVer rule that adding a contracted
+variant is a breaking change (§3.14.3).
+
 ### 7.1 Definition
 
 `Error` is an interface defined in `std.error` and re-exported by the

--- a/LANG_SPEC_v0.6/08-concurrency.md
+++ b/LANG_SPEC_v0.6/08-concurrency.md
@@ -1,5 +1,21 @@
 ## 8. Concurrency
 
+Osty v0.6 supports concurrency exclusively through *structured
+concurrency* — every task lives within a `taskGroup` scope and joins
+or fails with its parent. Detached tasks, `async`/`await`, and
+`spawn` keywords are excluded by §14. Green tasks multiplex onto an
+M:N scheduler (§8.0); communication uses channels (§8.5) or shared
+state under `std.sync` primitives (§8.6). The non-escaping rule for
+`Handle<T>` and `TaskGroup` capabilities (G13, §8.2) is enforced by a
+finite front-end check, not lifetimes.
+
+This chapter is unchanged from v0.5 in semantics. v0.6 introduces
+capability parameters (§20) which interact with concurrent code:
+spawning a child task that needs a `Clock` requires explicit
+forwarding from the enclosing scope, since ambient bindings do not
+cross function boundaries. The `Net` and `Fs` capabilities are
+cancellation-aware, matching the v0.5 stdlib contract.
+
 ### 8.0 Scheduler Model
 
 Osty specifies an **M:N scheduler**. Task-level units (`g.spawn(...)`, the

--- a/LANG_SPEC_v0.6/09-memory-management.md
+++ b/LANG_SPEC_v0.6/09-memory-management.md
@@ -1,7 +1,18 @@
 ## 9. Memory Management
 
-Osty is garbage collected. There are no explicit memory primitives:
-no `new`, no `delete`, no destructors.
+Osty v0.6 is a garbage-collected language. The runtime owns object
+lifetime; user code never explicitly allocates or frees. There are no
+`new`, `delete`, destructors, finalizers, or weak references — the
+contract is *all reachable objects survive, all unreachable objects
+are eventually reclaimed*. Resource cleanup outside memory (file
+handles, sockets, mutex guards) is bound to lexical scope through
+`defer` (§4.12) or closure-based stdlib helpers, never to GC timing.
+
+The v0.6 specification adds no new memory-management surface. The
+v0.6 capability surface (§20) and information flow (§21) compose with
+GC ownership but do not change it: a tainted `String` is reclaimed
+identically to an untainted one, and a `Clock` capability instance
+has the same lifetime rules as any reference value.
 
 Resource cleanup is done through `defer` (§4.12) or closure-based
 stdlib APIs (`fs.withFile`, `net.withConn`, etc.).

--- a/LANG_SPEC_v0.6/10-standard-library/README.md
+++ b/LANG_SPEC_v0.6/10-standard-library/README.md
@@ -1,11 +1,25 @@
 ## 10. Standard Library
 
-This chapter is split into one file per subsection for easier navigation. The introduction below states the structuring principles; each `std.*` package then lives in its own file.
+Osty v0.6 ships a batteries-included standard library. This chapter
+catalogues the canonical `std.*` packages, organized in tiers (§10.1
+Tier 1 / §10.2 Tier 2) plus per-package specifications. Each
+subsection is a separate file for navigation.
 
-## 10. Standard Library
+The v0.6 stdlib introduces 7 capability protocols (`Clock`, `Rng`,
+`Env`, `Fs`, `Net`, `Process`, `Console` per §20) in `std.capability`
+and host-adapter factories (`time.systemClock`, `random.host`,
+`env.host`, `fs.host`, `capability.hostNet`, `capability.hostProcess`,
+`io.console`). The legacy globals (`time.now()`, `random.next()`, etc.)
+remain available under the `--legacy-globals` compatibility mode for
+the v0.6.x lifetime; v0.7 removes them.
 
-**v0.4 stub policy.** Standard-library protocol signatures are tracked
-as checked `.osty` stubs before runtime parity. A stub may use a dummy
+Six stdlib types become sealed in v0.6 (G40, §3.4.5): `Email`,
+`Url`, `Path`, `SqlIdent`, `Duration`, `Uuid`. External code routes
+construction through `Type.parse(...)`; the `--legacy-construct` mode
+preserves direct literal construction during the v0.6.x transition.
+
+**Stub policy.** Standard-library protocol signatures are tracked as
+checked `.osty` stubs before runtime parity. A stub may use a dummy
 body, but it must parse, resolve, and type-check. If moving prose from
 §10, §15, §16, or §17 into stubs exposes a signature ambiguity, that
 ambiguity becomes a new language-decision gap; missing backend/runtime

--- a/LANG_SPEC_v0.6/11-testing.md
+++ b/LANG_SPEC_v0.6/11-testing.md
@@ -1,5 +1,15 @@
 ## 11. Testing
 
+Osty v0.6 ships a built-in testing surface. Tests live alongside code
+in `_test.osty` files or as `#[test]`-annotated functions in
+production sources; the runner is `osty test`, with assertions
+provided by `std.testing`. The v0.6 surface adds: declarative golden
+tests via `#[golden]` (§11.5.2, G45) which reuse the v0.5 snapshot
+on-disk format, executable specification clauses through `spec { }`
+blocks (§3.13, G43) which run as tests under `osty test --spec`, and
+the `#[example]` annotation (§3.12, G42) which auto-checks
+`input → output` declarations under `osty test --example`.
+
 Test files use the `_test.osty` suffix and live alongside code in the
 same package. Functions whose names begin with lowercase `test` and
 take no arguments are discovered and run by `osty test`. A top-level

--- a/LANG_SPEC_v0.6/12-foreign-function-interface.md
+++ b/LANG_SPEC_v0.6/12-foreign-function-interface.md
@@ -1,5 +1,19 @@
 ## 12. Foreign Function Interface
 
+Osty v0.6 interoperates with Go via `use go "..." { ... }` declaration
+blocks. The bridge maps Osty's `Result<T, Error>` to Go's
+`(T, error)`, optional types `T?` to nullable pointers `*T`, and
+preserves panic-as-process-abort semantics. Go closures, generics,
+empty interfaces, and channel types are not exposed across the
+boundary.
+
+The v0.6 information flow surface (§21) treats data crossing an FFI
+boundary as untagged by default. When data has been validated outside
+Osty's flow tracking, the `#[trusted_declassify(reason)]` annotation
+on the FFI wrapper drops flow tags with audit-marked attestation —
+all such sites are enumerable via `osty audit --trusted-declassify`
+(§13.7).
+
 ### 12.1 Importing Go Packages
 
 ```osty

--- a/LANG_SPEC_v0.6/13-tooling.md
+++ b/LANG_SPEC_v0.6/13-tooling.md
@@ -1,5 +1,19 @@
 ## 13. Tooling
 
+Osty v0.6 tooling exposes the spec surface through commands. The CLI
+(§13.1), package manifest format (§13.2), and zero-config formatter
+(§13.3) carry forward from v0.5 unchanged. v0.6 adds: `osty context`
+(§13.4, G47) for machine-readable intent extraction (purpose,
+example, spec_refs, error_contract, capabilities, taint, budget) as
+a single JSON document; `osty publish` (§13.5, G44) for SemVer
+enforcement against `#[stability]` declarations through API surface
+diff; `osty validate-spec` (§13.6, G38) for `#[spec(...)]` anchor
+validation; audit subcommands (§13.7) for trusted-declassify /
+trusted-construct / match-compat / legacy-globals enumeration; and
+test-subcommand extensions (§13.8) for `--spec`, `--example`,
+`--golden`, `--update-golden`, and `--doc` modes alongside `osty
+bench --budget` runtime gates.
+
 ### 13.1 CLI
 
 ```

--- a/LANG_SPEC_v0.6/15-iteration-protocol.md
+++ b/LANG_SPEC_v0.6/15-iteration-protocol.md
@@ -1,5 +1,17 @@
 ## 15. Iteration Protocol
 
+Osty v0.6 defines iteration through two structural interfaces:
+`Iterator<T>` and `Iterable<T>`. Any type implementing `Iterable<T>`
+participates in `for x in xs { ... }` loops. The protocol is
+unchanged from v0.5 in semantics; the v0.6 backend layer optimizes
+for `List<T>` / range / `Map<K, V>` shapes (cf. SPEC_GAPS
+`vectorize-hint`), but every conforming type works under the protocol
+regardless of backend optimization.
+
+Lazy iterator combinators (filter, map, take, …) live in `std.iter`
+(§10.7). User types implement `Iterable<T>` directly; the compiler
+does not auto-derive iteration support.
+
 `for x in xs { ... }` is defined in terms of two interfaces:
 
 ```osty

--- a/LANG_SPEC_v0.6/16-io-protocol.md
+++ b/LANG_SPEC_v0.6/16-io-protocol.md
@@ -1,5 +1,18 @@
 ## 16. I/O Protocol
 
+Osty v0.6 defines stream I/O through three structural interfaces:
+`Reader`, `Writer`, and `Closer`. The `EOF` sentinel is `Ok(0)` —
+there is no distinguished error type for end-of-stream. The contract
+is shared across `std.io`, stream-oriented standard-library modules,
+and FFI byte-stream bridges.
+
+The v0.6 capability surface (§20) layers on top of the I/O protocol:
+filesystem and network access flow through `Fs` and `Net` capability
+parameters rather than global functions. The protocol interfaces
+themselves are unchanged from v0.5; capability-typed handles
+(returned by `fs.open(path)`, `net.dial(...)`) implement the same
+`Reader`/`Writer`/`Closer` interfaces as their v0.5 predecessors.
+
 The `Reader` and `Writer` interfaces define the streaming I/O contract
 shared across `std.io`, stream-oriented standard-library modules, and
 FFI byte-stream bridges. `std.fs` currently exposes whole-file and

--- a/LANG_SPEC_v0.6/17-display-and-format-protocol.md
+++ b/LANG_SPEC_v0.6/17-display-and-format-protocol.md
@@ -1,5 +1,15 @@
 ## 17. Display and Format Protocol
 
+Osty v0.6 defines value-to-string conversion through a single
+interface, `ToString`. String interpolation `"{expr}"` (§4.8), the
+`println` / `print` / `eprint` family, and the formatter's
+`Display` rendering all dispatch through `toString()`. The interface
+is structural — any type that defines `fn toString(self) -> String`
+satisfies it. v0.6 adds no new format protocol surface; the
+machine-readable intent annotations (`#[purpose]`, `#[example]`,
+`#[fixture]` per §3.12) operate at a different layer (documentation
+/ context export) and do not interact with `ToString`.
+
 String interpolation and the `print*` family are defined in terms of a
 single interface:
 


### PR DESCRIPTION
## Summary

사용자 피드백 — *"0.6 이 구성과 분량 면에서도 정본이야?"* + *"완전히 0.6 기준으로 처음부터 다시 쓴 다음, 완성 후 0.5 를 반영하여 보완"*. 의 **첫 단계**.

v0.5 carry 챕터들의 opener 가 곧바로 본문 / 코드 예제로 들어가서 *"v0.5 본문 그대로 + v0.6 amendment"* 톤이었음. 각 챕터 첫 paragraph 에 ***v0.6 native* chapter-level intro** 추가.

## 갱신된 16 챕터

| 챕터 | 신규 intro 내용 |
|---|---|
| §1 Lexical | 18 reserved + 14 contextual keyword + G49/G43 grammar 영향 |
| §2 Type System | 모든 차원 enumerate + capability/flow tag 가 type rule 위에 layer |
| §3 Declarations | v0.6 hidden-dependency-surface annotation set (G36-G46) 위치 |
| §4 Expressions | expression-oriented 모델 + v0.6 §4.4 추가만 |
| §5 Modules | directory-based + osty publish (G44) cross-ref |
| §6 Scripts | implicit main + v0.6 자동 `#[ambient]` binding |
| §7 Error Interface | error-as-value + `#[error_contract]` (G41) |
| §8 Concurrency | structured concurrency + capability boundary rule |
| §9 Memory Management | GC 모델 + capability 와의 lifetime 관계 |
| §11 Testing | built-in surface + v0.6 (`#[golden]`, spec block, `#[example]`) |
| §12 FFI | Go interop + `#[trusted_declassify]` audit |
| §13 Tooling | CLI v0.5 carry + v0.6 (osty context/publish/validate-spec/audit/test ext.) |
| §15 Iteration | Iterator/Iterable + 백엔드 layer 관계 |
| §16 I/O | Reader/Writer/Closer + v0.6 capability layered 작동 |
| §17 Display/Format | `ToString` + v0.6 intent annotation 분리 |
| §10 stdlib README | v0.6 capability protocols + sealed types 명시 |

(§14 / §18 / §19 / §20 / §21 는 이전 PR 들에서 이미 canonical voice.)

## Files

- 16 files changed, 213 insertions, 6 deletions
- 본문 prose 자체는 *그대로 carry-over* — 첫 paragraph 만 v0.6 정본 voice 로 추가

## Test plan

- [x] `go build ./internal/diag/... ./cmd/codesdoc/...` 통과
- [x] v0.6 chapter 마다 *opener 가 v0.6 정본 톤* — "Osty v0.6 의 X 는 ..." 패턴
- [x] v0.5 carry 본문은 그대로 — 회귀 위험 0

## v0.6 정본화 진행도

| 단계 | 상태 |
|---|---|
| ✅ Spec decisions (G36-G49) baseline 동결 | 8 PR (#1469-#1476) |
| ✅ 디렉토리 / README / ABRIDGED / companion docs | 다수 PR |
| ✅ §20 / §21 standalone chapters | #1472 |
| ✅ §3/§7/§11/§13 inline 통합 | #1473 |
| ✅ Transition 정책 명문화 (CLAUDE.md) | #1487 |
| ✅ 정본 톤 정정 (v0.5 → v0.6 voice) | #1488 |
| 🟢 **v0.6 native chapter-level intro** | **본 PR** |
| ⚪ Body deep-rewrite — examples 갱신 + 결정 표현 v0.6 맥락화 | 별도 phase |
| ⚪ §10 stdlib capability migration 카탈로그 | 별도 phase |

## 다음 단계 (사용자 요구의 두 번째 phase)

*"완성 후 0.5 를 반영하여 보완"*:
- 각 챕터 본문 examples 를 v0.6 capability/sealed/intent 패턴 동반 형태로 부분 갱신
- v0.5 carry 본문의 specific 결정 (§3 G6-G19 등) 을 v0.6 맥락에서 다시 표현
- §10 stdlib 의 capability migration 표 (legacy global → v0.6 capability mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_