### PR TITLE
perf(dev): parallelize repair-check via xargs -P 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,10 @@ jobs:
 
       - name: Osty repair
         run: |
-          while IFS= read -r file; do
-            case "$file" in
-              testdata/spec/negative/*|internal/airepair/testdata/corpus/*.input.osty) continue ;;
-            esac
-            "$OSTY_BIN" repair --check "$file"
-          done < <(git ls-files '*.osty')
+          set -o pipefail
+          git ls-files '*.osty' \
+            | grep -vE '^(testdata/spec/negative/|internal/airepair/testdata/corpus/[^/]+\.input\.osty$)' \
+            | xargs -n 1 -P "${REPAIR_CHECK_PARALLEL:-4}" "$OSTY_BIN" repair --check
 
       - name: Osty airepair backlog
         if: always()

--- a/justfile
+++ b/justfile
@@ -189,7 +189,7 @@ diag test=".":
     go test {{test_flags}} ./internal/diag -run '{{test}}' -v
 
 repair-check: build
-    while IFS= read -r file; do case "$file" in testdata/spec/negative/*|internal/airepair/testdata/corpus/*.input.osty) continue ;; esac; {{bin}} repair --check "$file"; done < <(git ls-files '*.osty')
+    git ls-files '*.osty' | grep -vE '^(testdata/spec/negative/|internal/airepair/testdata/corpus/[^/]+\.input\.osty$)' | xargs -n 1 -P "${REPAIR_CHECK_PARALLEL:-4}" -I {} bash -c '{{bin}} repair --check "$1" || true' _ {}
 
 # Capture residual airepair cases into tmp/airepair-cases/ and rewrite
 # todo-airepair.md with the ranked learning backlog. Non-blocking.


### PR DESCRIPTION
## Summary

- `just repair-check` (in `prepush`) was a sequential bash `while` loop over 496 `.osty` files. Replaced with `xargs -n 1 -P 4` driving the same `osty repair --check` invocation per file.
- **20 largest .osty files: 275s → 68s (4×)** on a 10-core mac (warm cache).
- **Full 496-file corpus parallel: ~5min** vs ~8–15min serial (user-reported range).
- Override via `REPAIR_CHECK_PARALLEL=N just repair-check`.

## Why P=4 and not P=NCPU?

Each `osty` Go process defaults to `GOMAXPROCS=NCPU` (10 on a 10-core mac), spawning up to 10 worker goroutines. Running 10 processes in parallel = 100 threads on 10 cores → severe scheduler/allocator contention.

Empirical benchmark on 20 largest files:

| Parallelism | Wall time | Speedup |
|---:|---:|---:|
| P=1 (serial) | 275s | 1.0× |
| **P=4** | **68s** | **4.0×** |
| P=10 | 146s | 1.9× |

P=10 is *worse than P=4*. P=4 fits comfortably under the GOMAXPROCS oversubscription cliff.

## Failure-handling semantics

The justfile recipe wraps each invocation in `bash -c '... || true'` to **preserve** the original `bash while` loop's failure-masking behavior (without `set -e`, that loop exits with the last iteration's code, which silently passes on most failures).

The CI step (`.github/workflows/ci.yml`) retains **strict** failure detection — GitHub Actions runs `run:` blocks with `set -e` by default, so the original CI version did fail on the first error. This PR keeps that behavior.

A separate PR should reconcile these (probably tighten the justfile to match CI), but that requires fixing the underlying repair rules first — e.g., the `while_keyword` rule still flags `while`, which became a valid keyword in v0.6 (G49, §4.4).

## Test plan

- [x] `just --dry-run repair-check` expands cleanly
- [x] Full-corpus run completes in ~5 min, exits 0 (matches old behavior)
- [x] Bench on 20 largest files shows 4× speedup at P=4
- [ ] CI run on this branch passes the (now-strict) `Osty repair` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)