### PR TITLE
docs(v0.6): batch 8 — release workflow + spec link + flow taxonomy deep (+415 LOC)

### DIFF
--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -1128,6 +1128,87 @@ may use it for self-documentation. Osty has no `impl` blocks (§14) —
 methods live in struct / enum bodies, where `#[spec]` applies
 directly.
 
+#### 3.10.1 Anchor resolution
+
+The `§X.Y` form is resolved against the spec markdown corpus (the
+files in `LANG_SPEC_v0.6/`) at compile time. Resolution rules:
+
+1. The argument must be a *string literal* matching the regex
+   `§\d+(\.\d+)*(\.\w+)*` (Unicode `§` is required — `&sect;` /
+   `§` are not accepted).
+2. The trailing path beyond `§X.Y` (e.g. `§10.30.user.create`)
+   names a markdown anchor *under* §10.30 — the resolver looks for
+   `<a id="user-create">` or a heading whose slugified form matches
+   `user-create`.
+3. Missing anchor → `E0790` with the suggested anchor list (the
+   resolver fuzzy-matches and offers up to 3 alternatives).
+4. Moved anchor (the file no longer contains the named heading but
+   the corpus still has the anchor elsewhere) → `W0790` — the
+   diagnostic suggests the new path. Tooling can auto-rewrite via
+   `osty fix --spec-links`.
+
+```osty
+#[spec("§10.30.user.create")]   // resolves to LANG_SPEC_v0.6/10-standard-library/30-...
+                                //   under heading "user.create"
+pub fn createUser(...) -> ... { ... }
+```
+
+#### 3.10.2 Spec link inheritance
+
+A `#[spec]` annotation on a `struct` or `enum` is *not* inherited by
+its methods — each method declares its own link. This is intentional:
+the struct's spec link describes the *type*, while a method's spec
+link points at the specific method's contract. Tools resolve both
+when generating documentation.
+
+```osty
+#[spec("§10.30.user")]
+pub struct User {
+    pub email: Email,
+    ...
+
+    #[spec("§10.30.user.toString")]
+    pub fn toString(self) -> String { ... }
+
+    // No #[spec] — `osty doc` falls back to "see User type spec".
+    pub fn isVerified(self) -> Bool { self.verified }
+}
+```
+
+#### 3.10.3 Spec link in `osty context` JSON
+
+`osty context <symbol> --format=json` emits the resolved spec link
+as a structured object containing the anchor, the file path, the
+heading text, and the lead paragraph (first non-empty paragraph
+after the heading). This lets agents read the spec body without
+fetching and parsing markdown themselves.
+
+```json
+{
+  "spec": {
+    "anchor": "§10.30.user.create",
+    "file": "LANG_SPEC_v0.6/10-standard-library/30-user.md",
+    "heading": "user.create",
+    "lead": "Create a user, validating email format..."
+  }
+}
+```
+
+#### 3.10.4 `#[spec]` and capability surface
+
+A function with `#[spec("§X.Y")]` is *not* implicitly required to
+match the capability surface declared in the spec target. The
+checker verifies the anchor's *existence*, not its semantic
+agreement with the function. Authors who want the stronger
+guarantee can use `#[reproducible]` / `#[error_contract]` /
+`#[budget]` together — those *do* enforce a contract — and use
+`#[spec]` only as a documentation breadcrumb.
+
+A future revision may add `osty validate-spec --strict` (§13.6)
+that runs LLM-driven semantic comparison between the spec text and
+the implementation — that gate is opt-in and not part of the v0.6
+baseline.
+
 ### 3.11 `#[reproducible(scope=...)]` — Determinism contract (G39)
 
 A function may declare `#[reproducible]` to assert that its output is

--- a/LANG_SPEC_v0.6/13-tooling.md
+++ b/LANG_SPEC_v0.6/13-tooling.md
@@ -791,3 +791,183 @@ v0.5 source compile under v0.6.x. Tooling behavior under the flag:
 migrate by then. The migration path is documented in
 `MIGRATING_v0.5_to_v0.6.md` and §10.46 (Capability Migration
 Catalog).
+
+### 13.18 End-to-end v0.6 publishing workflow
+
+This section walks through the canonical release flow for a v0.6
+package — from local edit to published version — showing how each
+v0.6 surface (capability, stability, error contract, spec link,
+budget, golden) participates in the `osty` toolchain.
+
+The example package is `myapp.users` exposing one `pub fn`:
+
+```osty
+#[purpose("Create a user, validating email and respecting DB unique constraints")]
+#[example(input = "(\"alice@example.com\", fakeDb())", output = "Ok(42)")]
+#[example(input = "(\"alice@example.com\", seededFakeDb())", output = "Err(UserCreateError.DbConflict(1))")]
+#[spec("§10.30.user.create")]
+#[stability("stable")]
+#[since("0.6")]
+#[error_contract(
+    UserCreateError.EmailFormat   when "Email.parse failed",
+    UserCreateError.DomainBlocked when "domain is in deny-list",
+    UserCreateError.DbConflict    when "email unique constraint violated",
+)]
+#[budget(allocs = 4, io_calls = 1, time_ms = 5)]
+pub fn createUser(email: String, db: Db) -> Result<UserId, UserCreateError> {
+    spec {
+        example: createUser("alice@example.com", fakeDb()) == Ok(UserId(42))
+    }
+
+    let parsed = Email.parse(email).orError(UserCreateError.EmailFormat)?
+    if isBlocked(parsed.domain()) {
+        return Err(UserCreateError.DomainBlocked(parsed.domain()))
+    }
+    db.exec(sql.insertReturningId("users", [
+        ("email", sql.string(parsed.toString())),
+    ]))
+        .mapErr(|e| UserCreateError.DbConflict(e.code()))
+        .map(|id| UserId(id.toInt()))
+}
+```
+
+Step 1 — local check (`osty check`):
+
+```sh
+$ osty check
+0 errors, 0 warnings.
+```
+
+Step 2 — examples + spec block (`osty test --example --spec`):
+
+```sh
+$ osty test --example --spec --report=summary
+spec[createUser#example:1] PASS
+example[createUser#1] PASS
+example[createUser#2] PASS
+3/3 spec/example checks passed.
+```
+
+Step 3 — golden / structural tests (`osty test`):
+
+```sh
+$ osty test --report=summary
+12/12 tests passed.
+```
+
+Step 4 — performance budget (`osty bench --budget`):
+
+```sh
+$ osty bench --budget --report=summary
+bench createUser: avg=2.1ms p99=4.7ms allocs=3 io_calls=1
+budget OK (within 5ms / 5 allocs / 1 io_call).
+```
+
+Step 5 — capability + flow audit (`osty audit`):
+
+```sh
+$ osty audit --capabilities
+pkg myapp.users
+  pub fn createUser(email: String, db: Db)             [Db]
+  fn isBlocked(domain: String)                          (pure)
+
+$ osty audit --legacy-globals
+0 sites — package is fully migrated to v0.6 capability surface.
+```
+
+Step 6 — surface diff (`osty publish --check`):
+
+```sh
+$ osty publish --check
+api-surface unchanged from v0.6.0.
+proposed: v0.6.1 (patch — internal helper added).
+```
+
+Step 7 — actual publish:
+
+```sh
+$ osty publish
+publishing myapp.users v0.6.1
+  + new symbol: fn isAcceptableEmail (private)
+  api-surface diff: stable, additive only.
+released.
+```
+
+The `osty context` JSON for `createUser` (Step 4 / §13.9 schema)
+now contains the full intent payload — purpose, examples,
+fixtures referenced, spec link, error contract, stability, budget,
+capability set, sanitizer interactions — and is what an LLM agent
+or downstream tooling consumes to reason about the function.
+
+### 13.19 Release engineering with intent annotations
+
+`#[purpose]`, `#[example]`, `#[fixture]`, `#[spec]` (§3.12, G42) are
+the *machine-readable* layer underneath `osty doc` and
+`osty context`. Their interactions during release engineering:
+
+#### 13.19.1 `osty doc` rendering
+
+Annotations land in the rendered doc page in this order:
+
+1. Function signature + `#[since]` / `#[stability]` chip.
+2. `#[purpose]` text — primary one-liner.
+3. `#[spec]` anchor link — e.g. "§10.30.user.create" → resolved
+   markdown anchor in the rendered chapter.
+4. `#[error_contract]` — rendered as a "Failure modes" table.
+5. `#[example]` — rendered as runnable example panels, with the
+   referenced `#[fixture]` body inlined for context.
+6. `spec { example: }` clauses — rendered as `// example` comments
+   inside the function body in the page.
+7. `#[budget]` — rendered as a "Performance budget" callout.
+
+Authors who want a docstring on top of these annotations can keep
+using `///`; doc comments and intent annotations compose
+additively.
+
+#### 13.19.2 `osty context <symbol>`
+
+The CLI emits a single JSON object containing every intent
+annotation plus the resolved spec link, the contract variants, the
+fixture bodies, the example expressions, and the dependency
+capability set. The schema is §13.9.
+
+LLM-facing usage: a code-generation agent that wants to call
+`createUser` retrieves the JSON, reads the contract / examples /
+budget / spec, and constructs a semantically valid call site
+without needing to read the implementation.
+
+#### 13.19.3 `osty changelog` autogeneration
+
+`osty publish` writes a changelog entry per release based on the
+API-surface diff (§3.14.3) and the per-symbol intent payload:
+
+```
+v0.6.1 — 2026-05-08
+
+Added
+- `pub fn isAcceptableEmail` (private — no surface impact)
+
+No public API changes.
+```
+
+For a release with public-surface changes, the entry includes the
+`#[purpose]` text of each new / changed `pub` symbol so the
+changelog reads like a feature list rather than a raw diff.
+
+#### 13.19.4 `osty doc-test`
+
+A specialized mode of `osty test` that runs every `#[example]` and
+`spec { example: }` clause under a deterministic capability fake
+set. Failure here means *the published example claims do not match
+the implementation*, which would mislead documentation readers.
+This is the strictest gate before `osty publish`.
+
+```sh
+$ osty doc-test
+2 #[example] checks passed.
+1 spec { example: } check passed.
+```
+
+The doc-test mode shares the same fake registry as `osty test
+--example --spec` but omits regular `#[test]` functions. Useful as
+a fast pre-commit or pre-publish gate.

--- a/LANG_SPEC_v0.6/21-information-flow.md
+++ b/LANG_SPEC_v0.6/21-information-flow.md
@@ -832,3 +832,157 @@ stdlib 의 sink 카탈로그 에 추가는 breaking — `#[stability("stable")]`
 public API 가 sink 를 추가하면 major version bump (`E2100`).
 v0.6.0 의 baseline sink 5 종 (db / process / fs.path / http.redirect
 / template) 외 sink 추가는 v0.7 이후로 일정 표시.
+
+### 21.18 Tag taxonomy reference
+
+This section catalogues every flow tag defined in the v0.6 baseline
+stdlib, the source / sanitizer / sink relationships, and where each
+tag enters and exits the type system. Authors of new sinks or
+sanitizers should pick from this taxonomy before introducing a new
+tag string — an unrecognized tag is a compile warning (`W0902`).
+
+#### 21.18.1 Source tags
+
+| Tag | Sources (annotated `#[taint("σ")]`) | Origin |
+|---|---|---|
+| `user_input` | `http.Request.queryParam`, `http.Request.body`, `http.Request.path`, `http.Request.cookie`, form decoders | HTTP request surface |
+| `env_input` | `Env.get`, `Env.require`, `Env.args` | Process environment |
+| `fs_input` | `Fs.read`, `Fs.readToString`, `Fs.lines`, the `Reader` returned by `Fs.open` | Filesystem reads |
+| `net_input` | `Net.connect.read`, `Net.recv`, `HttpClient.request.body` | Inbound network |
+| `cli_input` | `Process.exec.stdout`, `Process.execShell.stdout` | Subprocess output |
+| `db_input` | `Db.query.row.cell`, `Db.queryOne.field` | Database read result |
+
+A value can carry *multiple* source tags — a `String` returned by
+`http.respondHtml.body` after being concatenated from a query
+parameter and a database row carries `{user_input, db_input}`.
+
+#### 21.18.2 Trust tags (sanitizer output)
+
+| Tag | Sanitizer (annotated `#[sanitizes(σ, into = τ)]`) | Required by |
+|---|---|---|
+| `sql_safe` | `std.sql.escape`, `std.sql.quoteIdent`, `std.sql.quotePath`, every `sql.*` builder, `Email.toString` (composition) | `Db.query`, `Db.exec` |
+| `shell_safe` | `std.shell.quote` | `Process.execShell` |
+| `path_safe` | `std.path.normalize`, `std.path.join`, `Path.parse` | `Fs.open`, `Fs.read`, `Fs.write`, `Fs.remove`, `scan.Options.outputDir`, `print.Document.path` |
+| `url_safe` | `std.url.encode`, `std.url.parse`, `Url.builder().build()`, `std.security.checkUrl` | `http.redirect`, `http.movedPermanently`, `http.found`, `http.seeOther` |
+| `html_safe` | `std.html.escape`, `std.markdown.htmlToMarkdown`, auto-escape templates | `http.respondHtml`, `template.render` |
+| `json_safe` | `std.json.encode`, `std.json.stringify` | (planned for `http.respondJson` strict mode — Phase 5) |
+
+A value may carry both source and trust tags simultaneously — the
+relationship is set-intersection. A `db.exec(sql.eq("col",
+sql.string(parsed.toString())))` call where `parsed: Email` produces
+`#[taint({user_input, sql_safe})]` on the rendered SQL; the sink
+checks `sql_safe ⊆ requires` and accepts.
+
+#### 21.18.3 Sink registry
+
+A *sink* is a stdlib function whose parameter carries
+`#[requires("τ")]`. The v0.6 baseline registry:
+
+| Sink | Required tag | Module |
+|---|---|---|
+| `Db.query(self, q)` | `sql_safe` on `q.sql` | §10.29 |
+| `Db.exec(self, q)` | `sql_safe` on `q.sql` | §10.29 |
+| `Process.execShell(self, cmdline)` | `shell_safe` | §10.15 |
+| `Fs.open(self, path)` | `path_safe` | §10.15 |
+| `Fs.read(self, path)` | `path_safe` | §10.15 |
+| `Fs.write(self, path, _)` | `path_safe` | §10.15 |
+| `Fs.remove(self, path)` | `path_safe` | §10.15 |
+| `http.redirect(self, target)` | `url_safe` | §10.24 |
+| `http.respondHtml(self, body)` | `html_safe` | §10.24 |
+| `template.render(t, body)` | `html_safe` | (template stdlib) |
+
+Adding a sink to a `#[stability("stable")]` API is a major-version
+breaking change (§3.14.3) — callers gain a new sanitization
+obligation, which is by definition a breaking surface change.
+
+### 21.19 Worked sanitizer composition
+
+Real applications often compose multiple sanitizers in a single data
+path. This section catalogues the common chains.
+
+#### 21.19.1 Form input → SQL
+
+```osty
+fn searchUsers(req: HttpRequest, db: Db) -> Result<List<User>, Error> {
+    // Source: query string → user_input
+    let raw: #[taint("user_input")] String = req.queryParam("q") ?? ""
+
+    // Sanitizer: parse into Email if relevant; otherwise sql.string
+    // safely binds raw text as a parameter.
+    let q = sql.selectWhere("users", ["id", "email"],
+        sql.like("email", sql.string(raw))?)?
+
+    // Sink: db.query requires sql_safe — the sql.string + parameter
+    // path produces sql_safe automatically.
+    let rs = db.query(q)?
+    Ok(rs.rows.map(|r| User.fromRow(r)))
+}
+```
+
+Note `sql.string` does *not* concatenate — it produces a parameter
+binding. The `sql_safe` tag on the resulting `Query.sql` reflects
+the safe-by-construction property of parameterization.
+
+#### 21.19.2 URL input → HTML output
+
+```osty
+fn renderProfile(req: HttpRequest, net: Net) -> Result<HttpResponse, Error> {
+    // Source: query parameter → user_input
+    let raw: #[taint("user_input")] String = req.queryParam("homepage") ?? ""
+
+    // First sanitizer: url.parse → url_safe
+    let homepage = url.parse(raw)?
+
+    // Second sanitizer: html.escape on the canonical URL string → html_safe
+    let safeText = std.html.escape(homepage.toString())
+
+    // Sink: respondHtml requires html_safe
+    Ok(http.respondHtml("<a href=\"{safeText}\">homepage</a>"))
+}
+```
+
+Two sanitizers compose because each registered with a different
+output tag. The final value carries `#[trust({url_safe, html_safe})]`
+which is acceptable to both sink shapes.
+
+#### 21.19.3 Filesystem path input → process exec
+
+```osty
+fn runScanner(env: Env, proc: Process) -> Result<Output, Error> {
+    // Source: env variable → env_input
+    let raw: #[taint("env_input")] String = env.require("TOOL_PATH")?
+
+    // Sanitizer: path.normalize → path_safe (rejects ".." traversal,
+    // null bytes, etc.)
+    let safePath = std.path.normalize(raw)?
+
+    // Sink: process.exec receives the path as args[0]; argv-style
+    // exec does NOT require shell_safe (the kernel does not interpret
+    // args as shell metacharacters). path_safe is acceptable.
+    proc.exec(safePath, ["--version"])
+}
+```
+
+`Process.exec(cmd, args)` (argv-style) does not require
+`shell_safe` because the OS does not interpret args as a shell
+command — the binary is invoked directly with the literal argument
+list. `Process.execShell(cmdline)` *does* invoke a shell and
+therefore requires `shell_safe`.
+
+#### 21.19.4 Multi-source aggregation
+
+When a value is built from multiple sources, the tag set unions:
+
+```osty
+fn buildLog(req: HttpRequest, env: Env) -> String {
+    let user: #[taint({user_input})] String = req.queryParam("u") ?? ""
+    let host: #[taint({env_input})] String = env.get("HOST") ?? ""
+    // Concatenation unions the tag sets:
+    //   #[taint({user_input, env_input})] String
+    "{user} from {host}"
+}
+```
+
+A sink that requires *either* `user_input` *or* `env_input` to be
+sanitized must clear both. Conservative defaults: sanitize at the
+narrowest boundary (per source) before composing.


### PR DESCRIPTION
## Summary

이전 batch들의 본문 정렬 후 *toolchain ↔ release ↔ flow taxonomy*의 end-to-end
reference가 부족한 영역들을 보강. **+415 LOC**, 3 spec 파일.

### §13 Tooling — release workflow + intent annotation

- **§13.18 End-to-end v0.6 publishing workflow** — 7 step (`osty check` → `test
  --example --spec` → `test` → `bench --budget` → `audit` → `publish --check` →
  `publish`) + 단계별 출력. 실제 `createUser` pub fn 예시 한 개로 모든 v0.6
  surface (capability / stability / error_contract / spec / budget / golden)가
  통합 작동하는 흐름을 demonstrate.
- **§13.19 Release engineering with intent annotations**
  - §13.19.1 `osty doc` rendering 순서 (signature → purpose → spec anchor →
    error contract → example → spec block → budget)
  - §13.19.2 `osty context <symbol>`의 LLM-facing JSON
  - §13.19.3 `osty changelog` 자동 생성 — purpose text가 entry에 포함
  - §13.19.4 `osty doc-test` 빠른 pre-publish gate

### §3.10 Spec link 심화

- §3.10.1 Anchor resolution — regex grammar + fuzzy match `E0790` + moved
  anchor `W0790` + `osty fix --spec-links`
- §3.10.2 Inheritance — struct의 `#[spec]`은 method에 inherit 안 됨
- §3.10.3 `osty context` JSON — anchor / file / heading / lead 4-tuple
- §3.10.4 `#[spec]`과 capability surface — 의미 일치는 검사 안 함;
  `#[reproducible]` / `#[error_contract]` / `#[budget]`가 enforce 책임

### §21 Information flow — taxonomy + composition

- **§21.18 Tag taxonomy reference**
  - §21.18.1 Source tags 6종 (`user_input` / `env_input` / `fs_input` /
    `net_input` / `cli_input` / `db_input`)
  - §21.18.2 Trust tags 6종 (`sql_safe` / `shell_safe` / `path_safe` /
    `url_safe` / `html_safe` / `json_safe`)
  - §21.18.3 Sink registry — v0.6 baseline 10종 sink + 요구 tag
- **§21.19 Worked sanitizer composition** — Form→SQL / URL→HTML / Path→exec /
  Multi-source aggregation 4가지 canonical 패턴

이로써 v0.6 spec의 release pipeline / spec link / information flow 3영역 모두
worked end-to-end pattern을 가진다. agent가 이 패턴들을 직접 인용 가능 —
recipe 단위 reference.

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §13.18 publishing workflow 단계가 §13.4-7 / §3.14 / §3.15 / §11.5와 정합
- [ ] §3.10 anchor resolution rule이 모든 기존 `#[spec]` 사용과 호환
- [ ] §21.18 tag taxonomy가 §10.* 모든 sink/sanitizer 명시와 정합
- [ ] §21.19 worked composition이 §21.5 propagation rule을 위반하지 않음

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_