### PR TITLE
feat(cfg,lexer): #[cfg] all/any/not composition + b"..." byte string …

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -63,11 +63,13 @@ func (a *Annotation) End() token.Pos { return a.EndV }
 //
 //	IDENT                — flag form (Key set, Value nil)
 //	IDENT '=' Literal    — key/value form (Key set, Value is the literal)
+//	all/any/not '(' ... ')' — composition form (Compose set, Key is "all"/"any"/"not")
 type AnnotationArg struct {
-	ID    NodeID
-	PosV  token.Pos
-	Key   string
-	Value Expr // nil for flag form
+	ID      NodeID
+	PosV    token.Pos
+	Key     string
+	Value   Expr             // nil for flag form
+	Compose []*AnnotationArg // non-nil for all/any/not composition
 }
 
 func (a *AnnotationArg) Pos() token.Pos { return a.PosV }

--- a/internal/format/printer.go
+++ b/internal/format/printer.go
@@ -486,10 +486,21 @@ func (p *printer) printAnnotation(a *ast.Annotation) {
 	p.write(a.Name)
 	if len(a.Args) > 0 {
 		printBracketedList(p, "(", ")", a.Args, spanMultiline(a.Args), func(arg *ast.AnnotationArg) {
-			p.write(arg.Key)
-			if arg.Value != nil {
-				p.write(" = ")
-				p.printExpr(arg.Value)
+			if len(arg.Compose) > 0 {
+				p.write(arg.Key)
+				printBracketedList(p, "(", ")", arg.Compose, false, func(child *ast.AnnotationArg) {
+					p.write(child.Key)
+					if child.Value != nil {
+						p.write(" = ")
+						p.printExpr(child.Value)
+					}
+				})
+			} else {
+				p.write(arg.Key)
+				if arg.Value != nil {
+					p.write(" = ")
+					p.printExpr(arg.Value)
+				}
 			}
 		})
 	}

--- a/internal/resolve/cfg.go
+++ b/internal/resolve/cfg.go
@@ -28,6 +28,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/token"
 )
 
 // CfgEnv carries the values that `#[cfg(key = "value")]` predicates
@@ -157,8 +158,12 @@ func evaluateCfgAnnotation(a *ast.Annotation, env *CfgEnv) (bool, []*diag.Diagno
 	return pass, diags
 }
 
-// evaluateCfgArg handles one `key = "value"` pair.
+// evaluateCfgArg handles one `key = "value"` pair or a composition
+// form (`all`/`any`/`not`).
 func evaluateCfgArg(arg *ast.AnnotationArg, env *CfgEnv) (bool, []*diag.Diagnostic) {
+	if len(arg.Compose) > 0 {
+		return evaluateCfgCompose(arg.Key, arg.Compose, arg.PosV, env)
+	}
 	value, ok := stringArg(arg.Value)
 	if !ok {
 		return false, []*diag.Diagnostic{
@@ -186,6 +191,52 @@ func evaluateCfgArg(arg *ast.AnnotationArg, env *CfgEnv) (bool, []*diag.Diagnost
 				Code(diag.CodeCfgUnknownKey).
 				PrimaryPos(arg.PosV, "unrecognised cfg key").
 				Note("v0.5 §5 / G29 recognises only `os`, `target`, `arch`, `feature`").
+				Build(),
+		}
+	}
+}
+
+func evaluateCfgCompose(op string, children []*ast.AnnotationArg, pos token.Pos, env *CfgEnv) (bool, []*diag.Diagnostic) {
+	switch op {
+	case "all":
+		var diags []*diag.Diagnostic
+		for _, child := range children {
+			result, ds := evaluateCfgArg(child, env)
+			diags = append(diags, ds...)
+			if !result {
+				return false, diags
+			}
+		}
+		return true, diags
+	case "any":
+		var diags []*diag.Diagnostic
+		for _, child := range children {
+			result, ds := evaluateCfgArg(child, env)
+			diags = append(diags, ds...)
+			if result {
+				return true, diags
+			}
+		}
+		return false, diags
+	case "not":
+		if len(children) != 1 {
+			return false, []*diag.Diagnostic{
+				diag.New(diag.Error,
+					"`not(...)` requires exactly one argument").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(pos, "not takes exactly one cfg predicate").
+					Build(),
+			}
+		}
+		result, ds := evaluateCfgArg(children[0], env)
+		return !result, ds
+	default:
+		return false, []*diag.Diagnostic{
+			diag.New(diag.Error,
+				"unknown cfg composition `"+op+"`").
+				Code(diag.CodeAnnotationBadArg).
+				PrimaryPos(pos, "unknown cfg composition").
+				Note("v0.5 §5 / G29: use `all`, `any`, or `not`").
 				Build(),
 		}
 	}

--- a/internal/selfhost/astbridge/gen_astbridge.go
+++ b/internal/selfhost/astbridge/gen_astbridge.go
@@ -540,6 +540,10 @@ func AnnotationArgNode(pos Pos, key string, value Expr) AnnotationArg {
 	return &ast.AnnotationArg{PosV: pos, Key: key, Value: value}
 }
 
+func AnnotationComposeArgNode(pos Pos, op string, children []AnnotationArg) AnnotationArg {
+	return &ast.AnnotationArg{PosV: pos, Key: op, Compose: compactAnnotationArgs(children)}
+}
+
 func NamedTypeNode(pos, end Pos, path []string, args []Type) Type {
 	return &ast.NamedType{PosV: pos, EndV: end, Path: compactStrings(path), Args: compactTypes(args)}
 }

--- a/internal/selfhost/astbridge/generated.go
+++ b/internal/selfhost/astbridge/generated.go
@@ -343,6 +343,10 @@ func AnnotationArgNode(pos Pos, key string, value Expr) AnnotationArg {
 	return &ast.AnnotationArg{PosV: pos, Key: key, Value: value}
 }
 
+func AnnotationComposeArgNode(pos Pos, op string, children []AnnotationArg) AnnotationArg {
+	return &ast.AnnotationArg{PosV: pos, Key: op, Compose: compactAnnotationArgs(children)}
+}
+
 func NamedTypeNode(pos, end Pos, path []string, args []Type) Type {
 	return &ast.NamedType{PosV: pos, EndV: end, Path: compactStrings(path), Args: compactTypes(args)}
 }

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -2839,6 +2839,44 @@ func frontendLexStream(source string) *FrontLexStream {
 					}
 					skip = _cur98 - _rhs99
 				}()
+			} else if unit == "b" && next == "\"" {
+				scan := frontStringLikeScan(units, idx, unitCount, FrontTokenKind(&FrontTokenKind_FrontByteString{}))
+				_ = scan
+				leadingDocLinesBs := frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
+				_ = leadingDocLinesBs
+				atFileStart = false
+				ownerTokenBs := tokenIndex
+				_ = ownerTokenBs
+				func() struct{} {
+					tokens = append(tokens, frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLinesBs, scan.triple, scan.interpolations, false))
+					return struct{}{}
+				}()
+				tokenIndex = tokenIndex + 1
+				factsBs := frontStringStructureScan(units, idx, unitCount, scan.kind, ownerTokenBs, stringPartIndex, interpolationTokenIndex, scan)
+				_ = factsBs
+				for _, part := range factsBs.parts {
+					func() struct{} { stringParts = append(stringParts, part); return struct{}{} }()
+				}
+				for _, interp := range factsBs.interpolationTokens {
+					func() struct{} { interpolationTokens = append(interpolationTokens, interp); return struct{}{} }()
+				}
+				for _, diag := range factsBs.diagnostics {
+					func() struct{} { diagnostics = append(diagnostics, diag); return struct{}{} }()
+				}
+				stringPartIndex = stringPartIndex + factsBs.partCount
+				interpolationTokenIndex = interpolationTokenIndex + factsBs.interpolationTokenCount
+				normalizedTripleUnits = normalizedTripleUnits + factsBs.normalizedTripleUnits
+				tripleIndentErrors = tripleIndentErrors + factsBs.tripleIndentErrors
+				escapeErrors = escapeErrors + factsBs.escapeErrors
+				if scan.errors > 0 {
+					func() struct{} {
+						diagnostics = append(diagnostics, frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, FrontTokenKind(&FrontTokenKind_FrontByteString{}), scan), start, frontPositionAt(units, idx+scan.consumed)))
+						return struct{}{}
+					}()
+				}
+				pendingDocLines = 0
+				insertTerm = frontKindInsertsTerm(scan.kind)
+				skip = scan.consumed - 1
 			} else if unit == "\"" {
 				// Osty: /tmp/selfhost_merged.osty:1303:17
 				scan := frontStringLikeScan(units, idx, unitCount, FrontTokenKind(&FrontTokenKind_FrontString{}))
@@ -6534,7 +6572,7 @@ func frontStringLikeScan(units []string, start int, unitCount int, kind FrontTok
 			if _rhs495 > 0 && _cur494 > math.MaxInt-_rhs495 {
 				panic("integer overflow")
 			}
-			if _rhs495 < 0 && _cur494 < math.MinInt-_rhs495 {
+			if _rhs495 < 0 && _cur494 < math.MinInt+_rhs495 {
 				panic("integer overflow")
 			}
 			contentStart = _cur494 + _rhs495
@@ -6542,21 +6580,18 @@ func frontStringLikeScan(units []string, start int, unitCount int, kind FrontTok
 		// Osty: /tmp/selfhost_merged.osty:2692:9
 		close = "'"
 	} else if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontByteString{})) {
-		// Osty: /tmp/selfhost_merged.osty:2690:9
 		consumed = 2
-		// Osty: /tmp/selfhost_merged.osty:2691:9
 		func() {
 			var _cur494b int = start
 			var _rhs495b int = 2
 			if _rhs495b > 0 && _cur494b > math.MaxInt-_rhs495b {
 				panic("integer overflow")
 			}
-			if _rhs495b < 0 && _cur494b < math.MinInt-_rhs495b {
+			if _rhs495b < 0 && _cur494b < math.MinInt+_rhs495b {
 				panic("integer overflow")
 			}
 			contentStart = _cur494b + _rhs495b
 		}()
-		// Osty: /tmp/selfhost_merged.osty:2692:9
 		close = "\""
 	} else if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontChar{})) {
 		// Osty: /tmp/selfhost_merged.osty:2694:9
@@ -23175,6 +23210,33 @@ func opParseAnnotationArg(p *OstyParser) int {
 		n.end = p.pos
 		// Osty: /tmp/selfhost_merged.osty:8828:9
 		return opAddNode(p, n)
+	}
+	// cfg composition: all(...), any(...), not(...)
+	if key != "" && (key == "all" || key == "any" || key == "not") && ostyEqual(opPeekAt(p, 1).kind, FrontTokenKind(&FrontTokenKind_FrontLParen{})) {
+		_ = opAdvance(p)
+		_ = opAdvance(p)
+		var compChildren []int = make([]int, 0, 1)
+		_ = compChildren
+		opSkipNewlines(p)
+		for !(opAt(p, FrontTokenKind(&FrontTokenKind_FrontRParen{}))) && !(opAt(p, FrontTokenKind(&FrontTokenKind_FrontEOF{}))) {
+			func() struct{} { compChildren = append(compChildren, opParseAnnotationArg(p)); return struct{}{} }()
+			opSkipNewlines(p)
+			if !(opEat(p, FrontTokenKind(&FrontTokenKind_FrontComma{}))) {
+				break
+			}
+			opSkipNewlines(p)
+		}
+		_ = opExpect(p, FrontTokenKind(&FrontTokenKind_FrontRParen{}))
+		calleeNode := emptyAstNode(AstNodeKind(&AstNodeKind_AstNIdent{}))
+		calleeNode.text = key
+		calleeNode.start = start
+		calleeNode.end = start + len(key)
+		cn := emptyAstNode(AstNodeKind(&AstNodeKind_AstNCall{}))
+		cn.left = opAddNode(p, calleeNode)
+		cn.children = compChildren
+		cn.start = start
+		cn.end = p.pos
+		return opAddNode(p, cn)
 	}
 	return opParseExpr(p)
 }
@@ -55525,6 +55587,23 @@ func srCheckCfgArgs(file *AstFile, ann *AstNode, result *SelfResolveResult) *Sel
 // Osty: /tmp/selfhost_merged.osty:28510:1
 func srCheckCfgArg(file *AstFile, argIdx int, result *SelfResolveResult) *SelfResolveResult {
 	// Osty: /tmp/selfhost_merged.osty:28515:5
+	arg := srAstNode(file, argIdx)
+	_ = arg
+	// composition: all(...), any(...), not(...)
+	if ostyEqual(arg.kind, AstNodeKind(&AstNodeKind_AstNCall{})) && arg.left >= 0 {
+		callee := srAstNode(file, arg.left)
+		if ostyEqual(callee.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) && (callee.text == "all" || callee.text == "any" || callee.text == "not") {
+			out := result
+			if callee.text == "not" && len(arg.children) != 1 {
+				out.diagnostics = append(out.diagnostics, selfResolveDiagnosticHintAtNode("E0739", "`not(...)` requires exactly one argument", "cfg", arg.start, arg.end, -1, "v0.5 §5 / G29: `not` takes exactly one cfg predicate"))
+				return out
+			}
+			for _, childIdx := range arg.children {
+				out = srCheckCfgArg(file, childIdx, out)
+			}
+			return out
+		}
+	}
 	view := srAnnotArgView(file, argIdx)
 	_ = view
 	// Osty: /tmp/selfhost_merged.osty:28516:5
@@ -55593,16 +55672,46 @@ func srCfgAnnotationPasses(file *AstFile, ann *AstNode, cfg *SelfResolveCfgEnv) 
 	}
 	// Osty: /tmp/selfhost_merged.osty:28572:5
 	for _, argIdx := range ann.children {
-		// Osty: /tmp/selfhost_merged.osty:28573:9
-		view := srAnnotArgView(file, argIdx)
-		_ = view
 		// Osty: /tmp/selfhost_merged.osty:28574:9
-		if !srCfgArgPasses(file, view, cfg) {
+		if !srCfgArgIdxPasses(file, argIdx, cfg) {
 			// Osty: /tmp/selfhost_merged.osty:28575:13
 			return false
 		}
 	}
 	return true
+}
+
+func srCfgArgIdxPasses(file *AstFile, argIdx int, cfg *SelfResolveCfgEnv) bool {
+	arg := srAstNode(file, argIdx)
+	if ostyEqual(arg.kind, AstNodeKind(&AstNodeKind_AstNCall{})) && arg.left >= 0 {
+		callee := srAstNode(file, arg.left)
+		if ostyEqual(callee.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
+			if callee.text == "all" {
+				for _, childIdx := range arg.children {
+					if !srCfgArgIdxPasses(file, childIdx, cfg) {
+						return false
+					}
+				}
+				return true
+			}
+			if callee.text == "any" {
+				for _, childIdx := range arg.children {
+					if srCfgArgIdxPasses(file, childIdx, cfg) {
+						return true
+					}
+				}
+				return false
+			}
+			if callee.text == "not" {
+				if len(arg.children) == 1 {
+					return !srCfgArgIdxPasses(file, arg.children[0], cfg)
+				}
+				return false
+			}
+		}
+	}
+	view := srAnnotArgView(file, argIdx)
+	return srCfgArgPasses(file, view, cfg)
 }
 
 // Osty: /tmp/selfhost_merged.osty:28581:1

--- a/internal/selfhost/lexer_contract_test.go
+++ b/internal/selfhost/lexer_contract_test.go
@@ -178,6 +178,38 @@ func TestLexStringPartsCarrySourceByteRanges(t *testing.T) {
 	}
 }
 
+func TestLexByteStringToken(t *testing.T) {
+	src := `let bs = b"hello"` + "\n"
+	lexed := ostyLexSource(src)
+	stream := lexed.stream
+	tc := frontLexTokenCount(stream)
+	var kinds []string
+	for i := 0; i < tc; i++ {
+		tok := frontLexTokenAt(stream, i)
+		raw := frontLexemeFromUnits(splitStringUnits(lexed.source), tok.start.offset, tok.length)
+		kinds = append(kinds, frontTokenKindName(tok.kind)+":"+raw)
+	}
+	t.Logf("front tokens: %v", kinds)
+	toks, diags, _ := Lex([]byte(src))
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	var found bool
+	for _, tok := range toks {
+		if tok.Kind == token.BYTESTRING && tok.Value == "hello" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		var adapted []string
+		for _, tok := range toks {
+			adapted = append(adapted, tok.Kind.String()+":"+tok.Value)
+		}
+		t.Fatalf("b\"hello\" not lexed correctly; adapted: %v", adapted)
+	}
+}
+
 func canonicalLexFacts(src string) (*OstyLexedSource, *OstyLexFacts, runeTable) {
 	lexed := ostyLexSource(src)
 	rt := newRuneTable(lexed.source)

--- a/internal/selfhost/resolve_adapter_test.go
+++ b/internal/selfhost/resolve_adapter_test.go
@@ -613,6 +613,85 @@ fn bad() -> Int { 1 }
 	}
 }
 
+func TestResolveCfgCompositionAll(t *testing.T) {
+	src := []byte(`#[cfg(all(os = "linux", arch = "arm64"))]
+fn linuxArm64() -> Int { 1 }
+
+#[cfg(all(os = "linux", arch = "amd64"))]
+fn linuxAmd64() -> Int { 2 }
+
+fn alwaysHere() -> Int { 3 }
+`)
+	env := &selfhost.CfgEnv{OS: "linux", Arch: "arm64", Target: "linux"}
+	resolved := selfhost.ResolveSourceStructuredWithCfg(src, env)
+	if resolved.Summary.Diagnostics != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", resolved.Diagnostics)
+	}
+	if findResolvedSymbol(resolved, "linuxArm64", "fn") == nil {
+		t.Errorf("linuxArm64 should survive: all(os=linux, arch=arm64)")
+	}
+	if findResolvedSymbol(resolved, "linuxAmd64", "fn") != nil {
+		t.Errorf("linuxAmd64 should drop: all(os=linux, arch=amd64) fails arch=arm64")
+	}
+	if findResolvedSymbol(resolved, "alwaysHere", "fn") == nil {
+		t.Errorf("unannotated fn should survive")
+	}
+}
+
+func TestResolveCfgCompositionAny(t *testing.T) {
+	src := []byte(`#[cfg(any(os = "linux", os = "darwin"))]
+fn unixy() -> Int { 1 }
+
+#[cfg(any(os = "windows", os = "wasm"))]
+fn notLinux() -> Int { 2 }
+`)
+	env := &selfhost.CfgEnv{OS: "linux", Arch: "amd64", Target: "linux"}
+	resolved := selfhost.ResolveSourceStructuredWithCfg(src, env)
+	if resolved.Summary.Diagnostics != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", resolved.Diagnostics)
+	}
+	if findResolvedSymbol(resolved, "unixy", "fn") == nil {
+		t.Errorf("unixy should survive: any(os=linux, os=darwin) matches linux")
+	}
+	if findResolvedSymbol(resolved, "notLinux", "fn") != nil {
+		t.Errorf("notLinux should drop: any(windows, wasm) neither matches linux")
+	}
+}
+
+func TestResolveCfgCompositionNot(t *testing.T) {
+	src := []byte(`#[cfg(not(os = "windows"))]
+fn notWindows() -> Int { 1 }
+
+#[cfg(not(os = "linux"))]
+fn notLinux() -> Int { 2 }
+`)
+	env := &selfhost.CfgEnv{OS: "linux", Arch: "amd64", Target: "linux"}
+	resolved := selfhost.ResolveSourceStructuredWithCfg(src, env)
+	if resolved.Summary.Diagnostics != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", resolved.Diagnostics)
+	}
+	if findResolvedSymbol(resolved, "notWindows", "fn") == nil {
+		t.Errorf("notWindows should survive: not(os=windows) under linux")
+	}
+	if findResolvedSymbol(resolved, "notLinux", "fn") != nil {
+		t.Errorf("notLinux should drop: not(os=linux) under linux")
+	}
+}
+
+func TestResolveCfgCompositionNested(t *testing.T) {
+	src := []byte(`#[cfg(all(os = "linux", not(arch = "wasm")))]
+fn linuxNative() -> Int { 1 }
+`)
+	env := &selfhost.CfgEnv{OS: "linux", Arch: "amd64", Target: "linux"}
+	resolved := selfhost.ResolveSourceStructuredWithCfg(src, env)
+	if resolved.Summary.Diagnostics != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", resolved.Diagnostics)
+	}
+	if findResolvedSymbol(resolved, "linuxNative", "fn") == nil {
+		t.Errorf("linuxNative should survive: all(os=linux, not(arch=wasm)) under linux/amd64")
+	}
+}
+
 func TestResolveSourceStructuredPartialStructMergesMethods(t *testing.T) {
 	// Two partial declarations of the same struct — fields in one,
 	// methods in the other. R19 allows this; no duplicate diag should

--- a/toolchain/frontend.osty
+++ b/toolchain/frontend.osty
@@ -899,6 +899,64 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
                 skip = scan.consumed - 1
+            } else if unit == "b" && next == "\"" {
+                let scan = frontStringLikeScan(units, idx, unitCount, FrontByte)
+                let leadingDocLines = frontAttachedDocLines(
+                    pendingDocLines,
+                    docLastLine,
+                    start.line,
+                )
+                atFileStart = false
+                let ownerToken = tokenIndex
+                tokens.push(
+                    frontLexTokenFromScan(
+                        units,
+                        idx,
+                        scan.consumed,
+                        scan.kind,
+                        leadingDocLines,
+                        scan.triple,
+                        scan.interpolations,
+                        false,
+                    ),
+                )
+                tokenIndex = tokenIndex + 1
+                let facts = frontStringStructureScan(
+                    units,
+                    idx,
+                    unitCount,
+                    scan.kind,
+                    ownerToken,
+                    stringPartIndex,
+                    interpolationTokenIndex,
+                    scan,
+                )
+                for part in facts.parts {
+                    stringParts.push(part)
+                }
+                for interp in facts.interpolationTokens {
+                    interpolationTokens.push(interp)
+                }
+                for diag in facts.diagnostics {
+                    diagnostics.push(diag)
+                }
+                stringPartIndex = stringPartIndex + facts.partCount
+                interpolationTokenIndex = interpolationTokenIndex + facts.interpolationTokenCount
+                normalizedTripleUnits = normalizedTripleUnits + facts.normalizedTripleUnits
+                tripleIndentErrors = tripleIndentErrors + facts.tripleIndentErrors
+                escapeErrors = escapeErrors + facts.escapeErrors
+                if scan.errors > 0 {
+                    diagnostics.push(
+                        frontLexDiagnostic(
+                            frontStringDiagnosticCode(units, idx, unitCount, FrontByte, scan),
+                            start,
+                            frontPositionAt(units, idx + scan.consumed),
+                        ),
+                    )
+                }
+                pendingDocLines = 0
+                insertTerm = frontKindInsertsTerm(scan.kind)
+                skip = scan.consumed - 1
             } else if unit == "\"" {
                 let scan = frontStringLikeScan(units, idx, unitCount, FrontString)
                 let leadingDocLines = frontAttachedDocLines(

--- a/toolchain/lexer.osty
+++ b/toolchain/lexer.osty
@@ -432,6 +432,9 @@ fn ostyDefaultStringPart(units: List<String>, tok: FrontLexToken, owner: Int) ->
 }
 
 fn ostyPublicTokenText(tok: FrontLexToken, raw: String) -> String {
+    if tok.kind == FrontByte && strings.hasPrefix(raw, "b\"") {
+        return "b\"" + ostyDecodeByteStringLiteralValue(raw) + "\""
+    }
     if tok.kind == FrontChar {
         return ostyDecodeCharLiteralValue(raw)
     }
@@ -642,6 +645,17 @@ fn ostyDecodeByteLiteralValue(text: String) -> String {
     value.toChar().toString()
 }
 
+fn ostyDecodeByteStringLiteralValue(text: String) -> String {
+    if !strings.hasPrefix(text, "b\"") {
+        return text
+    }
+    let mut body = ostyDropPrefixUnits(text, 2)
+    if strings.hasSuffix(body, "\"") {
+        body = ostyDropSuffixUnits(body, 1)
+    }
+    ostyDecodeEscapes(body)
+}
+
 fn ostyCharLiteralBody(text: String) -> String {
     let mut body = text
     if strings.hasPrefix(body, "b") {
@@ -650,7 +664,13 @@ fn ostyCharLiteralBody(text: String) -> String {
     if strings.hasPrefix(body, "'") {
         body = ostyDropPrefixUnits(body, 1)
     }
+    if strings.hasPrefix(body, "\"") {
+        body = ostyDropPrefixUnits(body, 1)
+    }
     if strings.hasSuffix(body, "'") {
+        body = ostyDropSuffixUnits(body, 1)
+    }
+    if strings.hasSuffix(body, "\"") {
         body = ostyDropSuffixUnits(body, 1)
     }
     body

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -2428,6 +2428,31 @@ fn opParseAnnotationArg(p: OstyParser) -> Int {
         n.end = p.pos
         return opAddNode(p, n)
     }
+    if key != "" && (key == "all" || key == "any" || key == "not") && opPeekAt(p, 1).kind == FrontLParen {
+        let _ = opAdvance(p)
+        let _ = opAdvance(p)
+        let mut compChildren: List<Int> = []
+        opSkipNewlines(p)
+        while !opAt(p, FrontRParen) && !opAt(p, FrontEOF) {
+            compChildren.push(opParseAnnotationArg(p))
+            opSkipNewlines(p)
+            if !opEat(p, FrontComma) {
+                break
+            }
+            opSkipNewlines(p)
+        }
+        let _ = opExpect(p, FrontRParen)
+        let mut calleeNode = emptyAstNode(AstNIdent)
+        calleeNode.text = key
+        calleeNode.start = start
+        calleeNode.end = start + key.length
+        let mut cn = emptyAstNode(AstNCall)
+        cn.left = opAddNode(p, calleeNode)
+        cn.children = compChildren
+        cn.start = start
+        cn.end = p.pos
+        return opAddNode(p, cn)
+    }
     opParseExpr(p)
 }
 

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -2991,6 +2991,29 @@ fn srCheckCfgArg(
     argIdx: Int,
     result: SelfResolveResult,
 ) -> SelfResolveResult {
+    let arg = srAstNode(file, argIdx)
+    if arg.kind == AstNCall && arg.left >= 0 {
+        let callee = srAstNode(file, arg.left)
+        if callee.kind == AstNIdent && (callee.text == "all" || callee.text == "any" || callee.text == "not") {
+            let mut out = result
+            if callee.text == "not" && arg.children.length != 1 {
+                out.diagnostics.push(selfResolveDiagnosticHintAtNode(
+                    "E0739",
+                    "`not(...)` requires exactly one argument",
+                    "cfg",
+                    arg.start,
+                    arg.end,
+                    -1,
+                    "v0.5 §5 / G29: `not` takes exactly one cfg predicate",
+                ))
+                return out
+            }
+            for childIdx in arg.children {
+                out = srCheckCfgArg(file, childIdx, out)
+            }
+            return out
+        }
+    }
     let view = srAnnotArgView(file, argIdx)
     let mut out = result
     if view.isFlag || view.key == "" || view.valueIdx < 0 || !srIsStringLitAtIdx(file, view.valueIdx) {
@@ -3049,12 +3072,44 @@ fn srCfgAnnotationPasses(file: AstFile, ann: AstNode, cfg: SelfResolveCfgEnv) ->
         return false
     }
     for argIdx in ann.children {
-        let view = srAnnotArgView(file, argIdx)
-        if !srCfgArgPasses(file, view, cfg) {
+        if !srCfgArgIdxPasses(file, argIdx, cfg) {
             return false
         }
     }
     true
+}
+
+fn srCfgArgIdxPasses(file: AstFile, argIdx: Int, cfg: SelfResolveCfgEnv) -> Bool {
+    let arg = srAstNode(file, argIdx)
+    if arg.kind == AstNCall && arg.left >= 0 {
+        let callee = srAstNode(file, arg.left)
+        if callee.kind == AstNIdent {
+            if callee.text == "all" {
+                for childIdx in arg.children {
+                    if !srCfgArgIdxPasses(file, childIdx, cfg) {
+                        return false
+                    }
+                }
+                return true
+            }
+            if callee.text == "any" {
+                for childIdx in arg.children {
+                    if srCfgArgIdxPasses(file, childIdx, cfg) {
+                        return true
+                    }
+                }
+                return false
+            }
+            if callee.text == "not" {
+                if arg.children.length == 1 {
+                    return !srCfgArgIdxPasses(file, arg.children[0], cfg)
+                }
+                return false
+            }
+        }
+    }
+    let view = srAnnotArgView(file, argIdx)
+    return srCfgArgPasses(file, view, cfg)
 }
 
 fn srCfgArgPasses(file: AstFile, view: SrAnnotArgView, cfg: SelfResolveCfgEnv) -> Bool {


### PR DESCRIPTION
…lexer

- Add cfg composition predicates (all/any/not) with recursive evaluation
- Add b"..." byte string literal lexer support (front-end + adapter)
- Back-port both changes to Osty sources (parser.osty, resolve.osty, frontend.osty, lexer.osty)