### PR TITLE
docs(v0.6): batch 10 — §3.12/§7.5/§11.5 deep mechanics (+397 LOC)

### DIFF
--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -1335,6 +1335,159 @@ fn aliceUser() -> Email { Email.parse("alice@example.com")? }
 
 `#[fixture]` is restricted to zero-arity functions. `E0432`.
 
+#### 3.12.1 `#[purpose]` — free-text intent
+
+`#[purpose("...")]` is a single string literal expressing *why* the
+declaration exists. Unlike a doc comment (`///`), the purpose:
+
+- Has a fixed syntactic shape — easy for tooling to extract.
+- Is required to be a single string literal, not a concatenation
+  or expression. `E0431`.
+- Is rendered as the *primary one-liner* in `osty doc`, separate
+  from longer explanatory prose in `///` comments.
+
+Recommended length: under 80 characters; one sentence; no internal
+formatting markers. The conventions favor a *what does this do?*
+phrasing, not a *how does this do it?* one — the `///` comment
+covers the latter.
+
+```osty
+// ✅ Good — declarative, one sentence, fits a render slot.
+#[purpose("Validate the email and create a user row, returning the row id")]
+pub fn createUser(...) -> ... { ... }
+
+// ❌ Bad — too long, embedded markup, prose-like.
+#[purpose("This function takes an `email` *string* and a `db` *capability* and ...")]
+pub fn createUser(...) -> ... { ... }
+```
+
+#### 3.12.2 `#[example]` — input/output pairs
+
+`#[example]` records a tested input/output pair. The annotation
+reads as a function call: pass `input`, expect `output`, optionally
+inject named fixtures via `uses`:
+
+```osty
+#[example(input = ["alice@example.com", "<Db>"], output = "Ok(42)")]
+#[example(input = ["alice@example.com", "<Db>"],
+          uses = "fakeDb",
+          output = "Err(SignupError.DbConflict(1))")]
+#[example(input = ["", "<Db>"], output = "Err(SignupError.EmailFormat)")]
+pub fn signup(email: String, db: Db) -> Result<UserId, SignupError> { ... }
+```
+
+**Argument grammar.**
+
+- `input = [a, b, c]` — a literal list whose elements match the
+  function's positional parameters in order. `<Db>` / `<Net>` /
+  etc. are *capability placeholders* — the runner substitutes the
+  fixture named by the `uses` argument (or the default fake from
+  `std.testing.capabilityFakes()` if no `uses` is given).
+- `output = "..."` — a string literal evaluated as an Osty
+  expression at test time. Must compare equal to the function's
+  actual return value with `==` (using the value's `Equal` impl).
+- `uses = "name"` — references a `#[fixture(name = "name")]`
+  function. Multiple `uses =` repeats inject each named fixture in
+  order; capability placeholders in `input` are resolved against
+  the fixture set.
+
+**Verification.** `osty test --example` runs each `#[example]` as
+an independent test. Output mismatch is a test failure. Missing
+fixture (named in `uses` but no matching `#[fixture]`) is `E0433`.
+
+#### 3.12.3 `#[fixture]` — canonical instances
+
+`#[fixture(name)]` registers a zero-arity function as a named
+canonical instance for tests, examples, and documentation:
+
+```osty
+#[fixture(name = "alice")]
+fn alice() -> Email {
+    Email.parse("alice@example.com").unwrap()
+}
+
+#[fixture(name = "fakeDb")]
+fn fakeDb() -> Db {
+    let db = std.capability.testing.FakeDb()
+    db.seed(alice())                // fixtures may call other fixtures
+    db
+}
+```
+
+**Composition rules.**
+
+1. Zero arity is mandatory (`E0432`). A fixture takes no parameters.
+2. Fixtures may call other fixtures by name. Cycles are `E0433`.
+3. Each call to a fixture function returns a *fresh instance* —
+   tests never share fixture state.
+4. Fixtures are package-local by default; `pub fn` annotated with
+   `#[fixture]` is exported for downstream packages but is rare in
+   practice (most fixtures are test-local).
+
+**Consumption.**
+
+- `#[example(uses = "name")]` — direct use as test input.
+- `osty doc` — fixture body inlined under the example panel.
+- `osty context <symbol> --format=json` — fixtures listed under
+  `fixtures_referenced[]`.
+- Property-test seeds (Phase 5, `forall x in fixture: ...`) — the
+  fixture's value is the starting point for shrinking.
+
+#### 3.12.4 Composition example — full intent surface
+
+```osty
+#[purpose("Validate the email and create a user row, returning the row id")]
+#[example(input = ["alice@example.com", "<Db>"],
+          uses = "freshDb",
+          output = "Ok(UserId(1))")]
+#[example(input = ["alice@example.com", "<Db>"],
+          uses = "dbWithAlice",
+          output = "Err(SignupError.DbConflict(1))")]
+#[example(input = ["invalid", "<Db>"],
+          uses = "freshDb",
+          output = "Err(SignupError.EmailFormat)")]
+#[spec("§10.30.user.signup")]
+#[since("0.6")]
+#[stability("stable")]
+#[error_contract(
+    SignupError.EmailFormat   when "Email.parse failed",
+    SignupError.DomainBlocked when "domain in deny-list",
+    SignupError.DbConflict    when "email unique constraint",
+)]
+pub fn signup(email: String, db: Db) -> Result<UserId, SignupError> {
+    spec {
+        example: signup("alice@example.com", freshDb()) == Ok(UserId(1))
+    }
+    ...
+}
+
+#[fixture(name = "freshDb")]
+fn freshDb() -> Db { std.capability.testing.FakeDb() }
+
+#[fixture(name = "dbWithAlice")]
+fn dbWithAlice() -> Db {
+    let db = freshDb()
+    db.exec(insertSql(Email.parse("alice@example.com").unwrap()))
+    db
+}
+```
+
+This single declaration emits to:
+
+- `osty doc` page with purpose / spec link / failure modes / 3
+  example panels (each with the fixture body inlined).
+- `osty context signup --format=json` with the full intent payload.
+- `osty test --spec --example --golden` runs all three examples + the
+  spec-block clause.
+- `osty publish` validates the API surface against `#[stability("stable")]`
+  and the contract.
+- LSP hover shows the purpose + spec lead paragraph.
+
+This is what *hidden dependency forbidden* looks like at a single
+declaration: every external dependency, every failure mode, every
+test fixture, every API stability promise — all surfaced explicitly
+at the function's signature.
+
 ### 3.13 `spec { ... }` — Executable Spec Block (G43)
 
 A function body may begin with a `spec { ... }` block stating

--- a/LANG_SPEC_v0.6/07-the-error-interface.md
+++ b/LANG_SPEC_v0.6/07-the-error-interface.md
@@ -234,6 +234,146 @@ Failure modes:
 
 `osty context <fn>` (§13.6) emits the same data as JSON.
 
+#### 7.5.1 Contract enforcement at function boundary
+
+`#[error_contract]` is checked at three points:
+
+1. **Definition site** — every `Err(V)` returned (including via
+   `?`-propagation that widens a callee's error to the contract
+   variant) must use a variant listed in the contract. Returning an
+   un-contracted variant is `E0410`. `Err`-from-helper must either
+   be widened explicitly or the contract must list the propagated
+   variant.
+
+2. **Caller match exhaustiveness** — when the contracted function is
+   the scrutinee of a `match`, exhaustiveness considers only contract
+   variants. Uncontracted enum variants do not need to be matched
+   (they're treated as dead per the contract). Match arms targeting
+   uncontracted variants emit `W0413`.
+
+3. **`?`-propagation through a contracted caller** — if the *caller*
+   carries `#[error_contract]`, every callee error variant that
+   could flow through `?` must be a subset of the caller's contract.
+   Mismatch is `E0414`; the fix is either to expand the caller's
+   contract or to convert the error explicitly.
+
+#### 7.5.2 Worked patterns
+
+**Wrapping multiple concrete errors into one contract.** A pipeline
+function that calls `Email.parse` and `db.exec` carries a wrapping
+enum that the contract enumerates:
+
+```osty
+pub enum SignupError {
+    EmailFormat,
+    DomainBlocked(String),
+    DbConflict(Int),
+    DbUnavailable,
+}
+
+#[error_contract(
+    SignupError.EmailFormat     when "Email.parse rejected the input",
+    SignupError.DomainBlocked   when "domain in deny-list",
+    SignupError.DbConflict      when "email unique constraint",
+    SignupError.DbUnavailable   when "DB connection lost mid-request",
+)]
+pub fn signup(email: String, db: Db) -> Result<UserId, SignupError> {
+    let parsed = Email.parse(email)
+        .orError(SignupError.EmailFormat)?
+    if isBlocked(parsed.domain()) {
+        return Err(SignupError.DomainBlocked(parsed.domain()))
+    }
+    db.exec(insertSql(parsed))
+        .mapErr(|e| match e.downcast::<DbError>() {
+            Some(DbError.Conflict(c)) -> SignupError.DbConflict(c),
+            Some(_) -> SignupError.DbUnavailable,
+            None -> SignupError.DbUnavailable,
+        })
+        .map(|_| UserId(0))
+}
+```
+
+The contract documents *which* failure modes the caller will see,
+and the type checker enforces that `db.exec`'s native error type
+cannot leak out un-rewrapped.
+
+**Optional-as-success in a contract context.** When a function
+returns `Result<T?, E>` (e.g. "find user — error means DB issue,
+`Ok(None)` means simply not found"), the contract is on the `E`
+side only:
+
+```osty
+#[error_contract(
+    LookupError.DbUnavailable when "DB connection lost",
+)]
+pub fn findUser(db: Db, id: Int) -> Result<User?, LookupError> {
+    match db.queryOne::<User>("SELECT * FROM users WHERE id = ?", [id]) {
+        Ok(u) -> Ok(u),                                // Some / None passes through
+        Err(_) -> Err(LookupError.DbUnavailable),
+    }
+}
+```
+
+This pattern is preferred over a 3-way `Result<T, NotFoundOrError>`
+because it keeps "user does not exist" — a normal flow outcome —
+out of the contract.
+
+#### 7.5.3 Contract evolution and SemVer
+
+Contract changes are SemVer-relevant per §3.14.3:
+
+| Change | `#[stability("stable")]` | `#[stability("experimental")]` |
+|---|---|---|
+| Add a contract variant | major bump | minor bump |
+| Remove a contract variant | major bump | minor bump |
+| Tighten the `when` clause text | patch bump (doc-only) | patch bump |
+| Loosen — variant now flows from a new condition | patch bump (additive) | patch bump |
+
+Adding a variant is breaking because callers' `match` expressions
+that exhausted the previous contract no longer cover the new
+variant. The recommended evolution path is to introduce the new
+variant as `experimental` first, let downstream `match
+#[match_compat]` clauses opt in, and promote to `stable` after a
+release cycle.
+
+#### 7.5.4 Cancellation in error contracts
+
+`Cancelled` (§7.6, §8.4.1) is a structural concern that flows
+orthogonally to domain failures. The convention is:
+
+- **Do not list `Cancelled` in `#[error_contract]`.** The contract
+  enumerates *domain* failure modes; cancellation is not a domain
+  failure.
+- **Cancellation propagates through a contracted Result naturally.**
+  When a contracted function calls a stdlib blocking method and the
+  caller's `taskGroup` is cancelled, the resulting `Err(Cancelled
+  { cause })` flows through `?` and exits the contracted function.
+  This *does not* count as an unlisted variant — `Cancelled` is
+  outside the contract surface entirely.
+- **Callers must handle cancellation separately.** A `match` against
+  a contracted Result needs an `Err(_)` arm to catch `Cancelled`
+  even when the contract is exhaustive on domain errors.
+
+```osty
+match createUser(email, db) {
+    Ok(uid) -> ...,
+    Err(SignupError.EmailFormat) -> ...,
+    Err(SignupError.DomainBlocked(d)) -> ...,
+    Err(SignupError.DbConflict(_)) -> ...,
+    Err(SignupError.DbUnavailable) -> ...,
+    Err(other) -> {
+        // Cancelled or any future contract addition.
+        if other.downcast::<Cancelled>().isSome() { return Err(other) }
+        unreachable("contract violation: {other}")
+    },
+}
+```
+
+The `unreachable` arm catches contract violations at runtime — a
+defense-in-depth backstop against soundness bugs in the contract
+checker. In practice the checker prevents reaching it; the
+`unreachable` panics if the invariant is violated.
+
 ### 7.6 Cancellation as a Recoverable Error
 
 The cancel signal is delivered as `Err(Cancelled { cause })` (see

--- a/LANG_SPEC_v0.6/11-testing.md
+++ b/LANG_SPEC_v0.6/11-testing.md
@@ -298,6 +298,110 @@ Header lines start with `#`; the body begins after one blank line.
 **Tooling.** `osty test --golden` runs the comparison; `osty test
 --update-golden[=<path>]` rewrites snapshots. See §13.8.
 
+#### 11.5.3 Mode selection guide
+
+The four golden modes target different output shapes. Choose the
+strictest mode that the output actually demands:
+
+| Output shape | Recommended mode | Why |
+|---|---|---|
+| Free-form text (logs, error messages without span info) | `"text"` | Byte-exact catches every regression |
+| Generated Osty source (formatter, codegen output) | `"ast"` | Whitespace / comment-only diffs ignored, semantic regressions caught |
+| Structured data exports (`osty context`, `osty doc --format=json`) | `"json"` | Key ordering / pretty-print noise ignored |
+| Diagnostic output (`osty check` with positions) | `"diag"` | Span column shifts ignored, code + message + suggested-fix preserved |
+
+Fallback rule: if uncertain, start with `"text"`. Loosen to `"ast"`
+or `"diag"` only when the strict mode produces noisy diffs that
+don't reflect real regressions.
+
+#### 11.5.4 Workflow for accepted golden updates
+
+A golden update is a deliberate change to a `.snap` file checked in
+alongside the test. The recommended workflow:
+
+```sh
+# 1. Run tests; observe golden mismatches.
+$ osty test --golden
+testing.assertGolden(...) mismatch at fixtures/format_expr.snap
+
+# 2. Inspect the diff; verify the new output is the intended one.
+$ osty test --golden --report=diff
+- fixtures/format_expr.snap
++ test output
+@@ -1,3 +1,3 @@
+- 1 + 2 * 3
++ 1 + (2 * 3)
+
+# 3. Accept the new output explicitly.
+$ osty test --update-golden=fixtures/format_expr.snap
+snapshot: updated fixtures/format_expr.snap
+
+# 4. Commit the snapshot change with the source change.
+$ git add fixtures/format_expr.snap toolchain/format.osty
+$ git commit -m "format: parenthesize precedence-ambiguous binary ops"
+```
+
+`osty test --update-golden` (no path) updates **every** mismatched
+snapshot in one pass. Use the per-path form for targeted updates so
+unrelated regressions stay visible as failures.
+
+**CI policy.** A pull request that touches snapshot files **must**
+also touch the source file producing the snapshot — the relationship
+is reviewed manually. `osty audit --golden-orphans` enumerates
+snapshots whose source-hash header does not match any current
+function in the workspace; orphans are removed at PR review time.
+
+#### 11.5.5 `#[fixture]` integration
+
+A `#[golden]` function may reference a `#[fixture(name)]` to
+parameterize the input. The fixture body runs once per test
+invocation and is *recorded* in the snapshot header so reviewers can
+see which input produced which output:
+
+```osty
+#[fixture(name = "sampleBinaryExpr")]
+fn sampleBinaryExpr() -> Expr {
+    parseExpr("1 + 2 * 3")
+}
+
+#[golden("fixtures/format_sampleBinary.snap")]
+fn testFormatSampleBinary() {
+    let expr = sampleBinaryExpr()
+    testing.assertGolden(formatExpr(expr))
+}
+```
+
+The snapshot's `# fixture: sampleBinaryExpr` header provides the
+audit trail. Updating `sampleBinaryExpr`'s body without rerunning
+`--update-golden` produces `W0444` (source-hash mismatch) on the
+next test run, prompting the author to either accept or revert the
+fixture change.
+
+#### 11.5.6 In-tree vs out-of-tree snapshot organization
+
+Two layouts are supported:
+
+```
+project/
+├── toolchain/
+│   ├── format.osty
+│   └── format_test.osty                 ← #[golden] functions live here
+└── fixtures/
+    └── format/
+        ├── format_binary_op.snap        ← snapshot files
+        └── format_sampleBinary.snap
+```
+
+The `path` argument of `#[golden(path, ...)]` is resolved relative
+to the project root (the directory containing `osty.toml`). Layout
+within `fixtures/` is a project convention; `osty audit
+--golden-orphans` walks the whole tree.
+
+For *runtime-form* snapshots (`testing.snapshot(name, value)`), the
+file lives at `<source_dir>/__snapshots__/<sanitize(name)>.snap` —
+a per-test-file directory. The two layouts coexist; pick one
+consistently per test file.
+
 ### 11.6 Parallel Execution
 
 Tests run in parallel by default. Use `--serial` to force sequential


### PR DESCRIPTION
## Summary

이전 batch들에서 §3.10/§3.11/§3.13/§3.14/§3.15 / §13 release / §21 flow가
deep section을 받았고, 이번엔 *intent annotation* (§3.12) / *error contract*
(§7.5) / *golden tests* (§11.5)의 internal mechanics를 sub-section으로 정리.
**+397 LOC**, 3 spec 파일.

### §3.12 Structured intent — purpose / example / fixture

- **§3.12.1 `#[purpose]`** — single string literal 제약 + good vs bad 예시
- **§3.12.2 `#[example]`** — input/output 문법 + capability placeholder
  (`<Db>` / `<Net>`) + `uses = "name"` fixture injection
- **§3.12.3 `#[fixture]`** — composition rules (zero arity / cycle 거부 /
  fresh instance / 4채널 consumption)
- **§3.12.4 Full intent surface 예시** — `signup` 함수 한 개에 모든 v0.6
  annotation 7종 적용 후 `osty doc` / `context` / `test` / `publish` 단계의
  output

### §7.5 Error contract — enforcement / patterns / SemVer / cancel

- **§7.5.1 Contract enforcement** — 3 지점 (definition site / caller match /
  `?`-propagation through contracted caller)
- **§7.5.2 Worked patterns** — wrapping multiple concrete errors /
  optional-as-success in contract context
- **§7.5.3 Contract evolution SemVer 표** — add / remove / tighten / loosen
  변화별 stable vs experimental 영향
- **§7.5.4 Cancellation in error contracts** — `Cancelled`은 contract에
  넣지 않음, `?`-propagation 자연스럽게 통과

### §11.5 Golden tests — mode / workflow / fixture / layout

- **§11.5.3 Mode selection guide** — `"text"` / `"ast"` / `"json"` /
  `"diag"` 각각 어떤 출력에 쓰는지
- **§11.5.4 Update workflow** — 4 step (test → diff → update → commit) +
  CI policy (snapshot file + source 동시 변경 review)
- **§11.5.5 `#[fixture]` integration** — snapshot header의 fixture name
  audit trail
- **§11.5.6 In-tree vs out-of-tree snapshot organization** — 두 layout
  지원

이로써 v0.6 surface annotation 카탈로그 *모두* sub-section reference가 있다.

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §3.12.4 full intent surface가 §13.18 publish workflow 단계와 정합
- [ ] §7.5.3 SemVer 표가 §3.14.3 publish algorithm과 정합
- [ ] §11.5.3 mode guide가 §11.5.2 #[golden] 본문과 정합
- [ ] §7.5.4 Cancellation 정책이 §8.4 cancel 본문과 정합

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_