### PR TITLE
docs(v0.6): batch 3+4 — API tables + 100% canonical voice + worked v0.6 patterns

### DIFF
--- a/LANG_SPEC_v0.6/02-type-system.md
+++ b/LANG_SPEC_v0.6/02-type-system.md
@@ -15,9 +15,13 @@ overflow semantics (§2.3), composite types (§2.4), the optional sugar
 `T?` (§2.5), structural interfaces and built-in protocols (§2.6),
 monomorphized generics (§2.7), value vs reference semantics (§2.8),
 equality and hashing (§2.9), mutability (§2.10), and nullability
-(§2.11). All v0.5 primitives and composites carry forward unchanged;
-v0.6 adds no new type-system surface — the new annotation surfaces
-(§3.10–§3.15, §20, §21) are layered on existing types.
+(§2.11). The v0.6 annotation surfaces — capability parameters
+(§20), information flow tags (§21), spec links and intent (§3.10 –
+§3.12), reproducibility (§3.11), sealed construction (§3.4.5), error
+contracts (§7.5), API evolution (§3.14), and budgets (§3.15) — all
+*ride on top of* the type rules in this chapter; they decorate or
+restrict declarations without introducing a new type kind. §2.12
+catalogues those interactions in one place.
 
 ### 2.1 Primitive Types
 
@@ -527,7 +531,21 @@ mutation through that binding.
 No `null`. Use `Option<T>` / `T?`:
 
 ```osty
-fn find(id: Int) -> User? { ... }
+fn find(db: Db, id: Int) -> User? { ... }
+```
+
+Capability parameters and `Option<T>` compose without special rules
+— a missing user is not the same as a missing database, so a
+function that *could* fail to find or *could* fail to access uses
+both forms:
+
+```osty
+fn lookup(db: Db, id: Int) -> Result<User?, Error> {
+    // Err(...)  — db itself failed (network, lock, etc.)
+    // Ok(None) — db succeeded, no row matched
+    // Ok(Some(u)) — found
+    db.queryOne::<User>("SELECT * FROM users WHERE id = ?", [id])
+}
 ```
 
 ---
@@ -659,11 +677,12 @@ sealed / error contract 는 *모두* 이 exclusion 을 지키는 형태로
 | `where` clause | `T: I1 + I2` 그대로 — capability 도 동일 |
 | Generic 기본값 | variation 없음 |
 
-### 2.13 Equality / Hashability / Ordering — v0.6 baseline 그대로
+### 2.13 Equality / Hashability / Ordering — annotation interactions
 
-v0.5 의 §2.9 (Equality and Hashing) 와 §2.10 (Mutability) 는 v0.6
-에서 *변경 없음*. 다만 v0.6 신규 어노테이션 의 `Equal` / `Hashable`
-영향:
+The `Equal` / `Hashable` / `Ordered` rules in §2.6.5 / §2.9 stand on
+their own; the v0.6 annotation surface does not perturb them.
+Specifically, the answer to *"does annotation X affect equality
+behavior?"* is uniformly **no** for all v0.6 surfaces:
 
 | Annotation | Equal/Hashable 영향 |
 |---|---|

--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -13,11 +13,29 @@ blocks for executable specification, `#[since]` / `#[stability]` /
 contracts.
 
 The v0.6 design north star (*hidden dependency is forbidden*) is
-realized in this chapter through the new annotation surface: every
-external dependency, intent, contract, or evolution rule that affects
-a declaration is now expressible at the declaration site. v0.5
-declarations carry forward unchanged; the v0.6 additions are *opt-in*
-metadata — declarations without v0.6 annotations have v0.5 semantics.
+realized in this chapter: every external dependency, intent,
+contract, or evolution rule that affects a declaration is expressible
+at the declaration site. The annotation surface in §3.10 – §3.15
+makes that visibility *machine-readable* so that diagnostics
+(§3.10.4 spec link, §7.5 error contract), enforcement (§3.11
+reproducibility, §3.4.5 sealed construct), and tooling (§13.6 `osty
+context`, §13.5 `osty publish`) all share one source of truth.
+
+The annotation set is finite — 31 compiler-recognized annotations as
+of v0.6 (§3.8). Three sub-categories sit on top of the underlying
+declaration grammar:
+
+| Category | Annotations | Purpose |
+|---|---|---|
+| **Effect & flow** | `#[ambient]`, `#[reproducible]`, `#[reproducible_capability]`, `#[taint]`, `#[sanitizes]`, `#[requires]`, `#[trusted_declassify]` | Make capability use, reproducibility scope, and information-flow tags explicit at the declaration boundary. |
+| **Intent & contract** | `#[purpose]`, `#[example]`, `#[fixture]`, `#[spec]`, `spec { }` block, `#[error_contract]`, `#[golden]` | Author-visible, machine-readable record of *what a declaration is for* and *what it must produce*. |
+| **Evolution & budget** | `#[since]`, `#[stability]`, `#[match_compat]`, `#[deprecated]`, `#[budget]` | Promises about API surface stability and performance regression bounds, enforced by `osty publish` and `osty bench --budget`. |
+
+Declarations without these annotations behave per the underlying
+grammar — the annotations are *opt-in attestations*, not new syntactic
+forms. The compiler does not synthesize defaults, so a function that
+omits `#[stability]` is treated as un-attested rather than implicitly
+stable.
 
 ### 3.1 Functions
 
@@ -1414,3 +1432,107 @@ fn test_lookupUser_returns_summary() {
 `FakeDb` / `FakeClock` 의 deterministic 동작이 테스트 결과의
 재현성을 보장. v0.6 테스트는 `--legacy-globals` 의존 없음 — 모든
 effect 가 fake 로 대체.
+
+### 3.17 Declaration anti-patterns and how v0.6 surfaces them
+
+The annotation surface in §3.10 – §3.15 / §20 / §21 is opt-in, but
+the v0.6 toolchain can detect declarations that *should* carry one
+of them and surface that as a lint or diagnostic. Six anti-patterns
+recur often enough to be tracked by `osty audit`:
+
+#### 3.17.1 Effect performed without a capability parameter
+
+```osty
+// ❌ Hidden dependency on the system clock — flagged by E0780.
+fn buildId() -> String {
+    "{time.now().toEpochMillis()}-{random.next()}"
+}
+
+// ✅ Explicit capability surface.
+fn buildId(clock: Clock, rng: Rng) -> String {
+    "{clock.now().toEpochMillis()}-{rng.next()}"
+}
+```
+
+`E0780` fires on every bare global effect call outside
+`--legacy-globals`. The fix is mechanical — accept the capability
+as a parameter; entry-point callers either bind ambient or forward
+explicitly.
+
+#### 3.17.2 `pub` API without `#[stability]`
+
+```osty
+// ⚠ W2105 — pub fn carries no stability attestation.
+pub fn createUser(email: String, db: Db) -> Result<UserId, Error> { ... }
+
+// ✅
+#[stability("stable")]
+#[since("0.6")]
+pub fn createUser(email: String, db: Db) -> Result<UserId, Error> { ... }
+```
+
+A `pub` symbol without `#[stability]` is *un-attested* — `osty
+publish` treats it as `experimental` for SemVer purposes, which
+allows breaking changes without a major bump but emits `W2100`
+warnings on every diff.
+
+#### 3.17.3 `Result<_, ConcreteEnum>` without `#[error_contract]`
+
+```osty
+// ⚠ W0414 — concrete Err type but no contract; documentation gap.
+pub fn parseEmail(s: String) -> Result<Email, EmailError> { ... }
+
+// ✅
+#[error_contract(
+    EmailError.Format        when "missing @ or wrong format",
+    EmailError.DomainBlocked when "domain in deny-list",
+)]
+pub fn parseEmail(s: String) -> Result<Email, EmailError> { ... }
+```
+
+The diagnostic is a warning, not an error: `#[error_contract]` is
+optional, but its absence on a concrete-enum return is almost always
+oversight rather than intent.
+
+#### 3.17.4 Sealed type external literal
+
+```osty
+// ❌ E0420 — Email is sealed; cannot construct outside its module.
+let e = Email { local: "alice", domain: "example.com" }
+
+// ✅
+let e = Email.parse("alice@example.com")?
+```
+
+#### 3.17.5 Sink without sanitizer on tainted input
+
+```osty
+fn handler(req: HttpRequest, db: Db) -> Response {
+    let id = req.queryParam("id") ?? ""
+    // ❌ E0901 — tainted input reaches sql_safe sink without sanitization.
+    db.query("SELECT * FROM users WHERE id = {id}")
+    ...
+}
+```
+
+The fix is parameterized query (`db.exec("SELECT ... WHERE id = ?",
+[id])`) or explicit sanitization (`std.sql.escape(id)`).
+
+#### 3.17.6 `#[reproducible]` with non-deterministic capability
+
+```osty
+// ❌ E0784 — reproducible function receives Clock (non-deterministic).
+#[reproducible(scope = "target")]
+fn cacheKey(clock: Clock, payload: Bytes) -> Bytes32 {
+    sha256(payload + clock.now().toBytes())
+}
+
+// ✅ Receive a precomputed timestamp instead.
+#[reproducible(scope = "target")]
+fn cacheKey(timestamp: Int64, payload: Bytes) -> Bytes32 {
+    sha256(payload + timestamp.toBytes())
+}
+```
+
+The caller is then responsible for capturing `clock.now()` at a
+non-reproducible boundary and passing the captured value down.

--- a/LANG_SPEC_v0.6/04-expressions.md
+++ b/LANG_SPEC_v0.6/04-expressions.md
@@ -12,8 +12,27 @@ member access (§4.9), indexing (§4.10), block scope (§4.11), `defer`
 semantics including cancellation interaction (§4.12), and assignment
 forms (§4.13).
 
-The v0.6 surface additions touch §4.4 only (the `while` synonym).
-All other expression forms carry forward from v0.5 unchanged.
+Three v0.6 surfaces interact with this chapter without changing its
+grammar:
+
+- **Capability flow.** `?`-propagation, `defer` cleanup, and `match`
+  exhaustiveness all see capability-typed bindings as ordinary values
+  — there is no `effect` keyword, no `try`/`catch`, and no special
+  `await` form. An `Err` from `fs.read(path)` propagates through `?`
+  identically to any other `Result<_, _>` (§4.5); `defer
+  conn.close()` runs through cancel paths exactly like every other
+  cleanup (§4.12, §8.4.3).
+- **Information flow.** `#[taint]`-tagged values flow through every
+  expression form (`if`, `match`, `?`, closures, indexing,
+  interpolation) preserving the tag set; sanitization is the only way
+  to drop a tag, and it must be explicit (§21.5).
+- **Spec block.** A function's `spec { }` block (§3.13, G43) sits in
+  *declaration position* — `spec { example: ... }` is not an
+  expression. It must be the function body's first statement; placing
+  it elsewhere is `E0440`.
+
+The v0.6 keyword addition is `while cond { }` as a synonym for
+`for cond { }` (G49, §4.4) — both lower to the same IR.
 
 ### 4.1 Block Expressions
 
@@ -554,5 +573,120 @@ Semantics:
 There are no compound forms for `&&`, `||`, `??`, or comparison
 operators. `++` and `--` are explicitly excluded (§14) and are not
 reintroduced by the compound family.
+
+### 4.14 Composing v0.6 surfaces in expression position
+
+The grammar in §4.1 – §4.13 is unchanged from v0.5; this section
+catalogues how the v0.6 attestation surfaces *appear* inside the
+expressions a programmer actually writes. None of these are new
+syntax — they are the existing constructs interacting with the v0.6
+annotation set.
+
+#### 4.14.1 `?` and capability-shaped errors
+
+`?` propagates `Err(...)` from a capability call without unwrapping
+the capability itself; the capability remains in scope across the
+propagation.
+
+```osty
+fn loadUser(fs: Fs, id: Int) -> Result<User, Error> {
+    let path = "users/{id}.json"
+    let text = fs.readToString(path)?       // Err(Cancelled) or Err(NotFound) bubbles
+    let user: User = json.parse(text)?
+    Ok(user)
+}
+```
+
+The function's return type is `Result<User, Error>`; the *concrete*
+errors that flow out are whatever `Fs.readToString` and `json.parse`
+produce, widened to `Error` at the up-cast site (§7.4). If the
+caller wants to discriminate, `err.downcast::<FsError>()` or a
+`#[error_contract(...)]` annotation makes that explicit.
+
+#### 4.14.2 `match` against `#[error_contract]` returns
+
+Match exhaustiveness against a contracted Result is computed against
+the contract variants, not the underlying enum's full surface
+(§7.5).
+
+```osty
+match createUser(email, db) {
+    Ok(uid) -> uid,
+    Err(UserCreateError.EmailFormat) -> ...,
+    Err(UserCreateError.DomainBlocked(d)) -> ...,
+    Err(UserCreateError.DbConflict(_)) -> ...,
+    // No `_ -> ...` needed if the contract enumerates exactly these
+    // three variants; future enum additions become Err arms via
+    // #[match_compat] (§3.14.4).
+}
+```
+
+#### 4.14.3 String interpolation and tainted bindings
+
+Interpolation `"{expr}"` desugars to `expr.toString()` per §17. The
+result `String` carries the tag set of `expr` — interpolation does
+not declassify:
+
+```osty
+fn welcome(user: #[taint("user_input")] User) -> String {
+    "hello {user.name}"     // result is #[taint("user_input")] String
+}
+```
+
+A sink that requires a clean `html_safe` tag rejects the result
+unless `std.html.escape` (or another registered sanitizer) sat
+between the binding and the sink.
+
+#### 4.14.4 Closures capture capabilities, not ambient bindings
+
+`#[ambient(...)]` binds names *only* inside the entry-point function
+body. A closure that runs later (in a `taskGroup`, in a callback
+passed to `iter.map`, in `defer`) needs the binding to be in lexical
+scope at the closure site:
+
+```osty
+#[ambient(net)]
+fn main() {
+    taskGroup(|g| {
+        g.spawn(|| net.fetch("https://a"))   // ✅ captures `net` from main
+        g.spawn(|| fetchOne(net, "https://b"))  // ✅ explicit pass
+    })
+}
+
+fn fetchOne(net: Net, url: String) -> Result<Bytes, Error> {
+    net.fetch(url)
+}
+```
+
+The closure inside `g.spawn(|| ...)` does not "inherit ambient" — it
+captures `net` by ordinary closure semantics. This is why
+`#[ambient]` is restricted to entry-point functions: ambient
+forwarding with structured concurrency would require an extra
+mechanism that v0.6 deliberately does not introduce (§14.5 rule 2).
+
+#### 4.14.5 `defer` is capability-blind
+
+A `defer`red expression runs whatever code it contains; the cleanup
+path can therefore call methods on the capability:
+
+```osty
+fn copyFile(fs: Fs, src: String, dst: String) -> Result<(), Error> {
+    let r = fs.open(src)?
+    defer logError(r.close(), "close src failed")
+
+    let w = fs.create(dst)?
+    defer logError(w.close(), "close dst failed")
+
+    io.copy(w, r)?
+    Ok(())
+}
+```
+
+`defer` runs on the cancel path too (§4.12 rule 7), so the close
+calls execute even when the surrounding `taskGroup` is being torn
+down. Blocking calls inside the `defer` body do **not** honor
+cancellation — cleanup is uninterruptible (§4.12 rule 8) — so
+authors who need bounded close-time use a timeout helper inside
+the body.
 
 ---

--- a/LANG_SPEC_v0.6/05-modules-and-packages.md
+++ b/LANG_SPEC_v0.6/05-modules-and-packages.md
@@ -3,11 +3,21 @@
 Osty v0.6 organizes code by directory: a directory is a package, and
 all `.osty` files in that directory share one namespace. Packages
 import each other through `use` statements. The import surface —
-including `use path::{a, b as c}` (G28), `pub use path.Sym` (G30),
-and `#[cfg(...)]`-conditional declarations (G29) — is unchanged in
-v0.6. v0.6 adds no new module-system syntax; the publishing surface
-(`osty publish` SemVer enforcement, G44) and its API-surface diff
-algorithm are described in §13.5 and §3.14.3 respectively.
+scoped imports (`use path::{a, b as c}`), re-exports
+(`pub use path.Sym`), and `#[cfg(...)]`-conditional declarations —
+is the v0.6 baseline.
+
+v0.6 layers two enforcement surfaces on this chapter's syntax,
+defined elsewhere:
+
+- **`osty publish` API-surface diff** (§13.5, §3.14.3) — a stable
+  package's public surface is hashed at publish time; subsequent
+  releases that drop or weaken a `#[stability("stable")]` symbol
+  bump the major version automatically (G44).
+- **Sealed `pub` types** (§3.4.5) — a struct annotated
+  `#[sealed_construct(parse)]` exports its name through `pub` but
+  rejects external literal construction; downstream packages must
+  route through the named constructor.
 
 ### 5.1 Package = Directory
 
@@ -101,5 +111,55 @@ build" — see §13.2.
 
 Each directory is exactly one package. Sub-packages live in
 subdirectories.
+
+### 5.6 Public surface and v0.6 evolution rules
+
+The public surface of a package is the set of `pub` declarations
+visible to importers — `pub fn`, `pub struct` (with its `pub`
+fields), `pub enum` variants, `pub interface`, `pub type` aliases,
+and `pub let` constants. v0.6 layers three machine-readable
+attestations onto that surface:
+
+#### 5.6.1 `#[stability]` and SemVer
+
+A `pub` declaration carries `#[stability(level)]` (§3.14) where
+`level` is one of `"stable"` / `"experimental"` / `"deprecated"` /
+`"internal"`. `osty publish` (§13.5) reads the manifest's
+`stability_default` and per-symbol overrides, then computes the
+API-surface diff against the previous published version:
+
+| Change | `stable` | `experimental` |
+|---|---|---|
+| Add a new `pub` symbol | minor bump | patch bump |
+| Add a new field to a `pub struct` (without sealed_construct) | major bump | minor bump |
+| Add a new variant to a `pub enum` | major bump (unless `#[match_compat]` covers it) | minor bump |
+| Remove a `pub` symbol | major bump | warning (`W2100`) |
+| Change the type of a `pub fn` parameter / return | major bump | warning (`W2100`) |
+| Add a new `Err` variant to `#[error_contract]` | major bump | minor bump |
+
+Bumping below the required level produces `E2100` and blocks publish.
+
+#### 5.6.2 Sealed types in the public surface
+
+A `pub struct` annotated `#[sealed_construct(parse)]` (§3.4.5)
+appears in the public surface as a *type only* — its fields, even
+the `pub` ones, do not allow external literal construction. Adding
+or removing fields on a sealed type is therefore *not* a SemVer-
+breaking change in itself; only the constructor signature
+(`Type.parse(...)` etc.) is part of the stable contract. This
+inverts the usual struct-evolution rule and is what makes the
+parse-don't-validate pattern compose well with v0.6 publish gates.
+
+#### 5.6.3 Capability surface is part of the contract
+
+A `pub fn` that takes a `Net` parameter exposes "this function
+performs a network effect" as part of its public contract. Adding,
+removing, or changing the capability set of a `pub fn` is a
+**breaking change** at the `stable` level — the API-surface diff
+algorithm includes capability-typed parameters in the signature
+hash. Authors who want to add a capability requirement to an
+existing `stable` API must either bump the major version or
+introduce a new function and deprecate the old one with
+`#[deprecated(use = "newName")]`.
 
 ---

--- a/LANG_SPEC_v0.6/06-scripts.md
+++ b/LANG_SPEC_v0.6/06-scripts.md
@@ -51,4 +51,80 @@ Rules:
 `osty run script.osty` compiles and executes a script. With the shebang
 line present, `chmod +x script.osty && ./script.osty` also works.
 
+### 6.1 Ambient capability binding
+
+The synthesized `main` in a script file carries an automatic
+`#[ambient(clock, rng, env, fs)]` (§20.3). The ambient binding is
+*scoped to the script's main only* — it does not propagate into:
+
+- `fn` declarations defined at the top level of the script (those
+  declarations are ordinary functions; they receive only what their
+  signature declares),
+- closures `g.spawn(|| ...)` inside a `taskGroup` (closures capture
+  the script's bindings by reference, so they can name `clock`
+  etc., but the *capture* is what makes them visible — not ambient
+  forwarding through the spawn boundary; see §8.7.2).
+
+```osty
+#!/usr/bin/env osty
+// hello.osty — script file
+
+let now = clock.now()                  // ambient binding visible
+let user = env.get("USER") ?? "world"
+
+println("hi {user}, {now}")
+
+// Helper fn — ambient does NOT cross. Capability must be a parameter.
+fn render(clock: Clock, prefix: String) -> String {
+    "{prefix} @ {clock.now().toString()}"
+}
+
+println(render(clock, "tick"))         // explicit hand-off
+```
+
+Scripts that need additional capabilities (`net`, `process`,
+`console`) must declare them via an explicit `#[ambient(...)]` at
+the top of the script source. The synthesized `main`'s default set
+covers the most common script needs but is intentionally limited;
+broader scripts opt in:
+
+```osty
+// script with additional ambient
+#[ambient(clock, rng, env, fs, net, console)]
+
+let resp = net.get("https://api.example.com/health")?
+console.println("health: {resp.status}")
+```
+
+A `#[ambient]` line at script top-level **replaces** the synthesized
+default set — it is not additive. Listing only `clock` here would
+remove `rng`, `env`, and `fs`. This is the design explicitly: *no
+hidden defaults*. The reduced set is what you signed up for.
+
+### 6.2 Scripts and information flow
+
+Scripts inherit the same flow-tracking rules as library code (§21).
+Tainted input flowing into a sink without sanitization is an error
+even at the script level — there is no relaxed mode. The expected
+pattern is:
+
+```osty
+#[ambient(env, process)]
+
+let target = env.get("TARGET") ?? "localhost"
+// `target` is tainted (env value); shell sink requires shell_safe.
+// Either parameterize…
+process.exec("ping", ["-c", "1", target])
+
+// …or sanitize explicitly.
+let safe = std.shell.quote(target)
+process.execShell("ping -c 1 {safe}")
+```
+
+The `process.exec(cmd, args)` form already takes a list of arguments
+and does not interpolate; tainted strings landing in `args` are
+acceptable to `process.exec` because the spawn does not interpret
+them as shell metacharacters. `process.execShell(cmdline)` *does*
+interpret them and therefore requires `shell_safe` on the input.
+
 ---

--- a/LANG_SPEC_v0.6/07-the-error-interface.md
+++ b/LANG_SPEC_v0.6/07-the-error-interface.md
@@ -1,16 +1,36 @@
 ## 7. The Error Interface
 
 Osty v0.6 represents errors as values, never as exceptions. The
-`Error` interface (§7.1) carries a nominal tag for runtime downcast
-(`as?` per §4 and §7.4), `BasicError` (§7.2) provides the standard
-constructor, custom error enums (§7.3) integrate via the structural
-interface rules of §2.6, and propagation uses the `?` operator
-(§7.4). The v0.6 addition is `#[error_contract]` (§7.5, G41) — a
-declaration-level annotation that catalogues which error variants
-flow out under which conditions, enabling caller-side exhaustiveness
-pruning, machine-readable failure-mode export via `osty context`
-(§13.4), and the publish-time SemVer rule that adding a contracted
-variant is a breaking change (§3.14.3).
+chapter defines four pieces:
+
+- **`Error` interface** (§7.1) — the structural protocol every error
+  satisfies. Values that flow through this interface carry a nominal
+  type tag for runtime downcast.
+- **`BasicError`** (§7.2) — the stdlib constructor for ad-hoc string
+  errors (`Error.new("...")`).
+- **Custom error enums** (§7.3) — application-specific error
+  hierarchies that integrate via the structural rules of §2.6.
+- **Propagation** (§7.4) — the `?` operator for `Result<T, E>` /
+  `Option<T>`, with up-cast to `Error` when the enclosing function
+  returns `Result<_, Error>`.
+
+Two v0.6 surfaces sit on top of this baseline:
+
+- **`#[error_contract]`** (§7.5, G41) — a declaration-level
+  attestation that catalogues which error variants flow out and
+  under which conditions. Enables caller-side exhaustiveness pruning,
+  machine-readable failure-mode export via `osty context` (§13.4),
+  and the publish-time SemVer rule that adding a contracted variant
+  is a breaking change (§3.14.3).
+- **Cancellation as a recoverable error** — `Err(Cancelled { cause
+  })` is the Result-shaped form of the cancel signal (§8.4.1). It
+  flows through `?` identically to any other `Error`, so canceling a
+  `taskGroup` requires no new control-flow construct in this
+  chapter.
+
+There is no `try`/`catch`. Programmer errors (`abort` / `unreachable`
+/ `todo`) are deliberate process termination, not recoverable failure
+— they bypass `?` propagation entirely (§4.12 rule 7).
 
 ### 7.1 Definition
 
@@ -213,3 +233,48 @@ Failure modes:
 ```
 
 `osty context <fn>` (§13.6) emits the same data as JSON.
+
+### 7.6 Cancellation as a Recoverable Error
+
+The cancel signal is delivered as `Err(Cancelled { cause })` (see
+§8.4.1). It is an *ordinary* `Error`-shaped value: every rule in this
+chapter — `?`-propagation, `match err.downcast::<Cancelled>()`,
+`#[error_contract(Cancelled when ...)]`, conversion to a wrapping
+enum — applies identically.
+
+```osty
+fn copyAll(fs: Fs, src: String, dst: String) -> Result<(), Error> {
+    let r = fs.open(src)?
+    defer r.close()
+    let w = fs.create(dst)?
+    defer w.close()
+
+    io.copy(w, r)?            // returns Err(Cancelled) on cancel
+    Ok(())
+}
+```
+
+If recovery is desired (rare), a downcast tells `Cancelled` apart
+from other errors. The recovered task **must** propagate cancellation
+upward immediately afterward — swallowing a cancel is a soundness
+bug:
+
+```osty
+fn try_with_log(fs: Fs, console: Console, src: String) -> Result<Bytes, Error> {
+    match fs.read(src) {
+        Ok(b) -> Ok(b),
+        Err(e) -> match e.downcast::<Cancelled>() {
+            Some(c) -> {
+                console.eprintln("cancel mid-read: {c.cause.message()}")
+                Err(e)         // re-propagate; do not return Ok or a placeholder
+            },
+            None -> Err(e),
+        },
+    }
+}
+```
+
+**Cancellation is *not* listed in `#[error_contract]` by default.** A
+contract that does not mention `Cancelled` still permits it to flow
+out — the contract describes domain-specific failure modes, while
+cancellation is a structural concern owned by §8.4.

--- a/LANG_SPEC_v0.6/08-concurrency.md
+++ b/LANG_SPEC_v0.6/08-concurrency.md
@@ -9,12 +9,25 @@ state under `std.sync` primitives (§8.6). The non-escaping rule for
 `Handle<T>` and `TaskGroup` capabilities (G13, §8.2) is enforced by a
 finite front-end check, not lifetimes.
 
-This chapter is unchanged from v0.5 in semantics. v0.6 introduces
-capability parameters (§20) which interact with concurrent code:
-spawning a child task that needs a `Clock` requires explicit
-forwarding from the enclosing scope, since ambient bindings do not
-cross function boundaries. The `Net` and `Fs` capabilities are
-cancellation-aware, matching the v0.5 stdlib contract.
+Capability parameters (§20) flow through `taskGroup` naturally:
+spawned closures *capture* the outer scope's capabilities by
+reference, so a child task that needs a `Clock` is satisfied by the
+enclosing function's `clock` parameter without any explicit hand-off.
+What does **not** cross is `#[ambient]` binding (§20.3) — ambient
+binding is scoped to the enclosing entry-point function, never to
+spawned closures. A child that wants ambient access must instead
+*receive* the capability as a parameter (or capture a binding that
+already received it).
+
+`Net`, `Fs`, and `Clock` are cancellation-aware: every blocking
+operation honors §8.4.2's cancellation contract and returns
+`Err(Cancelled { cause })` when the surrounding `taskGroup` is being
+torn down. CPU-bound work without stdlib calls must check
+`thread.isCancelled()` (§8.4.2) explicitly.
+
+The non-escaping rule for `Handle<T>` and `TaskGroup` (G13, §8.2) is
+enforced by a finite front-end check, not lifetimes — the rule
+predates v0.6 and is unchanged.
 
 ### 8.0 Scheduler Model
 
@@ -254,5 +267,80 @@ and a simultaneously-ready branch.
 channel is "ready" and fires once with `None` (matching the `recv`
 semantics of §8.5). A `send` branch on a closed channel aborts when
 selected.
+
+### 8.7 Capabilities and Tasks
+
+The capability surface (§20) and structured concurrency compose
+through three rules:
+
+#### 8.7.1 Closures capture by reference
+
+A closure passed to `g.spawn(...)` keeps the outer scope's
+capabilities alive for the closure's lifetime, exactly as it would
+keep any other captured binding alive. The captured reference is
+shared — multiple sibling tasks spawned from the same enclosing
+function may legitimately call methods on the same `Net` or `Fs`
+instance concurrently. Capabilities are themselves expected to be
+internally synchronized; a host `Net` adapter that opens a TCP
+connection per call is automatically thread-safe under this rule.
+
+```osty
+fn fanout(net: Net, urls: List<String>) -> Result<List<Bytes>, Error> {
+    taskGroup(|g| {
+        let handles = urls.map(|u| g.spawn(|| net.fetch(u)))   // shared `net`
+        handles.map(|h| h.join()).traverse(|r| r)
+    })
+}
+```
+
+#### 8.7.2 Ambient binding does not cross spawn
+
+`#[ambient(...)]` only binds names inside the *enclosing entry-point
+function*. A child task spawned via `g.spawn(|| ...)` cannot reference
+an ambient `clock` even if the entry point declared one — the closure
+must capture the binding explicitly:
+
+```osty
+#[ambient(clock)]
+fn main() {
+    taskGroup(|g| {
+        // ✅ closure captures the ambient `clock` from main's scope
+        g.spawn(|| clock.sleep(1.s))
+
+        // ❌ helper called below would receive *no* ambient clock
+        //    — its capability parameter must be passed explicitly
+        g.spawn(|| sweep(clock))
+    })
+}
+
+fn sweep(clock: Clock) -> Result<(), Error> {
+    clock.sleep(5.s)?
+    Ok(())
+}
+```
+
+#### 8.7.3 Cancel signals are capability-blind
+
+Cancellation flows by *task lineage*, not by capability identity. If
+a parent's `taskGroup` cancels, every descendant blocking call —
+regardless of which capability it is on, including ones the parent
+never directly used — observes `Err(Cancelled { cause })`. This is
+why the `Net` / `Fs` / `Clock` adapters are required to be
+cancellation-aware (§8.4.2).
+
+A capability that cannot honor cancellation (a hypothetical
+synchronous FFI symbol with no abort path) must document that limit
+and is *not* added to the canonical capability surface.
+
+#### 8.7.4 Capability-typed channels
+
+A channel's element type may be a capability instance, but it is
+almost always a mistake. A `thread.chan::<Net>(8)` would let a
+producer hand a network handle to a consumer that lives in a
+different `taskGroup`, breaking the lifetime model: capabilities
+are not `Handle<T>`-flavored and have no escape rule, but in practice
+a host `Net` adapter often holds resources tied to its construction
+context. Prefer sending request/response data through the channel
+and keep the capability bound to the original scope.
 
 ---

--- a/LANG_SPEC_v0.6/09-memory-management.md
+++ b/LANG_SPEC_v0.6/09-memory-management.md
@@ -15,7 +15,8 @@ identically to an untainted one, and a `Clock` capability instance
 has the same lifetime rules as any reference value.
 
 Resource cleanup is done through `defer` (§4.12) or closure-based
-stdlib APIs (`fs.withFile`, `net.withConn`, etc.).
+helpers on the relevant capability (`Fs.withFile(self, path, body)`,
+`Net.withConn(self, addr, body)`, etc.).
 
 `std.sync` provides `Mutex`, `RwLock`, and atomics.
 

--- a/LANG_SPEC_v0.6/10-standard-library/07-lazy-iterators.md
+++ b/LANG_SPEC_v0.6/10-standard-library/07-lazy-iterators.md
@@ -12,10 +12,17 @@ let result = iter.from(xs)
     .toList()
 ```
 
-The current v0.4 stdlib implementation is eager over a backing
-`List<T>`: adapters allocate a new `Iter<T>` immediately. The API is
-kept fluent so user code can move to a lazy pull-based implementation
-later without changing call sites.
+The current implementation is **eager** over a backing `List<T>`:
+each adapter allocates a new `Iter<T>`. The surface is fluent on
+purpose — when the runtime gains pull-based iteration, call sites
+keep working unchanged. `Iter<T>` participates in the iteration
+protocol (§15) like any other `Iterable<T>`, so `for x in iter` is
+always available alongside the chained terminators below.
+
+The chain itself is *capability-free* — `map` / `filter` /
+`take` / `toList` perform no I/O and are safe to compose inside a
+`#[reproducible(scope = "target")]` function (§3.11), provided the
+closure arguments are themselves capability-free.
 
 API:
 

--- a/LANG_SPEC_v0.6/10-standard-library/08-json.md
+++ b/LANG_SPEC_v0.6/10-standard-library/08-json.md
@@ -32,9 +32,9 @@ Mapping:
 
 - **Unknown keys are silently ignored.** A JSON object may contain keys
   not named by the target struct; the decoder skips them. This is the
-  forward-compatible default (Go/Rust convention). The `#[json(strict)]`
-  annotation is *not* part of the v0.4 set — use a custom `Decode`
-  implementation if strict rejection is required.
+  forward-compatible default (Go/Rust convention). A `#[json(strict)]`
+  variant is not part of the v0.6 annotation surface — use a custom
+  `Decode` implementation if strict rejection is required.
 - **Type mismatches are fatal.** When an incoming value's JSON type
   does not match the target (e.g. string where integer expected),
   `json.decode` returns `Err` immediately. There is no partial recovery

--- a/LANG_SPEC_v0.6/10-standard-library/15-operating-system.md
+++ b/LANG_SPEC_v0.6/10-standard-library/15-operating-system.md
@@ -44,7 +44,12 @@ os.exit(0)
 
 API:
 
+Path helpers are pure functions. Process effects (`exec`, `exit`, …) are
+methods on the `Process` capability (§20.9.6); the function-style
+listings below match the `--legacy-globals` desugar target.
+
 ```
+// Pure path helpers — no capability required.
 os.path.join(parts: List<String>) -> String
 os.path.split(path: String) -> (String, String)      // (dirname, basename)
 os.path.extension(path: String) -> String
@@ -53,10 +58,15 @@ os.path.basename(path: String) -> String
 os.path.absolute(path: String) -> Result<String, Error>
 os.path.canonical(path: String) -> Result<String, Error>
 os.path.isAbsolute(path: String) -> Bool
-os.path.separator() -> String                         // "/" or "\\"
+os.path.separator() -> String                        // "/" or "\\"
 
-os.exec(cmd: String, args: List<String>) -> Result<Output, Error>
-os.execShell(command: String) -> Result<Output, Error>
+// `Process` capability methods (canonical v0.6 surface).
+Process.exec(self, cmd: String, args: List<String>) -> Result<Output, Error>
+Process.execShell(self, command: String) -> Result<Output, Error>
+Process.exit(self, code: Int) -> Never
+Process.pid(self) -> Int
+Process.hostname(self) -> String
+Process.onSignal(self, sig: Signal, handler: fn())
 
 pub struct Output {
     pub exitCode: Int,
@@ -64,10 +74,17 @@ pub struct Output {
     pub stderr: String,
 }
 
-os.exit(code: Int) -> Never
-os.pid() -> Int
-os.hostname() -> String
-
-os.onSignal(sig: Signal, handler: fn())
 pub enum Signal { Interrupt, Terminate, Hangup }
+```
+
+Legacy aliases (desugar to the methods above when `--legacy-globals` is
+active; rejected otherwise — `E0780`):
+
+```
+os.exec(cmd, args)        ⟶  process.exec(cmd, args)
+os.execShell(command)     ⟶  process.execShell(command)
+os.exit(code)             ⟶  process.exit(code)
+os.pid()                  ⟶  process.pid()
+os.hostname()             ⟶  process.hostname()
+os.onSignal(sig, handler) ⟶  process.onSignal(sig, handler)
 ```

--- a/LANG_SPEC_v0.6/10-standard-library/23-net.md
+++ b/LANG_SPEC_v0.6/10-standard-library/23-net.md
@@ -63,11 +63,16 @@ fn addrInfo(net: Net) -> Result<Addr, Error> {
 
 API:
 
+The methods below hang off the `Net` capability (§20.9.5). Listings
+written `Net.method(self, ...)` are the canonical v0.6 form;
+`net.method(...)` legacy aliases desugar to the same call when
+`--legacy-globals` is active and are rejected otherwise (`E0780`).
+
 ```
 // TCP
-net.connect(addr: String) -> Result<TcpConn, Error>
-net.connectTimeout(addr: String, timeout: Duration) -> Result<TcpConn, Error>
-net.listen(addr: String) -> Result<TcpListener, Error>
+Net.connect(self, addr: String) -> Result<TcpConn, Error>
+Net.connectTimeout(self, addr: String, timeout: Duration) -> Result<TcpConn, Error>
+Net.listen(self, addr: String) -> Result<TcpListener, Error>
 
 pub struct TcpConn {
     // implements Reader, Writer, Closer (§16)
@@ -90,8 +95,8 @@ pub struct TcpListener {
 }
 
 // UDP
-net.udpBind(addr: String) -> Result<UdpSocket, Error>
-net.udpConnect(addr: String) -> Result<UdpSocket, Error>   // connected mode
+Net.udpBind(self, addr: String) -> Result<UdpSocket, Error>
+Net.udpConnect(self, addr: String) -> Result<UdpSocket, Error>  // connected mode
 
 pub struct UdpSocket {
     // implements Closer (§16)
@@ -103,9 +108,9 @@ pub struct UdpSocket {
     fn localAddr(self) -> Addr
 }
 
-// Address resolution
-net.resolve(addr: String) -> Result<Addr, Error>
-net.resolveAll(host: String) -> Result<List<Addr>, Error>
+// Address resolution (DNS — also a network effect, hence on the capability)
+Net.resolve(self, addr: String) -> Result<Addr, Error>
+Net.resolveAll(self, host: String) -> Result<List<Addr>, Error>
 
 pub struct Addr {
     pub host: String,

--- a/LANG_SPEC_v0.6/10-standard-library/24-http.md
+++ b/LANG_SPEC_v0.6/10-standard-library/24-http.md
@@ -93,20 +93,21 @@ pub type Params = Map<String, String>
 pub type Handler = fn(Request) -> Result<Response, Error>
 pub type RouteHandler = fn(Request, Params) -> Result<Response, Error>
 
-// Runtime-owned primitives
-http.request(req: Request) -> Result<Response, Error>
-http.get(url: String, headers: Headers = {:}) -> Result<Response, Error>
-http.serve(addr: String, handler: Handler) -> Result<(), Error>
+// Network-effecting primitives — methods on the client / server objects
+// returned by `Net.httpClient()` / `Net.httpServer()` (§20.9.5).
+HttpClient.request(self, req: Request) -> Result<Response, Error>
+HttpClient.get(self, url: String, headers: Headers = {:}) -> Result<Response, Error>
+HttpClient.send(self, method: Method, url: String, body: Bytes, headers: Headers = {:}) -> Result<Response, Error>
+HttpClient.head(self, ...) / post(self, ...) / put(self, ...) / patch(self, ...) / delete(self, ...) / options(self, ...) / trace(self, ...) / connect(self, ...)
+HttpClient.sendText(self, ...) / sendJson(self, ...) / sendForm(self, ...)
+HttpClient.postText(self, ...) / putText(self, ...) / patchText(self, ...)
+HttpClient.postJson(self, ...) / putJson(self, ...) / patchJson(self, ...)
+HttpClient.postForm(self, ...) / putForm(self, ...) / patchForm(self, ...)
+HttpServer.serve(self, addr: String, handler: Handler) -> Result<(), Error>
 
-// Client helpers
+// Pure helpers — operate on values, no capability needed.
 http.newRequest(method: Method, url: String) -> Request
 http.dispatch(router: Router, req: Request) -> Result<Response, Error>
-http.send(method: Method, url: String, body: Bytes, headers: Headers = {:}) -> Result<Response, Error>
-http.head(...) / post(...) / put(...) / patch(...) / delete(...) / options(...) / trace(...) / connect(...)
-http.sendText(...) / sendJson(...) / sendForm(...)
-http.postText(...) / putText(...) / patchText(...)
-http.postJson(...) / putJson(...) / patchJson(...)
-http.postForm(...) / putForm(...) / patchForm(...)
 
 // Query/form codecs
 http.parseQuery(text: String) -> Result<QueryValues, Error>
@@ -298,7 +299,9 @@ http.newRouter() -> Router
 - `problem(...)` and `Problem.toResponse()` emit
   `application/problem+json` bodies.
 - Server code dispatches routers through `http.dispatch(router, req)`. The
-  transport primitive remains `http.serve(addr, handler)`.
+  transport primitive is `HttpServer.serve(addr, handler)` on the
+  capability-supplied server object (legacy `http.serve(addr, handler)`
+  desugars there under `--legacy-globals`).
 
 **Current runtime limits.**
 

--- a/LANG_SPEC_v0.6/12-foreign-function-interface.md
+++ b/LANG_SPEC_v0.6/12-foreign-function-interface.md
@@ -1,18 +1,34 @@
 ## 12. Foreign Function Interface
 
-Osty v0.6 interoperates with Go via `use go "..." { ... }` declaration
-blocks. The bridge maps Osty's `Result<T, Error>` to Go's
-`(T, error)`, optional types `T?` to nullable pointers `*T`, and
-preserves panic-as-process-abort semantics. Go closures, generics,
-empty interfaces, and channel types are not exposed across the
-boundary.
+Osty v0.6 supports two FFI families:
 
-The v0.6 information flow surface (§21) treats data crossing an FFI
-boundary as untagged by default. When data has been validated outside
-Osty's flow tracking, the `#[trusted_declassify(reason)]` annotation
-on the FFI wrapper drops flow tags with audit-marked attestation —
-all such sites are enumerable via `osty audit --trusted-declassify`
-(§13.7).
+- **Go FFI** (`use go "..." { ... }`) — for the bootstrap toolchain
+  and any deployment that runs on the Go runtime. The bridge maps
+  `Result<T, Error>` ↔ `(T, error)`, `T?` ↔ `*T`, and
+  preserves panic-as-process-abort semantics. Closures, generics,
+  empty interfaces, and channel types are not exposed across the
+  boundary (§12.7).
+- **Native C ABI** (`use c "..." { ... }` / `use runtime.cabi.*`) —
+  for `--backend llvm` builds, where the Go runtime is not present.
+  Same constraint set as Go FFI; symbol resolution and link
+  contracts are described in §12.8.
+
+Three v0.6 surfaces apply at the FFI boundary:
+
+- **Information flow tags drop on entry.** Bytes that originate
+  outside Osty have no `#[taint]` history, so the FFI wrapper
+  receives them untagged. To re-tag (so downstream sinks pay the
+  appropriate sanitization cost), apply `#[taint("σ")]` on the
+  wrapper's return type at the boundary.
+- **Audited declassification.** When Osty-side data must cross *out*
+  of Osty's flow tracking despite carrying tags, the wrapper carries
+  `#[trusted_declassify(reason)]` — every such site is enumerable
+  via `osty audit --trusted-declassify` (§13.7).
+- **Capability passthrough is not allowed.** A capability instance
+  (`Clock`, `Net`, …) is an Osty-side object with no stable foreign
+  ABI. FFI wrappers that need foreign-side effects must take the
+  primitive arguments (paths, addresses, …) and own the effect
+  inside the Osty wrapper, not pass a `Net` value through.
 
 ### 12.1 Importing Go Packages
 

--- a/LANG_SPEC_v0.6/13-tooling.md
+++ b/LANG_SPEC_v0.6/13-tooling.md
@@ -742,3 +742,52 @@ tooling surface 의 SemVer 영향:
 `osty publish` 자체의 `osty publish` 가 publish surface 인 것은
 recursive 하지만 — `osty` CLI 자체는 의 publish 통한 SemVer 검증
 대상은 아니다 (CLI 는 별도 release flow).
+
+### 13.16 Capability inventory and review aids
+
+A reviewer / author who needs to see *which capabilities a package
+uses* without reading every file has three CLI surfaces:
+
+```sh
+# Per-package capability summary — one line per pub fn.
+osty audit --capabilities
+
+# Per-symbol detail — capabilities, flow tags, error_contract,
+# stability, since, budget, fixtures, examples, spec link.
+osty context <symbol> --format=json
+
+# Diff of capability usage between two refs (e.g. main vs PR).
+osty audit --capabilities --diff main..HEAD
+```
+
+Sample output of `osty audit --capabilities` (text mode):
+
+```
+pkg myapp.users
+  pub fn createUser(email: String, db: Db)             [Db]
+  pub fn parseEmail(s: String)                          (pure)
+  pub fn fetchAvatar(net: Net, url: Url)                [Net]
+
+pkg myapp.audit
+  pub fn record(clock: Clock, fs: Fs, event: Event)     [Clock, Fs]
+```
+
+The same data drives review-bot comments and the package home-page
+renderer.
+
+### 13.17 Tooling under `--legacy-globals`
+
+`--legacy-globals` is a *transitional* compatibility mode that lets
+v0.5 source compile under v0.6.x. Tooling behavior under the flag:
+
+| Surface | Default (`v0.6`) | `--legacy-globals` |
+|---|---|---|
+| `osty check` | rejects bare `time.now()` etc. (`E0780`) | accepts (`W0750` deprecation per call site) |
+| `osty publish` | manifest's stability default may be `stable` | forced to `experimental` (global desugar contaminates surface) |
+| `osty audit --legacy-globals` | enumerates remaining sites (none expected) | enumerates remaining sites |
+| `osty bench --budget` | unchanged | unchanged (capability methods desugar to the same calls at runtime) |
+
+`v0.7` removes the flag; programs that still depend on it must
+migrate by then. The migration path is documented in
+`MIGRATING_v0.5_to_v0.6.md` and §10.46 (Capability Migration
+Catalog).

--- a/LANG_SPEC_v0.6/14-excluded-features.md
+++ b/LANG_SPEC_v0.6/14-excluded-features.md
@@ -155,4 +155,38 @@ The v0.4 → v0.5 newly accepted syntax (`loop`, labeled `break` /
 [`18-change-history.md §18.1`](./18-change-history.md). All forms
 remain in v0.6 unchanged.
 
+### 14.5 Why v0.6 stops where it does
+
+The v0.6 surface adds 14 design decisions (G36–G49) catalogued in
+[`00-revision.md`](./00-revision.md). Each is a *narrow* attestation
+mechanism — capability parameter, taint tag, sealed construct,
+error contract, intent annotation, spec block, golden test,
+reproducibility scope, performance budget, API stability tier,
+match-compat fallback, while keyword. None of them introduce a new
+type kind, a new control-flow primitive, or a new evaluation rule.
+
+This is intentional. The exclusions in §14.1 (no exceptions, no
+inheritance, no lifetimes, no overloading, no implicit numeric
+conversion, no macros, no user annotations) constrain the language
+to a small grammar that compiles to a small IR. v0.6's additions
+must compose with that grammar without breaking it. Every G36–G49
+decision was vetted against three questions:
+
+1. **Does it expand the type kind set?** If yes, the proposal is
+   demoted to *attestation only* (e.g. `#[reproducible]` does not
+   create a new function type — it is a checker-side promise).
+2. **Does it introduce a new control-flow construct?** If yes, the
+   proposal is rejected. `Cancelled` flows through `?`, capabilities
+   ride on ordinary parameters, spec blocks are statement-shaped,
+   `while` desugars to `for`.
+3. **Does it require a new annotation argument shape?** If yes, the
+   proposal is reshaped to fit the literal-only argument grammar
+   (no expressions, no nested annotations).
+
+Future proposals (G50+) tracked in `SPEC_GAPS.md` are evaluated
+against the same three questions. Anonymous structural records, for
+example, were proposed during the v0.6 batch and withdrawn because
+they would have fork-extended the type-kind set without buying a
+proportional safety / clarity gain.
+
 ---

--- a/LANG_SPEC_v0.6/15-iteration-protocol.md
+++ b/LANG_SPEC_v0.6/15-iteration-protocol.md
@@ -2,11 +2,20 @@
 
 Osty v0.6 defines iteration through two structural interfaces:
 `Iterator<T>` and `Iterable<T>`. Any type implementing `Iterable<T>`
-participates in `for x in xs { ... }` loops. The protocol is
-unchanged from v0.5 in semantics; the v0.6 backend layer optimizes
-for `List<T>` / range / `Map<K, V>` shapes (cf. SPEC_GAPS
-`vectorize-hint`), but every conforming type works under the protocol
-regardless of backend optimization.
+participates in `for x in xs { ... }` loops.
+
+The protocol is intentionally minimal so it composes cleanly with the
+v0.6 surfaces:
+
+- A `for x in xs` loop carrying a capability (e.g. `Net`) keeps it
+  available in the body — the loop introduces no new scope boundary
+  that ambient binding (§20.3) would have to cross.
+- An iterator over `#[taint("σ")]` values yields tagged elements;
+  flow tracking (§21) propagates the tag into each loop iteration
+  binding without any `for`-specific rule.
+- Backend vectorization (§3.8.5) targets `List<T>` / range /
+  `Map<K, V>` shapes today; arbitrary `Iterable` implementations fall
+  back to method dispatch but participate in the protocol identically.
 
 Lazy iterator combinators (filter, map, take, …) live in `std.iter`
 (§10.7). User types implement `Iterable<T>` directly; the compiler
@@ -88,5 +97,93 @@ for x in (CountdownFrom { start: 3 }) {
 ```
 
 (The parentheses around the struct literal are required by §4.1.1.)
+
+### 15.1 Iteration over capability-derived sources
+
+A capability that yields a stream returns an `Iterable<T>` whose
+*construction* required the capability but whose *iteration* does
+not — once the iterator is built, the capability is no longer
+consulted to advance it. This separates the question of who is
+allowed to *open* the source from the question of how the body of
+the loop processes its elements:
+
+```osty
+fn auditLines(fs: Fs, path: String, console: Console) -> Result<(), Error> {
+    let lines = fs.lines(path)?           // construction needs `fs`
+    for line in lines {                   // iteration does not
+        console.println(line)
+    }
+    Ok(())
+}
+```
+
+The reverse — *consuming an iterator* that was built by someone else
+— is therefore safe in a more restricted scope. A pure helper can
+take an `Iterable<T>` of already-collected lines and process them
+without needing `Fs`:
+
+```osty
+#[reproducible(scope = "target")]
+fn classify(lines: Iterable<String>) -> Map<String, Int> {
+    let mut counts: Map<String, Int> = {:}
+    for line in lines {
+        let cat = categoryOf(line)
+        counts.update(cat, |n| (n ?? 0) + 1)
+    }
+    counts
+}
+```
+
+### 15.2 Iteration over channels
+
+`Channel<T>` (§8.5) implements `Iterable<T>`. Iteration ends
+naturally when the channel is closed and drained. Inside a
+`taskGroup`, the iterating task is automatically cancelled along
+with its siblings if the group enters cancellation:
+
+```osty
+fn pipeline(net: Net, jobs: List<Job>) -> Result<(), Error> {
+    let ch = thread.chan::<Job>(64)
+
+    taskGroup(|g| {
+        // Producer
+        g.spawn(|| {
+            for j in jobs { ch <- j }
+            ch.close()
+        })
+
+        // Consumer (main task)
+        for j in ch {
+            net.dispatch(j)?     // returns Err(Cancelled) on cancel
+        }
+        Ok(())
+    })
+}
+```
+
+Reading `ch.recv()` directly (not via `for ... in`) returns `None`
+both on natural close and on cancel; check `thread.isCancelled()` to
+distinguish the two cases (§8.5).
+
+### 15.3 Iteration and information flow
+
+A `for x in xs` loop binds `x` with the element type's flow tag set
+preserved. There is no implicit declassification at the loop
+boundary:
+
+```osty
+let lines: Iterable<#[taint("user_input")] String> = ...
+for line in lines {
+    // `line` is #[taint("user_input")] String — must sanitize before
+    // it reaches a sink such as db.query.
+    db.query("SELECT * FROM logs WHERE msg = ?", [line])
+}
+```
+
+The parameterized form (`db.query("...", [line])`) is the safe path
+— the sink does not concatenate `line` into the SQL text, so the
+flow tag never reaches a string-shaped sink and no sanitizer is
+required. Direct concatenation into the SQL string would be flagged
+by the §21 checker.
 
 ---

--- a/LANG_SPEC_v0.6/16-io-protocol.md
+++ b/LANG_SPEC_v0.6/16-io-protocol.md
@@ -6,12 +6,28 @@ there is no distinguished error type for end-of-stream. The contract
 is shared across `std.io`, stream-oriented standard-library modules,
 and FFI byte-stream bridges.
 
-The v0.6 capability surface (§20) layers on top of the I/O protocol:
-filesystem and network access flow through `Fs` and `Net` capability
-parameters rather than global functions. The protocol interfaces
-themselves are unchanged from v0.5; capability-typed handles
-(returned by `fs.open(path)`, `net.dial(...)`) implement the same
-`Reader`/`Writer`/`Closer` interfaces as their v0.5 predecessors.
+The v0.6 capability surface (§20) is the *only* path that produces an
+I/O handle: filesystem reads/writes flow through `Fs.open(self, path)`
+or `Fs.readToString(self, path)` (§10.15), network reads/writes
+through `Net.connect(self, addr)` or `Net.listen(self, addr)`
+(§10.23). The handles those methods return implement
+`Reader` / `Writer` / `Closer` exactly as defined here, so generic
+helpers like `io.copy(dst, src)` accept any capability-derived
+stream without a special case.
+
+Information flow (§21) interacts with the protocol at two points:
+
+- **Path-shaped sinks** on `Fs` (`open` / `read` / `write` / `remove`)
+  carry `#[requires("path_safe")]`. Bytes that flow into them must
+  have been sanitized (§21.8) — typically via `Path.parse(...)?` or
+  `std.path.normalize`.
+- **URL-shaped sinks** on `Net` (`connect` / `dial` / `httpClient`)
+  similarly require `url_safe`. Phase 5 enforces this; v0.6 baseline
+  surfaces the requirement in `osty audit`.
+
+The interfaces themselves are pure protocol definitions and carry no
+capability or flow tag — they describe what a stream *is*, not who
+holds the right to open one.
 
 The `Reader` and `Writer` interfaces define the streaming I/O contract
 shared across `std.io`, stream-oriented standard-library modules, and
@@ -155,5 +171,83 @@ with cursor-style methods such as `remaining()`, `peek(n)`,
 adds inspection helpers such as `bytes()` and `toString()`, plus
 buffer-management / piping helpers such as `clear()`, `truncate(n)`,
 `reader()`, `readFrom(r)`, and `writeTo(w)`.
+
+### 16.1 Composing capabilities and the I/O protocol
+
+A typical effectful pipeline opens a stream from a capability,
+operates on it through the protocol interfaces, and lets `defer`
+close it on every exit path:
+
+```osty
+fn copyFile(fs: Fs, src: String, dst: String) -> Result<Int, Error> {
+    let r = fs.open(src)?         // capability call → Reader+Closer
+    defer r.close()
+
+    let w = fs.create(dst)?       // capability call → Writer+Closer
+    defer w.close()
+
+    io.copy(w, r)                  // protocol-only — no capability
+}
+```
+
+The middle layer (`io.copy`) operates on `Reader` / `Writer` only.
+This is what lets in-memory adapters (`io.bytesReader` / `io.buffer`)
+participate in the same pipelines as real files or sockets — the
+test path constructs a pure adapter, and `io.copy` cannot tell the
+difference.
+
+### 16.2 In-memory adapters in tests
+
+A test that exercises an `io.copy`-shaped function does not need a
+`Fs` capability — it constructs `BytesReader` and `Buffer` directly
+and feeds them to the function:
+
+```osty
+#[test]
+fn test_copy_from_bytes_reader() {
+    let r = io.bytesReader(b"hello")
+    let w = io.buffer()
+    let n = io.copy(w, r)?
+    testing.assertEq(n, 5)
+    testing.assertEq(w.toString()?, "hello")
+}
+```
+
+For tests that *do* exercise capability-typed code, the
+`std.capability.testing.FakeFs` adapter (§11.9) returns the same
+`Reader`/`Writer`/`Closer`-shaped handles as the host adapter, so
+the production code under test runs unmodified.
+
+### 16.3 Information flow on streams
+
+A `Reader` produces `Bytes`. The bytes carry the flow tag set of the
+underlying source: `fs.read(path)` is conventionally tagged
+`#[taint("fs_input")]`, `net.read(conn, n)` is `#[taint("user_input")]`,
+and `io.bytesReader(data)` inherits whatever tags `data` had. Tags
+ride through `io.readAll`, `io.copy`, and `io.readLines` without
+declassification — sanitization must be explicit at the sink, not
+implicit at the protocol boundary.
+
+```osty
+fn safeRender(net: Net, conn: TcpConn) -> Result<String, Error> {
+    let raw = io.readAll(conn)?    // Bytes #[taint("user_input")]
+    let text = raw.toString()?     // String #[taint("user_input")]
+    Ok(std.html.escape(text))      // sanitize → #[trust("html_safe")]
+}
+```
+
+`std.html.escape` is registered as a sanitizer with
+`#[sanitizes("user_input", into = "html_safe")]` (§21.6); after the
+call, the result is acceptable to `http.respondHtml`.
+
+### 16.4 Cancellation surfaces on streams
+
+Every blocking method on a capability-derived stream
+(`net.read`/`net.write`/`fs.read`/`fs.write`) returns `Err(Cancelled
+{ cause })` when the surrounding `taskGroup` is cancelled (§8.4.2,
+§7.6). In-memory adapters (`BytesReader`, `Buffer`) never block, so
+they never return `Cancelled` — a test that wants to exercise
+cancellation paths must use a fake capability (`FakeNet`) that
+honors the cancel token, not the in-memory adapter.
 
 ---

--- a/LANG_SPEC_v0.6/17-display-and-format-protocol.md
+++ b/LANG_SPEC_v0.6/17-display-and-format-protocol.md
@@ -5,8 +5,23 @@ interface, `ToString`. String interpolation `"{expr}"` (§4.8), the
 `println` / `print` / `eprint` family, and the formatter's
 `Display` rendering all dispatch through `toString()`. The interface
 is structural — any type that defines `fn toString(self) -> String`
-satisfies it. v0.6 adds no new format protocol surface; the
-machine-readable intent annotations (`#[purpose]`, `#[example]`,
+satisfies it.
+
+`ToString` interacts with two v0.6 surfaces:
+
+- **Capability vs pure rendering.** `toString()` is a pure
+  declaration on the value itself — it receives no capability and
+  must not perform an effect. `print`/`println` consume the result
+  and *write it* through the ambient `Console` capability (§20.9.7),
+  which is where the effect actually lives. This split lets value
+  types implement `ToString` without becoming capability-coupled.
+- **Information flow.** A `ToString` impl preserves any
+  `#[taint(...)]` tag on its self argument: the tag rides on the
+  rendered `String` and must be sanitized before reaching a sink
+  such as `http.respondHtml` (§21.8). The interface itself is
+  flow-tag-agnostic.
+
+Machine-readable intent annotations (`#[purpose]`, `#[example]`,
 `#[fixture]` per §3.12) operate at a different layer (documentation
 / context export) and do not interact with `ToString`.
 
@@ -73,5 +88,73 @@ respective stream (`println` adds a trailing `\n`).
 **Relationship to `dbg`.** `dbg(x)` (§10.1) prints a developer-oriented
 form including source location and the unprocessed expression text. It
 is built on top of `ToString` for the value portion.
+
+### 17.1 Sealed types and `ToString`
+
+A `#[sealed_construct]` type (§3.4.5) implements `ToString` like any
+other struct — there is no special interaction. The auto-derived form
+exposes private fields as text, which is sometimes the wrong choice
+for sealed types since a parsed `Email` value is meant to be opaque
+to consumers:
+
+```osty
+#[sealed_construct(parse)]
+pub struct Email {
+    local: String,
+    domain: String,
+
+    pub fn parse(s: String) -> Email? { ... }
+
+    // Author-supplied — render the canonical text form, not the
+    // auto-derived `Email { local: ..., domain: ... }` debug form.
+    pub fn toString(self) -> String {
+        "{self.local}@{self.domain}"
+    }
+}
+
+println(Email.parse("alice@example.com")?)   // alice@example.com
+```
+
+The convention across the v0.6 stdlib sealed types (`Email`, `Url`,
+`Path`, `SqlIdent`, `Duration`, `Uuid`) is **always** to override
+`toString()` with the canonical reverse of `parse(...)` — round-trip
+through `ToString` ↔ `Type.parse` is part of the public contract.
+
+### 17.2 Interaction with information flow
+
+`toString()` preserves any `#[taint(σ)]` tag on its self argument:
+the rendered `String` carries the same tag set, so a tainted value
+flowing into `"{user.email}"` interpolation produces a tainted
+`String`, which the type checker tracks into whatever sink the
+interpolation result lands in.
+
+```osty
+fn render(form: #[taint("user_input")] FormData) -> String {
+    "submitted: {form.message}"     // result is also #[taint("user_input")]
+}
+
+// Sink that requires `html_safe` rejects the tainted result —
+// authors must sanitize first.
+http.respondHtml(render(form))      // E0901 — missing #[sanitizes(...)]
+```
+
+Sanitization happens *before* the value reaches `toString()`. There
+is no "format-time sanitizer" — that would hide the data flow that
+§21 is explicitly designed to surface.
+
+### 17.3 Capability-free guarantee
+
+`toString()` is declared without any capability parameter. The
+runtime does not synthesize one for the call, so a `ToString`
+implementation cannot read the clock, query the environment, or open
+a file. This is what lets the `print*` family safely route through
+ambient `Console` (§20.9.7) — the rendering work is pure, and only
+the *write* is effectful.
+
+A user implementation that *does* need to consult an effect to
+render a value should not abuse `ToString`; instead expose a
+deliberate `render(self, clock: Clock) -> String` method that the
+caller passes the capability to. The naming convention `render*`
+keeps `ToString` free of hidden dependence.
 
 ---

--- a/LANG_SPEC_v0.6/ABRIDGED.md
+++ b/LANG_SPEC_v0.6/ABRIDGED.md
@@ -351,8 +351,10 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
   (stdlib 또는 audit-marked 코드만).
 - v0.6: stdlib sealed types (`Email` / `Url` / `Path` / `SqlIdent` / `Duration` /
   `Uuid`) 의 외부 struct literal 금지 — `Type.parse(...)` 사용.
-- v0.6: 전역 effect 함수 (`time.now()` / `random.next()` 등) 미사용 권장.
-  capability parameter 또는 `#[ambient]` 사용. `--legacy-globals` 는 v0.7 제거.
+- v0.6: 전역 effect 함수 (`time.now()` / `random.next()` / `env.get(k)` /
+  `fs.read(p)` / `os.exec(...)` / `net.dial(...)`) 는 baseline 거부 (`E0780`).
+  capability parameter 명시 또는 entry-point `#[ambient]` 만 허용.
+  `--legacy-globals` flag 는 v0.6.x transition 한정 — v0.7 제거.
 
 ## 18. Agent Checklist
 


### PR DESCRIPTION
## Summary

v0.6 spec 100% 정본화의 두 batch를 한 PR로 결합. 총 +1073 / -101 LOC, 17 spec 파일.

### Batch 3 — API tables (v0.5 globals → capability method form)

| Chapter | Before | After |
|---|---|---|
| §10.15 OS | `os.exec(cmd, args)` | `Process.exec(self, cmd, args)` + legacy desugar table |
| §10.23 Net | `net.connect(addr)` | `Net.connect(self, addr)` + alias note |
| §10.24 HTTP | `http.request(req)` / `http.serve(addr, h)` | `HttpClient.request(self, req)` / `HttpServer.serve(self, addr, h)` |
| §9 Memory mgmt | `fs.withFile`, `net.withConn` | `Fs.withFile(self, ...)` / `Net.withConn(self, ...)` |
| ABRIDGED §17 | "미사용 권장" | "baseline 거부 (`E0780`)" + 6 enumerate |

### Batch 4 — Chapter intro reframe (v0.5 + amendments → v0.6 native)

- **§02 Type System**: "v0.5 carry forward" → v0.6 annotation surface가 type 위에 ride한다는 native 설명 + §2.13 reframe.
- **§05 Modules**: "import surface unchanged" → osty publish API-surface diff + sealed `pub` types 두 enforcement 명시.
- **§07 Error Interface**: try/catch 거부 / Cancelled가 ordinary Error / §7.6 Cancellation as Recoverable Error 추가.
- **§08 Concurrency**: capability flow / cancellation-aware adapter / non-escaping rule을 v0.6 voice로 정리.
- **§12 FFI**: Go FFI + Native C ABI 양 family + flow-tag drop / audited declassify / capability passthrough 거부.
- **§15 Iteration / §16 IO / §17 Display**: capability-handle composition / flow tag preservation / cancellation 명시.

### Batch 4 — Deep v0.6-native sections (신규)

| Section | Topic |
|---|---|
| §3.17 | Declaration anti-patterns (6 카탈로그) — effect 없는 capability / pub stability 누락 / error_contract 누락 / sealed external literal / sink without sanitizer / reproducible w/ non-deterministic capability |
| §4.14 | Composing v0.6 surfaces in expression position (?+capability / match+error_contract / interpolation+taint / closure capture / defer capability calls) |
| §5.6 | Public surface and v0.6 evolution rules (#[stability]+SemVer table / sealed types in pub / capability surface is part of contract) |
| §6.1-2 | Ambient capability binding for scripts + Scripts and information flow (process.exec vs execShell) |
| §7.6 | Cancellation as Recoverable Error (?-propagation / downcast pattern / error_contract interaction) |
| §8.7 | Capabilities and Tasks (closures capture by reference / ambient does not cross spawn / cancel signals capability-blind / capability-typed channels antipattern) |
| §13.16-17 | Capability inventory + `--legacy-globals` toolchain matrix |
| §14.5 | Why v0.6 stops where it does — 3-question vetting for G36-G49 design |
| §15.1-3 | Iteration over capability sources / channels / flow tags |
| §16.1-4 | Capability composition / in-memory test adapters / flow tags / cancellation |
| §17.1-3 | Sealed types `toString` / flow / capability-free guarantee |

### Smaller polish

- §10.7 lazy iter intro: capability-free 보장 명시
- §10.8 JSON: "v0.4 set" → "v0.6 annotation surface" wording fix
- §02 §2.11 Nullability: lookup pattern에 Db capability 추가

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §20.9 capability surface와 §10.15/§10.23/§10.24 시그니처 정합
- [ ] 의도적 v0.5 reference (audit subcommand / migration 표 / change-history)가 정확한 컨텍스트에서 보존
- [ ] 신규 §X.Y cross-link이 anchor에 도달

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd