### PR TITLE
docs(v0.6): batch 5+6 — stdlib chapter capability migration (16 chapters)

### DIFF
--- a/LANG_SPEC_v0.6/10-standard-library/12-cryptography.md
+++ b/LANG_SPEC_v0.6/10-standard-library/12-cryptography.md
@@ -3,20 +3,37 @@
 Hashing, message authentication, and cryptographically secure random
 bytes. Asymmetric cryptography (RSA, Ed25519) is out of scope.
 
+> **v0.6 capability split**: hashes (`sha256`, `hmac.sha256`,
+> `constantTimeEq`) are pure functions over `Bytes` — no capability
+> required. CSPRNG output is an *effect* (it consults the OS
+> entropy pool) and goes through a dedicated `CryptoRng` capability
+> distinct from `Rng` (§20.9.2). Ordinary `Rng` is non-cryptographic;
+> using it for tokens, keys, or IVs is a security bug, so the two
+> capabilities are typed apart.
+
 ```osty
 use std.crypto
 
+// Pure — no capability.
 let digest = crypto.sha256(bytes)                    // Bytes (32 bytes)
 let hex = encoding.hex.encode(digest)
-
 let mac = crypto.hmac.sha256(key, message)
 
-let secret = crypto.randomBytes(32)                  // CSPRNG
+// Effectful — receives `CryptoRng` capability.
+fn newSessionToken(rng: CryptoRng) -> Bytes {
+    rng.randomBytes(32)
+}
+
+#[ambient(cryptoRng)]
+fn main() {
+    let token = newSessionToken(cryptoRng)
+}
 ```
 
 API:
 
 ```
+// Pure — capability-free.
 crypto.sha256(data: Bytes) -> Bytes
 crypto.sha512(data: Bytes) -> Bytes
 crypto.sha1(data: Bytes) -> Bytes         // legacy compatibility only
@@ -25,9 +42,18 @@ crypto.md5(data: Bytes) -> Bytes          // legacy compatibility only
 crypto.hmac.sha256(key: Bytes, message: Bytes) -> Bytes
 crypto.hmac.sha512(key: Bytes, message: Bytes) -> Bytes
 
-crypto.randomBytes(n: Int) -> Bytes
 crypto.constantTimeEq(a: Bytes, b: Bytes) -> Bool
+
+// `CryptoRng` capability methods (canonical v0.6 surface).
+CryptoRng.randomBytes(self, n: Int) -> Bytes
+CryptoRng.uuid4(self) -> Uuid             // shortcut for §10.13 v4
 ```
 
-Use `crypto.randomBytes` for tokens, keys, and IVs. Use `std.random`
-(§10.14) for simulation, games, and non-security use.
+Legacy `crypto.randomBytes(n)` desugars to
+`std.crypto.host.randomBytes(n)` under `--legacy-globals` (v0.6.x
+only). Outside that mode it is `E0780`.
+
+Use `CryptoRng.randomBytes` for tokens, keys, IVs, and any other
+security-sensitive randomness. Use `Rng` (§10.14) for simulation,
+games, and non-security uses — `Rng` is seedable and reproducible,
+which is exactly the wrong property for cryptographic purposes.

--- a/LANG_SPEC_v0.6/10-standard-library/13-uuid.md
+++ b/LANG_SPEC_v0.6/10-standard-library/13-uuid.md
@@ -1,25 +1,53 @@
 ### 10.13 UUID (`std.uuid`)
 
+`Uuid` is a v0.6 sealed-construct type (§3.4.5, G40) — external
+literal construction is rejected. Values are produced by
+`uuid.v4(rng)` (random), `uuid.v7(clock, rng)` (time-ordered), or
+`uuid.parse(text)?` (round-trip).
+
 ```osty
 use std.uuid
 
-let id = uuid.v4()                                   // random
-let sortable = uuid.v7()                             // time-ordered
+// Construction — capability-injected (v4 = randomness only;
+// v7 = randomness + monotonic timestamp).
+fn mintRowId(clock: Clock, rng: CryptoRng) -> Uuid {
+    uuid.v7(clock, rng)
+}
 
-let text = id.toString()
-let parsed: Uuid = uuid.parse(text)?
+#[ambient(clock, cryptoRng)]
+fn main() {
+    let id = uuid.v4(cryptoRng)
+    let sortable = uuid.v7(clock, cryptoRng)
+
+    // Round-trip through canonical text — pure.
+    let text: String = id.toString()
+    let parsed: Uuid = uuid.parse(text)?
+}
 ```
 
 API:
 
 ```
-uuid.v4() -> Uuid
-uuid.v7() -> Uuid                         // preferred for database keys
+// `CryptoRng` capability is required for v4/v7 — UUID generation is
+// security-relevant in many call sites (session ids, message ids).
+uuid.v4(rng: CryptoRng) -> Uuid
+uuid.v7(clock: Clock, rng: CryptoRng) -> Uuid   // preferred for database keys
+
+// Pure — no capability.
 uuid.parse(text: String) -> Result<Uuid, Error>
-uuid.nil() -> Uuid
+uuid.nil() -> Uuid                              // the all-zero UUID — pure constant
 
 Uuid.toString(self) -> String
-Uuid.toBytes(self) -> Bytes               // 16 bytes
+Uuid.toBytes(self) -> Bytes                     // 16 bytes
 ```
 
-`Uuid` implements `Equal`, `Hashable`, `Ordered`.
+`Uuid` implements `Equal`, `Hashable`, `Ordered`. `toString()`
+emits the canonical lowercase 8-4-4-4-12 form; `parse(...)` is the
+exact reverse and is the **only** path to a `Uuid` from text outside
+the constructor pair above (see §17.1 for the round-trip contract).
+
+Legacy `uuid.v4()` / `uuid.v7()` (no capability args) desugar to
+`std.uuid.host.v4()` / `std.uuid.host.v7()` under `--legacy-globals`
+(v0.6.x only). Outside that mode the bare-arg form is `E0780` and
+external `Uuid { ... }` literal is `E0420` (sealed construct
+violation).

--- a/LANG_SPEC_v0.6/10-standard-library/16-url.md
+++ b/LANG_SPEC_v0.6/10-standard-library/16-url.md
@@ -2,10 +2,21 @@
 
 URL parsing and building.
 
+`Url` is a v0.6 sealed-construct type (§3.4.5, G40) — external
+struct literals (`Url { scheme: ..., host: ..., ... }`) are rejected.
+Values are constructed only via `url.parse(text)?` or
+`Url.builder()...build()`, both of which validate the result. This
+is what makes `Url` acceptable to `#[requires("url_safe")]` sinks
+like `http.redirect` (§21.8) — the type system can guarantee that a
+`Url` value passed to a redirect target was vetted by the parser, not
+spliced together from user input.
+
 ```osty
 use std.url
 
-let u = url.parse("https://example.com:8080/path?q=1&r=2#top")?
+// Pure — capability-free. Parsing is the only way to drop an
+// untrusted `String` into `Url` shape.
+let u: Url = url.parse("https://example.com:8080/path?q=1&r=2#top")?
 
 u.scheme       // "https"
 u.host         // "example.com"
@@ -14,20 +25,26 @@ u.path         // "/path"
 u.query        // Map<String, String>
 u.fragment     // Some("top")
 
-let built = Url.builder()
+// Builder produces a validated `Url` — invalid configurations
+// surface from `.build()`.
+let built: Url = Url.builder()
     .scheme("https")
     .host("api.example.com")
     .path("/v1/users")
     .queryParam("limit", "10")
-    .build()
-    .toString()
+    .build()?
+
+// `toString` emits the canonical reverse of `parse` — the round-trip
+// `parse(u.toString())? == u` holds for every valid `Url`.
+let canonical: String = built.toString()
 ```
 
 API:
 
 ```
+// Pure — capability-free.
 url.parse(text: String) -> Result<Url, Error>
-url.join(base: String, relative: String) -> Result<String, Error>
+url.join(base: Url, relative: String) -> Result<Url, Error>
 
 pub struct Url {
     pub scheme: String,
@@ -41,3 +58,17 @@ pub struct Url {
     fn queryValues(self, key: String) -> List<String>
 }
 ```
+
+#### Information flow interaction
+
+`url.parse(s)` is registered as a sanitizer with
+`#[sanitizes("user_input", into = "url_safe")]` (§21.6). Any `String`
+flowing through `url.parse` (and surviving as `Ok(u)`) re-emerges
+with the `url_safe` flow tag, so the resulting `Url` is acceptable
+to `#[requires("url_safe")]` sinks. A `Url` that originated from
+the builder (`Url.builder()...build()?`) is also `url_safe` because
+the builder rejects malformed inputs at `.build()` time.
+
+External literal construction is `E0420`. Authors who need to
+*assemble* a URL from validated parts must go through the builder,
+which is the only sealed-aware path.

--- a/LANG_SPEC_v0.6/10-standard-library/25-term.md
+++ b/LANG_SPEC_v0.6/10-standard-library/25-term.md
@@ -3,21 +3,30 @@
 `std.term` is the low-level terminal boundary used by text UIs and simple
 terminal games.
 
-Host-backed primitives:
+> **v0.6 capability**: terminal I/O is a host effect — reading a
+> keystroke, querying terminal size, switching to raw mode, and
+> writing escape sequences all consult `stdin`/`stdout`. The v0.6
+> surface routes these through a `Terminal` capability obtained from
+> `Console.terminal()` (§20.9.7); the legacy module-level functions
+> remain under `--legacy-globals` (v0.6.x only).
+
+Host-backed primitives — methods on a `Terminal` capability:
 
 ```osty
-term.open() -> Result<Terminal, Error>
-term.isTerminal() -> Bool
-term.size() -> Result<Size, Error>
-term.setRawMode(enabled: Bool) -> Result<(), Error>
-term.readKey() -> Result<Key, Error>
-term.pollKey(timeoutMillis: Int) -> Result<Key?, Error>
-term.readEvent() -> Result<Event, Error>
-term.write(text: String) -> Result<(), Error>
-term.flush() -> Result<(), Error>
+Console.terminal(self) -> Result<Terminal, Error>     // §20.9.7
+
+Terminal.isOpen(self) -> Bool
+Terminal.size(self) -> Result<Size, Error>
+Terminal.setRawMode(self, enabled: Bool) -> Result<(), Error>
+Terminal.readKey(self) -> Result<Key, Error>
+Terminal.pollKey(self, timeoutMillis: Int) -> Result<Key?, Error>
+Terminal.readEvent(self) -> Result<Event, Error>
+Terminal.write(self, text: String) -> Result<(), Error>
+Terminal.flush(self) -> Result<(), Error>
+Terminal.restore(self) -> Result<(), Error>
 ```
 
-Pure ANSI helpers:
+Pure ANSI helpers — capability-free:
 
 ```osty
 term.clearScreenSeq() -> String
@@ -31,6 +40,29 @@ term.styleSeq(style: Style) -> String
 term.styled(text: String, style: Style) -> String
 ```
 
+Worked pattern — entering raw mode with a `defer` for guaranteed
+cleanup on every exit path (including cancel, §4.12 / §8.4.3):
+
+```osty
+fn runTui(console: Console) -> Result<(), Error> {
+    let term = console.terminal()?
+    term.setRawMode(true)?
+    defer term.restore()             // restores raw mode + cursor + alt screen
+
+    term.write(term.enterAltScreenSeq())?
+    term.flush()?
+
+    for {
+        match term.pollKey(100)? {
+            Some(Key.Char('q')) -> { break },
+            Some(_) | None -> {},
+        }
+        thread.checkCancelled()?     // §8.4.2 cooperative cancel
+    }
+    Ok(())
+}
+```
+
 Coordinates are zero-based in the Osty API. `moveToSeq` converts to the
 one-based row/column convention used by ANSI terminals.
 
@@ -40,3 +72,8 @@ raw mode, hide the cursor, or switch to the alternate screen.
 Current LLVM backend coverage includes `isTerminal`, `size`, `write`, `flush`,
 `setRawMode`, `readKey`, and `pollKey`. Resize event decoding is part of the
 next host-backed terminal increment.
+
+Legacy `term.open()` / `term.readKey()` / etc. (no capability args)
+desugar to `std.term.host.open()` / `std.term.host.readKey()` under
+`--legacy-globals` (v0.6.x only). Outside that mode, bare-arg form
+is `E0780`.

--- a/LANG_SPEC_v0.6/10-standard-library/26-tui.md
+++ b/LANG_SPEC_v0.6/10-standard-library/26-tui.md
@@ -28,3 +28,26 @@ Screen.reset()
 `std.tui` intentionally renders to strings first. That keeps frame diffing
 testable and lets callers choose whether to write through `std.term`,
 capture output, or compare snapshots.
+
+#### Capability split
+
+Frame composition (`tui.frame`, `Frame.put`, `Frame.drawText`,
+`Frame.diffAnsi`) is *pure* — every method here is capability-free
+and acceptable inside `#[reproducible(scope = "target")]` (§3.11).
+
+Output (`Screen.present`) is the only effectful method; it consumes
+a `Terminal` capability obtained from `Console.terminal()`
+(§10.25 / §20.9.7). The split lets a `tui` test render a frame and
+compare its `renderAnsi()` output against a `#[golden]` snapshot
+(§11.5.2) without ever touching a host terminal:
+
+```osty
+#[golden("fixtures/tui_login_screen.snap", mode = "text")]
+#[reproducible(scope = "target")]
+fn testLoginScreen() {
+    let frame = tui.sized(40, 12)
+    frame.drawText(grid.point(2, 1), "login", styles.heading)
+    frame.drawHLine(2, 1, 38, "─", styles.border)
+    testing.assertGolden(frame.renderAnsi())
+}
+```

--- a/LANG_SPEC_v0.6/10-standard-library/28-sql.md
+++ b/LANG_SPEC_v0.6/10-standard-library/28-sql.md
@@ -4,6 +4,24 @@
 open database connections or execute queries; drivers such as SQLite or
 Postgres should accept the `Query` value produced by this module.
 
+`SqlIdent` (the type produced by `sql.quoteIdent` / `sql.quotePath`) is
+a v0.6 sealed-construct type (§3.4.5, G40) — external literal
+construction is rejected. Identifiers reach a `Db.query` sink only
+through this validated path:
+
+| Path | Yields | Sealed? |
+|---|---|---|
+| `sql.quoteIdent("users")?` | `SqlIdent` | yes — sole construction route |
+| `SqlIdent { value: "..." }` | — | rejected (`E0420`) |
+| Raw `String` concatenation into SQL text | — | flagged at the sink (`E0901` if input is tainted) |
+
+The `Query` struct itself is *not* sealed — it is constructed by every
+builder in this module — but its `sql: String` field is registered as
+`#[trust("sql_safe")]` because the builder guarantees parameterized
+form. Direct mutation of `Query.sql` via field write would invalidate
+that promise, so the field is `pub` *getter only* in v0.6 (consistent
+with §3.4.4).
+
 ```osty
 use std.sql
 

--- a/LANG_SPEC_v0.6/10-standard-library/29-db.md
+++ b/LANG_SPEC_v0.6/10-standard-library/29-db.md
@@ -5,7 +5,12 @@ runtime driver: connection configuration, DSN rendering, pool and transaction
 options, row/result containers, and migration planning helpers.
 
 It intentionally does not open SQLite files, sockets, TLS sessions, or execute
-queries. Runtime-backed drivers should consume `db.Config` and `sql.Query`.
+queries. Runtime-backed drivers should consume `db.Config` and `sql.Query`
+through a `Db` capability (§20.9.x — runtime-driver-shaped, not in the 7
+canonical set). The boundary is deliberate: `std.db` is *pure* — every
+function in this module operates on already-captured values and can run inside
+a `#[reproducible(scope = "target")]` context. Effectful operations
+(`Db.exec`, `Db.query`, `Db.beginTx`) live on the capability itself.
 
 ```osty
 use std.db
@@ -94,4 +99,36 @@ Behavior:
   parameter components.
 - `redactedDsn` preserves shape while replacing the password with `redacted`.
 - Migration helpers sort pending migrations by version and do not execute SQL.
-- Actual database I/O remains a runtime-driver responsibility.
+- Actual database I/O remains a runtime-driver responsibility — driven through
+  a `Db` capability shaped roughly as:
+
+  ```osty
+  pub interface Db {
+      fn exec(self, q: sql.Query) -> Result<ExecResult, Error>
+      fn query(self, q: sql.Query) -> Result<ResultSet, Error>
+      fn queryOne::<T>(self, q: sql.Query) -> Result<T?, Error>
+      fn beginTx(self, opts: TxOptions) -> Result<Tx, Error>
+  }
+  ```
+
+  Concrete drivers (e.g. SQLite, Postgres) implement this interface;
+  `std.capability.testing.FakeDb` provides a deterministic in-memory adapter
+  for tests. SQL flow into `Db.exec` / `Db.query` is a `sql_safe` sink
+  (§21.8) — `sql.Query` values constructed through `std.sql` builders carry
+  the tag automatically; raw `String` SQL must be sanitized via
+  `std.sql.escape` before reaching the sink.
+
+Worked pattern — explicit `Db` capability + flow-safe parameterized query:
+
+```osty
+fn lookupActive(db: Db, email: Email) -> Result<List<Row>, Error> {
+    let where = sql.eq("users.email", sql.string(email.toString()))?
+    let q = sql.selectWhere("users", ["id", "email"], where)?
+    let rs = db.query(q)?
+    Ok(rs.rows)
+}
+```
+
+`Email` (sealed, §10.13/§10.16-style) ensures the bound value is a parsed
+identifier — `sql.string(email.toString())` then renders it as a parameterized
+literal that the dialect-specific driver binds, never concatenated.

--- a/LANG_SPEC_v0.6/10-standard-library/30-smtp.md
+++ b/LANG_SPEC_v0.6/10-standard-library/30-smtp.md
@@ -4,6 +4,35 @@
 `std.email.Envelope` for message data, but does not claim TLS/socket execution
 until the runtime grows that transport layer.
 
+Like `std.db` (§10.29), every function in `std.smtp` is *pure* — protocol
+command rendering, reply parsing, capability-list extraction, and credential
+encoding all operate on values. Actual transport (TCP connect, STARTTLS
+handshake, command write/read) flows through the `Net` capability
+(§20.9.5). A wrapper layer drives the protocol command list against a
+`TcpConn`:
+
+```osty
+fn sendOnce(net: Net, cfg: ClientConfig, env: Envelope) -> Result<(), Error> {
+    let tx = smtp.transaction(cfg, env)
+    let cmds = smtp.commands(tx)?
+
+    let conn = net.connect("{cfg.host}:{cfg.port}")?
+    defer conn.close()
+
+    for cmd in cmds {
+        io.writeString(conn, cmd + "\r\n")?
+        let line = io.readLine(conn)?
+        let reply = smtp.parseReply(line)?
+        if reply.isError() { return Err(reply.toError()) }
+    }
+    Ok(())
+}
+```
+
+The protocol module never grows a transport surface of its own — the
+`std.smtp` ↔ `Net` split is the canonical layering for v0.6 protocol
+modules that target wire formats.
+
 ```osty
 use std.smtp
 

--- a/LANG_SPEC_v0.6/10-standard-library/32-image.md
+++ b/LANG_SPEC_v0.6/10-standard-library/32-image.md
@@ -3,6 +3,11 @@
 `std.image` detects common image formats and parses header metadata. Full
 pixel decoding is intentionally left for a future runtime-backed codec layer.
 
+`std.image` is *pure* — every function operates on already-captured
+`Bytes`. Filesystem reads happen at the caller's boundary through
+`Fs` (§20.9.4). The pure surface is acceptable inside
+`#[reproducible(scope = "target")]` and never consults a capability.
+
 Supported metadata formats:
 
 - PNG

--- a/LANG_SPEC_v0.6/10-standard-library/33-aiagents.md
+++ b/LANG_SPEC_v0.6/10-standard-library/33-aiagents.md
@@ -10,6 +10,20 @@ client, RPC server, or filesystem workflow. Those belong in host runtimes or
 application packages. The stdlib surface gives those packages a stable common
 vocabulary.
 
+> **v0.6 capability layering**: `std.aiagents` is *entirely pure* —
+> the chapter never touches `Net`, `Fs`, `Process`, or `Clock`. The
+> agent run surface (`runRequestWithOptions`, `RunResult` shapes,
+> `toolPolicy`) returns / consumes already-captured values. Hosts
+> drive the actual model call through `std.ai` (§10.36, `Net`
+> required), persist sessions through their own `Fs` capability,
+> and source timestamps through `Clock`. The `TrustLevel` enum
+> (`Trusted` / `UserProvided` / `Extracted` / `ToolOutput` /
+> `CompactionSummary`) is the agent-side analog of the §21 flow
+> tag set — `UserProvided` content carries the same suspicion as
+> `#[taint("user_input")]` and must pass through a sanitizer (or
+> a stricter `SafetyPolicy` check) before being routed into a
+> sensitive tool call.
+
 ```osty
 use std.aiagents
 

--- a/LANG_SPEC_v0.6/10-standard-library/34-deneb-utilities.md
+++ b/LANG_SPEC_v0.6/10-standard-library/34-deneb-utilities.md
@@ -39,6 +39,21 @@ the original session-key, HTML escaping, dangerous-scheme, localhost/private
 network, cloud metadata, IPv4-mapped IPv6, numeric IPv4, IPv6 zone, file URL,
 UNC path, Markdown-link stripping, dedupe, and balanced URL-tail cases.
 
+**v0.6 sanitizer registry.** Two helpers participate in the v0.6
+information-flow surface (§21.6):
+
+- `sanitizeHtml(s)` carries
+  `#[sanitizes("user_input", into = "html_safe")]` — output is
+  acceptable to `http.respondHtml` and `template.render` sinks.
+- `checkUrl(u)?` carries
+  `#[sanitizes("user_input", into = "url_safe")]` — output is
+  acceptable to `http.redirect` and similar URL-shaped sinks.
+
+`extractSafeLinks` is *not* a sanitizer in the flow-tag sense — it
+reduces a list of URLs by domain policy but does not retag the
+`String` element type. Apply `checkUrl` to each result if a sink
+requires `url_safe`.
+
 #### `std.search`
 
 Pure in-memory text search for small-to-medium local document sets. It performs

--- a/LANG_SPEC_v0.6/10-standard-library/35-table.md
+++ b/LANG_SPEC_v0.6/10-standard-library/35-table.md
@@ -4,6 +4,16 @@
 cleanup jobs. It keeps cells as strings for lossless CSV/TSV round-trips,
 then layers typed access and column inference on top.
 
+`std.table` is *pure* — every function operates on already-captured
+`String` / `Bytes` values. Reading a CSV from disk happens at the
+caller's `Fs` boundary; the resulting `String` is then passed to
+`table.fromCsv`. The pure surface is acceptable inside
+`#[reproducible(scope = "target")]`. Cell values inherit the flow
+tag set of the source `String` — a CSV constructed from user-uploaded
+bytes carries `#[taint("user_input")]` into every cell extracted via
+`table.row(i).cell("name")`, so authors handling untrusted CSV must
+sanitize before reaching SQL / shell / HTML sinks.
+
 ```osty
 use std.table
 

--- a/LANG_SPEC_v0.6/10-standard-library/37-scan.md
+++ b/LANG_SPEC_v0.6/10-standard-library/37-scan.md
@@ -5,20 +5,34 @@ drivers remain host-specific, so the module plans and runs host commands rather
 than embedding a driver stack. The built-in backend targets SANE `scanimage`;
 other tools can be wrapped with `CustomCommand` and placeholder arguments.
 
+> **v0.6 capability**: planning is pure (`scan.plan`,
+> `scan.scanimageOptions`, `scan.parseScanimageDevices`); *execution*
+> spawns a host process and writes files, so `scan.run` and
+> `scan.scanAndOcr` require both `Process` and `Fs` capabilities
+> (§20.9.5/6). The legacy zero-arg form desugars under
+> `--legacy-globals` (v0.6.x).
+
 Core surface:
 
 ```osty
+// Pure — capability-free option builders + plan computation.
 scan.scanimageOptions(outputDir) -> Options
 scan.adfOptions(outputDir) -> Options
 scan.duplexAdfOptions(outputDir) -> Options
 scan.customCommandOptions(command, outputDir) -> Options
 scan.plan(options) -> Result<CommandPlan, Error>
-scan.run(options) -> Result<ScanResult, Error>
-scan.scanAndOcr(options, ocrOptions, maxChunkChars, reviewThreshold) -> Result<OcrScanResult, Error>
 scan.parseScanimageDevices(text) -> List<Device>
-scan.listDevices(command) -> Result<List<Device>, Error>
-scan.listDefaultDevices() -> Result<List<Device>, Error>
 scan.manifest(result) -> String
+
+// Effectful — methods on `Process` + `Fs` capability set.
+fn run(proc: Process, fs: Fs, options: Options) -> Result<ScanResult, Error>
+fn scanAndOcr(
+    proc: Process, fs: Fs,
+    options: Options, ocrOptions: OcrOptions,
+    maxChunkChars: Int, reviewThreshold: Float,
+) -> Result<OcrScanResult, Error>
+fn listDevices(proc: Process, command: String) -> Result<List<Device>, Error>
+fn listDefaultDevices(proc: Process) -> Result<List<Device>, Error>
 ```
 
 `Options` covers device id, source (`Flatbed`, `Adf`, `DuplexAdf`), color mode,
@@ -39,3 +53,12 @@ Custom command placeholders:
 
 The OCR handoff uses `std.ocr.run` for each scanned page, returns a scan-local
 `OcrBatch`, and builds indexed documents with `ocr.indexDocument`.
+
+#### Information flow
+
+`Options.outputDir` is a path-shaped sink — passing a tainted
+`String` (e.g. an HTTP form value) directly into `scanimageOptions`
+without going through `std.path.normalize` is `E0902`. The
+`outputDir` field carries `#[requires("path_safe")]` at the type
+level, so the checker enforces sanitization at construction time
+rather than at run.

--- a/LANG_SPEC_v0.6/10-standard-library/38-print.md
+++ b/LANG_SPEC_v0.6/10-standard-library/38-print.md
@@ -4,6 +4,15 @@
 does not implement page rendering in the language runtime; applications should
 produce a PDF or image first, then ask the host printer stack to print it.
 
+> **v0.6 capability**: planning (`print.plan`, `print.options`,
+> `print.pageRange`) is pure. Effectful operations (`print.print`,
+> `print.printers`, `print.defaultPrinterName`) require the
+> `Process` capability (§20.9.6) — they spawn `lp` / `lpr` /
+> `WindowsShell` and read the spooler's reply. The `path` arguments
+> are path-shaped sinks; tainted input must pass `std.path.normalize`
+> first (§21.8). The legacy zero-arg form desugars under
+> `--legacy-globals` (v0.6.x).
+
 Core types:
 
 ```osty

--- a/LANG_SPEC_v0.6/10-standard-library/40-xlsx.md
+++ b/LANG_SPEC_v0.6/10-standard-library/40-xlsx.md
@@ -3,6 +3,24 @@
 `std.xlsx` builds simple Excel-compatible `.xlsx` workbooks on top of
 stored ZIP packaging and `std.table` row adapters.
 
+`std.xlsx` is *pure* — every function operates on `Bytes` /
+`String` / `Table` values; the chapter never touches the
+filesystem. Reading a `.xlsx` from disk and writing one back are
+ordinary `Fs.read`/`Fs.write` calls in the caller's code:
+
+```osty
+fn loadAndAnnotate(fs: Fs, path: String) -> Result<Bytes, Error> {
+    let raw = fs.read(path)?               // Fs effect at the boundary
+    let rows = xlsx.decodeRows(raw, "Sheet1")?
+    let annotated = rows.map(|r| r.appendCell("checked"))
+    xlsx.encodeRows("Sheet1", annotated)   // pure, returns new Bytes
+}
+```
+
+The encode/decode pair is acceptable inside
+`#[reproducible(scope = "target")]` since it does not consult any
+capability.
+
 The first supported format is intentionally conservative: workbooks are ZIP
 packages whose entries use the ZIP "store" method, worksheet cells use inline
 strings or scalar numeric/bool values, and decode supports those same stored

--- a/LANG_SPEC_v0.6/10-standard-library/42-pdf.md
+++ b/LANG_SPEC_v0.6/10-standard-library/42-pdf.md
@@ -5,6 +5,19 @@ pages or decode compressed streams; those require host/runtime-backed PDF
 engines. The stdlib surface focuses on portable checks that are useful in CLI
 tools, document search, ingestion pipelines, and diagnostics.
 
+`std.pdf` is *pure* — every function operates on already-captured
+`Bytes`. Filesystem reads happen at the caller's boundary through
+`Fs` (§20.9.4), and the resulting `Bytes` are passed in. The pure
+surface is acceptable inside `#[reproducible(scope = "target")]` —
+the same input always produces the same parse tree.
+
+Tainted PDF input (e.g. a user-uploaded file) carries the source's
+flow tag through `pdf.extractText(data)` into the returned `String`.
+A `String` extracted from a tainted PDF therefore lands at sinks
+with the same `#[taint(...)]` set as the input bytes, and must be
+sanitized before reaching `html_safe` / `sql_safe` / `shell_safe`
+sinks.
+
 ```osty
 use std.bytes
 use std.pdf


### PR DESCRIPTION
## Summary

v0.6 정본화 후속 — 아직 v0.5 형식의 effect 호출 / 분류되지 않은 순수 모듈을 가진
stdlib chapter들을 capability method form 으로 정리. **Batch 5 + Batch 6 합산**:
+372 / -36 LOC, **16 chapters**.

### Batch 5 — Capability split (effectful → capability method)

| Chapter | 변경 |
|---|---|
| **§10.12 crypto** | pure (`sha256`, `hmac`, `constantTimeEq`) ↔ effectful (`CryptoRng.randomBytes`/`uuid4`). `Rng` (non-crypto, seedable) ↔ `CryptoRng` (CSPRNG) 명시 구분 |
| **§10.13 UUID** | `v4(rng)` / `v7(clock, rng)` capability args + sealed construct (`E0420`) + ToString round-trip |
| **§10.16 URL** | sealed construct + `url.parse` 가 user_input → url_safe sanitizer 등록 |
| **§10.25 term** | `term.*` → `Terminal` capability via `Console.terminal()`. raw mode + `defer restore` worked pattern + cancel cooperation |
| **§10.26 TUI** | Frame composition (pure) ↔ `Screen.present` (Terminal capability) + `#[golden]` reproducible 테스트 |
| **§10.28 SQL** | `SqlIdent` sealed + `Query.sql` 의 `sql_safe` trust tag |
| **§10.29 DB** | pure module + `Db` capability interface + sql_safe sink + parameterized worked pattern |
| **§10.30 SMTP** | pure protocol module + `Net` capability transport layering |
| **§10.34 deneb** | `sanitizeHtml` / `checkUrl` 가 §21.6 sanitizer registry 항목임을 명시 |

### Batch 6 — 추가 7 chapters: pure / capability split note

| Chapter | 변경 |
|---|---|
| **§10.37 scan** | `scan.run` / `scanAndOcr` / `listDevices` 가 Process+Fs capability 요구. plan/parse 는 pure. `Options.outputDir` 은 path_safe sink |
| **§10.38 print** | `print.print` / `printers` / `defaultPrinterName` 가 Process capability 요구. plan/options/pageRange 는 pure. path 인자는 path_safe sink |
| **§10.32 image** | pure module — Bytes 만 다루며 `#[reproducible(scope="target")]` 안전 |
| **§10.33 aiagents** | 전체 pure — Net/Fs/Process/Clock 미사용. host가 `std.ai`로 effect 처리. `TrustLevel`은 §21 flow tag의 agent-side 등가물 |
| **§10.35 table** | pure module — cell 값은 source String의 taint 상속 |
| **§10.40 xlsx** | pure module — fs.read → decode → encode → fs.write 패턴 |
| **§10.42 PDF** | pure module — Bytes만 다루며 caller가 Fs 경계 처리. `extractText`가 source PDF의 taint 상속 |

이로써 stdlib chapter 31개 모두 v0.6 capability voice 정렬 완료. 남은 v0.5
reference는 의도된 위치 (§00 / §10.46 / migration callout)에만 보존.

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §20.9 capability surface와 §10.12/§10.13/§10.16/§10.25/§10.28/§10.29/§10.37/§10.38 capability 시그니처 정합
- [ ] §21.6 sanitizer registry와 §10.16/§10.34 sanitizer 등록 정합
- [ ] §3.4.5 sealed construct rule과 §10.13/§10.16/§10.28 sealed type 정합
- [ ] §3.11 reproducible scope와 §10.32/§10.35/§10.40/§10.42 pure module 호환성

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd