### PR TITLE
test(toolchain): lock interface layout bridge

### DIFF
--- a/LLVM_BACKEND_GAP_PLAN.md
+++ b/LLVM_BACKEND_GAP_PLAN.md
@@ -196,6 +196,9 @@ Go MIR emitter 미러는 PR #1405에서 제거됐다 (`internal/llvmgen` 112K LO
 **E1 — Interface type lowering + boxing layout 정의** (GAP-IFACE-001, 002)
 - `lirLowerMirType_module`에 interface case 추가 → `%osty.iface = type { ptr, ptr }` 자동 emit.
 - HIR/MIR 단계에서 boxing site 식별 (let site `let s: Iface = concrete`).
+- 진행: PR #1522에서 self-host MIR layout table과 LIR Proto가 interface 타입을 `%osty.iface`
+  fat-pointer layout으로 낮추는 E1 토대를 열었다. 후속 회귀락은 Go MIR lowering/JSON bridge가
+  method slot과 `(impl, iface)` vtable symbol을 보존하는지 고정한다. Boxing site materialization은 E3에 남김.
 - 회귀: 1 IR snapshot fixture.
 
 **E2 — Vtable + per-method shim emission** (GAP-IFACE-004, 005)

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -146,6 +146,58 @@ func TestValidateRejectsDuplicateSymbol(t *testing.T) {
 
 // ==== lowering tests ====
 
+func TestLowerBuildsInterfaceLayouts(t *testing.T) {
+	sized := &ir.InterfaceDecl{
+		Name: "Sized",
+		Methods: []*ir.FnDecl{{
+			Name:   "size",
+			Params: []*ir.Param{{Name: "self", Type: &ir.NamedType{Name: "Sized"}}},
+			Return: ir.TInt,
+		}},
+	}
+	vec := &ir.StructDecl{
+		Name:   "Vec",
+		Fields: []*ir.Field{{Name: "count", Type: ir.TInt}},
+		Methods: []*ir.FnDecl{{
+			Name:   "size",
+			Params: []*ir.Param{{Name: "self", Type: &ir.NamedType{Name: "Vec"}}},
+			Return: ir.TInt,
+			Body:   &ir.Block{Result: &ir.IntLit{Text: "0", T: ir.TInt}},
+		}},
+	}
+	color := &ir.EnumDecl{
+		Name:     "Color",
+		Variants: []*ir.Variant{{Name: "Red"}},
+		Methods: []*ir.FnDecl{{
+			Name:   "size",
+			Params: []*ir.Param{{Name: "self", Type: &ir.NamedType{Name: "Color"}}},
+			Return: ir.TInt,
+			Body:   &ir.Block{Result: &ir.IntLit{Text: "0", T: ir.TInt}},
+		}},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{sized, vec, color}}
+	out := Lower(mod)
+	if out == nil || out.Layouts == nil {
+		t.Fatalf("Lower returned missing layouts")
+	}
+	layout := out.Layouts.Interfaces["Sized"]
+	if layout == nil {
+		t.Fatalf("interface layout missing: %#v", out.Layouts.Interfaces)
+	}
+	if len(layout.Methods) != 1 || layout.Methods[0].Name != "size" || layout.Methods[0].Slot != 0 {
+		t.Fatalf("interface methods = %#v, want size slot 0", layout.Methods)
+	}
+	if len(layout.Impls) != 2 {
+		t.Fatalf("interface impls = %#v, want Vec and Color", layout.Impls)
+	}
+	if layout.Impls[0].ImplName != "Vec" || layout.Impls[0].VtableSym != "@osty.vtable.Vec__Sized" {
+		t.Fatalf("first interface impl = %#v, want Vec", layout.Impls[0])
+	}
+	if layout.Impls[1].ImplName != "Color" || layout.Impls[1].VtableSym != "@osty.vtable.Color__Sized" {
+		t.Fatalf("second interface impl = %#v, want Color", layout.Impls[1])
+	}
+}
+
 // helper: wrap a single statement into a main() function and lower.
 func lowerHIR(t *testing.T, decl *ir.FnDecl) *Module {
 	t.Helper()

--- a/internal/mirjson/json_test.go
+++ b/internal/mirjson/json_test.go
@@ -30,6 +30,16 @@ func TestModuleRoundTripPreservesMIREmissionShape(t *testing.T) {
 	if decoded.Layouts.Structs["pkg.Point"] == nil {
 		t.Fatalf("qualified struct layout key was not preserved: %#v", decoded.Layouts.Structs)
 	}
+	if got := decoded.Layouts.Interfaces["pkg.Sized"]; got == nil {
+		t.Fatalf("qualified interface layout key was not preserved: %#v", decoded.Layouts.Interfaces)
+	} else {
+		if len(got.Methods) != 1 || got.Methods[0].Name != "size" || got.Methods[0].Slot != 0 {
+			t.Fatalf("interface methods = %#v, want size slot 0", got.Methods)
+		}
+		if len(got.Impls) != 1 || got.Impls[0].ImplName != "Point" || got.Impls[0].VtableSym != "@osty.vtable.Point__Sized" {
+			t.Fatalf("interface impls = %#v, want Point vtable", got.Impls)
+		}
+	}
 }
 
 func roundTripFixtureMIR() *mir.Module {
@@ -50,6 +60,17 @@ func roundTripFixtureMIR() *mir.Module {
 		Name:    "Point",
 		Mangled: "Point",
 		Fields:  []mir.FieldLayout{{Index: 0, Name: "x", Type: ir.TInt}},
+	}
+	layouts.Interfaces["pkg.Sized"] = &mir.InterfaceLayout{
+		Name: "Sized",
+		Methods: []mir.InterfaceMethod{{
+			Name: "size",
+			Slot: 0,
+		}},
+		Impls: []mir.InterfaceImpl{{
+			ImplName:  "Point",
+			VtableSym: "@osty.vtable.Point__Sized",
+		}},
 	}
 	return &mir.Module{Package: "main", Functions: []*mir.Function{fn}, Layouts: layouts}
 }


### PR DESCRIPTION
## Summary
- document the already-merged E1 interface layout production path in the LLVM backend gap plan
- add Go MIR lowering coverage for interface method slots and impl vtable symbols
- extend MIR JSON roundtrip coverage so interface layout metadata survives the bridge

## Validation
- git diff --check
- go test -count=1 -vet=off ./internal/mir -run TestLowerBuildsInterfaceLayouts
- go test -count=1 -vet=off ./internal/mirjson -run TestModuleRoundTripPreservesMIREmissionShape
- go test -count=1 -vet=off ./internal/selfhost -run TestCheckSnapshot