### PR TITLE
docs(v0.6): batch 7 — sealed-construct + testing recipes + capability composition (+432 LOC)

### DIFF
--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -447,6 +447,85 @@ when applied to a sealed struct from outside the named constructor:
 to `std.*` and toolchain-internal packages (`E0422` from user code). All
 sites are enumerated by `osty audit --trusted-construct`.
 
+#### 3.4.5.1 Constructor signature requirements
+
+The named constructor — `parse` in the example above — must satisfy
+three rules at definition time:
+
+1. **It returns the sealed type** (or `Result<Self, _>` / `Self?`).
+   Returning a wrapper or a generic `Self?` not parameterized on the
+   sealed type is `E0423`.
+2. **It is package-public** if the struct itself is `pub`. A `pub
+   struct` with a non-`pub` constructor is `E0424` — external code
+   needs *some* path to construct values, otherwise the type would be
+   uninhabitable to importers.
+3. **It accepts only ordinary parameters** — no `Self` / `mut self` /
+   sealed-aware special args. The constructor reaches the body via
+   normal call resolution and is not allowed to short-circuit
+   sealed-construction checks via reflection.
+
+A struct may declare *multiple* `#[sealed_construct(name)]` annotations
+to register more than one validating constructor. Each name must
+satisfy the three rules independently:
+
+```osty
+#[sealed_construct(parse)]
+#[sealed_construct(fromBytes)]
+pub struct Sha256Digest {
+    bytes: Bytes,
+}
+
+impl Sha256Digest {
+    pub fn parse(hex: String) -> Sha256Digest? { ... }
+    pub fn fromBytes(b: Bytes) -> Sha256Digest? { ... }
+}
+```
+
+#### 3.4.5.2 Round-trip with `ToString`
+
+Stdlib v0.6 sealed types (`Email`, `Url`, `Path`, `SqlIdent`,
+`Duration`, `Uuid`) maintain the contract `parse(value.toString())?
+== Some(value)` for every value the constructor produces. User code
+that defines a sealed type **should** uphold the same round-trip;
+formalizing it via a `spec { law: ... }` clause (§3.13) gives the
+checker a target:
+
+```osty
+#[sealed_construct(parse)]
+pub struct Slug {
+    text: String,
+
+    pub fn parse(s: String) -> Slug? {
+        spec {
+            law: result.map(|sl| Slug.parse(sl.toString())) == Some(Some(result))
+        }
+        ...
+    }
+
+    pub fn toString(self) -> String { self.text }
+}
+```
+
+The law is documentation in v0.6 baseline (§3.13.2 — Phase 3 v0
+runs `example:` only). Phase 5 turns it into a property test.
+
+#### 3.4.5.3 Information flow integration
+
+A `#[sealed_construct(parse)]` constructor that performs full
+validation should also register as a sanitizer through
+`#[sanitizes("source", into = "trust")]`:
+
+```osty
+#[sanitizes("user_input", into = "url_safe")]
+pub fn parse(s: String) -> Url? { ... }
+```
+
+Outputs of the parser then carry the `url_safe` trust tag, which is
+what `#[requires("url_safe")]` sinks (§21.8) expect. Sealed
+construction and sanitization compose orthogonally — sealed enforces
+*who* can construct a value, sanitization records *which trust set*
+the value carries.
+
 ### 3.5 Enums
 
 ```osty

--- a/LANG_SPEC_v0.6/11-testing.md
+++ b/LANG_SPEC_v0.6/11-testing.md
@@ -766,3 +766,190 @@ osty test --spec --example --golden --doc
 
 `#[stability("stable")]` API 가 테스트 surface (e.g., custom Fake
 impl) 를 노출하면 `osty publish` 의 SemVer 룰 적용.
+
+### 11.18 Capability test recipes
+
+This section catalogues canonical recipes for testing capability-typed
+code. Each recipe states the production shape, the deterministic test
+fake, and what the recipe specifically guards against.
+
+#### 11.18.1 Pure recipe — no capability needed
+
+If a function takes no capability parameter, no fake is required.
+This is the cheapest test path; the recipe is to *keep functions
+this way* whenever possible.
+
+```osty
+#[reproducible(scope = "target")]
+pub fn classify(text: String) -> Category { ... }
+
+#[test]
+fn test_classify_short_text() {
+    testing.assertEq(classify("hello"), Category.Greeting)
+}
+```
+
+Production code that performs an effect should accept a capability
+parameter rather than calling a global; the recipes below assume that
+discipline.
+
+#### 11.18.2 Single capability — direct fake
+
+```osty
+fn buildId(clock: Clock, rng: Rng) -> String {
+    "{clock.now().toEpochMillis()}-{rng.next()}"
+}
+
+#[test]
+fn test_buildId_is_deterministic() {
+    let clock = std.capability.testing.FakeClock(epoch_ms = 1_000_000)
+    let rng = std.capability.testing.FakeRng(seed = 42)
+    let id = buildId(clock, rng)
+    testing.assertEq(id, "1000000-1608637542")
+}
+```
+
+Guards against: hidden time / randomness dependencies. The result is
+byte-equal across runs because both fakes are deterministic.
+
+#### 11.18.3 Filesystem recipe — `FakeFs` layout
+
+```osty
+fn loadConfig(fs: Fs, path: String) -> Result<Config, Error> {
+    let text = fs.readToString(path)?
+    json.parse(text)
+}
+
+#[test]
+fn test_loadConfig_reads_layout() {
+    let fs = std.capability.testing.FakeFs.fromLayout({
+        "/etc/app.toml": "{ \"port\": 8080 }",
+    })
+    let cfg = loadConfig(fs, "/etc/app.toml")?
+    testing.assertEq(cfg.port, 8080)
+}
+
+#[test]
+fn test_loadConfig_missing_file_errors() {
+    let fs = std.capability.testing.FakeFs.empty()
+    let result = loadConfig(fs, "/nope")
+    testing.expectError(result)
+}
+```
+
+Guards against: tests reaching the real filesystem (and thus
+race-conditioning with other tests, leaking artifacts, or depending
+on the test runner's working directory).
+
+#### 11.18.4 Network recipe — `FakeNet` route table
+
+```osty
+fn fetchHealth(net: Net, host: String) -> Result<HealthStatus, Error> {
+    let conn = net.connect("{host}:80")?
+    defer conn.close()
+    io.writeString(conn, "GET /health HTTP/1.0\r\n\r\n")?
+    let body = io.readAll(conn)?
+    HealthStatus.parse(body.toString()?)
+}
+
+#[test]
+fn test_fetchHealth_parses_response() {
+    let net = std.capability.testing.FakeNet.routes({
+        "example.com:80": std.capability.testing.cannedResponse(
+            "HTTP/1.0 200 OK\r\n\r\n{\"status\":\"ok\"}",
+        ),
+    })
+    let result = fetchHealth(net, "example.com")?
+    testing.assertEq(result.status, "ok")
+}
+```
+
+Guards against: tests requiring live network endpoints, port
+collisions, network policy issues in CI.
+
+#### 11.18.5 Cancellation recipe — `taskGroup` + `g.cancel`
+
+```osty
+fn longRunning(clock: Clock) -> Result<(), Error> {
+    clock.sleep(60.s)?
+    Ok(())
+}
+
+#[test]
+fn test_longRunning_honors_cancel() {
+    let clock = std.capability.testing.FakeClock(epoch_ms = 0)
+    taskGroup(|g| {
+        let h = g.spawn(|| longRunning(clock))
+        g.cancel(Cancelled.New("test"))
+        match h.join() {
+            Err(e) -> testing.assert(e.downcast::<Cancelled>().isSome()),
+            Ok(_) -> testing.fail("expected Cancelled"),
+        }
+        Ok(())
+    })
+}
+```
+
+Guards against: blocking calls that fail to honor `taskGroup`
+cancellation. `FakeClock.sleep` returns immediately by default, but
+honors the cancel signal of the surrounding `taskGroup` exactly as
+the production `Clock.sleep` does.
+
+#### 11.18.6 Information-flow recipe — taint preserved through fakes
+
+```osty
+fn safeRender(net: Net, console: Console, conn: TcpConn) -> Result<(), Error> {
+    let raw: Bytes = io.readAll(conn)?
+    let text: String = raw.toString()?
+    let html = std.html.escape(text)         // sanitizes user_input → html_safe
+    console.println(html)
+    Ok(())
+}
+
+#[test]
+fn test_safeRender_writes_escaped_output() {
+    let f = std.testing.capabilityFakes()
+    let conn = std.capability.testing.fakeTcp("<script>alert(1)</script>")
+    safeRender(f.fakeNet, f.fakeConsole, conn)?
+    let out = f.fakeConsole.stdoutCaptured()
+    testing.assertEq(out, "&lt;script&gt;alert(1)&lt;/script&gt;\n")
+}
+```
+
+Guards against: regression in sanitization. The fake `Console`'s
+captured output is byte-equal to what the production `Console` would
+emit, so flow-tag bugs surface as observable failures.
+
+#### 11.18.7 Spec block + capability recipe
+
+`spec { example: ... }` clauses (§3.13) inside a capability-typed
+function run under the `--spec` mode. Capability instances that the
+function takes must be provided either by `#[example(uses = "name")]`
+referencing a fixture, or by explicit closure construction inside the
+example expression:
+
+```osty
+#[fixture(name = "frozenClock")]
+fn frozenClock() -> Clock {
+    std.capability.testing.FakeClock(epoch_ms = 0)
+}
+
+#[fixture(name = "seededRng")]
+fn seededRng() -> Rng {
+    std.capability.testing.FakeRng(seed = 42)
+}
+
+#[example(input = "()", uses = "frozenClock", uses = "seededRng",
+          output = "\"0-1608637542\"")]
+fn buildId(clock: Clock, rng: Rng) -> String {
+    spec {
+        example: buildId(frozenClock(), seededRng()) == "0-1608637542"
+    }
+    "{clock.now().toEpochMillis()}-{rng.next()}"
+}
+```
+
+The `uses = "name"` form composes; multiple `uses =` repeats inject
+each named fixture in order. v0.6 baseline runs the inline
+`example:` clause; the `#[example]` annotation form runs under
+`osty test --example`.

--- a/LANG_SPEC_v0.6/20-capabilities.md
+++ b/LANG_SPEC_v0.6/20-capabilities.md
@@ -807,6 +807,172 @@ production code that implements `Clock` (uncommon — usually the host
 adapter is the only implementation) need only carry forward the
 interface implementation.
 
+### 20.17 Capability composition patterns
+
+This section catalogues recurring patterns for combining capabilities
+in real applications. Each pattern names the capability set, the
+shape of the composing structure, and the trade-offs of the
+alternatives.
+
+#### 20.17.1 Capability bag struct
+
+When a function or struct method needs three or more capabilities, a
+*capability bag* — a struct that aggregates them — keeps the
+parameter list bounded:
+
+```osty
+pub struct AppCaps {
+    pub clock: Clock,
+    pub rng: Rng,
+    pub env: Env,
+    pub fs: Fs,
+    pub net: Net,
+    pub console: Console,
+}
+
+pub fn loadAndAnnotate(caps: AppCaps, path: String) -> Result<Annotated, Error> {
+    let raw = caps.fs.readToString(path)?
+    let now = caps.clock.now()
+    let token = caps.rng.next()
+    Ok(Annotated { raw, fetchedAt: now, requestId: token })
+}
+```
+
+Trade-offs:
+
+- **+** signatures stay readable when a function naturally needs many
+  effects;
+- **+** test injection is one struct literal instead of seven
+  arguments;
+- **−** the function's *actual* capability set is opaque to a reader
+  — `AppCaps` says nothing about which fields the body actually
+  uses;
+- **−** `osty audit --capabilities` reports the bag, not the
+  individual effects, so security review loses some signal.
+
+The discipline that recovers the lost signal: keep the bag *narrow*
+to a layer (an HTTP handler bag, a CLI command bag) rather than
+aggregating every capability the program might ever need. A
+`HandlerCaps` struct that holds just `Clock` + `Db` + `Net` is more
+informative than an `AppCaps` that holds all seven.
+
+#### 20.17.2 Per-request capability forwarding
+
+A web server's request handler typically receives capabilities from
+the dispatch layer rather than from `#[ambient]`:
+
+```osty
+fn dispatch(caps: AppCaps, req: HttpRequest) -> Result<HttpResponse, Error> {
+    match (req.method, req.path()) {
+        (Method.Get, "/health") -> handleHealth(caps.clock),
+        (Method.Get, p) if p.startsWith("/users/") ->
+            handleGetUser(caps.db, parseUserId(p)?),
+        (Method.Post, "/users") ->
+            handleCreateUser(caps.clock, caps.rng, caps.db, req),
+        _ -> Ok(http.notFound("")),
+    }
+}
+```
+
+Each handler receives only the capabilities it actually needs. The
+dispatch layer itself receives the full `AppCaps`. This makes
+per-handler capability sets explicit and shows up as such in
+`osty audit --capabilities`.
+
+#### 20.17.3 Reproducible derivation
+
+A function annotated `#[reproducible(scope = "target")]` cannot
+receive non-deterministic capabilities (`Clock`, `Rng`, `Env`, `Fs`,
+`Net`, `Process`). The composition pattern is to *capture* the
+non-deterministic value at a non-reproducible boundary and pass the
+captured value into the reproducible function:
+
+```osty
+// Non-reproducible boundary — owns the Clock.
+fn writeBuildSnapshot(clock: Clock, fs: Fs, payload: Bytes) -> Result<(), Error> {
+    let timestamp = clock.now().toEpochMillis()
+    let key = computeKey(timestamp, payload)        // reproducible call
+    fs.write("snapshots/{key.toHex()}.bin", payload)
+}
+
+// Reproducible inner — receives the captured timestamp value.
+#[reproducible(scope = "target")]
+fn computeKey(timestamp: Int64, payload: Bytes) -> Bytes32 {
+    sha256(payload + timestamp.toBytes())
+}
+```
+
+The reproducible inner is *fully* deterministic on its inputs — the
+same `timestamp` + `payload` always produces the same key. The
+non-reproducible outer admits the timestamp into the system once.
+
+#### 20.17.4 Capability-typed factory
+
+When a capability's *construction* is itself an effect (e.g. opening
+a database connection), expose the construction step explicitly
+rather than synthesizing it inside `#[ambient]`:
+
+```osty
+// Construction is an effect — surface it.
+fn connectDb(env: Env, net: Net) -> Result<Db, Error> {
+    let dsn = env.require("DATABASE_URL")?
+    let cfg = db.parseDsn(dsn)?
+    db.host.connect(net, cfg)
+}
+
+#[ambient(env, net)]
+fn main() {
+    let db = connectDb(env, net)?
+    runApp(db)
+}
+```
+
+`Db` is then passed by value into application code. This composes
+cleanly with the bag pattern (§20.17.1) — the `AppCaps` bag is
+constructed at the entry point with concrete capability instances,
+including ones that required effects to construct.
+
+### 20.18 Capability matrix per stdlib chapter
+
+This matrix summarizes which capabilities each stdlib chapter's
+methods require. Pure modules (no capability) compose freely; effectful
+modules name the capability needed at each call site.
+
+| Chapter | Capability methods | Pure helpers |
+|---|---|---|
+| §10.1 std.io | `Console.print` / `println` / `eprint` etc. | `io.copy`, `io.readAll`, `io.bytesReader`, `io.buffer`, `io.writeAll` |
+| §10.6 collections | (none) | All `List` / `Map` / `Set` operations |
+| §10.7 std.iter | (none) | All combinators |
+| §10.8 std.json | (none) | `parse` / `stringify` / typed `decode` / `encode` |
+| §10.10 std.log | dispatches through ambient `Console` | `Fields` builder |
+| §10.12 std.crypto | `CryptoRng.randomBytes` | `sha256`, `hmac.sha256`, `constantTimeEq` |
+| §10.13 std.uuid | `uuid.v4(rng)`, `uuid.v7(clock, rng)` | `uuid.parse`, `uuid.nil`, `Uuid.toString` |
+| §10.14 std.random | `Rng.int`, `Rng.float`, `Rng.bytes`, `Rng.choice` | `random.seeded` (constructor for derivation) |
+| §10.15 std.os / std.process | `Process.exec`, `Process.exit`, `Process.pid` | `os.path.*` |
+| §10.16 std.url | (none — `url.parse` is pure) | All |
+| §10.20 std.time | `Clock.now`, `Clock.monotonic`, `Clock.sleep` | `Instant.format`, `Duration.toString`, `time.parse` |
+| §10.23 std.net | `Net.connect`, `Net.listen`, `Net.udpBind`, `Net.resolve` | (`Addr` rendering only) |
+| §10.24 std.http | `HttpClient.request`, `HttpServer.serve` | `http.newRequest`, builders, codecs |
+| §10.25 std.term | `Terminal.*` (via `Console.terminal()`) | `term.*Seq` ANSI helpers |
+| §10.26 std.tui | `Screen.present` | `tui.frame`, `Frame.draw*`, `Frame.renderAnsi`, `Frame.diffAnsi` |
+| §10.28 std.sql | (none) | All |
+| §10.29 std.db | `Db.exec`, `Db.query`, `Db.queryOne`, `Db.beginTx` | All non-driver helpers |
+| §10.30 std.smtp | (none — caller drives transport via `Net`) | All |
+| §10.32 std.image | (none) | All |
+| §10.33 std.aiagents | (none — caller drives transport via `std.ai` + `Net`) | All |
+| §10.35 std.table | (none) | All |
+| §10.37 std.scan | `scan.run` (Process+Fs), `scan.listDevices` (Process) | `scan.plan`, `scan.parseScanimageDevices` |
+| §10.38 std.print | `print.print`, `print.printers` (Process) | `print.options`, `print.plan`, `print.pageRange` |
+| §10.39 std.clipboard | dispatches through ambient `Process` | (none) |
+| §10.40 std.xlsx | (none) | All |
+| §10.41 std.keychain | dispatches through ambient `Process` | (none) |
+| §10.42 std.pdf | (none) | All |
+
+A glance at this matrix tells the reader two things at once: which
+imports trigger capability requirements, and which can be used inside
+`#[reproducible]` / `#[pure]` contexts. Maintaining the matrix is part
+of any new stdlib module's PR.
+
 Removing a method or changing a method signature is a breaking
 change requiring a major version bump (per §3.14.3). The non-canonical
 adapters (`net.host`, `process.host`) carry their own removal schedule


### PR DESCRIPTION
## Summary

이전 batch들의 본문 정렬이 끝난 뒤 *주제별로 한 곳에 모인 깊이 있는 v0.6 reference*가
부족한 영역들을 보강. **+432 LOC**, 3 spec 파일.

### §3.4.5 Sealed construct 심화 (3 신규 sub-sections)

- **§3.4.5.1 Constructor signature requirements** — 3 rules (return type / `pub`
  visibility / ordinary parameters) + 다중 `#[sealed_construct]` 등록 (`parse` +
  `fromBytes` 같은 multi-source 파싱)
- **§3.4.5.2 Round-trip with ToString** — `parse(value.toString())? == Some(value)`
  계약을 spec block `law`로 형식화하는 패턴
- **§3.4.5.3 Information flow integration** — `#[sanitizes]` ↔ `#[sealed_construct]`
  composition: sealed = *who* can construct, sanitize = *which trust set*

### §11.18 Capability test recipes (7개 canonical)

| Recipe | 가드하는 위험 |
|---|---|
| 11.18.1 Pure (no capability) | 불필요한 fake |
| 11.18.2 Single capability — direct fake | hidden time/randomness 의존 |
| 11.18.3 Filesystem — `FakeFs.fromLayout` | real-fs race / leaked artifacts |
| 11.18.4 Network — `FakeNet.routes` | live endpoint 의존 / port 충돌 |
| 11.18.5 Cancellation — `taskGroup + g.cancel + FakeClock` | cancel 미존중 blocking |
| 11.18.6 Information flow — taint preserved through fakes | sanitization regression |
| 11.18.7 Spec block + capability fixture | spec example의 deterministic 주입 |

각 recipe는 production shape, test fake, "이걸로 무엇을 막는가"를 명시.

### §20.17 Capability composition patterns (4개)

- **20.17.1 Capability bag struct** — 3+ capability일 때 narrow-per-layer 권장
  (`HandlerCaps` ⊂ `AppCaps`)
- **20.17.2 Per-request forwarding** — handler가 dispatch 단계에서 정확히 필요한
  capability만 수령 → `osty audit --capabilities` 가시성 유지
- **20.17.3 Reproducible derivation** — 외부 capture (`clock.now()` 등) + 내부
  `#[reproducible]` 함수가 captured 값만 받음
- **20.17.4 Capability-typed factory** — 생성 자체가 effect인 경우 (`connectDb`)

### §20.18 Capability matrix per stdlib chapter

stdlib 27 chapter의 capability method ↔ pure helper 분류 표. "이 import가
capability 요구하는가?"를 한 눈에 보는 reference. 신규 stdlib module PR의
maintenance checklist.

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §3.4.5 sealed construct rule이 §10.13/§10.16/§10.28 stdlib sealed 사용과 정합
- [ ] §11.18 recipe들이 §11.9 (capability fakes) 인터페이스와 호환
- [ ] §20.18 capability matrix가 §10.* 각 chapter 본문과 정합

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_