### PR TITLE
docs(v0.6 stdlib): add §10.46 Capability Migration Catalog

### DIFF
--- a/LANG_SPEC_v0.6/10-standard-library/46-capability-migration.md
+++ b/LANG_SPEC_v0.6/10-standard-library/46-capability-migration.md
@@ -1,0 +1,193 @@
+## §10.46 Capability Migration Catalog
+
+This chapter is the **authoritative mapping** of v0.5 global effect
+functions to their v0.6 capability equivalents. Use it when migrating
+existing code, when implementing the `--legacy-globals` desugar, when
+auditing pre-v0.6 sources, or when extending stdlib with capability
+methods. Each row pins exactly one v0.5 surface and exactly one v0.6
+replacement; no new mappings are added without a corresponding entry
+here.
+
+### §10.46.1 Migration timeline
+
+| Phase | What works |
+|---|---|
+| v0.6.0 | Both surfaces: v0.5 globals via `--legacy-globals` (with `W0750` deprecation warning), v0.6 capability methods. |
+| v0.6.x | Same. Migration is incremental — leaf functions first, callers last. |
+| v0.7.0 | Only the v0.6 capability methods. The `--legacy-globals` flag is removed; v0.5 source compiled without prior migration fails. |
+
+Packages that activate `[legacy] globals = true` in `osty.toml` are
+forced to `[stability] default = "experimental"` automatically — a
+package depending on legacy globals cannot promise stable APIs (§3.14).
+
+### §10.46.2 Function-by-function mapping
+
+#### `std.time` — `Clock` capability
+
+| v0.5 global | v0.6 capability method | Notes |
+|---|---|---|
+| `time.now()` | `clock.now()` | Returns `Time` (UTC, monotonic). |
+| `time.monotonic()` | `clock.monotonic()` | `Duration` since process start. |
+| `time.sleep(d)` | `clock.sleep(d)` | Cancellation-aware. |
+| `time.systemClock` | (no change) | Host adapter factory; returns a `Clock` instance. |
+
+#### `std.random` — `Rng` capability
+
+| v0.5 global | v0.6 capability method | Notes |
+|---|---|---|
+| `random.next()` | `rng.next()` | Pseudo-random `Int`. |
+| `random.nextBytes(n)` | `rng.nextBytes(n)` | `Bytes` of length `n`. |
+| `random.default()` | `random.host` | The default `Rng` host adapter. |
+
+#### `std.env` — `Env` capability
+
+| v0.5 global | v0.6 capability method | Notes |
+|---|---|---|
+| `env.get(k)` | `env.get(k)` | Same name on both sides — capability method on `Env` instance. |
+| `env.set(k, v)` | `env.set(k, v)` | Same. |
+| `env.args()` | `env.args()` | Same. |
+| `env.vars()` | `env.vars()` | Same. |
+
+#### `std.fs` — `Fs` capability
+
+| v0.5 global | v0.6 capability method | Notes |
+|---|---|---|
+| `fs.readToString(p)` | `fs.readToString(p)` | Same. |
+| `fs.write(p, c)` | `fs.write(p, c)` | Same. |
+| `fs.exists(p)` | `fs.exists(p)` | Same. |
+| `fs.create(p)` | `fs.create(p)` | Same. |
+| `fs.remove(p)` | `fs.remove(p)` | Same. |
+| `fs.mkdir(p)` | `fs.mkdir(p)` | Same. |
+| `fs.host` | (factory) | Default `Fs` host adapter. |
+
+#### `std.os` → `std.process` — `Process` capability
+
+| v0.5 global | v0.6 capability method | Notes |
+|---|---|---|
+| `os.exec(c, a)` | `process.exec(c, a)` | **Module renamed** — `os` → `process`. |
+| `os.exit(code)` | `process.exit(code)` | Same. |
+| `os.hostname()` | `process.hostname()` | Same. |
+| `os.pid()` | `process.pid()` | Same. |
+
+#### `std.net` — `Net` capability
+
+| v0.5 global | v0.6 capability method | Notes |
+|---|---|---|
+| `net.dial(h, p)` | `net.dial(h, p)` | Same name; capability method on `Net`. |
+| `net.listen(p)` | `net.listen(p)` | Same. |
+| `net.host` | (factory) | Default `Net` host adapter. |
+
+#### `std.io` — `Console` capability
+
+| v0.5 global | v0.6 capability method | Notes |
+|---|---|---|
+| `println(...)` | `console.println(...)` | `Console` instance per `#[ambient(console)]` or explicit parameter. |
+| `print(...)` | `console.print(...)` | Same. |
+| `eprintln(...)` | `console.eprintln(...)` | Stderr variant. |
+| `eprint(...)` | `console.eprint(...)` | Stderr variant. |
+
+The `println` family remains accessible as a v0.5 global under
+`--legacy-globals`. New v0.6 code receives `Console` either via
+`#[ambient(console)]` (entry-point only) or as an explicit parameter.
+
+### §10.46.3 Deterministic capability variants for testing
+
+`std.capability.testing` exposes deterministic fakes for each
+non-deterministic capability. Use them in `#[test]` functions to
+replace `--legacy-globals`-style implicit determinism:
+
+| Production capability | Test fake | Determinism |
+|---|---|---|
+| `Clock` | `std.capability.testing.FakeClock(epoch_ms = N)` | Returns the configured epoch on every `now()`. |
+| `Rng` | `std.capability.testing.FakeRng(seed = N)` | Sequence determined by `seed`. |
+| `Env` | `std.capability.testing.FakeEnv(vars = {...})` | In-memory variable map. |
+| `Fs` | `std.capability.testing.FakeFs(layout = {...})` | In-memory tree. |
+| `Net` | `std.capability.testing.FakeNet(routes = {...})` | Pre-canned responses by host:port. |
+| `Process` | `std.capability.testing.FakeProcess(...)` | Programmable exec stubs. |
+| `Console` | `std.capability.testing.FakeConsole()` | Captures stdout/stderr. |
+
+The fake set is also reachable through the convenience factory
+`std.testing.capabilityFakes()` for tests that need every capability
+fake at once.
+
+### §10.46.4 Runtime adapter factories
+
+The host adapters that produce real `Clock` / `Rng` / `Env` / `Fs`
+instances live where the capability is defined:
+
+| Capability | Factory |
+|---|---|
+| `Clock` | `time.systemClock` |
+| `Rng` | `random.host` |
+| `Env` | `env.host` |
+| `Fs` | `fs.host` |
+| `Net` | `capability.hostNet` |
+| `Process` | `capability.hostProcess` |
+| `Console` | `io.console` |
+
+Cross-module bridge factories `net.host` / `process.host` exist as
+**migration helpers** during the v0.6.x transition; they delegate to
+the canonical factories in `std.capability` and will be marked
+deprecated for v0.7 removal.
+
+### §10.46.5 Migration pattern
+
+Library code (`pub fn` outside `main` / `#[test]` / `#[bench]`):
+
+```osty
+// v0.5 (still compiles under --legacy-globals)
+pub fn buildId() -> String {
+    "{time.now().toEpochMillis()}-{random.next()}"
+}
+
+// v0.6 (recommended)
+pub fn buildId(clock: Clock, rng: Rng) -> String {
+    "{clock.now().toEpochMillis()}-{rng.next()}"
+}
+```
+
+Entry point (`fn main` or scripts):
+
+```osty
+// v0.5 (still compiles under --legacy-globals)
+fn main() {
+    let id = buildId()
+    println("{id}")
+}
+
+// v0.6 (recommended)
+#[ambient(clock, rng, console)]
+fn main() {
+    let id = buildId(clock, rng)
+    console.println("{id}")
+}
+```
+
+Tests with deterministic fakes:
+
+```osty
+fn test_buildId_format() {
+    let fakeClock = std.capability.testing.FakeClock(epoch_ms = 1_000_000)
+    let fakeRng = std.capability.testing.FakeRng(seed = 42)
+    let id = buildId(fakeClock, fakeRng)
+    testing.assertEq(id, "1000000-1608637542")
+}
+```
+
+### §10.46.6 Audit
+
+`osty audit --legacy-globals` enumerates every site in the workspace
+that calls a v0.5 global covered by this catalog. The audit output is
+suitable for tracking migration progress in CI:
+
+```sh
+$ osty audit --legacy-globals --report=pretty
+src/util.osty:42:18  time.now()       → clock.now()
+src/util.osty:55:12  random.next()    → rng.next()
+src/main.osty:8:5    println("ready") → console.println("ready") (auto via #[ambient])
+3 deprecated sites; 0 with #[trusted_declassify]
+```
+
+When the report is empty, the package is fully migrated. Removing
+`[legacy] globals = true` from `osty.toml` then unblocks `[stability]
+default = "stable"`.

--- a/LANG_SPEC_v0.6/10-standard-library/README.md
+++ b/LANG_SPEC_v0.6/10-standard-library/README.md
@@ -74,6 +74,7 @@ lowering remains implementation backlog.
 - [§10.43 Supabase (`std.supabase`)](./43-supabase.md)
 - [§10.44 GitHub (`std.github`)](./44-github.md)
 - [§10.45 Webhooks (`std.webhook`)](./45-webhook.md)
+- [**§10.46 Capability Migration Catalog**](./46-capability-migration.md) — v0.5 → v0.6 stdlib effect mapping
 
 Capability protocols (`std.capability`) are specified in
 [§20 Capabilities](../20-capabilities.md) because they govern effect


### PR DESCRIPTION
## Summary

사용자 요구의 두 번째 phase — *"완성 후 0.5 를 반영하여 보완"* 의 첫 단계. v0.5 → v0.6 stdlib effect 변환을 *한눈에 보여주는* 권위 mapping 표를 별도 standalone 챕터로 추가.

`LANG_SPEC_v0.6/10-standard-library/46-capability-migration.md` (193 LOC) 신규.

## 챕터 구조

| § | 내용 |
|---|---|
| §10.46.1 | Migration timeline — v0.6.0 / v0.6.x / v0.7.0 phase 별 surface 가용성 |
| §10.46.2 | Function-by-function mapping — 7 capability 별 mapping 표 |
| §10.46.3 | Deterministic capability variants for testing — `Fake*` mapping |
| §10.46.4 | Runtime adapter factories — host-boundary 위치 + bridge deprecation |
| §10.46.5 | Migration pattern — 3 worked examples |
| §10.46.6 | Audit — `osty audit --legacy-globals` 출력 형식 |

## 7 capability mapping 핵심

| 모듈 | v0.5 global | v0.6 capability | 변경 |
|---|---|---|---|
| `std.time` | `time.now()` | `clock.now()` | rename |
| `std.random` | `random.next()` | `rng.next()` | rename |
| `std.env` | `env.get(k)` | `env.get(k)` | same name (capability method) |
| `std.fs` | `fs.readToString(p)` | `fs.readToString(p)` | same |
| `std.os` → `std.process` | `os.exec(c, a)` | `process.exec(c, a)` | **모듈 rename** |
| `std.net` | `net.dial(h, p)` | `net.dial(h, p)` | same name |
| `std.io` | `println(...)` | `console.println(...)` | console capability |

`std.capability.testing.Fake*` (FakeClock, FakeRng, FakeEnv, FakeFs, FakeNet, FakeProcess, FakeConsole) 가 7 capability 별 deterministic fake 제공.

## Cross-references

- `BREAKING_v0.6.md §3` (capability migration)
- `MIGRATING_v0.5_to_v0.6.md §3`
- `CHANGELOG_v0.6.md` (Phase 1 status)
- `CLAUDE.md` 부록 C.1
- `LANG_SPEC_v0.6/20-capabilities.md`
- `LANG_SPEC_v0.6/00-revision.md §3.14.3`

## Files

- 2 files changed, +194 insertions
- 신규: `LANG_SPEC_v0.6/10-standard-library/46-capability-migration.md`
- 수정: `LANG_SPEC_v0.6/10-standard-library/README.md` (ToC 등록)

## Test plan

- 모든 mapping 이 기존 stdlib surface (`std.capability`, `std.time`, `std.random`, …) 와 정합
- legacy globals deprecation timeline 이 `BREAKING_v0.6.md §3 / §4` 및 `MIGRATING §3` 와 일치
- v0.5 carry 본문 그대로 — 새 챕터로 v0.6 reflection 추가

## v0.6 정본화 진행도

| 단계 | 상태 |
|---|---|
| ✅ Spec decisions baseline | 8 PR |
| ✅ 디렉토리 / companion docs | |
| ✅ §20 / §21 standalone | |
| ✅ §3/§7/§11/§13 inline | |
| ✅ Transition 정책 (CLAUDE.md) | |
| ✅ 정본 톤 정정 (#1488) | |
| ✅ v0.6 native chapter intro (#1490) | |
| 🟢 **§10.46 Capability Migration Catalog** | **본 PR** |
| ⚪ §3 declarations examples 갱신 | 다음 |
| ⚪ §11 testing examples (Fake* 동반) | 다음 |

## 다음 단계 후보

- §3 declarations 의 examples 를 capability parameter 동반 형태로 갱신
- §11 testing 의 examples 갱신 (`FakeClock` / `FakeRng` 사용 패턴)
- §10.* 다른 stdlib 챕터의 capability migration 영향 marking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_