### PR TITLE
docs(v0.6): batch 11+12 — 22-file deep mechanics expansion (+1326 LOC)

### DIFF
--- a/LANG_SPEC_v0.6/02-type-system.md
+++ b/LANG_SPEC_v0.6/02-type-system.md
@@ -156,6 +156,29 @@ a.saturatingDiv(b)  // clamps to T.MIN / T.MAX on overflow; aborts on b = 0
 **`pow`.** `Int.pow(exp: Int) -> Int` aborts when `exp < 0` (no integer
 result). Use `Float.pow` for fractional/negative exponents.
 
+#### 2.3.1 Numeric overflow and v0.6 surfaces
+
+Overflow behavior in v0.6 is the same as v0.5 (§2.3): default
+arithmetic on `Int` / `Int8…Int64` / `UInt8…UInt64` aborts on
+overflow, with explicit `wrapping*` / `checked*` / `saturating*`
+methods for non-aborting alternatives. The v0.6 annotation surface
+adds two interactions:
+
+- **`#[reproducible]`** — arithmetic that aborts is *deterministic*
+  in the sense that the same input always produces the same abort.
+  This is acceptable inside `#[reproducible]` because the function
+  contract concerns *successful* return values; aborts are a
+  separate failure path that doesn't break determinism.
+- **`#[budget(allocs)]`** — `wrapping*` / `checked*` /
+  `saturating*` add no allocations (they're inlined into
+  arithmetic instruction sequences). The `instructions` budget may
+  reflect the slightly higher operation count for `checked*`
+  (overflow detection branch).
+
+The integer overflow contract holds across both backends (Go and
+LLVM); a v0.6 program that aborts on `Int.MAX + 1` does so with the
+same error message regardless of backend.
+
 ### 2.4 Composite Types
 
 ```osty
@@ -205,6 +228,13 @@ The byte-string literal `b"..."` accepts only printable ASCII characters
 plus the escapes `\n`, `\r`, `\t`, `\\`, `\"`, `\0`, and `\xNN`. It does
 not interpolate. To embed non-ASCII data, use `\xNN` or build the value
 programmatically with `Bytes.from(...)`.
+
+**`Bytes` and information flow.** `Bytes` carries flow tags
+identically to `String`. A `Bytes` returned from `Net.read` /
+`Fs.read` carries the source's `#[taint(...)]` set; transformations
+(`concat`, `slice`, indexing) preserve the tag set. Conversion
+between `Bytes` and `String` (`Bytes.toString`,
+`String.toBytes`) is tag-preserving.
 
 **API.**
 

--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -206,6 +206,33 @@ did not compile. Such changes must ship under a normal minor version
 bump; no FORBID row silently flips to ALLOW inside a v0.6.x patch
 release.
 
+##### `const fn` and v0.6 surfaces
+
+The v0.6 annotation surface composes with `const fn` as follows:
+
+- **`#[reproducible]`** — every `const fn` is implicitly
+  reproducible at every scope (the body is compile-time evaluable;
+  the result is a constant). An explicit
+  `#[reproducible(scope = "portable")]` is permitted but redundant.
+- **`#[pure]`** — every `const fn` is implicitly pure (the body
+  cannot consult any capability — capabilities are runtime
+  values). Explicit `#[pure]` is permitted but redundant.
+- **`#[budget]`** — `const fn` calls in default-argument position
+  count for *zero* `allocs` / `io_calls` because the result is a
+  compile-time constant. They count for `instructions` only at the
+  runtime call site (when the `const fn` is called with non-const
+  arguments).
+- **`#[taint]`** — a `const fn` cannot receive a tainted input
+  because tainted values are runtime constructs. The annotation is
+  meaningless on a `const fn` parameter (`W0903`).
+- **`#[stability]`** — applies normally; a `const fn` declaration
+  is part of the public surface like any other function.
+
+The discipline: `const fn` is a *compile-time* construct, while
+v0.6's annotation surface is mostly about *runtime* contracts.
+Most annotations are vacuously true on `const fn` and the formatter
+omits redundant ones from rendered docs.
+
 ### 3.2 Variables
 
 ```osty
@@ -410,6 +437,45 @@ AuthToken.builder()   // ERROR: no builder generated
 
 **Override.** If the user defines `default`, `builder`, or `toBuilder`
 on the type, the user's definition replaces the auto-generated one.
+
+#### 3.4.4 Struct method receivers
+
+Struct method declarations take their receiver in the first
+parameter slot, with one of three shapes:
+
+```osty
+pub struct User {
+    name: String,
+    email: Email,
+
+    // Borrowing — the most common shape. Body cannot mutate `self`.
+    pub fn greet(self) -> String {
+        "hi, {self.name}"
+    }
+
+    // Mutating — body may write through `self.field` and call
+    // `mut self` methods. The receiver is the struct itself; there
+    // is no separate "this".
+    pub fn rename(mut self, newName: String) {
+        self.name = newName
+    }
+
+    // Static (no receiver) — the method is namespaced under the
+    // struct name but has no implicit `self`. Used for constructors
+    // and free helpers tightly tied to the type.
+    pub fn fromDsn(dsn: String) -> Result<User, Error> {
+        ...
+    }
+}
+```
+
+`self` and `mut self` are *contextual keywords* (§1.3) — they are
+identifiers in any other position. Type annotations are not
+permitted on the receiver: `fn greet(self: User)` is `E0716`.
+
+A method declared `mut self` may be called only through a `mut`
+binding or a `mut` field. Calling a `mut self` method on an
+immutable receiver is `E0717`.
 
 ### 3.4.5 `#[sealed_construct]` — Parse-don't-validate primitive (G40)
 
@@ -1351,6 +1417,67 @@ Any argument is rejected with `E0739`.
 - In partial struct/enum declarations (§3.4), each declaration's
   annotations apply only to members named in that declaration; the
   compiler does not merge annotations across declarations.
+
+#### 3.8.13 Annotation interaction matrix
+
+The annotation set is intentionally small (31 entries in v0.6, §1.10.3),
+which keeps the *interactions* between annotations bounded. The table
+below catalogues the meaningful pairings — empty cells mean the
+annotations are orthogonal (no special rule applies).
+
+| Caller annotation | `#[reproducible]` | `#[pure]` | `#[error_contract]` | `#[budget]` | `#[golden]` |
+|---|---|---|---|---|---|
+| `#[ambient]` | rejected (only in entry-point) | rejected | OK | OK | OK |
+| `#[reproducible]` | scope ≤ caller | implied stronger | OK | OK | implicit `#[reproducible]` |
+| `#[pure]` | implies all scopes | (self) | OK | OK | OK |
+| `#[error_contract]` | OK | OK | (only for `Result<_, E>`) | OK | OK |
+| `#[budget(static)]` | OK | OK | OK | (self) | OK |
+| `#[budget(runtime)]` | warned (perf measurement is non-deterministic) | warned | OK | (self) | warned |
+| `#[golden]` | implicit `#[reproducible(scope = "target")]` | OK | OK | OK | (self) |
+
+Reading examples:
+
+- `#[ambient(clock)]` + `#[reproducible]`: rejected. `#[ambient]` is
+  permitted only on entry-point functions, which are not
+  reproducible. `E0782`.
+- `#[golden]` + `#[budget(time_ms = 5)]`: warned. The golden
+  comparison runs in the test harness; mixing it with runtime
+  budget measurement makes the budget signal noisy. The recommended
+  pattern is to keep `#[budget(runtime)]` on the production
+  function and `#[golden]` on the test fixture that drives it.
+- `#[error_contract]` + `#[pure]`: OK. A pure function may return
+  `Result<_, E>` and carry an error contract.
+- `#[reproducible(scope = "portable")]` + transitively-called
+  `#[reproducible(scope = "target")]`: rejected with `E0786`. A
+  `portable` caller cannot delegate to a `target` callee — the
+  scope contract propagates downward (§3.11.1).
+
+#### 3.8.14 Recommended ordering convention
+
+Multiple annotations on the same declaration are independent — order
+does not affect semantics. The conventional ordering, used by the
+formatter and `osty doc` rendering, places annotations in this
+sequence (top to bottom):
+
+1. **Visibility** — `pub` (not technically an annotation, but
+   appears in the slot)
+2. **Intent** — `#[purpose]`
+3. **Examples** — `#[example]` (one or more)
+4. **Spec link** — `#[spec]`
+5. **Error contract** — `#[error_contract]`
+6. **Reproducibility / purity** — `#[reproducible]` / `#[pure]`
+7. **Budget** — `#[budget]`
+8. **Stability / since** — `#[stability]`, `#[since]`, `#[deprecated]`
+9. **Performance hints** — `#[inline]`, `#[hot]` / `#[cold]`,
+   `#[target_feature]`, `#[noalias]`, `#[parallel]`,
+   `#[vectorize]`, `#[unroll]`, `#[no_vectorize]`
+10. **Compatibility** — `#[match_compat]`
+11. **Information flow** — `#[taint]` / `#[sanitizes]` / `#[trusted_declassify]` (function-level)
+12. **Capability marker** — `#[reproducible_capability]` (interfaces)
+
+The formatter normalizes to this ordering on save. Authors who
+prefer a different sequence should set `formatter.annotation_order =
+"as-written"` in `osty.toml`.
 
 ### 3.10 `#[spec("§X.Y")]` — Spec link (G38)
 

--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -567,6 +567,101 @@ An enum with an explicit integer representation auto-derives
 `.discriminant() -> Int` and `.fromDiscriminant(n: Int) -> Self?`.
 Payload variants may not assign discriminants (`E0721`).
 
+#### 3.5.1 `#[since]` on variants
+
+A variant may carry `#[since("X.Y")]` to record when it was added.
+The annotation is consumed by `osty publish` (§3.14.3) — adding a
+`#[since]`-marked variant to a `#[stability("stable")]` enum is a
+**major** SemVer bump because exhaustive `match` expressions on the
+old enum become non-exhaustive.
+
+```osty
+pub enum HttpEvent {
+    Get,
+    Post,
+
+    #[since("0.7")]
+    Patch,                          // 도착 예정 v0.7
+}
+```
+
+Callers that exhaustively match `HttpEvent` should reach for
+`#[match_compat("0.6", fallback = name)]` (§3.14.4) to absorb the
+new variant on upgrade. The compiler emits `W0413` (dead-per-
+contract) for arms that target a variant *added later than the
+caller's `#[match_compat]` pin*.
+
+#### 3.5.2 Variant payloads and information flow
+
+A variant payload is an ordinary value — flow tags ride through
+construction and pattern-matching identically:
+
+```osty
+pub enum FormResult {
+    Accepted(UserId),
+    Rejected(#[taint("user_input")] String),  // payload-tagged at site
+}
+
+fn handle(req: HttpRequest) -> Response {
+    let raw = req.queryParam("name") ?? ""    // String #[taint("user_input")]
+    let r = FormResult.Rejected(raw)          // payload carries the tag
+
+    match r {
+        FormResult.Rejected(msg) -> {
+            // `msg` is #[taint("user_input")] String
+            log.warn("rejected: {std.html.escape(msg)}")     // sanitize before sink
+        },
+        FormResult.Accepted(id) -> ...,
+    }
+}
+```
+
+The pattern `FormResult.Rejected(msg)` binds `msg` with the same
+flow-tag set the payload carried at construction time. The checker
+tracks tags through both construction and destructuring without a
+special rule.
+
+#### 3.5.3 Methods inside enum bodies
+
+Methods declared inside an enum body apply to *every variant* — the
+same surface as struct methods (§3.4) but receiving a sum-typed
+`self`:
+
+```osty
+pub enum Shape {
+    Circle(Float),
+    Rect(Float, Float),
+    Empty,
+
+    pub fn area(self) -> Float {
+        match self {
+            Circle(r) -> 3.14159 * r * r,
+            Rect(w, h) -> w * h,
+            Empty -> 0.0,
+        }
+    }
+}
+```
+
+Methods inside the enum body may be `pub` (exported), private, or
+have `mut self` for mutation through the receiver. Capability
+parameters work like any other parameter: `fn render(self, console:
+Console)` is a perfectly normal enum method.
+
+#### 3.5.4 `#[error_contract]`-eligible enum
+
+An enum used as the `E` parameter of `Result<T, E>` may participate
+in `#[error_contract]` (§7.5). The contract enumerates which
+variants flow out under which conditions; the type checker uses the
+contract to prune match exhaustiveness on the caller side.
+
+A `#[error_contract]`-eligible enum has no special declaration
+syntax — any concrete enum suffices. The contract is on the
+*function* that returns `Result<T, ThisEnum>`, not on the enum
+declaration itself. This separation lets the same enum back
+multiple functions with different contracts (subsetting the variant
+list per-function).
+
 ### 3.6 Interfaces
 
 ```osty
@@ -587,6 +682,158 @@ pub interface Hash {
 See §2.6 for the full structural-typing rules and §20 for the canonical
 capability set (`Clock`, `Rng`, `Env`, `Fs`, `Net`, `Process`,
 `Console`).
+
+#### 3.6.1 Default method implementations
+
+An interface method may carry a body — a *default implementation* —
+that types satisfying the interface inherit when they do not provide
+their own. This avoids duplicating shared default logic across every
+implementer:
+
+```osty
+pub interface Reader {
+    fn read(self, maxBytes: Int) -> Result<Bytes, Error>
+
+    // Default — derived from `read`.
+    fn readAll(self) -> Result<Bytes, Error> {
+        let mut acc = Bytes.empty()
+        for {
+            let chunk = self.read(4096)?
+            if chunk.isEmpty() { break }
+            acc = acc.concat(chunk)
+        }
+        Ok(acc)
+    }
+}
+```
+
+A concrete type that implements `Reader` only needs to provide
+`read`; `readAll` is inherited. Overriding the default by providing
+the method body in the concrete type is permitted and is the path
+when a more efficient implementation exists (e.g. a `Bytes`-backed
+reader can return its full payload in one shot).
+
+Default implementations may not call methods that the interface does
+not define (no escaping the structural envelope). Defaults that
+require additional state or capabilities should instead be exposed
+as ordinary helpers on the implementing type.
+
+#### 3.6.2 Interface composition (`Reader + Writer`)
+
+Interfaces compose by declaring multiple parent interface names in
+the body — an interface that lists `Reader` and `Writer` is the
+union of both contracts:
+
+```osty
+pub interface ReadWriter {
+    Reader
+    Writer
+}
+
+pub interface ReadCloser {
+    Reader
+    Closer
+}
+
+pub interface BufferedReader {
+    ByteReader
+    LineReader
+}
+```
+
+A concrete type satisfies `ReadWriter` iff it satisfies both `Reader`
+and `Writer` structurally. There is no diamond-inheritance hazard
+because Osty has no inheritance — every method in the composed
+interface is part of a single flat method set.
+
+Interface composition is *deeply structural*. Adding a method to a
+parent interface (e.g. `Reader`) makes every dependent composed
+interface (`ReadWriter`, `ReadCloser`, …) require the new method
+too. This is intentional — interfaces describe contracts, not
+hierarchy.
+
+#### 3.6.3 Interface as parameter — value vs generic
+
+Two ways to take an interface-typed parameter:
+
+```osty
+// Generic — monomorphized; one specialized body per concrete T.
+fn copyGen<R: Reader, W: Writer>(src: R, dst: W) -> Result<Int, Error> { ... }
+
+// Interface value — single body, fat-pointer dispatch through vtable.
+fn copyDyn(src: Reader, dst: Writer) -> Result<Int, Error> { ... }
+```
+
+The generic form runs faster (no vtable indirection, inlining
+opportunities) but compiles each call site separately. The interface-
+value form is what Rust calls `dyn Trait` — a fat pointer of (data,
+vtable). Picking between them:
+
+| Constraint | Choose |
+|---|---|
+| Hot path / small method set / known concrete types at most call sites | Generic |
+| Heterogeneous collection (`List<Reader>` of mixed concrete types) | Interface value |
+| Cross-package API (the function is published; binary size matters) | Interface value |
+| Capability parameters | Interface value (capabilities are interfaces; `Net` etc. are passed as fat pointers in production builds) |
+
+The mix is permitted on the same parameter list: a function may
+take a generic `T: Reader` and an interface-value `Writer` in the
+same signature.
+
+#### 3.6.4 `#[reproducible_capability]` — deterministic interface
+
+`#[reproducible_capability]` (§20.5) on an interface declaration
+asserts that *every* method on the interface is `#[reproducible]`
+at some scope. The compiler enforces this at the interface
+definition: a method body that omits `#[reproducible(...)]` is
+`E0780.1`.
+
+```osty
+#[reproducible_capability]
+pub interface Hash {
+    #[reproducible(scope = "portable")]
+    fn hash(self, data: Bytes) -> Bytes32
+
+    // ❌ E0780.1 — interface annotated #[reproducible_capability]
+    //    but this method has no #[reproducible].
+    fn salt(self) -> Bytes
+}
+```
+
+A `Hash` value can therefore be received inside a `#[reproducible]`
+function — the type checker knows every call goes to a deterministic
+method, so the function's reproducibility contract holds.
+
+Stdlib v0.6 baseline `#[reproducible_capability]` interfaces:
+
+| Interface | Methods | Scope |
+|---|---|---|
+| `Hash` | `hash(self, data)` → `Bytes32` | `portable` |
+| `Encoder<T>` | `encode(self, value)` → `Bytes` | `portable` |
+| `Decoder<T>` | `decode(self, bytes)` → `Result<T, Error>` | `portable` |
+
+Implementers must annotate every method with the same scope or
+stronger. A weaker-scope method on a `#[reproducible_capability]`
+interface is `E0786`.
+
+#### 3.6.5 Interface 진화 rules
+
+`#[stability("stable")]` interfaces follow standard SemVer rules
+(§3.14.3) plus an interface-specific clause:
+
+| Change | Stable interface | Experimental interface |
+|---|---|---|
+| Add a method *with* default body | minor bump (additive — implementers don't need changes) | patch bump |
+| Add a method *without* default body | major bump (existing implementers fail compilation) | minor bump |
+| Remove a method | major bump | minor bump |
+| Change a method signature | major bump | minor bump |
+| Change a default body | patch bump (semantic-only change) | patch bump |
+| Promote `#[reproducible_capability]` | major bump (existing impls may need new annotations) | minor bump |
+
+The "add method *with* default body" rule is the canonical *minor
+bump* path for interface evolution — it lets stdlib add helper
+methods to `Reader` / `Writer` without breaking downstream
+implementers.
 
 ### 3.7 Type Aliases
 

--- a/LANG_SPEC_v0.6/04-expressions.md
+++ b/LANG_SPEC_v0.6/04-expressions.md
@@ -266,6 +266,78 @@ exits. A bare `break` exits with `()`; `break value` is valid only when
 the target is a `loop` expression. For a labeled break, the value follows
 the label: `break 'search result`.
 
+#### 4.4.2 Loop forms summary
+
+The complete catalogue of v0.6 loop forms:
+
+| Form | Purpose | Result type | Cancellation point? |
+|---|---|---|---|
+| `for x in iterable { }` | Each-iteration over an `Iterable<T>` | `()` | No (use `thread.checkCancelled()`) |
+| `for cond { }` | While-style loop | `()` | No |
+| `while cond { }` | While-style synonym (G49) | `()` | No |
+| `for { }` | Infinite, no value | `()` | No |
+| `for let Some(x) = expr { }` | Loop while pattern matches | `()` | No |
+| `loop { ... break value }` | Value-returning loop | type of `break value` | No |
+
+None of the loop forms is a *language-level* cancellation point —
+the compiler does not insert cancel checks at loop heads. Tasks
+that loop without making any stdlib blocking call must explicitly
+call `thread.checkCancelled()?` to participate in cooperative
+cancellation:
+
+```osty
+fn processQueue(jobs: List<Job>) -> Result<(), Error> {
+    for job in jobs {
+        thread.checkCancelled()?       // cooperative cancel check
+        process(job)
+    }
+    Ok(())
+}
+```
+
+A future revision may add compiler-inserted preemption at loop
+backedges (§8.0); programs written to the explicit-check contract
+keep working.
+
+#### 4.4.3 Loops and capability flow
+
+A loop body inherits the surrounding scope's capability bindings.
+There is no per-iteration capability re-binding; `fs` named in the
+function signature stays in scope for every iteration:
+
+```osty
+fn copyAll(fs: Fs, src: List<String>, dstDir: String) -> Result<(), Error> {
+    for path in src {
+        let bytes = fs.read(path)?       // fs reused per iteration
+        fs.write("{dstDir}/{path}", bytes)?
+    }
+    Ok(())
+}
+```
+
+Capability instances are typically interface values (fat pointer);
+keeping them in scope across a loop is constant cost. There is no
+hidden allocation per iteration.
+
+#### 4.4.4 Loops and information flow
+
+Loop iteration variables inherit the element type's flow tag set:
+
+```osty
+let lines: List<#[taint("user_input")] String> = [...]
+for line in lines {
+    // line: #[taint("user_input")] String
+    // — must sanitize before reaching a sink
+    let safe = std.html.escape(line)
+    log.info("processed: {safe}")
+}
+```
+
+The tag set is *per-iteration* — each `line` binding carries its
+own tag. Loop body code that aggregates `line` into an outer
+collection produces a tag-union for the collection element type
+(per §21.5.1).
+
 ### 4.5 Error Propagation
 
 ```osty

--- a/LANG_SPEC_v0.6/08-concurrency.md
+++ b/LANG_SPEC_v0.6/08-concurrency.md
@@ -318,6 +318,61 @@ delivered whole — never partially observed.
   early when the surrounding task is cancelled (the caller distinguishes
   cancel from drain by checking `thread.isCancelled()`).
 
+#### 8.5.1 Channels and information flow
+
+A `Channel<T>` carrying tainted values preserves the flow tag set
+through send and receive. There is no implicit declassification at
+the channel boundary:
+
+```osty
+let ch = thread.chan::<#[taint("user_input")] String>(64)
+
+// Producer
+ch <- userInput
+
+// Consumer
+for msg in ch {
+    // `msg` is #[taint("user_input")] String — sanitize before sink
+    db.exec(sql.eq("col", sql.string(msg))?)
+}
+```
+
+A consumer task at a different point in the program receives the
+same flow tags as the producer attached. Channels do not flatten
+trust — they are a synchronous-with-respect-to-tags transport.
+
+#### 8.5.2 Channels and capability lifetime
+
+Sending a capability instance through a channel is *legal* but
+discouraged. The capability remains live for as long as a receiver
+holds it, which may extend its effective lifetime past the
+construction context. Idiomatic patterns:
+
+- **Send work, not capabilities.** A producer sends *requests*;
+  the consumer holds its own capability and applies it to each
+  request. Capabilities stay scoped to construction.
+- **Send results, not handles.** A producer that does its own I/O
+  sends `Result<T, Error>` payloads; the consumer never needs the
+  upstream `Net` / `Fs` instance.
+
+The non-escaping rule for `Handle<T>` and `TaskGroup` (§8.1, G13)
+applies *only* to those two types — capability instances are not
+included, but the discipline of avoiding cross-scope capability
+sharing is recommended.
+
+#### 8.5.3 Channels and `#[budget]`
+
+A `thread.chan::<T>(capacity)` allocation counts as one allocation
+site for `#[budget(allocs)]` purposes. Each `ch <- value` and
+`ch.recv()` counts as one channel operation; a function that
+loops `ch.recv()` to drain a channel of `n` items counts `n`
+channel operations.
+
+The runtime's per-channel state (FIFO buffer, sender/receiver
+queues) is one allocation per channel; growing the buffer past its
+declared capacity is not supported (the channel rejects further
+sends until the receiver makes progress).
+
 ### 8.6 Select
 
 ```osty

--- a/LANG_SPEC_v0.6/08-concurrency.md
+++ b/LANG_SPEC_v0.6/08-concurrency.md
@@ -200,6 +200,85 @@ cancel signal from the **enclosing** `taskGroup` propagates into the
 `collectAll` children normally — the collected list then contains
 `Err(Cancelled { cause })` for any child that was mid-flight.
 
+#### 8.4.5 Triggering Cancellation Explicitly
+
+A `taskGroup` body may call `g.cancel(cause)` to trigger cancellation
+on every descendant task without first failing a sibling. Use cases:
+
+- A "first-success" pattern where one child finds the answer and the
+  others should stop:
+
+  ```osty
+  fn findFirst(net: Net, urls: List<String>) -> Result<Bytes, Error> {
+      taskGroup(|g| {
+          let handles = urls.map(|u| g.spawn(|| net.fetch(u)))
+          for h in handles {
+              if let Ok(body) = h.join() {
+                  g.cancel(Cancelled.New("found"))   // tell siblings to stop
+                  return Ok(body)
+              }
+          }
+          Err(Error.new("all fetches failed"))
+      })
+  }
+  ```
+
+- A timeout scope — the caller cancels after a deadline elapses:
+
+  ```osty
+  fn withTimeout<T>(clock: Clock, d: Duration,
+                    body: fn(Group) -> Result<T, Error>) -> Result<T, Error> {
+      taskGroup(|g| {
+          g.spawn(|| {
+              clock.sleep(d)?
+              g.cancel(Cancelled.New("timeout"))
+              Ok(())
+          })
+          body(g)
+      })
+  }
+  ```
+
+`g.cancel(cause)` is **idempotent** — calling it twice on the same
+group raises the same signal once. The cause from the first call
+wins; subsequent calls' causes are dropped.
+
+#### 8.4.6 Cancellation does not equal failure
+
+A `taskGroup` that completes successfully *despite* an internal
+cancel (e.g. the first-success pattern above) returns `Ok(...)` to
+its caller. Cancellation is the mechanism that *stops sibling work*,
+not a failure mode in itself. The receiver of `Cancelled` must:
+
+1. Run any necessary `defer` cleanup.
+2. Return `Err(Cancelled { ... })` to its caller (do **not** swallow).
+3. Avoid blocking calls inside `defer` (uninterruptible cleanup —
+   §8.4.3).
+
+A child that catches `Cancelled` and returns `Ok(())` is a soundness
+bug: the parent then continues with stale state. The compiler does
+not enforce this; it is a discipline that the cancellation contract
+relies on.
+
+#### 8.4.7 Capability adapter responsibilities
+
+Every capability adapter that performs a blocking operation **must**
+honor the cancel signal of the surrounding task. The contract for
+adapter authors:
+
+| Operation | Cancellation behavior |
+|---|---|
+| Read/write on a stream (`Net.read`, `Fs.read`, ...) | Return `Err(Cancelled { cause })` as soon as the signal is observed — partial buffer is fine |
+| Sleep / wait (`Clock.sleep`, `clock.until(...)`) | Return immediately with `Err(Cancelled { cause })` |
+| Channel ops (`ch.recv`, `ch.send` on full buffer) | Return `None` / unblock and propagate |
+| FFI calls | Cannot generally be interrupted; document the limit and consider running them on a carrier thread |
+| In-memory adapters (`io.bytesReader`, `io.buffer`) | No-op (never block, never see the signal) |
+
+Adapters that do *not* honor cancellation are not added to the
+canonical capability surface. A bespoke capability that wraps such
+an adapter must document the limitation and is *not* automatically
+acceptable to `#[reproducible_capability]` enforcement.
+
 ### 8.5 Channels
 
 ```osty

--- a/LANG_SPEC_v0.6/10-standard-library/01-tier-1-core.md
+++ b/LANG_SPEC_v0.6/10-standard-library/01-tier-1-core.md
@@ -37,3 +37,44 @@
   via `std.log` (§10.10) of the form `"{msg}: {e.message()}"`. Both are
   the canonical helpers for use inside `defer` (§4.12).
 - `std.debug` — `dbg(value)`
+
+#### 10.1.1 Tier 1 capability split
+
+Most of Tier 1 is *pure* — no capability is required. The exceptions
+are filesystem and console I/O, which route through `Fs` / `Console`
+capabilities (§20.9). The split:
+
+| Module | Pure | Effectful |
+|---|---|---|
+| `std.io` | `Reader`/`Writer` protocol, `BytesReader`, `Buffer`, `readAll`, `copy`, `writeString` | `Console.print`, `Console.println`, `Console.eprint`, `Console.eprintln`, `Console.readLine` |
+| `std.fs` | `Path.parse`, path manipulation helpers | `Fs.read`, `Fs.write`, `Fs.exists`, `Fs.walk`, `Fs.create`, `Fs.atomicWrite`, etc. |
+| `std.strings` | All | (none) |
+| `std.collections` | All | (none) |
+| `std.option` | All | (none) |
+| `std.result` | All | (none) |
+| `std.error` | All | (none) |
+| `std.cmp` | All | (none) |
+| `std.ref` | `same(a, b)` | (none) |
+| `std.process` | `ignoreError`, `logError` | `abort`, `unreachable`, `todo` (process termination — not capability-bound but still effectful) |
+| `std.debug` | `dbg(value)` (writes via ambient `Console`) | implicit `Console` use |
+
+A function that uses only the *pure* part of Tier 1 — `std.strings`,
+`std.collections`, `std.option`, `std.result`, `std.cmp` — is
+acceptable inside `#[reproducible(scope = "portable")]` without
+modification. `std.io` / `std.fs` callers must accept a capability
+parameter.
+
+#### 10.1.2 Tier 1 evolution policy
+
+Tier 1 is the most stable surface in the standard library. The v0.6
+evolution rule:
+
+- New methods may be added (additive, minor bump).
+- New types may be added (additive, minor bump).
+- Existing method signatures may not change without a major bump.
+- Existing types may not be removed without a major bump and a full
+  release-cycle deprecation.
+
+Consequence: Tier 1 grows monotonically across minor versions. A
+v0.6 program continues to compile against v0.7's Tier 1 without
+modification.

--- a/LANG_SPEC_v0.6/10-standard-library/02-tier-2-production-essentials.md
+++ b/LANG_SPEC_v0.6/10-standard-library/02-tier-2-production-essentials.md
@@ -58,3 +58,57 @@
   explicit calibration state
 - `std.shortid` — deterministic short id formatting
 - `std.metrics` — lightweight labeled counters
+
+#### 10.2.1 Tier 2 capability summary
+
+The Tier 2 chapter listing is dense; the *capability shape* of each
+module is summarized below. Use this when deciding which Tier 2
+import is acceptable in a `#[reproducible]` / `#[pure]` /
+capability-typed context.
+
+| Module | Effectful methods (capability) | Pure helpers |
+|---|---|---|
+| `std.json` | (none) | encode / decode / parseValue |
+| `std.http` | `HttpClient.*` (Net), `HttpServer.serve` (Net) | builders, codecs, router |
+| `std.time` | `Clock.now/monotonic/sleep` | format/parse, duration math |
+| `std.thread` | `taskGroup`, `parallel`, `chan`, `select` | (the primitives are themselves effects) |
+| `std.sync` | `Mutex.lock`, `RwLock.*`, atomics | (none) |
+| `std.testing` | (test-only effects) | assertions, golden, capability fakes |
+| `std.env` | `Env.get/require/args/vars` | (none) |
+| `std.iter` | (none) | All combinators |
+| `std.regex` | (none) | All |
+| `std.log` | (writes via ambient `Console`) | `Fields` builder |
+| `std.encoding` | (none) | base64 / hex / URL encode-decode |
+| `std.crypto` | `CryptoRng.randomBytes` | hashes / hmac / constantTimeEq |
+| `std.uuid` | `uuid.v4(rng)`, `uuid.v7(clock, rng)` | parse / nil / toString |
+| `std.random` | `Rng.*` | `random.seeded` |
+| `std.os`/`std.process` | `Process.*` | `os.path.*` |
+| `std.url` | (none) | parse / build / canonical |
+| `std.math` | (none) | All |
+| `std.csv` | (none) | encode / decode |
+| `std.table` | (none) | All |
+| `std.xlsx` | (none) | encode / decode |
+| `std.compress` | (none) | gzip encode / decode |
+| `std.term` | `Terminal.*` (via `Console.terminal()`) | ANSI sequence builders |
+| `std.tui` | `Screen.present` | `Frame.*` builders, ANSI rendering |
+| `std.grid` | (none) | All |
+| `std.clipboard` | dispatches via ambient `Process` | (none) |
+| `std.ai` | (caller drives via `Net`) | request builders, response parsers |
+| `std.aiagents` | (none) | All |
+| `std.redact` | (none) | All |
+| `std.security` | (none) | URL classification, HTML escape |
+| `std.search` | (none) | indexing, search, scoring |
+| `std.markdown` | (none) | extraction, conversion |
+| `std.media` | (none) | sniffing, parsing |
+| `std.httpretry` | (none) | retry policy, classification |
+| `std.webhook` | `Clock` (replay window), caller's `Env` (secret) | verification, dispatch |
+| `std.jsonl` | (none) | parse / write |
+| `std.tokenest` | (none) | estimation |
+| `std.shortid` | (none) | formatting |
+| `std.metrics` | (none) | counters |
+
+This matrix is the inverse view of §20.18: §20.18 lists each
+capability's stdlib clients; §10.2.1 lists each stdlib module's
+capability dependencies. Both are maintained alongside chapter
+edits; a divergence is a soundness issue that `osty audit
+--capability-matrix` enumerates.

--- a/LANG_SPEC_v0.6/10-standard-library/05-standard-numeric-methods.md
+++ b/LANG_SPEC_v0.6/10-standard-library/05-standard-numeric-methods.md
@@ -76,3 +76,30 @@ Char.fromInt(n: Int) -> Char?        // None on invalid scalar or surrogate
 
 `Int.toChar()` aborts on invalid input (out of range or surrogate);
 `Char.fromInt` is the safe form that returns `None`.
+
+#### v0.6 reproducibility note
+
+Every method in this chapter is *pure* — no capability is consulted,
+no allocation occurs (numeric methods return scalar values), and
+the output is fully determined by the input. This makes the entire
+numeric surface acceptable inside `#[reproducible(scope =
+"portable")]` and `#[pure]` contexts.
+
+Float methods (`Float.sqrt`, `Float.pow`, `Float.sin`, etc.) inherit
+the platform's IEEE-754 implementation. The v0.6 contract guarantees:
+
+1. **Determinism within a target triple** — `Float.sqrt(2.0)`
+   produces the same bit pattern on repeated runs on the same
+   `<arch>-<os>` triple.
+2. **NaN bit-pattern stability** — operations preserve NaN bit
+   patterns across compatible operations, so a `#[reproducible(scope
+   = "portable")]` function that does `f.sqrt().sqrt()` produces a
+   bit-equal NaN regardless of platform when the input was NaN.
+3. **No subnormal-flushing surprises** — Osty's float ops do not
+   silently flush subnormals. A program that depends on subnormals
+   produces the same answer on every supported target.
+
+The above guarantees are why `Float` is `Ordered` (with the total
+ordering convention from §2.6.5) but **not** `Hashable` — bit-
+pattern stability is not the same as hash-ability under NaN
+reflexivity (§2.9).

--- a/LANG_SPEC_v0.6/10-standard-library/06-collection-methods.md
+++ b/LANG_SPEC_v0.6/10-standard-library/06-collection-methods.md
@@ -98,3 +98,44 @@ insert(item: T)
 remove(item: T) -> Bool
 clear()
 ```
+
+#### v0.6 reproducibility note
+
+Collection methods that **return a new collection** preserve the
+ordering of their inputs — a `List<T>.sortBy(...)` is deterministic,
+and `List<T>.filter(...)` preserves the original order. Methods on
+`Map<K, V>` / `Set<T>` that *iterate* are *not* deterministic in
+iteration order:
+
+| Method | Deterministic order? |
+|---|---|
+| `Map.iter()` / `Map.keys()` / `Map.values()` | No (hash-based, may vary across runs) |
+| `Map.entriesSorted()` / `Map.entriesSortedBy(f)` | Yes |
+| `Set.iter()` | No |
+| `Set.toListSorted()` / `Set.toListSortedBy(f)` | Yes |
+| `List.iter()` / `for x in list` | Yes (insertion order) |
+
+A function annotated `#[reproducible(scope = "target")]` (§3.11)
+that iterates a `Map` or `Set` must use the `*Sorted` variant —
+calling `Map.iter()` from a reproducible context is `E0786`.
+
+#### Information flow propagation
+
+Collection methods preserve flow tags element-wise:
+
+```osty
+let names: List<#[taint("user_input")] String> = [...]
+let upper = names.map(|n| n.toUpperCase())   // List<#[taint("user_input")] String>
+```
+
+`map`, `filter`, `flatMap`, `take`, `drop`, `chunked`, etc. all
+preserve the tag set of their elements. Aggregation methods that
+collapse multiple elements (`reduce`, `fold`) union the tag sets:
+
+```osty
+let pairs: List<#[taint("user_input")] String> = [...]
+let joined: #[taint("user_input")] String = pairs.reduce(|a, b| a + b)
+```
+
+The tag set on the result is the union of all element tag sets that
+flowed into the reduction.

--- a/LANG_SPEC_v0.6/10-standard-library/09-regular-expressions.md
+++ b/LANG_SPEC_v0.6/10-standard-library/09-regular-expressions.md
@@ -1,5 +1,14 @@
 ### 10.9 Regular Expressions (`std.regex`)
 
+> **v0.6 capability note**: `std.regex` is *pure* — every function
+> transforms strings without consulting any capability. The module
+> is acceptable inside `#[reproducible(scope = "portable")]` and
+> `#[pure]` contexts. Match results inherit the input string's flow
+> tag set — `regex.findAll(taintedHaystack, "...")` produces a
+> `List<String>` where each match carries `taintedHaystack`'s tags.
+> The regex itself (compiled `Pattern`) is metadata and does not
+> contribute tags.
+
 RE2-based regular expressions. Linear-time matching; no catastrophic
 backtracking, no ReDoS. Does not support backreferences or lookaround
 (RE2 limitations).

--- a/LANG_SPEC_v0.6/10-standard-library/10-logging.md
+++ b/LANG_SPEC_v0.6/10-standard-library/10-logging.md
@@ -83,3 +83,73 @@ explicitly.
 `Fields {"k": v}` outside a `log.{debug,info,warn,error,...}` call is
 just an ordinary `Map<String, LogValue>` literal — the implicit
 conversion is what makes the heterogeneous value notation valid.
+
+#### v0.6 logging and information flow
+
+`LogValue` carries the flow tag set of the value it was constructed
+from. When a tainted `String` becomes a `LogValue.String`, the tag
+set rides through. Log handlers are sinks for two reasons:
+
+1. **Stdout / stderr write** — handlers ultimately write to a
+   stream owned by the ambient `Console` capability (§20.9.7). Log
+   output is therefore visible to whoever can read those streams.
+2. **External persistence** — handlers may forward records to log
+   aggregators (Loki, Datadog, etc.) over the network. Personally
+   identifiable information that flows into a log line may end up
+   in places the original consent did not anticipate.
+
+The v0.6 stdlib provides `std.redact` (§10.34) for redacting
+sensitive values *before* they reach a log handler. Authors who
+want stronger guarantees can register `log.warn` etc. as
+`#[requires("log_safe")]` sinks via a custom `Handler`
+implementation; the `log_safe` tag is then produced by `std.redact`
+or the application's own sanitizer.
+
+#### Log handler as capability
+
+The default `Handler` is process-global. For deterministic tests
+and for code that must declare its log dependencies explicitly, the
+v0.6 path is to receive a `Logger` parameter (a thin wrapper over
+`Handler`) instead of using the global `log.*` functions:
+
+```osty
+fn handleRequest(logger: Logger, req: Request) -> Response {
+    logger.info("incoming", Fields { "path": req.path() })
+    ...
+}
+
+#[ambient(console)]
+fn main() {
+    let logger = log.handler(console)
+    handleRequest(logger, ...)
+}
+```
+
+This pattern is *opt-in* — process-global handlers remain the easy
+path for scripts and tools where capability discipline is not the
+priority.
+
+#### Performance budget for log calls
+
+A `log.info(...)` call counts as one `io_calls` budget unit when
+the active level is at or below `Info`. Levels suppressed by
+`setLevel` count zero — the call is short-circuited before any
+work.
+
+```osty
+#[budget(io_calls = 1)]
+fn handleRead() {
+    log.info("read complete")        // counts 1
+    log.debug("...")                  // counts 0 if level >= Info
+}
+```
+
+The `instructions` budget includes the format-string interpolation
+work even at suppressed levels (the args are evaluated). Use the
+pre-check pattern when interpolation is expensive:
+
+```osty
+if log.isEnabled(log.Debug) {
+    log.debug("expensive: {expensiveComputation()}")
+}
+```

--- a/LANG_SPEC_v0.6/10-standard-library/11-encoding.md
+++ b/LANG_SPEC_v0.6/10-standard-library/11-encoding.md
@@ -21,3 +21,38 @@ Submodules:
   for URL-safe alphabet.
 - `encoding.hex` — lowercase output.
 - `encoding.url` — percent-encoding for URL components.
+
+#### v0.6 reproducibility and flow
+
+Every encoding function is *pure* — `Bytes` ↔ `String` round-trips
+preserve bit patterns and consult no capability. The whole module
+is acceptable inside `#[reproducible(scope = "portable")]` and
+`#[pure]` contexts.
+
+Flow tags ride through encoding identically — `base64.encode` of a
+tainted `Bytes` produces a tainted `String` with the same source
+tag set. `encoding.url.encode` is *not* the same as the URL-safety
+sanitizer:
+
+- `encoding.url.encode(s)` does percent-encoding for placement in a
+  URL component. It is a pure transformation; the result inherits
+  the input's flow tag set.
+- `std.url.encode(s)` (as registered in §21.18.2) is a *sanitizer*
+  that produces `url_safe`-tagged output. It is the same byte-level
+  transformation but with the additional flow-tag promotion.
+
+Authors who need the sanitizer effect should use `std.url.encode`,
+not `std.encoding.url.encode`. The two share an implementation but
+differ in their type-system attestation.
+
+#### Round-trip contract
+
+Each pair satisfies `decode(encode(x))? == Some(x)` for every
+`Bytes` `x`. The reverse `encode(decode(s)?)? == Some(s)` is also
+guaranteed for every well-formed encoded string `s`. Malformed
+input to `decode` returns `Err(...)`; the round-trip assertion is
+on well-formed input only.
+
+This round-trip property is documented as a `spec { law: ... }`
+clause on each encode function (§3.13.1). Phase 5 turns the laws
+into property tests.

--- a/LANG_SPEC_v0.6/10-standard-library/17-math.md
+++ b/LANG_SPEC_v0.6/10-standard-library/17-math.md
@@ -40,3 +40,29 @@ math.hypot(a, b)
 ```
 
 Integer math lives on the integer methods (§10.5).
+
+#### v0.6 reproducibility
+
+Every function in `std.math` is *pure* — no capability is consulted,
+no allocation occurs, and the output is fully determined by the
+input. The whole module is acceptable inside
+`#[reproducible(scope = "portable")]` and `#[pure]` contexts.
+
+The float-determinism guarantees from §10.5 apply: `math.sin(0.5)`
+produces the same bit pattern on every run on a given target
+triple, NaN bit patterns are preserved across compatible
+operations, and subnormals are not silently flushed.
+
+`math.NAN` is a single canonical NaN (the quiet NaN with the
+implementation-defined payload). Operations that would produce a
+NaN (`math.sqrt(-1.0)`, `0.0 / 0.0`, etc.) return a NaN with the
+same bit pattern as `math.NAN`; this is necessary for `portable`
+scope reproducibility.
+
+#### Constants and `#[budget]`
+
+The math constants (`math.PI`, `math.E`, `math.TAU`,
+`math.INFINITY`, `math.NAN`) are compile-time `const fn` values
+(§3.1.1) — referencing them counts as zero allocations and zero
+operations beyond the constant load. Use them freely in
+`#[budget(allocs = 0)]` functions.

--- a/LANG_SPEC_v0.6/10-standard-library/18-csv.md
+++ b/LANG_SPEC_v0.6/10-standard-library/18-csv.md
@@ -55,6 +55,14 @@ Behavior:
   permits quoted fields to be surrounded by ASCII space or tab, and
   `encodeWith(..., trimSpace = true)` quotes fields whose leading or
   trailing space/tab would otherwise be lost on decode.
+#### v0.6 reproducibility and flow
+
+`std.csv` is *pure* — every function transforms strings/lists
+without consulting any capability. The whole module is acceptable
+inside `#[reproducible(scope = "portable")]`. Decoded `String`
+cells inherit the source `String`'s flow tags; sanitize before
+reaching SQL / shell / HTML sinks.
+
 - `decodeHeaders` treats the first row as column names. Header names must
   be non-empty and unique, and every data row must have exactly the same
   field count as the header row.

--- a/LANG_SPEC_v0.6/10-standard-library/19-compression.md
+++ b/LANG_SPEC_v0.6/10-standard-library/19-compression.md
@@ -23,3 +23,21 @@ compress.gzip.decode(data: Bytes) -> Result<Bytes, Error>
 compress.gzip.reader(source: Reader) -> Reader
 compress.gzip.writer(dest: Writer) -> Writer
 ```
+
+#### v0.6 reproducibility and flow
+
+`std.compress` is *pure* — every function transforms `Bytes` to
+`Bytes` (or wraps a `Reader`/`Writer` pipeline) without consulting
+any capability. Compression / decompression are acceptable inside
+`#[reproducible(scope = "portable")]`.
+
+Flow tags ride through compression — `compress.gzip.encode` of a
+tainted `Bytes` produces a tainted `Bytes` with the same source
+tag set. The compressed bytes are still tainted; decompressing
+them produces the original tag set. This means compression is
+*not* a sanitizer — moving data through gzip does not declassify
+it from the type system's perspective.
+
+Reader/Writer pipeline forms inherit the underlying stream's flow
+tag set: `compress.gzip.reader(netConn)` produces a `Reader` whose
+`.read()` calls return `Bytes` carrying `netConn`'s tags.

--- a/LANG_SPEC_v0.6/10-standard-library/21-bytes.md
+++ b/LANG_SPEC_v0.6/10-standard-library/21-bytes.md
@@ -68,3 +68,19 @@ bytes.fromHex(s: String) -> Result<Bytes, Error>
 - `toHex` / `fromHex` are convenience wrappers over `std.encoding.hex`.
   Importing `std.encoding` directly is preferred when both encode and
   decode are needed in the same file.
+
+#### v0.6 reproducibility and flow
+
+`std.bytes` is *pure* — every operation transforms `Bytes` to
+`Bytes` (or `String`) without consulting any capability. The whole
+module is acceptable inside `#[reproducible(scope = "portable")]`.
+
+Flow tags propagate identically — `bytes.toUpper` of a tainted
+`Bytes` produces a tainted `Bytes` with the same source tag set.
+`bytes.slice` preserves the parent's tag set on every byte.
+
+`bytes.toString` is a *fallible* operation (returns `Result<String,
+Error>`) because the byte sequence may be invalid UTF-8. The
+fallible path keeps the conversion explicit at the type level —
+authors who want lossless byte-level work stay in `Bytes`; UTF-8
+work requires explicit `toString` with error handling.

--- a/LANG_SPEC_v0.6/10-standard-library/22-fmt.md
+++ b/LANG_SPEC_v0.6/10-standard-library/22-fmt.md
@@ -137,3 +137,23 @@ fmt.tableAligned(headers: List<String>, rows: List<List<String>>, alignments: Li
   `parts.len() <= 1` the `last` separator is not used.
 - `tableAligned` accepts `"left"`, `"right"`, and `"center"`; unknown or
   missing alignment entries default to `"left"`.
+
+#### v0.6 reproducibility and flow
+
+`std.fmt` is *pure* — every function transforms values to `String`
+without consulting any capability. The module is acceptable inside
+`#[reproducible(scope = "portable")]` and `#[pure]` contexts.
+
+Flow tags ride through formatting — `fmt.padLeft(taintedStr, 10)`
+produces a `String` carrying the same source tag set as
+`taintedStr`. Authors who use `std.fmt` to render values for log
+output or HTTP responses must sanitize before reaching the sink;
+the formatter itself does not declassify.
+
+The `tableAligned` helper produces *deterministic* output even
+when input rows have differing widths — pad characters are spaces
+(`U+0020`), and column boundaries are computed by a single
+left-to-right pass that counts grapheme widths via §10.34
+`std.markdown` rules. This determinism is part of the v0.6
+contract; `tableAligned` is suitable for `#[golden]` snapshot
+output.

--- a/LANG_SPEC_v0.6/10-standard-library/46-capability-migration.md
+++ b/LANG_SPEC_v0.6/10-standard-library/46-capability-migration.md
@@ -191,3 +191,50 @@ src/main.osty:8:5    println("ready") → console.println("ready") (auto via #[a
 When the report is empty, the package is fully migrated. Removing
 `[legacy] globals = true` from `osty.toml` then unblocks `[stability]
 default = "stable"`.
+
+### §10.46.7 Migration order — recommended sequence
+
+Migrating a non-trivial package is best done in the following order:
+
+1. **Add capability parameters to leaf functions.** A leaf function
+   is one that other code calls but that itself only calls stdlib —
+   no internal callers depend on its signature change. Adding a
+   `clock: Clock` parameter at the leaf is the smallest unit of
+   change.
+
+2. **Update the leaf's tests.** Replace `time.now()` usage with
+   `FakeClock` injection. The tests are now deterministic; the
+   transition mode (`--legacy-globals`) need not be active for
+   leaf tests once they pass.
+
+3. **Add capability parameters to one caller layer at a time.** Each
+   caller of a migrated leaf takes the leaf's capability parameters
+   and forwards them. Repeat until you reach `fn main`.
+
+4. **Promote `fn main` to `#[ambient]`.** Replace the legacy
+   global usages in `main` with `#[ambient(clock, rng, env, fs,
+   net, console)]` (or a narrower set), and forward each
+   capability into top-level callees explicitly.
+
+5. **Remove `[legacy] globals = true` from `osty.toml`.** The package
+   is now `--legacy-globals`-clean. `osty audit --legacy-globals`
+   should report zero sites.
+
+6. **Promote `[stability] default = "stable"`** if appropriate. The
+   capability surface is now part of the public API contract.
+
+A Phase 5 run of `osty fix --capability-migrate` (planned for v0.7)
+will mechanize steps 1-4 by inserting capability parameters and
+forwarding them, but the v0.6 baseline does the migration manually
+— the leaf-first order keeps each commit small and reviewable.
+
+### §10.46.8 Common pitfalls during migration
+
+| Pitfall | Diagnostic | Fix |
+|---|---|---|
+| Library function annotated `#[ambient]` | `E0780` (entry-point only) | Remove `#[ambient]`; accept the capability as a parameter |
+| Forwarding `clock` into a callee that takes `Clock` but with name `wallClock` | (no error — names don't have to match) | OK; the parameter name on the callee side is independent |
+| Capability instance returned from a function | (no error) but breaks reproducibility | Returning `Net` is allowed (it's an interface value); but receivers can no longer reason about *who* created the instance — prefer to keep capabilities scoped to their construction context |
+| Double `#[ambient]` (in `main` and a helper) | `E0780` on the helper | Keep `#[ambient]` only at the entry point; helpers receive parameters |
+| `--legacy-globals` enabled but `[stability] default = "stable"` | `E2103` (incompatible mode) | Either migrate first, or downgrade stability to `experimental` |
+| `time.now()` reaches a `#[reproducible]` function via `--legacy-globals` desugar | `E0784` | Migrate the leaf to a `Clock` parameter; reproducible functions cannot receive non-deterministic capabilities |

--- a/LANG_SPEC_v0.6/11-testing.md
+++ b/LANG_SPEC_v0.6/11-testing.md
@@ -192,6 +192,56 @@ In bench mode:
   flag uses Go-style durations (`500ms`, `2s`, `1m`) and requires
   `--bench`.
 
+#### 11.4.1 `#[budget]` integration
+
+A bench function may target a specific function carrying
+`#[budget(time_ms = X, p99_ms = Y)]` (§3.15). When `osty bench
+--budget` is run, the bench harness records the measured `time_ms`
+/ `p99_ms` and compares against the declared budget:
+
+```osty
+#[budget(time_ms = 5, p99_ms = 20)]
+pub fn createUser(email: String, db: Db) -> Result<UserId, Error> { ... }
+
+fn benchCreateUser() {
+    let db = std.capability.testing.FakeDb()
+    testing.benchmark(1000, || {
+        let _ = createUser("alice@example.com", db)?
+        Ok(())
+    })
+}
+```
+
+`osty bench --budget` output:
+
+```
+bench benchCreateUser: avg=2.1ms p99=4.7ms
+budget OK (within 5ms / 20ms).
+```
+
+Regression beyond the manifest's `regression-threshold` (§13.2.1)
+promotes the warning to error and blocks `osty publish`.
+
+#### 11.4.2 Capability fakes inside benchmarks
+
+A benchmark of capability-typed code uses fake instances
+(§11.18.1-7). Fakes are intentionally low-overhead: `FakeClock` /
+`FakeRng` operations cost a single instruction each, so benchmark
+results reflect the production code's overhead, not fake harness
+overhead. Specifically:
+
+- `FakeClock.now()` returns a precomputed `Instant` constant.
+- `FakeRng.next()` advances an internal `xorshift64` state.
+- `FakeFs.read(path)` returns a precomputed `Bytes` slice from the
+  layout map.
+- `FakeNet.connect(...)` returns a precomputed `TcpConn` that
+  serves canned bytes.
+
+Production benchmarks that need realistic fake overhead (e.g.
+network latency simulation) use `FakeNet.withDelay(d)` etc.; the
+`with*` modifiers add measurable overhead so the benchmark reflects
+the wall-clock pattern of real I/O.
+
 ### 11.5 Snapshots / Golden Tests
 
 Two surface forms are provided: a *runtime form* via

--- a/LANG_SPEC_v0.6/13-tooling.md
+++ b/LANG_SPEC_v0.6/13-tooling.md
@@ -212,6 +212,102 @@ driver before backend emission.
 lists those records, `osty cache info` prints one fingerprint, and
 `osty cache clean` removes `.osty/cache/` plus `.osty/out/`.
 
+#### 13.2.1 v0.6-specific manifest tables
+
+Three v0.6 surfaces add manifest tables on top of the v0.5 baseline:
+
+##### `[stability]`
+
+```toml
+[stability]
+default = "stable"               # stable | experimental | deprecated | internal
+```
+
+The `default` value applies to every `pub` declaration that does not
+carry an explicit `#[stability(...)]` annotation. `osty publish`
+reads this default during the API-surface diff (§3.14.3) — a
+package whose default is `experimental` is permitted to make
+breaking changes within minor versions. A package whose default is
+`stable` requires explicit `#[stability("experimental")]` on each
+unstable symbol.
+
+##### `[legacy]`
+
+```toml
+[legacy]
+globals = false                  # default: false in v0.6
+construct = false                # default: false in v0.6
+```
+
+`globals = true` activates the v0.5 → v0.6 desugar for global effect
+calls (`time.now()` etc.) — see §10.46. `construct = true` permits
+external literal construction of stdlib sealed types (§3.4.5). Both
+flags are scheduled for removal in v0.7.
+
+Activating either flag forces `[stability] default = "experimental"`
+automatically — a package depending on legacy compatibility cannot
+promise stable APIs.
+
+##### `[budget]`
+
+```toml
+[budget]
+strict = true                    # default: false
+regression-threshold = 0.20      # 20% regression promotes W0795 to E0795
+```
+
+`strict = true` makes runtime budget violations (`W0795`) into
+errors, blocking `osty publish` until fixed or the budget is
+intentionally loosened. `regression-threshold` is the relative
+performance loss that *automatically* triggers the strict path;
+default 20% is the v0.6 baseline.
+
+#### 13.2.2 Capability injection in manifest
+
+A package that wants to *override* the default capability adapter
+set (e.g. for embedded targets that lack a real `Net`) declares
+the override via `[capability]`:
+
+```toml
+[capability.net]
+adapter = "myproject.embedded.NetAdapter"  # custom Net implementation
+
+[capability.fs]
+adapter = "myproject.virtual.VfsAdapter"   # virtual file system
+```
+
+The named adapter must implement the corresponding capability
+interface (§20.9). When the package is built, the adapter
+substitutes for the canonical host adapter at the entry-point
+`#[ambient]` binding site. This is how Osty supports targets where
+a particular capability has no usable host implementation —
+embedded systems, sandboxed runtimes, deterministic replay
+environments.
+
+`osty audit --capability-overrides` enumerates active overrides for
+review.
+
+#### 13.2.3 Workspace-level annotations defaults
+
+A workspace may declare default annotation policies that propagate
+to member packages unless overridden:
+
+```toml
+[workspace]
+members = ["pkg-a", "pkg-b", "pkg-c"]
+
+[workspace.defaults.stability]
+default = "stable"
+
+[workspace.defaults.budget]
+strict = true
+```
+
+A workspace member's own `[stability]` / `[budget]` tables override
+the workspace defaults. The workspace-level defaults exist so a
+multi-package workspace can establish a uniform release discipline
+without each package re-declaring it.
+
 ### 13.3 Formatter
 
 `osty fmt` is the canonical formatter. It accepts no configuration.
@@ -219,6 +315,46 @@ Among other normalizations:
 - Rewrites `Option<T>` to `T?`
 - Enforces naming conventions (§1.4)
 - Normalizes trailing commas
+
+#### 13.3.1 v0.6 formatter additions
+
+The v0.6 formatter adds three normalizations:
+
+1. **Annotation ordering** — annotations on a declaration are
+   re-sequenced into the conventional order (§3.8.14). The
+   formatter writes them top-to-bottom: visibility / intent /
+   examples / spec link / error contract / reproducibility / budget
+   / stability / performance hints / compatibility / flow /
+   capability marker.
+2. **Capability parameter placement** — when a function takes both
+   capability parameters and ordinary parameters, the formatter
+   places capabilities first (left-aligned). Existing function
+   signatures are not auto-rearranged unless `osty fmt
+   --reorder-capabilities` is passed.
+3. **Sealed type literal rewrite** — an external attempt to write
+   `Email { local: ..., domain: ... }` (forbidden by §3.4.5) is
+   rewritten by `osty fix --sealed-rewrite` into `Email.parse(...)?`
+   if the field-level information is recoverable from the literal.
+   The rewrite is opt-in because it changes call-site error
+   handling (introduces a `?` propagation).
+
+#### 13.3.2 Idempotence
+
+`osty fmt` is idempotent — `fmt(fmt(x)) == fmt(x)` for any source
+`x`. The implementation reaches idempotence by reparsing the
+formatter's output and asserting the AST matches the input AST. Any
+non-idempotent formatter behavior is a compiler bug (`osty fmt
+--check` exits non-zero in CI to catch regressions).
+
+#### 13.3.3 Annotation hint normalization
+
+Performance hints (`#[vectorize]`, `#[parallel]`, `#[unroll]`,
+`#[inline]`, `#[hot]`/`#[cold]`, `#[target_feature]`,
+`#[noalias]`, `#[pure]`) are *advisory* — the compiler is free to
+ignore them when the cost model disagrees. The formatter does not
+strip ignored hints; it preserves the author's intent for future
+readers. To enumerate which hints actually affected codegen, use
+`osty build --report=hints`.
 
 ---
 

--- a/LANG_SPEC_v0.6/20-capabilities.md
+++ b/LANG_SPEC_v0.6/20-capabilities.md
@@ -303,6 +303,61 @@ capability 수신을 허용한다.
 | `Console` | side-effect (deterministic 출력) | scope = `"run"` 만 가능 |
 | `Hash` | deterministic (사용자 정의) | ✅ |
 
+#### 20.6.1 Capability class — formal definition
+
+A *deterministic capability* is one whose every method satisfies:
+
+1. The output is fully determined by the inputs (no hidden state).
+2. The implementation does not consult the system clock, random
+   sources, environment, filesystem, network, or any process state.
+3. The implementation is annotated `#[reproducible(scope = X)]` on
+   each method, with X consistent across the interface.
+
+A deterministic capability is permitted as a parameter of a
+`#[reproducible(scope ≤ X)]` function. Non-deterministic capabilities
+are forbidden in any reproducible context.
+
+The compiler cannot in general prove a capability is deterministic
+— it relies on the `#[reproducible_capability]` attestation
+(§3.6.4). The attestation is checked structurally: every method on
+a `#[reproducible_capability]` interface must carry
+`#[reproducible(scope = X)]`. Implementing the interface with a
+non-reproducible body is a programmer error caught at the
+interface-implementation site (`E0786`).
+
+#### 20.6.2 Console at scope `"run"`
+
+`Console` is unique: it has *side effects* (writes to stdout/stderr)
+but the *output* itself is deterministic given the inputs (the same
+arguments produce the same byte sequence). A function that only
+reads from `Console` is rare; most functions write, which is the
+side effect that bars stronger reproducibility scopes.
+
+A `#[reproducible(scope = "run")]` function may take `Console` —
+the function is reproducible *within a single process run* (the
+output is the same on re-run), and the side effect is acceptable
+under `run` scope.
+
+#### 20.6.3 Adding deterministic capabilities
+
+Future stdlib additions (e.g. `Hash`-shaped interfaces for SHA-3,
+BLAKE3, etc.) follow the same pattern:
+
+```osty
+#[reproducible_capability]
+pub interface Sha3 {
+    #[reproducible(scope = "portable")]
+    fn sha3_256(self, data: Bytes) -> Bytes32
+
+    #[reproducible(scope = "portable")]
+    fn sha3_512(self, data: Bytes) -> Bytes64
+}
+```
+
+The interface is registered in §10.46.4 (Runtime adapter factories)
+with a host adapter; the deterministic class is auto-derived from
+the `#[reproducible_capability]` annotation.
+
 ### 20.7 Capability 와 G15 arity erasure
 
 함수값 으로 저장 시 capability 파라미터는 **그대로 시그니처에 유지**된다 (G15 의

--- a/LANG_SPEC_v0.6/21-information-flow.md
+++ b/LANG_SPEC_v0.6/21-information-flow.md
@@ -27,6 +27,69 @@ pub fn sqlIdent(s: String) -> SqlIdent? { ... }
 pub fn query(table: #[requires("sql_safe")] SqlIdent) -> Rows { ... }
 ```
 
+#### 21.2.1 Annotation argument grammar
+
+세 annotation 모두 *string literal* 만 인자로 받는다. 표현식이나
+식별자 인자는 거부 (`E0904`). 이 제약은 두 가지를 보장한다:
+
+1. **Type-checker가 컴파일 시점에 tag 식별** — runtime evaluation
+   이나 reflection 없이 결정.
+2. **Audit 도구가 grep 가능** — `osty audit` 가 어떤 source / sink
+   인지 알기 위해 type checker 호출 필요 없음.
+
+```osty
+// ✅ String literal — 합법.
+#[taint("user_input")]
+
+// ❌ Identifier — 거부 (E0904).
+const tag = "user_input"
+#[taint(tag)]
+
+// ❌ String concatenation — 거부.
+#[taint("user_" + "input")]
+```
+
+#### 21.2.2 Annotation 위치 규칙
+
+- `#[taint(t)]` — 함수 반환 위치 (선언 앞). 함수 결과 전체에 tag 부여.
+- `#[sanitizes(t, into = u)]` — 함수 반환 위치 (선언 앞). 입력의
+  tag `t` 가 출력의 tag `u` 로 변환.
+- `#[requires(u)]` — *parameter* 위치 (Pattern 앞 또는 Type 앞).
+  parameter 별로 다른 trust 요구 가능.
+- `#[taint(t)]` — parameter 위치 (Pattern 앞 또는 Type 앞)도 가능.
+  *입력*에 tag 부여 — 데이터가 함수 안에 들어올 때 이미 tagged
+  임을 callee 측에서 attest.
+
+함수 *body* 내부에는 어떠한 flow annotation 도 attach 불가 — 이는
+declaration-level annotation 의 일관된 규칙 (§3.8 positioning rules).
+
+#### 21.2.3 Multiple tags
+
+한 declaration 에 같은 종류의 annotation 을 여러 번 적용 가능 —
+tag set 의 합집합으로 해석:
+
+```osty
+// 두 source tag 모두 부여 — 결과에 {user_input, web_input} 둘 다
+#[taint("user_input")]
+#[taint("web_input")]
+pub fn readBody(req: HttpRequest) -> String { ... }
+
+// 두 trust tag 모두 요구 — 입력에 {sql_safe, web_safe} 모두 있어야
+pub fn unsafeStore(value: #[requires("sql_safe")] #[requires("web_safe")] String) { ... }
+```
+
+`#[sanitizes]` 는 다른 의미: 첫 인자의 tag 를 제거, 두 번째의
+tag 를 추가. 여러 sanitizer annotation 은 *순차* 적용:
+
+```osty
+#[sanitizes("user_input", into = "url_safe")]
+#[sanitizes("user_input", into = "html_safe")]   // 두 번째 호출 — 같은 source 다른 trust
+pub fn doubleSanitize(s: String) -> String { ... }
+```
+
+이 형태는 흔하지 않으며, 일반적으로는 하나의 `#[sanitizes]` 가
+충분하다.
+
 ### 21.3 의미론
 
 타입에 *flow tag set* 이 첨부된다 (concrete syntax 노출 없음 — annotation 으로만


### PR DESCRIPTION
## Summary

baseline declaration form (enums / interfaces / cancellation) + v0.6 정본화의
*sub-section reference* 들을 한 PR에 결합. **Batch 11 + Batch 12 합산**:
+1326 LOC, 22 spec 파일.

### Batch 11 — §3.5 / §3.6 / §8.4 (+326 LOC)

- **§3.5 Enums** (4 sub-section) — `#[since]` / flow / methods /
  `#[error_contract]` eligibility
- **§3.6 Interfaces** (5 sub-section) — default impl / composition /
  value vs generic / `#[reproducible_capability]` / evolution
- **§8.4 Cancellation** (3 sub-section) — explicit triggers /
  cancel ≠ failure / capability adapter responsibilities

### Batch 12 — 21 files deep mechanics (+1000 LOC)

#### Top-level chapters

| Section | Topic |
|---|---|
| §2.3.1 | numeric overflow + reproducible / budget interaction |
| §2.4.1 | `Bytes` flow tag preservation |
| §3.4.4 | struct method receivers (3 shapes) |
| §3.8.13 | annotation interaction matrix (5×6) |
| §3.8.14 | recommended ordering (12 slots) |
| §3.1.1 | `const fn` + v0.6 surface composition |
| §4.4.2-4 | loop forms summary / capability flow / information flow |
| §8.5.1-3 | channel flow / capability lifetime / budget |
| §20.6.1-3 | capability class formal definition / Console at run / adding deterministic |
| §21.2.1-3 | annotation argument grammar / position rules / multiple tags |

#### §10 stdlib chapters

| Section | Topic |
|---|---|
| §10.1.1-2 | Tier 1 capability split + evolution policy |
| §10.2.1 | Tier 2 capability summary 표 (37 module) |
| §10.5 | numeric reproducibility (float bit-pattern stability) |
| §10.6 | collection method reproducibility + flow propagation |
| §10.9 / §10.11 / §10.17 / §10.18 / §10.19 / §10.21 / §10.22 | per-chapter capability notes |
| §10.10 | logging + flow / handler as capability / budget |
| §10.46.7-8 | migration order (6 step) + 6 pitfalls |

#### §11 / §13

| Section | Topic |
|---|---|
| §11.4.1-2 | `#[budget]` integration + capability fakes in benches |
| §13.2.1-3 | v0.6 manifest tables (`[stability]` / `[legacy]` / `[budget]` / `[capability]` / `[workspace.defaults]`) |
| §13.3.1-3 | v0.6 formatter additions / idempotence / annotation hint preservation |

이로써 v0.6 spec의 모든 declaration / module / annotation 해석 surface가
sub-section reference를 가진다.

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §3.8.13 interaction matrix가 §3.10-§3.15 본문과 정합
- [ ] §10.2.1 Tier 2 capability summary가 §20.18 capability matrix와 정합
- [ ] §10.46.7-8 migration order가 §10.46 본문과 정합
- [ ] §13.2.1 manifest tables가 §3.14.3 publish algorithm과 정합

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd