### PR TITLE
perf(dev): drop airepair-capture from prepush gate

### DIFF
--- a/justfile
+++ b/justfile
@@ -230,7 +230,7 @@ backend-loop-gates: build-all
 
 check: fmt-check vet front
 
-prepush: fmt-check vet repair-check airepair-capture ci
+prepush: fmt-check vet repair-check ci
 
 pipe target:
     test -x {{bin}} || just build


### PR DESCRIPTION
## Summary

- `airepair-capture` refreshes `todo-airepair.md` (informational AI-slip backlog). The script always exits 0 (`|| true` per file) and the recipe comment notes "Non-blocking" — it never gated a push, but added ~8min to every `just prepush`.
- CI keeps running it via the existing `Osty airepair backlog` step (`if: always()`), which `::warning::`s when the file is stale, so the workflow stays intact.
- `just airepair-capture` is still available for manual refresh.

Combined with #1514, prepush goes from ~14min → ~6min on a 10-core mac.

## Test plan

- [x] `just --list` still shows `airepair-capture` (standalone target preserved)
- [x] `.github/workflows/ci.yml` still runs `airepair-update-backlog.sh` on every CI run
- [ ] Local `just prepush` no longer triggers airepair-capture step

🤖 Generated with [Claude Code](https://claude.com/claude-code)