### PR TITLE
chore(security): activate initial osty-self signing key

### DIFF
--- a/docs/security/trusted-keys.md
+++ b/docs/security/trusted-keys.md
@@ -9,10 +9,7 @@
 
 | Status | Key ID (first 16 hex) | Full hex (64 chars) | Activated | Notes |
 |---|---|---|---|---|
-| _none_ | _no signing key configured yet_ | — | — | warn-only mode (A6 default) |
-
-The first row will be replaced once a maintainer runs the bootstrap
-key generation flow (see [`signing-rotation.md`](signing-rotation.md)).
+| **active** | `47a2fccb88dee314` | `47a2fccb88dee314ec7b32d16b223f20c0108de7812427065c2f29c7d65fa2e3` | 2026-05-08 | Initial production key. Generated alongside the first-publish playbook run. |
 
 ## 2. Verification — what fresh clones do
 

--- a/internal/toolchain/selfhostcache/default_trusted_key.go
+++ b/internal/toolchain/selfhostcache/default_trusted_key.go
@@ -22,4 +22,4 @@ package selfhostcache
 // over default). Disable verification entirely: blank both. The env
 // var path also lets a fork user run a private registry without
 // touching this constant.
-const DefaultTrustedKeyHex = ""
+const DefaultTrustedKeyHex = "47a2fccb88dee314ec7b32d16b223f20c0108de7812427065c2f29c7d65fa2e3"


### PR DESCRIPTION
## Summary

First-publish playbook §1 — activate the initial ed25519 signing key.

- `osty sign-self genkey` ran on the maintainer machine
- Private key uploaded to repo secret \`OSTY_SELF_SIGNING_KEY\`
- Public key (fingerprint: \`47a2fccb88dee314\`) committed as \`DefaultTrustedKeyHex\`
- \`docs/security/trusted-keys.md\` §1 active row populated

After merge, every \`Build osty-self\` workflow run produces detached \`.json.sig\` files alongside cache manifests, and fresh clones verify by default with no env-var dance.

## Custody (Q4-a)

- Repo secret: ✅ uploaded
- 1Password backup: **maintainer manual step** — see \`docs/security/signing-rotation.md\` §1 step 1.2

## Test plan

- [x] \`go test ./internal/toolchain/selfhostcache/\` — \`TestDefaultTrustedKeyHexIsValidOrEmpty\` (sanity-pin) passes with the new value
- [ ] After merge: \`workflow_dispatch\` of \`Build osty-self\` produces \`.json.sig\` files (manifest signing path active)