### PR TITLE
fix(selfhost): recognize v0.6 annotations

### DIFF
--- a/CHANGELOG_v0.6.md
+++ b/CHANGELOG_v0.6.md
@@ -40,6 +40,7 @@ rationale.
 | `while cond { body }` | **planned** (G49) | `for cond { body }` 와 동등 lowering. 사용자 0 단계의 breaking change — 식별자 `while` 사용했던 코드는 rename. |
 | `spec { example: ... }` block | **planned** (G43, v0) | example: 만 v0 에 실행, law:/invariant: 는 doc only |
 | Parameter annotation `fn f(#[taint("...")] x: T)` | **planned** (G37) | parameter 위치 annotation 신규 허용 |
+| v0.6 declaration annotation vocabulary | **partial** (G36-G46) | Go parser/resolver and selfhost resolver both recognize the declaration/field/method/variant annotation names. Per-feature semantic gates and parameter-position annotations still land by phase. |
 
 ### Capabilities (G36 — Phase 1, blocking everything else)
 

--- a/LANG_SPEC_v0.6/01-lexical-structure.md
+++ b/LANG_SPEC_v0.6/01-lexical-structure.md
@@ -467,4 +467,5 @@ band 의 코드 재사용 또는 §3.8 / §20 / §21 의 의미론 진단으로 
 
 `E0400` (CodeUnknownAnnotation) 는 v0.6 의 21 추가 annotation 모두
 recognize — `internal/ast/ast.go::annotationRules` 와
-`toolchain/resolve.osty::srAnnotAllowedTargets` 가 sync.
+`toolchain/resolve.osty::srAnnotAllowedTargets`, checked-in selfhost
+generated mirror 가 sync.

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -55111,6 +55111,66 @@ func srAnnotAllowedTargets(name string) int {
 		// Osty: /tmp/selfhost_merged.osty:28207:28
 		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
 	}
+	if name == "ambient" {
+		return srAnnotTargetTopLevel()
+	}
+	if name == "reproducible_capability" {
+		return srAnnotTargetTopLevel()
+	}
+	if name == "taint" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod() | srAnnotTargetField()
+	}
+	if name == "sanitizes" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "trusted_declassify" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "taint_field" {
+		return srAnnotTargetField()
+	}
+	if name == "spec" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "reproducible" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "sealed_construct" {
+		return srAnnotTargetTopLevel()
+	}
+	if name == "trusted_construct" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "test_construct" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "error_contract" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "purpose" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "example" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "fixture" {
+		return srAnnotTargetTopLevel()
+	}
+	if name == "since" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod() | srAnnotTargetField() | srAnnotTargetVariant()
+	}
+	if name == "stability" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "match_compat" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
+	if name == "golden" {
+		return srAnnotTargetTopLevel()
+	}
+	if name == "budget" {
+		return srAnnotTargetTopLevel() | srAnnotTargetMethod()
+	}
 	return 0
 }
 
@@ -56387,7 +56447,7 @@ func srCharToDigit(ch rune) int {
 
 // Osty: /tmp/selfhost_merged.osty:29239:1
 func srAnnotationNameList() []string {
-	return []string{"json", "deprecated", "allow", "intrinsic_methods", "requires", "no_alloc", "intrinsic", "c_abi", "export", "pod", "repr", "cfg", "op", "test", "vectorize", "no_vectorize", "parallel", "unroll", "inline", "hot", "cold", "pure", "target_feature", "noalias"}
+	return []string{"json", "deprecated", "allow", "intrinsic_methods", "requires", "no_alloc", "intrinsic", "c_abi", "export", "pod", "repr", "cfg", "op", "test", "vectorize", "no_vectorize", "parallel", "unroll", "inline", "hot", "cold", "pure", "target_feature", "noalias", "ambient", "reproducible_capability", "taint", "sanitizes", "trusted_declassify", "taint_field", "spec", "reproducible", "sealed_construct", "trusted_construct", "test_construct", "error_contract", "purpose", "example", "fixture", "since", "stability", "match_compat", "golden", "budget"}
 }
 
 // Osty: /tmp/selfhost_merged.osty:29269:1

--- a/internal/selfhost/resolve_adapter_test.go
+++ b/internal/selfhost/resolve_adapter_test.go
@@ -926,6 +926,68 @@ func TestV06AnnotationsRecognized(t *testing.T) {
 	}
 }
 
+// G36-G46 declaration annotations are intentionally fixed-vocabulary.
+// This pins the selfhost resolver mirror to the Go-side annotation table:
+// these names may still be semantically "planned", but they must not fail
+// as unknown annotations while later phase gates are implemented.
+func TestV06SemanticAnnotationsRecognized(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"ambient", "#[ambient(clock)]\nfn main() {}\n"},
+		{"reproducible_capability", "#[reproducible_capability]\ninterface HashCap {\n    #[reproducible]\n    fn hash(self, value: String) -> String\n}\n"},
+		{"taint", "#[taint(\"user_input\")]\nfn source() -> String { \"\" }\n"},
+		{"taint_field", "pub struct Form {\n    #[taint_field(\"user_input\")]\n    pub name: String,\n}\n"},
+		{"sanitizes", "#[sanitizes(\"user_input\", into = \"trusted\")]\nfn clean(value: String) -> String { value }\n"},
+		{"trusted_declassify", "#[trusted_declassify(\"audit\")]\nfn escape(value: String) -> String { value }\n"},
+		{"spec", "#[spec(\"3.10\")]\nfn linked() -> Int { 0 }\n"},
+		{"reproducible", "#[reproducible(scope = \"target\")]\nfn stable() -> Int { 0 }\n"},
+		{"sealed_construct", "#[sealed_construct(\"Email\")]\npub struct Email { pub value: String }\n"},
+		{"trusted_construct", "#[trusted_construct(\"stdlib parser\")]\nfn makeEmail(value: String) -> String { value }\n"},
+		{"test_construct", "#[test_construct]\nfn makeTestEmail(value: String) -> String { value }\n"},
+		{"error_contract", "#[error_contract(\"invalid input\")]\nfn parse() -> Result<Int, Error> { Ok(0) }\n"},
+		{"purpose", "#[purpose(\"demo\")]\nfn documented() -> Int { 0 }\n"},
+		{"example", "#[example(input = \"1\", output = \"2\")]\nfn doubled() -> Int { 2 }\n"},
+		{"fixture", "#[fixture(name = \"basic\")]\npub struct FixtureThing { pub value: Int }\n"},
+		{"since", "#[since(\"0.6\")]\nfn introduced() -> Int { 0 }\n"},
+		{"stability", "#[stability(\"experimental\")]\nfn unstable() -> Int { 0 }\n"},
+		{"match_compat", "#[match_compat(\"0.6\", fallback = \"Unknown\")]\npub enum Compat { Known, Unknown }\n"},
+		{"golden", "#[golden(\"fixtures/demo.snap\")]\nfn goldenText() -> String { \"\" }\n"},
+		{"budget", "#[budget(allocs = 0, io_calls = 0)]\nfn bounded() -> Int { 0 }\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := selfhost.ResolveSourceStructured([]byte(c.src))
+			for _, d := range r.Diagnostics {
+				if d.Code == "E0400" || d.Code == "E0607" || d.Code == "E0739" {
+					t.Errorf("unexpected %s on %s: %q", d.Code, c.name, d.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestV06SemanticAnnotationTargetMismatchIsNotUnknown(t *testing.T) {
+	r := selfhost.ResolveSourceStructured([]byte(`pub struct Bad {
+    #[ambient(clock)]
+    value: Int,
+}
+`))
+	var sawTarget bool
+	for _, d := range r.Diagnostics {
+		if d.Code == "E0400" {
+			t.Fatalf("ambient should be recognized before target checking, got unknown annotation: %#v", r.Diagnostics)
+		}
+		if d.Code == "E0607" {
+			sawTarget = true
+		}
+	}
+	if !sawTarget {
+		t.Fatalf("expected E0607 target diagnostic, got %#v", r.Diagnostics)
+	}
+}
+
 func TestV06BareFlagRejectsArgs(t *testing.T) {
 	cases := []string{
 		"#[hot(foo)]\nfn f() -> Int { 0 }\n",


### PR DESCRIPTION
## Summary
- sync the checked-in selfhost resolver mirror with the v0.6 G36-G46 declaration annotation vocabulary
- add resolver regression coverage for all semantic annotation names plus wrong-target E0607 behavior
- document the partial shipped status for declaration annotation recognition

## Validation
- go test -count=1 -vet=off ./internal/selfhost -run 'TestV06(SemanticAnnotationsRecognized|SemanticAnnotationTargetMismatchIsNotUnknown|AnnotationsRecognized|BareFlagRejectsArgs)' -v
- go test -count=1 -vet=off ./internal/selfhost -run 'TestResolve|TestParseSnapshot/testdata_spec_positive_15-v06-capabilities|TestParseSnapshot/testdata_spec_negative_reject' -v
- go test -count=1 -vet=off ./internal/speccorpus -run 'TestSpec(Negative|Positive)' -v
- just build
- .bin/osty check testdata/spec/positive/15-v06-capabilities.osty --no-airepair --max-errors 20
- git diff --check