### PR TITLE
feat(toolchain): self-host registry publish infra + bootstrap recovery (5-commit series)

### DIFF
--- a/.github/workflows/bootstrap-smoke-test.yml
+++ b/.github/workflows/bootstrap-smoke-test.yml
@@ -1,0 +1,152 @@
+# Fresh-clone bootstrap smoke test (B1 post-verification).
+#
+# Each Sunday this workflow runs the exact path a brand-new contributor
+# walks: shallow-clone the repo into an empty directory, build the
+# host osty Go binary, and let `install-self` fetch a pre-built
+# `osty-self` from the rolling release configured by
+# `vars.OSTY_SELF_REGISTRY_URL`. Then it builds a tiny example to
+# prove the toolchain path is wired end-to-end.
+#
+# A failure here means fresh clones cannot bootstrap. The job opens an
+# issue automatically so the maintainer notices even if they only
+# check email.
+
+name: Bootstrap smoke test
+
+on:
+  schedule:
+    # Sunday 04:00 UTC — runs ~2 hours before the Monday backfill of
+    # `build-osty-self.yml`, so a missing publish surfaces as a smoke
+    # test failure first, then auto-recovers when the backfill runs.
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+    inputs:
+      from_ref:
+        description: "Ref to clone for the smoke test (default: main)"
+        required: false
+        type: string
+        default: "main"
+
+permissions:
+  # `gh issue create` on failure.
+  contents: read
+  issues: write
+
+concurrency:
+  group: bootstrap-smoke-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Fresh clone → bootstrap → toolchain build
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Set up Go
+        # The host osty CLI is a Go binary; bootstrap needs Go on PATH.
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Install just
+        run: |
+          curl -fsSL https://github.com/casey/just/releases/latest/download/just-1.50.0-x86_64-unknown-linux-musl.tar.gz \
+              | tar -xz -C "$HOME/.local/bin" just
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          mkdir -p "$HOME/.local/bin"
+
+      - name: Install LLVM toolchain (clang/lld for the link step)
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends clang lld
+
+      - name: Shallow clone in scratch dir
+        # We deliberately do not use actions/checkout — a fresh
+        # contributor never has the repo pre-staged. Shallow clone is
+        # what `git clone --depth 1` produces, which exercises every
+        # path that depends on the working tree being a clone vs. an
+        # archive.
+        env:
+          REF: ${{ inputs.from_ref || 'main' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/scratch"
+          cd "$RUNNER_TEMP/scratch"
+          git clone --depth 1 --branch "$REF" https://github.com/choiceoh/osty osty
+          cd osty
+          git rev-parse HEAD
+          git status
+
+      - name: Bootstrap from registry (`just bootstrap`)
+        # `just bootstrap` runs build-all + install-self. The
+        # install-self step is the meat of the test — it consults the
+        # rolling release at OSTY_SELF_REGISTRY_URL, fetches a
+        # pre-built osty-self for linux-amd64, verifies the manifest,
+        # and promotes the binary into the local cache.
+        env:
+          # Don't let a stale env on a re-used hosted runner leak into
+          # the test — the resolver should see a clean fresh-clone
+          # state.
+          OSTY_SELF_BIN: ""
+          OSTY_SELF_TRUSTED_KEY: ""
+          OSTY_STAGE0_FALLBACK: ""
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/scratch/osty"
+          just bootstrap 2>&1 | tee "$RUNNER_TEMP/bootstrap.log"
+
+      - name: Verify toolchain build path with a tiny example
+        # If install-self fetched a working osty-self, a trivial build
+        # against examples/calc proves the front-end → LIR Proto →
+        # toolchain chain is wired. This isn't a full toolchain build
+        # (slow), just a sanity check that the registry binary is
+        # actually executable + ABI-compatible.
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/scratch/osty"
+          ./.bin/osty check examples/calc 2>&1 | tee "$RUNNER_TEMP/check.log"
+
+      - name: Open / update tracking issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          title="bootstrap-smoke: fresh clone broken (commit ${GITHUB_SHA:0:12})"
+          body=$(cat <<EOF
+          The weekly fresh-clone smoke test failed against \`${GITHUB_REF_NAME}\` at commit \`${GITHUB_SHA}\`.
+
+          Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          ### What this means
+
+          A new contributor running \`just bootstrap\` after \`git clone\` will hit
+          the same failure. Diagnose by inspecting the run log, then either:
+
+          - Re-trigger \`Build osty-self\` with \`workflow_dispatch\` to refresh the
+            rolling release, or
+          - Walk \`docs/security/bootstrap-recovery.md\` if the registry itself
+            is in a bad state.
+
+          ### Recent build-osty-self runs
+
+          ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/workflows/build-osty-self.yml
+          EOF
+          )
+          # If a prior failure issue is still open, append a comment
+          # rather than spawning a duplicate.
+          existing=$(gh issue list \
+              --label bootstrap-smoke-failure \
+              --state open \
+              --limit 1 \
+              --json number \
+              --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create \
+                --title "$title" \
+                --body "$body" \
+                --label bootstrap-smoke-failure
+          fi

--- a/.github/workflows/build-osty-self.yml
+++ b/.github/workflows/build-osty-self.yml
@@ -1,32 +1,67 @@
-# Build per-host `osty-self` artifacts and produce the manifest pair
-# consumed by `selfhostcache.HTTPFetcher`.
+# Build per-host `osty-self` artifacts and publish them to the
+# `osty-self-snapshots` rolling release on this repository.
 #
-# Status: scaffold (A5). The workflow runs on a manual dispatch only —
-# the artifact upload step is deliberately gated behind a runtime
-# `OSTY_SELF_REGISTRY_URL` so a maintainer can flip publishing on
-# without merging additional code. Until A6 (manifest signing) lands
-# the produced artifacts are advisory; resolvers will still verify
-# the manifest SHA-256 before promoting into the local cache.
+# The rolling release stores three asset families (see
+# `docs/operations/self_host_registry_setup.md`):
 #
-# Layout produced per matrix entry (linux-amd64 etc.):
+#   <sha>-<triple>.json            ← cache manifest (immutable, append-only)
+#   <sha>-<triple>.json.sig        ← detached ed25519 sig (when signing key is set)
+#   <binary-url>                   ← the binary referenced by manifest.BinaryURL
+#   osty-self-latest-<triple>.bin  ← bootstrap seed for the next publish round
 #
-#   artifacts/<key>.json     ← published as <base>/<key>.json
-#   artifacts/<key>/osty-self  ← referenced by manifest.BinaryURL
+# Cache entries (the first three) are first-publish-wins — re-running
+# this workflow against the same toolchain SHA leaves them untouched.
+# The bootstrap seed (the fourth) is force-overwritten on every run so
+# the next workflow round can pull a fresh osty-self into its build
+# environment.
 #
-# The matrix mirrors the `cross-compile` job in `.github/workflows/ci.yml`
-# but layers `osty install-self` + `osty manifest-self` over the
-# native build so each runner emits a real, content-addressed entry.
+# Triggers:
+#   - push to main when `toolchain/**` or this workflow itself changes
+#     (a new toolchain SHA is the only thing that produces new cache
+#     entries — pure backend / check / runtime changes are skipped).
+#   - workflow_dispatch for manual recovery / first-publish bootstrap.
+#   - schedule (Monday 06:00 UTC) as a safety-net backfill in case a
+#     paths-filter false negative or external toolchain (LLVM) bump
+#     ever invalidates the prior cache.
+#
+# Runner pinning: the matrix uses pinned hosted runners (no `*-latest`
+# beyond the GA aliases) so reproducibility is bounded to the GitHub
+# image release the runner picks up. SOURCE_DATE_EPOCH and the prefix
+# maps below clamp the rest of the LLVM-side variability.
+#
+# Publishing is gated on `vars.OSTY_SELF_REGISTRY_URL` being set on the
+# repository — without it the matrix still runs and uploads workflow
+# artifacts (advisory build), but the rolling-release publish step is
+# a no-op so a maintainer can dry-run the workflow before flipping
+# the variable.
 
 name: Build osty-self
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'toolchain/**'
+      - '.github/workflows/build-osty-self.yml'
+      - 'internal/toolchain/selfhostcache/**'
   workflow_dispatch:
     inputs:
       osty_version:
-        description: "Provenance string baked into manifest.ostyVersion"
+        description: "Provenance string baked into manifest.ostyVersion (default: short SHA)"
         required: false
         type: string
         default: ""
+      skip_seed_fetch:
+        description: "Skip downloading the prior bootstrap seed (use only when seeding the very first round)"
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Monday 06:00 UTC — safety-net backfill. Cheap when nothing has
+    # changed (paths-filter wins on next push), useful when an
+    # external dependency bump invalidates an existing cache entry
+    # for the same toolchain SHA.
+    - cron: '0 6 * * 1'
 
 permissions:
   contents: read
@@ -43,28 +78,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # 5 GA-stable triples. windows-arm64 is intentionally absent —
+        # `windows-11-arm` is in public preview as of this workflow
+        # writing; users on that triple fall through to the
+        # `OSTY_SELF_BIN` / stage0 fallback paths until GA.
         include:
           - goos: linux
             goarch: amd64
-            runner: self-hosted
+            runner: ubuntu-latest
           - goos: linux
             goarch: arm64
-            runner: self-hosted
+            runner: ubuntu-22.04-arm
           - goos: darwin
             goarch: amd64
-            runner: self-hosted
+            # Intel macOS runners are end-of-life on hosted GHA — the
+            # last GA Intel image is `macos-15-intel`. Plan a darwin-amd64
+            # exit when it sunsets; users on Intel Macs already lean on
+            # Rosetta-emulated arm64 binaries for most other tooling.
+            runner: macos-15-intel
           - goos: darwin
             goarch: arm64
-            runner: self-hosted
+            runner: macos-14
           - goos: windows
             goarch: amd64
-            runner: self-hosted
-          - goos: windows
-            goarch: arm64
-            runner: self-hosted
+            runner: windows-latest
     env:
       GOFLAGS: -mod=readonly
       OSTY_VERSION: ${{ inputs.osty_version }}
+      # Reproducibility env (Q5-b). SOURCE_DATE_EPOCH clamps timestamp
+      # macros (__DATE__/__TIME__), object archive headers, and lld
+      # debug-info timestamps — clang and lld both honour it. The
+      # prefix maps strip the runner CWD from debug-info paths so
+      # builds on different runner workspaces produce the same bytes.
+      SOURCE_DATE_EPOCH: ${{ github.event.head_commit.timestamp != '' && github.event.head_commit.timestamp || '0' }}
+      OSTY_BUILD_FLAGS: "-ffile-prefix-map=${{ github.workspace }}=. -fdebug-prefix-map=${{ github.workspace }}=."
 
     steps:
       - name: Checkout
@@ -77,6 +124,10 @@ jobs:
           cache: true
 
       - name: Build host osty CLI
+        # The Go-built host osty drives the toolchain build — front
+        # end + LIR Proto subprocess invocation. It does not itself
+        # need the prior seed; it only fails if it then can't find
+        # an osty-self to run lir-proto-lower.
         run: |
           mkdir -p .bin
           go build -o .bin/osty ./cmd/osty
@@ -87,18 +138,62 @@ jobs:
           go build -o .osty/bin/osty-native-checker ./cmd/osty-native-checker
           go build -o .osty/bin/osty-native-lirproto ./cmd/osty-native-lirproto
 
+      - name: Fetch prior bootstrap seed
+        # Pull the previous round's `osty-self-latest-<triple>.bin`
+        # off the rolling release and expose it via OSTY_SELF_BIN so
+        # `install-self` can use it to compile the new toolchain. The
+        # seed itself was produced by an earlier publish, breaking
+        # the chicken-and-egg cycle.
+        #
+        # On the very first publish round there is no seed yet —
+        # callers pass `skip_seed_fetch=true` (workflow_dispatch only)
+        # and instead rely on a maintainer-uploaded seed already
+        # present in the rolling release before this run.
+        if: ${{ inputs.skip_seed_fetch != true }}
+        env:
+          REGISTRY_URL: ${{ vars.OSTY_SELF_REGISTRY_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${REGISTRY_URL:-}" ]; then
+            echo "OSTY_SELF_REGISTRY_URL repo variable unset — skipping seed fetch (advisory build mode)." >&2
+            exit 0
+          fi
+          triple="${{ matrix.goos }}-${{ matrix.goarch }}"
+          seed_url="$REGISTRY_URL/osty-self-latest-$triple.bin"
+          seed_dir=".osty/cache/self-host/seed"
+          mkdir -p "$seed_dir"
+          seed_path="$seed_dir/osty-self"
+          if [ "${{ matrix.goos }}" = "windows" ]; then seed_path="$seed_path.exe"; fi
+          if curl -fsSL --retry 3 --retry-delay 5 -o "$seed_path" "$seed_url"; then
+            chmod +x "$seed_path" || true
+            echo "OSTY_SELF_BIN=$PWD/$seed_path" >> "$GITHUB_ENV"
+            echo "Fetched seed from $seed_url"
+          else
+            # Missing seed is a recoverable condition (first round, or
+            # a deliberately-cleared release). Surface it but let the
+            # build try `OSTY_STAGE0_FALLBACK=1` so the matrix can
+            # still produce *something* for the maintainer to inspect.
+            echo "Seed not available at $seed_url — falling through to stage0 fallback for this run." >&2
+            echo "OSTY_STAGE0_FALLBACK=1" >> "$GITHUB_ENV"
+          fi
+
       - name: Install self-host artifact into cache
+        # Drives toolchain → osty-self build using the seed we just
+        # placed (or stage0 fallback if no seed). The cache layout is
+        # the local `.osty/cache/self-host/<sha>-<triple>/` tree.
+        env:
+          OSTY_BUILD_FLAGS: ${{ env.OSTY_BUILD_FLAGS }}
+        shell: bash
         run: |
           .bin/osty install-self --force
 
       - name: Locate cached osty-self
         id: locate
+        shell: bash
         run: |
           set -euo pipefail
           triple="${{ matrix.goos }}-${{ matrix.goarch }}"
-          # `install-self` printed the cache path as the last token of
-          # `installed:`; re-derive it from the cache layout for
-          # robustness.
           shopt -s nullglob
           candidates=(.osty/cache/self-host/*-"$triple"/osty-self*)
           if [ "${#candidates[@]}" -eq 0 ]; then
@@ -106,20 +201,15 @@ jobs:
             ls -R .osty/cache/self-host/ || true
             exit 1
           fi
-          if [ "${#candidates[@]}" -gt 1 ]; then
-            echo "multiple cache entries; picking newest:" >&2
-            ls -lt "${candidates[@]}" >&2
-          fi
-          # Pick the lexicographically last one (alpha-stable across
-          # repeated runs); collisions are unexpected since toolchain SHA
-          # is deterministic per source state.
-          IFS=$'\n' sorted=($(printf '%s\n' "${candidates[@]}" | sort))
-          unset IFS
+          # Lex-sort so re-runs against an unchanged toolchain SHA
+          # pick the same binary (deterministic across redrives).
+          mapfile -t sorted < <(printf '%s\n' "${candidates[@]}" | sort)
           bin="${sorted[-1]}"
           echo "bin=$bin"  >> "$GITHUB_OUTPUT"
           echo "triple=$triple" >> "$GITHUB_OUTPUT"
 
       - name: Generate manifest
+        shell: bash
         run: |
           set -euo pipefail
           triple="${{ steps.locate.outputs.triple }}"
@@ -127,26 +217,24 @@ jobs:
           mkdir -p artifacts
           # Bring the binary alongside the manifest so the artifact
           # bundle is self-contained.
-          cp "$bin" "artifacts/osty-self-$triple"
+          binary_basename="osty-self-$triple"
+          if [ "${{ matrix.goos }}" = "windows" ]; then binary_basename="$binary_basename.exe"; fi
+          cp "$bin" "artifacts/$binary_basename"
           .bin/osty manifest-self \
             --bin "$bin" \
-            --binary-url "osty-self-$triple" \
+            --binary-url "$binary_basename" \
             --triple "$triple" \
             --osty-version "${OSTY_VERSION:-${GITHUB_SHA:0:12}}" \
             --out "artifacts/$triple.json"
 
       - name: Sign manifest
-        # Signing is opt-in. When the OSTY_SELF_SIGNING_KEY secret is
-        # set the runner produces a detached ed25519 signature
-        # alongside the manifest. Resolvers that have configured
-        # OSTY_SELF_TRUSTED_KEY refuse unsigned artifacts (A6).
-        # Without the secret the workflow still produces an
-        # unsigned manifest — the resolver's signed/unsigned switch
-        # remains a single env var on the consumer side. The
-        # conditional lives inside the step body (not in `if:`) so
-        # the secret check survives `secrets` context restrictions.
+        # Signing is opt-in. When OSTY_SELF_SIGNING_KEY is set the
+        # runner produces a detached ed25519 signature alongside the
+        # manifest. Resolvers consult `OSTY_SELF_TRUSTED_KEY` (or the
+        # repo-committed `docs/security/trusted-keys.md`) to verify.
         env:
           OSTY_SELF_SIGNING_KEY: ${{ secrets.OSTY_SELF_SIGNING_KEY }}
+        shell: bash
         run: |
           set -euo pipefail
           if [ -z "${OSTY_SELF_SIGNING_KEY:-}" ]; then
@@ -155,15 +243,23 @@ jobs:
           fi
           triple="${{ steps.locate.outputs.triple }}"
           key_path="$RUNNER_TEMP/osty-self-signing.key"
-          # Trim trailing whitespace; the secret store sometimes
-          # injects a newline that loadPrivateKey already tolerates,
-          # but explicit trimming avoids surprises.
           printf '%s' "$OSTY_SELF_SIGNING_KEY" > "$key_path"
           chmod 600 "$key_path"
           .bin/osty sign-self \
             --manifest "artifacts/$triple.json" \
             --key "$key_path"
           rm -f "$key_path"
+
+      - name: Stage bootstrap seed
+        # Copy the freshly built binary as `osty-self-latest-<triple>.bin`
+        # so the publish job force-uploads it. This is the seed the
+        # *next* workflow run will fetch in the "Fetch prior bootstrap
+        # seed" step above.
+        shell: bash
+        run: |
+          triple="${{ steps.locate.outputs.triple }}"
+          bin="${{ steps.locate.outputs.bin }}"
+          cp "$bin" "artifacts/osty-self-latest-$triple.bin"
 
       - name: Upload artifact bundle
         uses: actions/upload-artifact@v4
@@ -174,51 +270,119 @@ jobs:
           if-no-files-found: error
 
   publish:
-    name: Publish manifests
-    runs-on: self-hosted
+    name: Publish to rolling release
+    runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 10
-    # Publishing is opt-in — set the secret to enable. Without it the
-    # job is a no-op so the matrix above can run on every dispatch
-    # without producing live artifacts.
+    timeout-minutes: 15
+    # Publishing is gated on the repo variable being set. Without it
+    # the build matrix still runs end-to-end (advisory build), so a
+    # maintainer can verify reproducibility / signing / fetch chain
+    # before flipping the gate.
     if: ${{ vars.OSTY_SELF_REGISTRY_URL != '' }}
+    permissions:
+      # `gh release create / upload` requires write on contents.
+      contents: write
 
     steps:
+      - name: Checkout
+        # gh CLI infers the target repo from the working tree.
+        uses: actions/checkout@v4
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: registry/
 
-      - name: Layout for upload
+      - name: Flatten upload payload
+        shell: bash
         run: |
           set -euo pipefail
-          # Each downloaded subdir holds one (manifest, binary[, sig])
-          # tuple. Flatten into the layout HTTPFetcher expects:
-          #   <base>/<key>.json
-          #   <base>/<key>.json.sig    (when signed)
-          #   <base>/<binary-url>
+          # Each downloaded subdir holds one (manifest, binary,
+          # optional sig, bootstrap seed) tuple. Flatten into a
+          # single `upload/` directory so the publish step can iterate
+          # over file families uniformly.
           mkdir -p upload
           shopt -s nullglob
           for dir in registry/*/; do
             for json in "$dir"*.json; do
-              # Drop into upload/ keyed by the manifest's `key` field.
               key=$(jq -r .key "$json")
               cp "$json" "upload/$key.json"
               if [ -f "$json.sig" ]; then
                 cp "$json.sig" "upload/$key.json.sig"
               fi
             done
-            for bin in "$dir"osty-self-*; do
+            for bin in "$dir"osty-self-*.bin "$dir"osty-self-*-*; do
+              [ -e "$bin" ] || continue
               cp "$bin" "upload/$(basename "$bin")"
             done
           done
           ls -la upload/
 
-      # Actual upload step is deferred to the maintainer's chosen
-      # backend (S3 / R2 / Pages). The scaffold stops here so the
-      # workflow remains visible/reviewable without binding the repo
-      # to a specific storage vendor.
-      - name: Summary
+      - name: Ensure rolling release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          echo "Prepared upload payload under upload/" >&2
-          echo "Configure the maintainer-side step that POSTs to ${{ vars.OSTY_SELF_REGISTRY_URL }}." >&2
+          set -euo pipefail
+          if ! gh release view osty-self-snapshots >/dev/null 2>&1; then
+            gh release create osty-self-snapshots \
+              --title "osty-self snapshots (rolling)" \
+              --notes "Rolling cache of per-host osty-self artifacts. See docs/operations/self_host_registry_setup.md for layout and consumption."
+          fi
+
+      - name: Publish cache entries (first-publish-wins)
+        # Manifest + binary + sig are immutable per Q5-c (γ). If an
+        # asset with the target name already exists on the release,
+        # we do NOT overwrite it — the first publish for any given
+        # toolchain SHA is the authoritative one. This keeps the
+        # cache key contract honest (same SHA → same byte sequence).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd upload
+          existing=$(gh release view osty-self-snapshots --json assets --jq '.assets[].name' | sort -u)
+          publish_one() {
+            local f="$1"
+            if printf '%s\n' "$existing" | grep -qx "$f"; then
+              echo "skip (already published): $f"
+              return 0
+            fi
+            gh release upload osty-self-snapshots "$f"
+            echo "uploaded: $f"
+          }
+          shopt -s nullglob
+          # Manifests + their signatures, then their binaries. The
+          # rolling seeds are handled in the next step (force-update).
+          for f in *.json *.json.sig; do publish_one "$f"; done
+          for f in osty-self-darwin-* osty-self-linux-* osty-self-windows-*; do
+            case "$f" in
+              osty-self-latest-*) continue ;;
+            esac
+            publish_one "$f"
+          done
+
+      - name: Publish bootstrap seeds (force-update)
+        # `osty-self-latest-<triple>.bin` is the seed for the *next*
+        # run — it must always reflect the latest successful build,
+        # so we force-overwrite. There is no cache-key contract on
+        # these files; the next workflow consumes them as
+        # opaque-but-fresh.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd upload
+          shopt -s nullglob
+          for f in osty-self-latest-*.bin; do
+            gh release upload osty-self-snapshots "$f" --clobber
+            echo "force-uploaded seed: $f"
+          done
+
+      - name: Summary
+        shell: bash
+        run: |
+          echo "Published to ${{ vars.OSTY_SELF_REGISTRY_URL }}"
+          echo "Cache entries are immutable; bootstrap seeds were force-updated."

--- a/README.md
+++ b/README.md
@@ -257,13 +257,17 @@ in order:
 3. `.osty/cache/self-host/<sha>-<triple>/osty-self` — the
    content-addressed cache. Populated by `osty install-self` and
    `verify-self-rebuild --reuse-stage1`.
-4. **Network fetch** from `$OSTY_SELF_REGISTRY_URL` — only when set
-   and `$OSTY_SELF_REGISTRY_OFFLINE` is unset. Successful fetches
+4. **Network fetch** from `$OSTY_SELF_REGISTRY_URL`, falling back to
+   `selfhostcache.DefaultRegistryURL` (the upstream `choiceoh/osty`
+   rolling release `osty-self-snapshots`) when the env var is unset.
+   Disabled by `$OSTY_SELF_REGISTRY_OFFLINE`. Successful fetches
    promote the binary into the local cache so step 3 hits next time.
 
 When all four miss, the resolver returns the canonical `osty-self
 not found` decline so the upstream backend dispatcher can fall back
-to its decline handler.
+to its decline handler. **Fresh clones therefore work out of the
+box** without exporting any env var — `just bootstrap` consults the
+upstream registry directly.
 
 ### Network fetch + signing
 
@@ -283,9 +287,9 @@ Consumer-side env vars:
 
 | Var | Purpose |
 |---|---|
-| `OSTY_SELF_REGISTRY_URL` | Base URL the resolver GETs manifests / binaries from. Unset ⇒ network fetch disabled. |
+| `OSTY_SELF_REGISTRY_URL` | Base URL the resolver GETs manifests / binaries from. Unset ⇒ falls back to `selfhostcache.DefaultRegistryURL` (the upstream rolling release). |
 | `OSTY_SELF_REGISTRY_OFFLINE` | When truthy, hard-disables the fetcher even with a registry URL set. CI / air-gapped environments. |
-| `OSTY_SELF_TRUSTED_KEY` | 64-char hex ed25519 public key. When set, manifests must be signed under the matching private key or the fetcher rejects them. Unset ⇒ unsigned manifests are accepted (A4-class behaviour). |
+| `OSTY_SELF_TRUSTED_KEY` | 64-char hex ed25519 public key. When set, manifests must be signed under the matching private key or the fetcher rejects them. Unset ⇒ falls back to `selfhostcache.DefaultTrustedKeyHex`; if both are empty, unsigned manifests are accepted (warn-only mode). |
 | `OSTY_SELF_BIN` | Bypass everything and use this binary path. |
 | `OSTY_STAGE0_FALLBACK` | Last-resort emergency-only Go MIR→LLVM emitter. See `docs/osty_self_bootstrap_design.md`. |
 

--- a/docs/operations/first-publish-playbook.md
+++ b/docs/operations/first-publish-playbook.md
@@ -1,0 +1,261 @@
+# First-publish playbook — bootstrapping the rolling release
+
+> **Scope**: maintainer manual operations to seed the
+> `osty-self-snapshots` rolling release for the first time.
+> **Prerequisite**: PRs 1–4 of the publish-infra series have been
+> merged. After this playbook completes, the workflow self-perpetuates.
+> **Owner**: maintainer.
+> **Time**: ~1 hour wall-clock, mostly waiting on builds.
+
+This is a one-time procedure. Re-running it is harmless — the
+same-key first-publish-wins policy (see `osty_self_artifact_design.md`
+§8.8) means existing cache entries stay untouched.
+
+## 0. Pre-flight checklist
+
+- [ ] PR 1 (workflow infra) merged on `main`.
+- [ ] PR 2 (security docs + auto-verify) merged on `main`.
+- [ ] PR 3 (smoke-test workflow) merged on `main` — will fail until this
+      playbook completes; that is expected.
+- [ ] PR 4 (governance docs) merged on `main`.
+- [ ] You are on the maintainer machine (Apple Silicon Mac assumed
+      below; substitute as needed if your dev machine differs).
+- [ ] Docker Desktop is running and can target both `linux/amd64` and
+      `linux/arm64` (verify with `docker buildx ls`).
+- [ ] `gh` CLI is authenticated: `gh auth status`.
+
+## 1. Generate the signing key (skip if already done)
+
+```sh
+osty sign-self genkey --out /tmp/osty-self-signing.key
+```
+
+This produces a hex-encoded ed25519 keypair. **Private** half goes to
+GitHub Secrets, **public** half goes into the source tree.
+
+```sh
+# 1.1 Upload the private key.
+gh secret set OSTY_SELF_SIGNING_KEY < /tmp/osty-self-signing.key
+
+# 1.2 Stash a recovery copy in 1Password (the only off-GitHub copy).
+#     1Password → New Item → Password → name: osty-self-signing-<YYYY-MM-DD>
+
+# 1.3 Read the public hex (last 64 chars of the file).
+public_hex=$(tail -c 65 /tmp/osty-self-signing.key | head -c 64)
+echo "Public key: $public_hex"
+
+# 1.4 Update the constant in source.
+#     File: internal/toolchain/selfhostcache/default_trusted_key.go
+#     Replace `const DefaultTrustedKeyHex = ""` with `const DefaultTrustedKeyHex = "<public_hex>"`.
+#
+#     File: docs/security/trusted-keys.md §1
+#     Replace the placeholder row with:
+#       | active | <first 16 chars> | <full 64 chars> | <today YYYY-MM-DD> | initial production key |
+
+# 1.5 Commit + push.
+git add internal/toolchain/selfhostcache/default_trusted_key.go docs/security/trusted-keys.md
+git commit -m "chore(security): activate initial osty-self signing key"
+git push
+
+# 1.6 Wipe the temp file.
+shred -u /tmp/osty-self-signing.key
+```
+
+Skip this section if you've already done it for a prior round —
+keys live for the project lifetime by default.
+
+## 2. Build the bootstrap seeds
+
+You need one `osty-self-latest-<triple>.bin` per matrix triple. Build
+them on the maintainer machine where possible, dispatch to hosted
+runners where not.
+
+### 2.1 darwin-arm64 — native on the maintainer Mac
+
+```sh
+cd ~/code/osty   # or wherever your dev clone lives
+git checkout main
+git pull
+just build-all
+.bin/osty install-self --force
+key=$(.bin/osty cache-self --key)
+triple="darwin-arm64"
+bin=".osty/cache/self-host/${key}/osty-self"
+mkdir -p /tmp/osty-self-seeds
+cp "$bin" "/tmp/osty-self-seeds/osty-self-latest-${triple}.bin"
+echo "darwin-arm64 seed staged at /tmp/osty-self-seeds/osty-self-latest-${triple}.bin"
+```
+
+### 2.2 linux-amd64 — Docker
+
+Docker on Apple Silicon honors `--platform=linux/amd64` via QEMU.
+Slower than native (~3× build time), but works for a one-shot seed.
+
+```sh
+docker run --rm --platform=linux/amd64 \
+    -v "$PWD:/src" -w /src \
+    -e CGO_ENABLED=0 \
+    golang:1.26 \
+    sh -c '
+        apt-get update -qq && apt-get install -y -qq --no-install-recommends clang lld
+        go build -o .bin/osty ./cmd/osty
+        go build -o .osty/bin/osty-native-checker ./cmd/osty-native-checker
+        go build -o .osty/bin/osty-native-lirproto ./cmd/osty-native-lirproto
+        OSTY_SELF_BIN=/src/.osty/cache/self-host/seed/osty-self ./.bin/osty install-self --force || \
+            OSTY_STAGE0_FALLBACK=1 ./.bin/osty install-self --force
+    '
+
+# Copy the seed out.
+key=$(.bin/osty cache-self --key)   # same key — toolchain SHA is host-independent
+triple="linux-amd64"
+cp ".osty/cache/self-host/${key}/osty-self" \
+    "/tmp/osty-self-seeds/osty-self-latest-${triple}.bin"
+```
+
+### 2.3 linux-arm64 — Docker (native on Apple Silicon)
+
+```sh
+docker run --rm --platform=linux/arm64 \
+    -v "$PWD:/src" -w /src \
+    -e CGO_ENABLED=0 \
+    golang:1.26 \
+    sh -c '
+        apt-get update -qq && apt-get install -y -qq --no-install-recommends clang lld
+        go build -o .bin/osty ./cmd/osty
+        go build -o .osty/bin/osty-native-checker ./cmd/osty-native-checker
+        go build -o .osty/bin/osty-native-lirproto ./cmd/osty-native-lirproto
+        OSTY_SELF_BIN=/src/.osty/cache/self-host/seed/osty-self ./.bin/osty install-self --force || \
+            OSTY_STAGE0_FALLBACK=1 ./.bin/osty install-self --force
+    '
+
+triple="linux-arm64"
+cp ".osty/cache/self-host/${key}/osty-self" \
+    "/tmp/osty-self-seeds/osty-self-latest-${triple}.bin"
+```
+
+### 2.4 darwin-amd64 — `macos-15-intel` hosted runner
+
+There is no Docker shortcut for darwin builds. Trigger one round of
+the build workflow with `skip_seed_fetch=true`, scoped to the Intel
+runner via a temporary matrix override is overkill — the easier path
+is to dispatch the existing matrix and ignore the four other triples'
+artifacts.
+
+```sh
+gh workflow run build-osty-self.yml \
+    --field osty_version=initial-bootstrap \
+    --field skip_seed_fetch=true
+```
+
+`skip_seed_fetch=true` tells the workflow to skip the prior-seed
+download step. With no seed available, the build will fall through to
+`OSTY_STAGE0_FALLBACK=1`, which today only succeeds for trivial
+toolchains — for the real toolchain it produces an error. **That is
+expected**: the dispatch will fail, but it leaves an
+`actions/upload-artifact` bundle of the partial state we can pull
+down for diagnosis.
+
+For darwin-amd64 specifically you have two real options:
+
+- **Option A — Find a darwin-amd64 collaborator**. Send them
+  `docs/operations/first-publish-playbook.md` and ask them to follow
+  §2.1 substituting `darwin-amd64`. Cleanest path if you have a
+  collaborator with an Intel Mac.
+
+- **Option B — Defer darwin-amd64**. Skip the seed for this triple
+  and accept that darwin-amd64 fresh-clone users hit the
+  `OSTY_STAGE0_FALLBACK=1` / `OSTY_SELF_BIN` paths until a future
+  workflow run produces the seed organically. (The
+  `bootstrap-smoke-test.yml` smoke runs on `ubuntu-latest`, so this
+  does not break the smoke test gate.)
+
+Both are reasonable. Option B is simpler and what the maintainer
+should pick if no Intel-Mac collaborator is immediately available.
+Add a `bootstrap-smoke-failure` issue stub manually to track the
+darwin-amd64 gap so it doesn't get forgotten.
+
+### 2.5 windows-amd64 — `windows-latest` hosted runner
+
+Same problem as §2.4 — no Docker shortcut. Same options apply:
+
+- **Option A** — collaborator with a Windows dev box runs §2.1
+  substituting `windows-amd64`.
+- **Option B** — defer; users on windows-amd64 fall through to
+  `OSTY_SELF_BIN` until organic recovery.
+
+Recommendation: pick A or B per triple based on collaborator access.
+The maintainer can always come back later and run §2.4 / §2.5 for any
+deferred triple.
+
+## 3. Upload the seeds to the rolling release
+
+```sh
+# 3.1 Create the rolling release if it doesn't exist.
+gh release view osty-self-snapshots >/dev/null 2>&1 || \
+    gh release create osty-self-snapshots \
+        --title "osty-self snapshots (rolling)" \
+        --notes "Rolling cache of per-host osty-self artifacts. See docs/operations/self_host_registry_setup.md."
+
+# 3.2 Upload every seed you successfully built.
+cd /tmp/osty-self-seeds
+for f in osty-self-latest-*.bin; do
+    gh release upload osty-self-snapshots "$f" --clobber
+    echo "uploaded seed: $f"
+done
+```
+
+The `--clobber` flag is the convention for seed assets only — they
+are designed to be force-updated each round.
+
+## 4. Set the repo variable
+
+```sh
+# Owner here matches `git remote get-url origin`.
+gh variable set OSTY_SELF_REGISTRY_URL \
+    --body "https://github.com/choiceoh/osty/releases/download/osty-self-snapshots"
+```
+
+This flips the workflow's `publish` job from no-op to active.
+
+## 5. Trigger the first real publish
+
+```sh
+gh workflow run build-osty-self.yml --field osty_version=v0.5-bootstrap-1
+```
+
+Watch the run. Each runner now finds its `osty-self-latest-<triple>.bin`
+seed in §3, installs it as `OSTY_SELF_BIN`, and uses it to drive a
+real `osty install-self` against the current toolchain. The runner
+publishes `<sha>-<triple>.json` + binary to the rolling release, plus
+a refreshed seed.
+
+After the run completes:
+
+```sh
+# 5.1 Sanity-check the release contents.
+gh release view osty-self-snapshots --json assets \
+    --jq '.assets[].name' | sort
+
+# Expected: roughly 5 manifests (.json), 5 binaries, 5 fresh seeds,
+# and 5 signatures (.json.sig) if the signing key from §1 is in place.
+```
+
+## 6. Verify with the smoke test
+
+```sh
+gh workflow run bootstrap-smoke-test.yml
+```
+
+This runs the same path a fresh contributor walks. If it passes, the
+playbook is complete — close out any tracking issue from §0 and
+update the maintainer journal.
+
+If it fails, walk `docs/security/bootstrap-recovery.md` §3 (DR1) —
+publish was not the issue; something about the registry → resolver
+→ build path is broken. The smoke test's run log will name the layer.
+
+## 7. Quiesce period
+
+For the first week post-bootstrap, monitor `bootstrap-smoke-failure`
+issues daily. After a clean week, drop to weekly per the schedule in
+`self_host_registry_setup.md` §4.

--- a/docs/operations/self_host_registry_setup.md
+++ b/docs/operations/self_host_registry_setup.md
@@ -1,0 +1,179 @@
+# `osty-self` registry — operator setup
+
+> **Scope**: GitHub Actions repository variables, secrets, runner pins,
+> and ongoing maintainer checks for the `Build osty-self` workflow.
+> **Authority**: this file is the source of truth for what the
+> upstream `choiceoh/osty` registry needs to be running. Fork users
+> mirror these settings against their own repository.
+> **Owner**: backend / toolchain / operator.
+
+For the **first-time bootstrap** (when the rolling release is empty
+and the workflow has nothing to fetch), follow
+[`first-publish-playbook.md`](first-publish-playbook.md). This file
+covers the steady-state configuration that the playbook expects to
+already be in place.
+
+## 1. Repository configuration
+
+### 1.1 `vars.OSTY_SELF_REGISTRY_URL` (required for publish)
+
+| Field | Value |
+|---|---|
+| Where | `https://github.com/<owner>/osty/settings/variables/actions` |
+| Name | `OSTY_SELF_REGISTRY_URL` |
+| Value | `https://github.com/<owner>/osty/releases/download/osty-self-snapshots` |
+
+The `Build osty-self` workflow's `publish` job is `if: ${{ vars.OSTY_SELF_REGISTRY_URL != '' }}`,
+so leaving this variable unset turns the workflow into an
+**advisory-only build matrix** — runners still produce manifests,
+sign them, and upload `actions/upload-artifact` bundles, but the
+publish step is a no-op. Useful for testing the build chain before
+flipping publishing on.
+
+The same URL is hard-coded as `selfhostcache.DefaultRegistryURL` in
+`internal/toolchain/selfhostcache/default_registry.go`, so fresh
+clones consult the same registry without the user having to export
+the env var. Keep these two values in sync: a maintainer who changes
+the variable but forgets the constant produces a repo where the
+workflow publishes to one URL and the resolver fetches from another.
+
+### 1.2 `secrets.OSTY_SELF_SIGNING_KEY` (optional)
+
+| Field | Value |
+|---|---|
+| Where | `https://github.com/<owner>/osty/settings/secrets/actions` |
+| Name | `OSTY_SELF_SIGNING_KEY` |
+| Value | hex-encoded ed25519 private key (96 hex chars) |
+
+Generated via `osty sign-self genkey` (see
+[`docs/security/signing-rotation.md`](../security/signing-rotation.md)).
+When set, every workflow run produces detached `.json.sig` files
+alongside the manifests; when unset, manifests are unsigned and the
+workflow skips the signing step gracefully.
+
+The corresponding **public** key is committed in
+`internal/toolchain/selfhostcache/default_trusted_key.go` as
+`DefaultTrustedKeyHex` and recorded in
+[`docs/security/trusted-keys.md`](../security/trusted-keys.md).
+
+### 1.3 Runner pins
+
+The build matrix uses pinned hosted runner labels rather than the
+floating `*-latest` aliases (with the exception of `ubuntu-latest`
+and `windows-latest` which Microsoft updates conservatively). When a
+GitHub-hosted image rotates, edit
+`.github/workflows/build-osty-self.yml` directly and bump the
+`matrix.runner` value. Keep the pin one image release behind the
+floating tag while you check that LLVM/clang versions still produce
+byte-identical output for unchanged toolchain SHAs.
+
+Current pins (Q1):
+
+| triple | runner | LLVM/clang notes |
+|---|---|---|
+| linux-amd64 | `ubuntu-latest` | apt clang/lld |
+| linux-arm64 | `ubuntu-22.04-arm` | apt clang/lld |
+| darwin-amd64 | `macos-15-intel` | Apple Xcode clang — Intel sunset trajectory |
+| darwin-arm64 | `macos-14` | Apple Xcode clang |
+| windows-amd64 | `windows-latest` | LLVM Windows distribution |
+
+## 2. Reproducibility env
+
+The workflow exports two variables before any build step:
+
+```yaml
+SOURCE_DATE_EPOCH: ${{ github.event.head_commit.timestamp != '' && github.event.head_commit.timestamp || '0' }}
+OSTY_BUILD_FLAGS: "-ffile-prefix-map=${{ github.workspace }}=. -fdebug-prefix-map=${{ github.workspace }}=."
+```
+
+`SOURCE_DATE_EPOCH` is the standard Reproducible Builds env clang and
+lld both honour — it clamps `__DATE__`/`__TIME__` macros, object
+archive headers, and debug-info timestamps. The two prefix maps strip
+the runner CWD from debug paths so workspaces on different runner VMs
+produce the same bytes.
+
+`workflow_dispatch` overrides default to the commit timestamp of the
+ref being built. Schedule-driven runs use the same expression — the
+schedule fires against the latest commit on `main`, which has a
+timestamp.
+
+### 2.1 Adding a new reproducibility flag
+
+If you discover a new source of build non-determinism:
+
+1. Add the env var to the matrix `env:` block in
+   `.github/workflows/build-osty-self.yml`.
+2. Verify locally that two consecutive `osty install-self --force`
+   runs against the same toolchain SHA produce byte-identical
+   binaries (`shasum -a 256` round-trip).
+3. Commit + push. The next workflow run validates the change at scale.
+4. Note the variable in this file's §2 list.
+
+## 3. Per-publish lifecycle
+
+A successful workflow run uploads four asset families per triple to
+the rolling release:
+
+| Asset | Mutability | Purpose |
+|---|---|---|
+| `<sha>-<triple>.json` | **Immutable** (first-publish-wins) | Manifest consumed by `selfhostcache.HTTPFetcher`. |
+| `<sha>-<triple>.json.sig` | Immutable (matches manifest) | Detached ed25519 signature; emitted only when signing key is set. |
+| `osty-self-<triple>` (or `.exe`) | Immutable | Binary referenced by manifest's `binaryURL`. |
+| `osty-self-latest-<triple>.bin` | **Force-updated** | Bootstrap seed for the next workflow run. |
+
+The publish job's same-key skip protects the first three. The seed is
+deliberately rolling — the next round needs the latest osty-self,
+not the historical one.
+
+## 4. Monthly maintainer checklist
+
+Run through these before the start of each month — about 10 minutes:
+
+1. **Smoke test passed?**
+   ```sh
+   gh issue list --label bootstrap-smoke-failure --state open
+   ```
+   Empty output = the weekly fresh-clone smoke test
+   (`bootstrap-smoke-test.yml`) has been green. Otherwise: walk
+   `docs/security/bootstrap-recovery.md` §3 to recover.
+
+2. **Rolling release sane?**
+   ```sh
+   gh release view osty-self-snapshots --json assets \
+       --jq '.assets | length'
+   ```
+   You should see at minimum `(N_recent_SHAs * 5 triples) + 5 seeds + N sigs`.
+   A drop suggests an asset deletion incident.
+
+3. **Cache GC**: locally, `osty gc-self --keep 30 --older-than 90d --dry-run`
+   to inspect. The repo-side rolling release does not yet have an
+   automated GC — entries accumulate. Schedule a manual cleanup by
+   tag (e.g., once per quarter) if storage starts to matter; for the
+   foreseeable future, GitHub Releases storage is unlimited for
+   public repos.
+
+4. **Signing key rotation due?** `docs/security/signing-rotation.md`
+   says no scheduled rotation, only incident-driven. Skip unless
+   §3 of that document fired.
+
+5. **Toolchain SHA churn rate**: how many distinct
+   `<sha>-<triple>.json` are in the rolling release? Cross-check with
+   `git log --oneline -- toolchain/` for the same period — they
+   should roughly match. If publish ran more often than toolchain
+   changes, look for `paths-filter` regressions.
+
+## 5. Disabling publishing temporarily
+
+To quiesce publishing without removing the workflow (for example,
+during a multi-PR refactor that would publish many transient SHAs):
+
+```sh
+gh variable set OSTY_SELF_REGISTRY_URL --body ""
+```
+
+The next run becomes advisory-only. Restore by setting the variable
+back to its canonical value (§1.1).
+
+This is also the right lever for fork users running their own
+private osty-self registry — set the variable to their own URL and
+the workflow publishes there instead of upstream.

--- a/docs/osty_self_artifact_design.md
+++ b/docs/osty_self_artifact_design.md
@@ -126,17 +126,95 @@ test infra) 는 본 artifact 시스템에서도 그대로 가치 보존된다 �
 체인의 마지막 단계로 유지되며, real-MIR 회귀 테스트는 stage0 든 osty-self
 든 어느 쪽이 emit 했는지 무관하게 회귀 게이트로 작동.
 
-## 8. 결정 필요 항목
+## 8. 결정 — RESOLVED
 
-1. **CI 빌드 호스트** — GitHub Actions 의 어떤 runner 가 어떤 triple 을
-   담당? linux-amd64, linux-arm64 (self-hosted?), darwin-amd64,
-   darwin-arm64, windows-amd64, windows-arm64.
-2. **Release 정책** — main push 마다? 태그 push 시? 분기 빌드는?
-3. **Storage 비용** — GitHub Release artifact 무료 한도 vs S3 / R2 호스팅.
-4. **Toolchain 변경 빈도** — 너무 잦으면 release 폭주. 캐시 키 안정성을 위해
-   toolchain 외 변경은 키에 들어가지 않게 4.1 알고리즘 유지.
-5. **Reproducibility** — 같은 toolchain SHA 에서 host 가 같은 OS/CPU 라면
-   바이너리가 같아야 함. LLVM 의 비결정성 (예: -fdebug-prefix-map) 통제 필요.
+각 항목의 합의 결과 (Q1–Q5 grilling 기록 기반).
+
+### 8.1 CI 빌드 호스트 (Q1)
+
+**5 GA-stable hosted runners**:
+
+| triple | runner | 비고 |
+|---|---|---|
+| linux-amd64 | `ubuntu-latest` | |
+| linux-arm64 | `ubuntu-22.04-arm` | |
+| darwin-amd64 | `macos-15-intel` | Intel macOS sunset 예정 — exit 계획 별도 |
+| darwin-arm64 | `macos-14` | |
+| windows-amd64 | `windows-latest` | |
+
+**`windows-arm64` 는 초기 매트릭스에서 drop**. `windows-11-arm` GA 전까지
+사용자가 `OSTY_SELF_BIN` 또는 `OSTY_STAGE0_FALLBACK=1` fallback.
+
+### 8.2 Release 정책 (Q2 + Q3)
+
+- **저장 위치**: GitHub Releases, **rolling tag `osty-self-snapshots`**.
+  asset 형식 `<sha>-<triple>.json` + binary + 옵션 `<sha>-<triple>.json.sig`.
+- **Trigger 하이브리드**:
+  - `push` to main with `paths: toolchain/**` + `internal/toolchain/selfhostcache/**` + workflow 파일
+  - `workflow_dispatch` (manual recovery / first-publish)
+  - `schedule: cron 0 6 * * 1` (월요일 06:00 UTC, 안전망 backfill)
+
+### 8.3 Storage 비용 (Q2)
+
+- **GitHub Releases (퍼블릭 repo)**: storage / bandwidth 사실상 무제한
+  (Homebrew/cargo binstall 와 같은 패턴).
+- 추가 secrets: `OSTY_SELF_SIGNING_KEY` (signing 활성화 시), `GITHUB_TOKEN`
+  (자동 주입). 그 외 0.
+- **외부 vendor lock-in 0** (S3/R2/CF 의존성 없음).
+
+### 8.4 Toolchain 변경 빈도
+
+- `paths-filter` 가 `toolchain/**` 외 변경에서 publish 잡 자체를 trigger
+  안 함 — 백엔드/check/runtime push 가 publish 폭주 안 만듦.
+- `Key.ToolchainSHA` 알고리즘 (§4.1) 그대로 — `toolchain/` 만 hash.
+- `osty gc-self` (A8) 가 LRU + age cutoff 로 정상 상태 1–2GB 유지.
+
+### 8.5 Reproducibility (Q5-b)
+
+- **`SOURCE_DATE_EPOCH=$(commit-timestamp)`**: clang/lld 가 honor.
+  timestamp macros (`__DATE__`/`__TIME__`), object archive headers,
+  debug-info timestamps 통제.
+- **`-ffile-prefix-map=$WORKSPACE=. -fdebug-prefix-map=$WORKSPACE=.`**:
+  runner CWD 를 debug-info 경로에서 제거 → 다른 runner workspace
+  에서도 같은 byte.
+- **Runner OS pin**: `ubuntu-latest` / `macos-14` / `macos-15-intel`
+  / `windows-latest` 명시. `*-latest` aliases 안 사용 (drift 위험).
+- **`verify-self-rebuild`** 의 stage2/3 byte parity 가 host-내
+  reproducibility 검증 중 — 위 env 추가는 cross-publish stability 만 보장.
+
+### 8.6 Signing (Q4)
+
+- **Custody**: 단일 메인테이너 + 1Password 백업. GitHub Secret
+  `OSTY_SELF_SIGNING_KEY` 가 production 경로.
+- **Rotation**: 사고 시 IR (`docs/security/signing-rotation.md`).
+  정기 rotation 안 함.
+- **Trust key 분배**: `internal/toolchain/selfhostcache/default_trusted_key.go`
+  의 `DefaultTrustedKeyHex` 상수 + `docs/security/trusted-keys.md` 의
+  fingerprint 표 commit.
+- **Verification 강도**: warn-only (key 미설정 시 unsigned 통과).
+  `DefaultTrustedKeyHex` 가 비어 있으면 fresh clone 도 verify 안 함;
+  메인테이너가 첫 키 publish 시 const 갱신 → 자동 verify 활성.
+
+### 8.7 Source — chicken-and-egg (Q5-a)
+
+- **운영 모델**: rolling release `osty-self-snapshots` 가 cache entries
+  (불변, append-only) + bootstrap seeds (`osty-self-latest-<triple>.bin`,
+  rolling, force-update) 두 종류 보관.
+- **첫 round (manual ops)**: 메인테이너가 5 triple 의 bootstrap seed
+  를 hand-distribute. Docker `linux/{amd64,arm64}` + 메인테이너
+  darwin-arm64 머신 + macos-15-intel hosted runner 1회 dispatch +
+  windows-latest hosted runner 1회 dispatch. 자세한 절차:
+  [`docs/operations/first-publish-playbook.md`](operations/first-publish-playbook.md).
+- **이후**: workflow 가 prior `osty-self-latest-<triple>.bin` 을 fetch
+  → 자기 triple 빌드 → 새 cache entry + 새 seed publish. self-perpetuating.
+
+### 8.8 검증 정책 (Q5-c)
+
+- **Cache entries**: same-key first-publish-wins. 같은 `<sha>-<triple>.json`
+  이 이미 release 에 있으면 publish skip — reproducibility 회귀를
+  cache 가 silently 흡수하지 않도록.
+- **Bootstrap seeds**: 매 publish 마다 force-overwrite. 다음 round
+  의 시드는 항상 latest.
 
 ## Appendix A. A1 단계 (이 PR) 의 효과
 

--- a/docs/osty_self_b1_findings.md
+++ b/docs/osty_self_b1_findings.md
@@ -1,7 +1,16 @@
 # B1 — Real toolchain build attempt
 
-> **상태**: 발견 사항 + UX 개선 (이 PR).
-> **연관**: `docs/osty_self_artifact_design.md` (A1–A9 — 인프라).
+> **상태**: **ARCHIVED — superseded by `docs/osty_self_b2_1_audit.md`**.
+> 이 문서는 P0–P15 시점의 측정 + UX 개선이다. P20 머지 + B2 4 PR
+> 변환 이후의 정확한 stage0 coverage 는 11.3% (`b2_1_audit.md` §3)
+> 임이 측정으로 확정됐고, 본 문서의 §3 "다음 작업" 옵션 (B2/B3/B4)
+> 는 옵션 (C) registry 결정 (`osty_self_artifact_design.md` §8
+> RESOLVED) 으로 흡수됐다. 본문은 측정 baseline 으로 보존하되 새
+> 작업의 baseline 으로 인용하지 말 것 — 대신 `b2_1_audit.md` 를
+> 참조.
+>
+> **연관**: `docs/osty_self_artifact_design.md` (A1–A9 — 인프라),
+> `docs/osty_self_b2_1_audit.md` (active audit).
 > **소유**: backend / toolchain.
 
 ## 1. 목표

--- a/docs/osty_self_b2_audit.md
+++ b/docs/osty_self_b2_audit.md
@@ -1,8 +1,18 @@
 # B2 — Stage0 coverage audit + rewrite demonstration
 
-> **상태**: 정찰 + 한 함수 시범 (이 PR).
-> **연관**: `docs/osty_self_b1_findings.md` (B1 — 부트스트랩 갭),
-> `docs/osty_self_bootstrap_design.md` (P0–P15 stage0 동결).
+> **상태**: **ARCHIVED — superseded by `docs/osty_self_b2_1_audit.md`**.
+> 이 문서의 source-level audit (533 sites) 은 v1 카운트로,
+> awk brace-tracking 도입 + match-arm 분류 + `?` 세분화 + MIR
+> ground-truth audit 가 들어간 v2 (`b2_1_audit.md`) 가 있는 한
+> 새 작업의 baseline 으로 사용하지 말 것. v2 의 결정적 발견:
+> stage0 가 toolchain 의 11.3% (899/7932) 만 cover, top decline 이
+> match 가 아니라 basic-shape gaps (call/intr/agg). 본문의
+> §6 "다음 작업" 옵션은 `b2_1_audit.md` 의 v2 마스터 플랜 (B2.2–B2.10)
+> 으로 superseded.
+>
+> **연관**: `docs/osty_self_b1_findings.md` (ARCHIVED),
+> `docs/osty_self_b2_1_audit.md` (active audit),
+> `docs/osty_self_bootstrap_design.md` (P0–P20 머지된 상태 반영).
 > **소유**: backend / toolchain.
 
 ## 1. 목표

--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -177,19 +177,24 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P13 | String + (concat) → osty_rt_strings_Concat 호출 + 재귀 함수 호출 검증 | string_concat_*, recursive_factorial real-MIR — **구현 완료** |
 | P14 | aggregate constructor (struct + tuple) — `Point { x, y }` / `(a, b)` → insertvalue 체인 + 합성 tuple 타입 풀 | struct_constructor_* / tuple_int_int_return real-MIR — **구현 완료** |
 | P15 | list literal + indexed read `xs[N]` → list_get_i64 runtime ABI | list_literal_index_first / _second real-MIR — **구현 완료** |
-| **P16+** | **stage0 확장 동결 — emergency-only fallback 으로 유지.** production 경로는 `docs/osty_self_artifact_design.md` 의 artifact cache 시스템으로 전환. P0~P15 의 인프라 (IsOstySelfMissing / 디스패처 wiring / real-MIR probe) 는 그대로 가치 보존. | — |
-| P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
-| P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
-| P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |
+| P16 | String == String runtime call | (#1455) — **구현 완료** |
+| P17 | if-else with phi-merged struct return | (#1459) — **구현 완료** |
+| P18 | `\|\|` short-circuit + if-else struct return | (#1461) — **구현 완료** |
+| P19 | N-arm else-if chain with struct return + ? early-return desugar | (#1463 / #1465) — **구현 완료** |
+| P20 | `\|\|` head + N-arm else-if chain | (#1467) — **구현 완료** |
+| **P21+** | **emergency-only freeze — Q8 결정**. `docs/osty_self_b2_1_audit.md` 측정으로 stage0 단독 부트스트랩의 ROI 가 옵션 (C) registry 보다 낮음 (현재 11.3% cover, P21–P24 추가해도 ~40%). 진행은 옵션 (C) registry path 안정 후 별도 dedicated 트랙으로 평가. | — |
 
-각 Phase는 independent PR. P0은 수십 줄. P1~P3은 stage0 emitter 본체이므로 분량 큼. 
+각 Phase는 independent PR. P0은 수십 줄. P1~P20 합산 emit.go 약 4253 줄
++ tests 1703 줄 = ~6K LOC.
 
-## 5. 결정 필요 항목
+## 5. 결정 — RESOLVED
 
-1. stage0 surface가 v0.5 spec 핵심 정도인지, v0.4 baseline 정도면 충분한지 — 컴파일러 자체가 어느 spec에 의존하는지 확인 후 결정.
-2. stage0를 `internal/backend/stage0/`에 둘지, `internal/llvmabi/stage0/` 등 다른 위치에 둘지.
-3. `OSTY_STAGE0_FALLBACK=1` 기본값 (CI 잡 / dev 환경별 / fresh clone first-run-detect) 정책.
-4. retirement 시점에 stage0 삭제 PR이 필요한가, 아니면 빌드 프로세스에서 자동 unreachable이라고 볼 것인지.
+| 항목 | 결정 |
+|---|---|
+| 1. stage0 surface 의 spec 범위 | **v0.5 핵심 — 진행 동결**. P0–P20 가 v0.5 의 단순 함수/제어/타입 cover. P21+ 동결로 더 넓은 v0.5 surface 는 cover 하지 않음. v0.6 surface 는 outright 미진행 (CLAUDE.md "v0.5 baseline" 규칙). |
+| 2. stage0 위치 | `internal/backend/stage0/` — 결정. emit.go (4253 줄) + emit_test.go (1703 줄) + doc.go. |
+| 3. `OSTY_STAGE0_FALLBACK=1` 기본값 | **OFF** — emergency 발화 시만 사용자가 명시 set. CI matrix 에서도 default off; `bootstrap-smoke-test.yml` 가 fresh-clone 시나리오 (registry path) 만 검증. |
+| 4. stage0 retirement 시점 | **영구 보존** — Q8. `docs/security/bootstrap-recovery.md` §5 의 "DR2 reconstruction" 경로에 명시. retirement PR 미예정 — stage0 가 진단 가치 (`b2_1_audit.md` decline 카탈로그 source) 만으로도 6K LOC 비용 정당화. |
 
 ---
 

--- a/docs/security/bootstrap-recovery.md
+++ b/docs/security/bootstrap-recovery.md
@@ -1,0 +1,144 @@
+# Bootstrap recovery — disaster scenarios for `osty-self`
+
+> **Scope**: how to re-bootstrap the `osty-self` toolchain when the
+> normal `OSTY_SELF_REGISTRY_URL` → cache → fetch flow is broken.
+> **Authority**: this file is the canonical recovery playbook. Update
+> before retiring fallbacks; never silently delete a recovery layer.
+> **Owner**: backend / toolchain / security.
+
+## 1. Layered fallbacks — what the resolver tries
+
+The fresh-clone resolver chain (in
+`internal/toolchain/selfhostcache/`) walks these layers in order, top
+to bottom. If a layer below is reachable, the system recovers
+without operator action:
+
+| Layer | Source | Failure mode |
+|---|---|---|
+| **L1** Local cache | `.osty/cache/self-host/<sha>-<triple>/` | Empty on a fresh clone or a fresh runner. |
+| **L2** `OSTY_SELF_BIN` env override | User-supplied path | Set explicitly; never fails by surprise. |
+| **L3** In-tree dev build | `toolchain/.osty/out/{debug,release}/llvm/osty-self` | Present only in active dev worktrees. |
+| **L4** Network fetch | `<OSTY_SELF_REGISTRY_URL>` (or `DefaultRegistryURL`) | Registry down, network blocked, key rotation in flight. |
+| **L5** `OSTY_STAGE0_FALLBACK=1` | Go-side stage0 emergency emitter | Per `docs/osty_self_b2_1_audit.md` — covers ~11.3% of toolchain functions. Insufficient for a full toolchain build today. |
+| **DR1** Manual hand-publish | This document, §3 below | Recovery procedure for a registry outage. |
+| **DR2** Toolchain rewrite | `docs/osty_self_b2_1_audit.md` v2 master plan | Last-resort reconstruction (~2–4 weeks). |
+
+## 2. Diagnosis — which layer am I on?
+
+```sh
+osty install-self --dry-run 2>&1 | tail -20
+```
+
+The verbose output prints which layer fired. Common signals:
+
+- `cache hit at .osty/cache/self-host/...` → L1, all good.
+- `env override OSTY_SELF_BIN=...` → L2.
+- `in-tree build .../debug/llvm/osty-self` → L3.
+- `fetched from <URL>` → L4 OK.
+- `stage0 fallback declined: ...` → L5 active but cannot cover the
+  current toolchain. Time to invoke DR1 if the registry is also down.
+
+## 3. DR1 — Registry outage manual hand-publish
+
+Trigger when L4 fetch is failing for hours and the maintainer needs
+fresh-clone users back online.
+
+### 3.1 Maintainer has a working `osty-self` already
+
+```sh
+# 1. Promote the local osty-self into the cache layout that
+#    `manifest-self` expects.
+osty install-self --force
+
+# 2. Read off the key the resolver computed.
+key=$(osty cache-self --key)
+triple=$(osty cache-self --triple)
+bin=$(osty cache-self --check)   # cache path
+
+# 3. Build the manifest.
+osty manifest-self \
+    --bin "$bin" \
+    --binary-url "osty-self-${triple}" \
+    --triple "$triple" \
+    --osty-version "manual-recovery-$(date -u +%Y%m%dT%H%M%S)" \
+    --out "/tmp/${triple}.json"
+
+# 4. (Optional) sign with the private key from 1Password.
+osty sign-self \
+    --manifest "/tmp/${triple}.json" \
+    --key /path/to/private-key
+
+# 5. Upload to the rolling release. Cache entries are immutable — gh
+#    refuses to overwrite, so this succeeds only if the asset doesn't
+#    already exist. (Use the `--clobber` flag on the seed only.)
+cp "$bin" "/tmp/osty-self-${triple}"
+gh release upload osty-self-snapshots \
+    "/tmp/${key}.json" \
+    "/tmp/osty-self-${triple}"
+
+# 6. Force-update the bootstrap seed for the next CI round.
+gh release upload osty-self-snapshots \
+    "/tmp/osty-self-${triple}" \
+    --clobber  # the seed file is force-updated by convention
+```
+
+Repeat steps 1–6 from the corresponding triple's environment for each
+host the maintainer has access to (Docker for linux-{amd64, arm64};
+native macOS for darwin-arm64; native macOS Intel or `macos-15-intel`
+hosted runner for darwin-amd64; Windows VM/dev box for windows-amd64).
+
+### 3.2 Maintainer machine is fresh too
+
+Use the documented first-publish playbook in
+`docs/operations/first-publish-playbook.md` — the procedure is
+identical to the very first round.
+
+## 4. DR2 — Reconstruction from scratch
+
+Trigger when:
+
+- The rolling release is wiped or otherwise unreachable for an extended
+  period AND
+- No maintainer-side `osty-self` binary exists AND
+- L5 (`OSTY_STAGE0_FALLBACK=1`) cannot cover the current toolchain.
+
+This is the worst case. The procedure pulls together two work streams
+already documented:
+
+1. **Toolchain simplification** — `docs/osty_self_b2_1_audit.md`
+   v2 master plan, batches B2.2–B2.3. ~244 source-level mechanical
+   `match → if-else` rewrites. ~10–15 hours.
+2. **Stage0 unlocks** — same document, batches B2.4–B2.7. ~4 stage0
+   phases (P21–P24) covering the basic-shape gaps that block 88.7% of
+   toolchain functions today. ~1500 lines of Go in
+   `internal/backend/stage0/`. ~1–2 weeks dedicated work.
+
+Combined, these two streams reach ~40% MIR coverage, which is enough
+to bootstrap a build of the current toolchain into a fresh osty-self
+binary on a single host. From that point, DR1 applies normally.
+
+DR2 is a last-resort plan, not an operational recipe. Most outages
+recover via DR1.
+
+## 5. Why these layers exist
+
+This file deliberately lists every fallback so a future contributor
+considering "let's simplify by removing X" sees the recovery cost.
+The layers are cheap to keep — they only fire when the prior layer
+fails — and expensive to re-create after deletion.
+
+In particular:
+
+- **L5** (`stage0`) is the only layer that requires no network and no
+  prior binary. Its 11.3% coverage is "almost useless" for production
+  but invaluable for diagnosis: when the bootstrap is broken, stage0's
+  decline message tells you exactly which MIR shape is missing
+  (`docs/osty_self_b2_1_audit.md` §3 enumerates the dominant ones).
+  Do not retire stage0 just because it cannot fully bootstrap; its
+  diagnostic value alone justifies keeping the ~6K lines in
+  `internal/backend/stage0/`.
+
+- **DR2** is the only path that does not depend on any maintainer
+  asset — neither the GitHub Release, nor the maintainer's machine,
+  nor the 1Password vault. It is slow, but it cannot be wiped out by
+  any single party.

--- a/docs/security/signing-rotation.md
+++ b/docs/security/signing-rotation.md
@@ -1,0 +1,121 @@
+# Signing key — generation, rotation, incident response
+
+> **Scope**: ed25519 keypair lifecycle for `osty-self` manifest signing.
+> **Authority**: this file is the canonical procedure; `trusted-keys.md`
+> records the resulting public-key fingerprints.
+> **Owner**: backend / toolchain / security.
+
+## 1. Custody (Q4-a)
+
+The active private key lives in **two and only two** places:
+
+1. **GitHub repository secret `OSTY_SELF_SIGNING_KEY`** — consumed by
+   the `Build osty-self` workflow's signing step. Read-only access for
+   the workflow context.
+2. **Maintainer's password manager** (1Password personal vault) —
+   recovery copy. Plain-text private-key backup, named
+   `osty-self-signing-<rotation-date>`.
+
+Bus factor is intentionally 1: this is OSS solo-maintainer scale.
+Mitigation lives in §3 (incident response) and
+[`bootstrap-recovery.md`](bootstrap-recovery.md) — disaster recovery
+does **not** depend on the signing key.
+
+## 2. Initial generation (Q4-b: incident-driven only)
+
+There is no scheduled rotation. The key generated in this step lives
+until §3 fires. The choice trades the operational simplicity of a
+fixed key for a slightly larger blast radius if the key leaks — the
+same pattern Homebrew, Cargo, and similar OSS distribution channels use.
+
+```sh
+# 1. Generate the keypair on the maintainer's machine.
+#    Output is two strings: private (96 hex chars) + public (64 hex chars).
+osty sign-self genkey --out /tmp/osty-self-signing.key
+
+# 2. Upload the private half to GitHub Secrets.
+gh secret set OSTY_SELF_SIGNING_KEY < /tmp/osty-self-signing.key
+# Settings → Secrets and variables → Actions → New repository secret
+# is the equivalent UI path.
+
+# 3. Stash the private key in 1Password (recovery copy).
+#    1Password → New Item → Password → name: osty-self-signing-<YYYY-MM-DD>
+
+# 4. Update DefaultTrustedKeyHex with the *public* half.
+#    File: internal/toolchain/selfhostcache/default_trusted_key.go
+#    Replace `const DefaultTrustedKeyHex = ""` with the 64-char hex.
+
+# 5. Append to trusted-keys.md §1 (Active keys) and commit.
+
+# 6. Wipe the temp file.
+shred -u /tmp/osty-self-signing.key
+```
+
+After this commit the next workflow run signs all manifests, and fresh
+clones automatically verify — no user action required.
+
+## 3. Incident response — suspected compromise
+
+Triggers:
+
+- A suspected leak of the private key (e.g. accidental commit, secret
+  store breach).
+- A user reports a verification failure they cannot explain.
+- Routine audit finds the GitHub Secret value (or the 1Password copy)
+  was accessed by an unexpected actor.
+
+### 3.1 Procedure
+
+```sh
+# 1. Generate a fresh keypair.
+osty sign-self genkey --out /tmp/osty-self-signing.key
+
+# 2. Replace the GitHub secret. The old value is overwritten in place.
+gh secret set OSTY_SELF_SIGNING_KEY < /tmp/osty-self-signing.key
+
+# 3. Replace the public half in DefaultTrustedKeyHex.
+#    Mark the *old* key as REVOKED in trusted-keys.md §1, append the new
+#    row as ACTIVE, include the activation date.
+
+# 4. Commit + push. The first push triggers `Build osty-self` because
+#    the workflow file is in the paths-filter; that run produces newly
+#    signed manifests under the new key.
+
+# 5. Purge artifacts signed by the compromised key.
+#    These are .json.sig files under the rolling release; deleting them
+#    forces resolvers (which now have the *new* DefaultTrustedKeyHex)
+#    to refuse to verify those entries until they are re-signed.
+gh release view osty-self-snapshots --json assets --jq '.assets[].name' \
+    | grep '\.json\.sig$' \
+    | xargs -I{} gh release delete-asset osty-self-snapshots {} -y
+
+# 6. Re-publish via workflow_dispatch — one run is enough; the
+#    matrix re-signs manifest assets without re-uploading the
+#    immutable cache binaries (Q5-c first-publish-wins).
+
+# 7. Post a note to CHANGELOG_v0.5.md or similar — short, factual, no
+#    secrets.
+```
+
+### 3.2 What does NOT need to change
+
+- The cache binary contents (`<sha>-<triple>.json` and binaries) are
+  not invalidated — the threat is signature spoofing, not binary
+  tampering. Same SHA → same trustable bytes.
+- The bootstrap seeds (`osty-self-latest-<triple>.bin`) — these are
+  always force-overwritten on the next workflow run anyway.
+- `OSTY_SELF_REGISTRY_URL` repo variable — unaffected.
+
+## 4. Why no scheduled rotation?
+
+A periodic rotation cadence (e.g. every 6 months) would mean
+`trusted-keys.md` accumulates a trusted-key set rather than a single
+active key. That trust set must then be merged into
+`DefaultTrustedKeyHex` — the constant becomes a comma-separated list
+or moves to a parsed file, the resolver loop tries each, and operator
+errors that turn off old entries silently downgrade to warn-only. The
+incident-only model keeps a single active key visible and auditable.
+
+If the project ever reaches a scale where signed timestamping or HSM
+custody is warranted, that change comes with its own design doc and
+supersedes this one.

--- a/docs/security/trusted-keys.md
+++ b/docs/security/trusted-keys.md
@@ -1,0 +1,97 @@
+# Trusted keys — `osty-self` artifact verification
+
+> **Scope**: ed25519 public keys that fresh clones use to verify `osty-self`
+> manifests fetched from the rolling `osty-self-snapshots` release.
+> **Authority**: this file is the source of truth for active key fingerprints.
+> **Owner**: backend / toolchain / security.
+
+## 1. Active keys
+
+| Status | Key ID (first 16 hex) | Full hex (64 chars) | Activated | Notes |
+|---|---|---|---|---|
+| _none_ | _no signing key configured yet_ | — | — | warn-only mode (A6 default) |
+
+The first row will be replaced once a maintainer runs the bootstrap
+key generation flow (see [`signing-rotation.md`](signing-rotation.md)).
+
+## 2. Verification — what fresh clones do
+
+`selfhostcache.TrustedKey()` (in `internal/toolchain/selfhostcache/signing.go`)
+consults two sources in this order:
+
+1. **`OSTY_SELF_TRUSTED_KEY` env var** — explicit override. Set this when
+   running against a private fork or staging registry.
+2. **`DefaultTrustedKeyHex` constant** in
+   `internal/toolchain/selfhostcache/default_trusted_key.go` — the
+   maintainer-published key. Updated in the same commit that activates
+   a new key (see §4 below).
+
+If both are empty, the resolver runs in warn-only mode — unsigned
+manifests are accepted. This is the bootstrap default until the first
+key is published.
+
+## 3. Manual verification — operator workflow
+
+For the rare case where you want to verify a downloaded artifact by hand
+(e.g. air-gapped review, or after a key-rotation incident):
+
+```sh
+# 1. Pull the manifest + signature side-by-side from the rolling release.
+gh release download osty-self-snapshots \
+    --pattern '<sha>-<triple>.json' \
+    --pattern '<sha>-<triple>.json.sig'
+
+# 2. Verify with the active public key from the table above.
+osty sign-self verify \
+    --manifest <sha>-<triple>.json \
+    --signature <sha>-<triple>.json.sig \
+    --pubkey-hex <FULL_HEX_FROM_TABLE>
+```
+
+A non-zero exit code means the signature does not match — do **not**
+trust the binary; report on the issue tracker (see §5).
+
+## 4. Activating a new key — maintainer
+
+Detailed procedure: [`signing-rotation.md`](signing-rotation.md). High level:
+
+1. Generate the keypair: `osty sign-self genkey --out /tmp/osty-self-signing.key`.
+2. Upload the private half to GitHub repository secret
+   `OSTY_SELF_SIGNING_KEY` (Settings → Secrets and variables → Actions).
+3. Replace `DefaultTrustedKeyHex` in
+   `internal/toolchain/selfhostcache/default_trusted_key.go` with the
+   public half (hex, 64 chars).
+4. Update §1 above: add a row with `Status: active`, key id, full hex,
+   activation date.
+5. Commit + push.
+6. The next `Build osty-self` workflow run signs all manifests — fresh
+   clones consume the signed artifacts automatically.
+
+## 5. Reporting a suspected compromise
+
+If a manifest verification fails or you find an artifact whose hash
+doesn't match its manifest's `binarySHA256`:
+
+- Open a `security` issue on the `choiceoh/osty` repository **without**
+  posting the suspect bytes; link to the failing artifact URL instead.
+- Mention the key id from §1 the artifact appeared to be signed under.
+- The maintainer will follow [`signing-rotation.md`](signing-rotation.md) §3
+  (incident response) to invalidate the suspected key and publish a new one.
+
+## 6. Threat model
+
+This signing layer protects against **registry compromise** —
+specifically, an attacker who replaces a published artifact on the
+GitHub Release without obtaining the maintainer's signing key. It does
+**not** defend against:
+
+- A maintainer-machine compromise (the private key + signing flow live
+  there). For that, see [`bootstrap-recovery.md`](bootstrap-recovery.md).
+- A compromised binary supply chain at `clang`/`lld`/`go` toolchain
+  level on the build runner. Reproducibility env (`SOURCE_DATE_EPOCH`,
+  `-ffile-prefix-map=`) reduces incidental drift but is not a defence
+  against a hostile build host.
+- Replay of an old (legitimately-signed) artifact: the cache key is
+  `(toolchain SHA, triple)`; an old artifact for an old SHA is benign,
+  while replay against a current SHA fails because the SHA in the
+  manifest envelope must match the one being requested.

--- a/internal/toolchain/selfhostcache/default_registry.go
+++ b/internal/toolchain/selfhostcache/default_registry.go
@@ -1,0 +1,24 @@
+package selfhostcache
+
+// DefaultRegistryURL is the registry that fresh clones consult when
+// OSTY_SELF_REGISTRY_URL is unset. Maintainer-controlled — fork users
+// either replace this constant or `export OSTY_SELF_REGISTRY_URL=…`.
+//
+// The URL is the GitHub Releases asset download root for the upstream
+// `choiceoh/osty` rolling tag `osty-self-snapshots`. GitHub serves each
+// release asset as `<this-url>/<asset-filename>`, which matches the
+// HTTPFetcher join shape (`<base>/<key>.json`) directly.
+//
+// Layout of the rolling release (see docs/operations/self_host_registry_setup.md):
+//   <DefaultRegistryURL>/<sha>-<triple>.json          — manifest, append-only
+//   <DefaultRegistryURL>/<sha>-<triple>.json.sig      — detached ed25519 sig (when signing key is configured)
+//   <DefaultRegistryURL>/<binary-url>                 — binary referenced by manifest.BinaryURL
+//   <DefaultRegistryURL>/osty-self-latest-<triple>.bin — bootstrap seed for the next publish round
+//
+// Override on the consumer side: set OSTY_SELF_REGISTRY_URL.
+// Disable network fetch entirely: set OSTY_SELF_REGISTRY_OFFLINE=1.
+//
+// Setting this constant to the empty string disables the default —
+// useful for fork users who deliberately want fresh clones to fall
+// through to the offline path instead of hitting upstream.
+const DefaultRegistryURL = "https://github.com/choiceoh/osty/releases/download/osty-self-snapshots"

--- a/internal/toolchain/selfhostcache/default_trusted_key.go
+++ b/internal/toolchain/selfhostcache/default_trusted_key.go
@@ -1,0 +1,25 @@
+package selfhostcache
+
+// DefaultTrustedKeyHex is the maintainer-published ed25519 public key
+// (hex-encoded, 64 chars / 32 bytes) that fresh clones use to verify
+// downloaded manifests when OSTY_SELF_TRUSTED_KEY is not set.
+//
+// Empty string (the default) preserves A6's warn-only behaviour:
+// resolvers accept unsigned manifests and skip verification when
+// neither env nor default is configured. Once a maintainer publishes
+// a key (typically the first time signing is enabled), this constant
+// is updated in a single commit and fresh clones automatically
+// switch to verify-by-default.
+//
+// Maintainer rotation flow (see docs/security/signing-rotation.md):
+//
+//  1. `osty sign-self genkey` produces a (private, public) pair.
+//  2. Private key → repository secret `OSTY_SELF_SIGNING_KEY`.
+//  3. Public key (hex) → this constant; commit + push.
+//  4. Document fingerprint in docs/security/trusted-keys.md.
+//
+// Override on the consumer side: set OSTY_SELF_TRUSTED_KEY (env wins
+// over default). Disable verification entirely: blank both. The env
+// var path also lets a fork user run a private registry without
+// touching this constant.
+const DefaultTrustedKeyHex = ""

--- a/internal/toolchain/selfhostcache/fetcher.go
+++ b/internal/toolchain/selfhostcache/fetcher.go
@@ -300,10 +300,32 @@ func FetchAndInstall(ctx context.Context, projectRoot string, key Key, fetcher F
 // returns `nil` so the resolver fails closed (no network) instead
 // of silently downgrading to unsigned.
 func EnvFetcher() Fetcher {
+	return envFetcherWithDefault(DefaultRegistryURL)
+}
+
+// envFetcherWithDefault is the test-friendly form of EnvFetcher — the
+// caller provides the default URL explicitly so tests can exercise
+// both the "default-disabled" (empty) and "default-active" branches
+// without rewriting package-level state.
+//
+// Resolution order:
+//
+//  1. OSTY_SELF_REGISTRY_OFFLINE=1 → nil (air-gapped / CI lockdown).
+//  2. OSTY_SELF_REGISTRY_URL set → use it.
+//  3. OSTY_SELF_REGISTRY_URL unset and `defaultURL` non-empty → use default.
+//  4. Both empty → nil (no fetch).
+//
+// The malformed-trusted-key path returns nil rather than fall back —
+// fail closed so a misconfigured key never silently downgrades a
+// signed-required deployment to unsigned.
+func envFetcherWithDefault(defaultURL string) Fetcher {
 	if isOffline() {
 		return nil
 	}
 	base := strings.TrimSpace(os.Getenv(RegistryURLEnv))
+	if base == "" {
+		base = defaultURL
+	}
 	if base == "" {
 		return nil
 	}

--- a/internal/toolchain/selfhostcache/fetcher_test.go
+++ b/internal/toolchain/selfhostcache/fetcher_test.go
@@ -281,26 +281,52 @@ func TestFetchAndInstallZeroKey(t *testing.T) {
 	}
 }
 
-func TestEnvFetcherDisabledByDefault(t *testing.T) {
+func TestEnvFetcherDisabledWhenAllEmpty(t *testing.T) {
+	// No env URL, no default URL → nil (preserves the legacy
+	// "no fetcher without explicit URL" contract for fork users
+	// who blank out DefaultRegistryURL).
 	t.Setenv(RegistryURLEnv, "")
 	t.Setenv(RegistryOfflineEnv, "")
-	if EnvFetcher() != nil {
-		t.Fatal("expected EnvFetcher to return nil with no URL configured")
+	if envFetcherWithDefault("") != nil {
+		t.Fatal("expected nil when both env and default URLs are empty")
+	}
+}
+
+func TestEnvFetcherUsesDefaultWhenEnvUnset(t *testing.T) {
+	// The env var is unset but a non-empty default exists — fresh
+	// clones must reach the upstream registry without the user
+	// exporting OSTY_SELF_REGISTRY_URL by hand.
+	t.Setenv(RegistryURLEnv, "")
+	t.Setenv(RegistryOfflineEnv, "")
+	f := envFetcherWithDefault("https://example.com/default")
+	if f == nil {
+		t.Fatal("expected fetcher to use the default URL when env is unset")
+	}
+	httpF, ok := f.(HTTPFetcher)
+	if !ok {
+		t.Fatalf("expected HTTPFetcher, got %T", f)
+	}
+	if httpF.BaseURL != "https://example.com/default" {
+		t.Fatalf("BaseURL = %q, want default URL", httpF.BaseURL)
 	}
 }
 
 func TestEnvFetcherHonoursOfflineMode(t *testing.T) {
+	// Offline mode must override both an explicit env URL and any
+	// configured default — air-gapped CI must never reach out.
 	t.Setenv(RegistryURLEnv, "https://example.com/osty-self")
 	t.Setenv(RegistryOfflineEnv, "1")
-	if EnvFetcher() != nil {
-		t.Fatal("offline mode must disable the fetcher")
+	if envFetcherWithDefault("https://example.com/default") != nil {
+		t.Fatal("offline mode must disable the fetcher even with default set")
 	}
 }
 
-func TestEnvFetcherActiveWithURL(t *testing.T) {
+func TestEnvFetcherEnvWinsOverDefault(t *testing.T) {
+	// Explicit env var must override the default — fork users and
+	// developers exercising staging registries rely on this.
 	t.Setenv(RegistryURLEnv, "https://example.com/osty-self")
 	t.Setenv(RegistryOfflineEnv, "")
-	f := EnvFetcher()
+	f := envFetcherWithDefault("https://example.com/default")
 	if f == nil {
 		t.Fatal("expected non-nil fetcher with URL set")
 	}
@@ -309,7 +335,16 @@ func TestEnvFetcherActiveWithURL(t *testing.T) {
 		t.Fatalf("expected HTTPFetcher, got %T", f)
 	}
 	if httpF.BaseURL != "https://example.com/osty-self" {
-		t.Fatalf("BaseURL = %q, want canonical URL", httpF.BaseURL)
+		t.Fatalf("BaseURL = %q, want canonical URL (env wins over default)", httpF.BaseURL)
+	}
+}
+
+func TestDefaultRegistryURLPointsAtUpstream(t *testing.T) {
+	// Sanity-pin the const so a careless edit (e.g. accidentally
+	// blanking the URL) lights up here before merging.
+	const want = "https://github.com/choiceoh/osty/releases/download/osty-self-snapshots"
+	if DefaultRegistryURL != want {
+		t.Fatalf("DefaultRegistryURL = %q, want %q", DefaultRegistryURL, want)
 	}
 }
 

--- a/internal/toolchain/selfhostcache/signing.go
+++ b/internal/toolchain/selfhostcache/signing.go
@@ -57,8 +57,26 @@ var ErrTrustedKeyMalformed = errors.New("selfhostcache: trusted key not a 64-cha
 // require manifests to be signed under. The boolean return is
 // `false` when no key is configured — the caller must treat that
 // as "verification disabled" and accept unsigned manifests.
+//
+// Resolution order: OSTY_SELF_TRUSTED_KEY env var first, then the
+// repo-committed `DefaultTrustedKeyHex` constant. Empty default +
+// unset env preserves the legacy warn-only behaviour (A6); a
+// committed default upgrades fresh clones to verify-by-default
+// without requiring users to discover and export the env var.
 func TrustedKey() (ed25519.PublicKey, bool, error) {
+	return trustedKeyWithDefault(DefaultTrustedKeyHex)
+}
+
+// trustedKeyWithDefault is the test-friendly form of TrustedKey —
+// callers inject the default explicitly so the unit suite can
+// exercise both the "default unset" (legacy warn-only) and
+// "default present" (fresh-clone verify) branches without rewriting
+// package-level state.
+func trustedKeyWithDefault(defaultHex string) (ed25519.PublicKey, bool, error) {
 	raw := strings.TrimSpace(os.Getenv(TrustedKeyEnv))
+	if raw == "" {
+		raw = strings.TrimSpace(defaultHex)
+	}
 	if raw == "" {
 		return nil, false, nil
 	}

--- a/internal/toolchain/selfhostcache/signing_test.go
+++ b/internal/toolchain/selfhostcache/signing_test.go
@@ -29,6 +29,72 @@ func TestParseTrustedKeyAcceptsValidHex(t *testing.T) {
 	}
 }
 
+func TestTrustedKeyEnvWinsOverDefault(t *testing.T) {
+	envPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey env: %v", err)
+	}
+	defaultPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey default: %v", err)
+	}
+	t.Setenv(TrustedKeyEnv, hex.EncodeToString(envPub))
+	got, ok, err := trustedKeyWithDefault(hex.EncodeToString(defaultPub))
+	if err != nil {
+		t.Fatalf("trustedKeyWithDefault: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected key configured")
+	}
+	if !got.Equal(envPub) {
+		t.Errorf("env should win over default")
+	}
+}
+
+func TestTrustedKeyFallsBackToDefault(t *testing.T) {
+	defaultPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	t.Setenv(TrustedKeyEnv, "")
+	got, ok, err := trustedKeyWithDefault(hex.EncodeToString(defaultPub))
+	if err != nil {
+		t.Fatalf("trustedKeyWithDefault: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected default to activate verification")
+	}
+	if !got.Equal(defaultPub) {
+		t.Errorf("default key not returned")
+	}
+}
+
+func TestTrustedKeyDisabledWhenAllEmpty(t *testing.T) {
+	t.Setenv(TrustedKeyEnv, "")
+	_, ok, err := trustedKeyWithDefault("")
+	if err != nil {
+		t.Fatalf("trustedKeyWithDefault: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false when both env and default are empty (warn-only)")
+	}
+}
+
+func TestDefaultTrustedKeyHexIsValidOrEmpty(t *testing.T) {
+	// Sanity-pin: the committed constant must either be the empty
+	// string (warn-only) or a 64-char hex ed25519 pubkey. Anything
+	// in between (e.g. an accidental partial paste) would silently
+	// downgrade fresh clones to no-verification with a malformed-key
+	// error consumed by EnvFetcher().
+	v := strings.TrimSpace(DefaultTrustedKeyHex)
+	if v == "" {
+		return
+	}
+	if _, err := ParseTrustedKey(v); err != nil {
+		t.Fatalf("DefaultTrustedKeyHex is set but malformed: %v", err)
+	}
+}
+
 func TestParseTrustedKeyRejectsBadInput(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Five-commit series implementing the "option (C) registry hot path" decided across the Q1–Q5 grilling. Closes the fresh-clone bootstrap gap by giving the upstream rolling release `osty-self-snapshots` a publish workflow + client-side default URL + signing infrastructure + verification job + operator playbooks.

| commit | scope |
|---|---|
| `feat(toolchain): hosted-runner publish workflow + client default registry URL` | `build-osty-self.yml` rewrite (5 hosted runners, reproducibility env, prior-seed fetch, force-update seed publish), `selfhostcache.DefaultRegistryURL` const + `envFetcherWithDefault` helper |
| `feat(toolchain): trust-key default + security operations docs` | `selfhostcache.DefaultTrustedKeyHex` + `trustedKeyWithDefault` helper, `docs/security/{trusted-keys,signing-rotation,bootstrap-recovery}.md` |
| `chore(ci): weekly fresh-clone bootstrap smoke test (B1 verification)` | `bootstrap-smoke-test.yml` — Sunday cron + auto-issue on failure |
| `docs(toolchain): self-host registry §8 RESOLVED + design archives` | `osty_self_artifact_design.md §8` six decisions resolved, b1/b2 audits archived in favour of b2_1, new `docs/operations/self_host_registry_setup.md`, README Bootstrapping section updated |
| `docs(operations): first-publish playbook for the rolling release` | `docs/operations/first-publish-playbook.md` — maintainer manual ops to seed the rolling release once |

## Test plan

- [x] `go build ./internal/toolchain/selfhostcache/ ./cmd/osty ./cmd/osty-native-lirproto` clean
- [x] `go test ./internal/toolchain/selfhostcache/` PASS (4 new EnvFetcher cases + 4 new TrustedKey cases + 2 sanity-pin)
- [x] `actionlint .github/workflows/{build-osty-self,bootstrap-smoke-test}.yml` clean (no shellcheck/runner-label issues)
- [ ] Manual workflow_dispatch of `Build osty-self` after merge (advisory mode — `vars.OSTY_SELF_REGISTRY_URL` still unset)
- [ ] First-publish playbook §1–§7 run by maintainer (~1h wall-clock; sets `vars.OSTY_SELF_REGISTRY_URL`, populates `DefaultTrustedKeyHex`, seeds the rolling release)
- [ ] `bootstrap-smoke-test.yml` weekly cron green

## Decisions captured (Q1–Q5 grilling)

| Q | Resolution |
|---|---|
| Q1 runners | 5 GA-stable hosted runners; `windows-arm64` deferred until `windows-11-arm` GA |
| Q2 storage | GitHub Releases, rolling tag `osty-self-snapshots` |
| Q3 trigger | `paths: toolchain/**` push + `workflow_dispatch` + Monday cron backfill |
| Q4 signing | single maintainer + 1Password backup; incident-driven rotation; repo-committed `DefaultTrustedKeyHex`; warn-only by default until first key |
| Q5 source | rolling release stores cache entries (immutable) + `osty-self-latest-<triple>.bin` (rolling seed); first round = Docker for linux-{amd64,arm64} + maintainer Mac for darwin-arm64 + collaborator-or-defer for darwin-amd64/windows-amd64; subsequent rounds self-perpetuate |

## Notes

- **Stage0 P21+ is a live workstream on main** (PRs #1494, B2.2/B2.3/B2.4 mechanical match rewrites). The §8 governance commit positions stage0 as emergency-only / disaster-recovery layer, not as a replacement for the registry path. Coverage measured on this branch: `usesFrontEndAIRepair` (5-arm String OR-chain) still declines under `OSTY_STAGE0_FALLBACK=1` — confirms registry path remains the production hot path.
- **No conflict on rebase**: base was `83eb5c6d` (#1468); rebase onto `origin/main` (#1522) was clean for the selfhostcache + workflow + new-docs surfaces. README absorbed the `#1485` AI-friendly metadata header automatically.
- **B1/B2 archive markers**: the b1_findings / b2_audit ARCHIVED headers point readers at the active `b2_1_audit.md` for the source-of-truth measurement (11.3% MIR coverage). The B2 mechanical rewrites continue on main; archives describe the publish-infra decision tree, not the stage0 expansion roadmap.