### PR TITLE
feat(ir,mir): G22 loop { break value } expression lowering

### DIFF
--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -129,7 +129,7 @@ func cloneNode(n Node) Node {
 	case *ReturnStmt:
 		return &ReturnStmt{Value: cloneExprOrNil(n.Value), SpanV: n.SpanV}
 	case *BreakStmt:
-		return &BreakStmt{Label: n.Label, SpanV: n.SpanV}
+		return &BreakStmt{Label: n.Label, Value: cloneExprOrNil(n.Value), SpanV: n.SpanV}
 	case *ContinueStmt:
 		return &ContinueStmt{Label: n.Label, SpanV: n.SpanV}
 	case *IfStmt:
@@ -466,7 +466,7 @@ func cloneStmt(s Stmt) Stmt {
 	case *ReturnStmt:
 		return &ReturnStmt{Value: cloneExprOrNil(s.Value), SpanV: s.SpanV}
 	case *BreakStmt:
-		return &BreakStmt{Label: s.Label, SpanV: s.SpanV}
+		return &BreakStmt{Label: s.Label, Value: cloneExprOrNil(s.Value), SpanV: s.SpanV}
 	case *ContinueStmt:
 		return &ContinueStmt{Label: s.Label, SpanV: s.SpanV}
 	case *IfStmt:
@@ -646,6 +646,13 @@ func cloneExpr(e Expr) Expr {
 	case *BlockExpr:
 		return &BlockExpr{
 			Block: cloneBlockOrNil(e.Block),
+			T:     CloneType(e.T),
+			SpanV: e.SpanV,
+		}
+	case *LoopExpr:
+		return &LoopExpr{
+			Label: e.Label,
+			Body:  cloneBlockOrNil(e.Body),
 			T:     CloneType(e.T),
 			SpanV: e.SpanV,
 		}

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -715,8 +715,11 @@ func (r *ReturnStmt) At() Span { return r.SpanV }
 
 // BreakStmt exits the targeted loop.
 // Label is empty for the innermost enclosing loop.
+// Value is the optional expression on `break <expr>` (G22), only
+// legal inside a `loop { … }` expression. Nil for bare `break`.
 type BreakStmt struct {
 	Label string
+	Value Expr
 	SpanV Span
 }
 
@@ -1079,6 +1082,20 @@ type BlockExpr struct {
 func (*BlockExpr) exprNode()    {}
 func (b *BlockExpr) At() Span   { return b.SpanV }
 func (b *BlockExpr) Type() Type { return b.T }
+
+// LoopExpr is `loop { … }` — an infinite loop whose value is the
+// `break <expr>` that exits it (G22, §A.4). The type is Never when
+// no break-value exists; otherwise the join of all break values.
+type LoopExpr struct {
+	Label string
+	Body  *Block
+	T     Type
+	SpanV Span
+}
+
+func (*LoopExpr) exprNode()    {}
+func (l *LoopExpr) At() Span   { return l.SpanV }
+func (l *LoopExpr) Type() Type { return l.T }
 
 // IfExpr is an `if` used in expression position. Both arms are
 // guaranteed present; statement-form `if` without else lowers to

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1010,7 +1010,11 @@ func (l *lowerer) lowerStmt(s ast.Stmt) Stmt {
 		}
 		return out
 	case *ast.BreakStmt:
-		return &BreakStmt{Label: s.Label, SpanV: nodeSpan(s)}
+		out := &BreakStmt{Label: s.Label, SpanV: nodeSpan(s)}
+		if s.Value != nil {
+			out.Value = l.lowerExpr(s.Value)
+		}
+		return out
 	case *ast.ContinueStmt:
 		return &ContinueStmt{Label: s.Label, SpanV: nodeSpan(s)}
 	case *ast.AssignStmt:
@@ -1555,6 +1559,8 @@ func (l *lowerer) lowerExpr(e ast.Expr) Expr {
 		return l.lowerClosure(e)
 	case *ast.TurbofishExpr:
 		return l.lowerTurbofish(e)
+	case *ast.LoopExpr:
+		return l.lowerLoopExpr(e)
 	}
 	l.note("unsupported expression %T at %v", e, e.Pos())
 	return &ErrorExpr{Note: fmt.Sprintf("%T", e), T: ErrTypeVal, SpanV: nodeSpan(e)}
@@ -3633,6 +3639,19 @@ func (l *lowerer) lowerTurbofish(tf *ast.TurbofishExpr) Expr {
 	}
 	l.note("bare turbofish at %v attached to non-ident base; type args dropped", tf.Pos())
 	return base
+}
+
+func (l *lowerer) lowerLoopExpr(e *ast.LoopExpr) Expr {
+	t := l.exprType(e)
+	if t == nil || t == ErrTypeVal {
+		t = TUnit
+	}
+	return &LoopExpr{
+		Label: e.Label,
+		Body:  l.lowerBlock(e.Body),
+		T:     t,
+		SpanV: nodeSpan(e),
+	}
 }
 
 func (l *lowerer) lowerMatchStmt(m *ast.MatchExpr) Stmt {

--- a/internal/ir/print.go
+++ b/internal/ir/print.go
@@ -243,9 +243,21 @@ func (p *printer) printStmt(s Stmt) {
 		p.b.WriteByte(')')
 	case *BreakStmt:
 		if s.Label != "" {
-			p.writef("(break '%s)", s.Label)
+			if s.Value != nil {
+				p.writef("(break '%s ", s.Label)
+				p.printExpr(s.Value)
+				p.b.WriteByte(')')
+			} else {
+				p.writef("(break '%s)", s.Label)
+			}
 		} else {
-			p.b.WriteString("(break)")
+			if s.Value != nil {
+				p.b.WriteString("(break ")
+				p.printExpr(s.Value)
+				p.b.WriteByte(')')
+			} else {
+				p.b.WriteString("(break)")
+			}
 		}
 	case *ContinueStmt:
 		if s.Label != "" {
@@ -559,6 +571,14 @@ func (p *printer) printExpr(e Expr) {
 		p.b.WriteByte(')')
 	case *BlockExpr:
 		p.printBlock(e.Block)
+	case *LoopExpr:
+		p.b.WriteString("(loop")
+		if e.Label != "" {
+			p.writef(" '%s", e.Label)
+		}
+		p.b.WriteByte(' ')
+		p.printBlock(e.Body)
+		p.b.WriteByte(')')
 	case *IfExpr:
 		p.b.WriteString("(if-expr ")
 		p.printExpr(e.Cond)

--- a/internal/ir/subst.go
+++ b/internal/ir/subst.go
@@ -159,8 +159,11 @@ func subst(n Node, env SubstEnv) {
 		if n.Value != nil {
 			subst(n.Value, env)
 		}
-	case *BreakStmt, *ContinueStmt:
-		// leaves
+	case *BreakStmt:
+		if n.Value != nil {
+			subst(n.Value, env)
+		}
+	case *ContinueStmt:
 	case *IfStmt:
 		if n.Cond != nil {
 			subst(n.Cond, env)
@@ -301,6 +304,11 @@ func subst(n Node, env SubstEnv) {
 		n.T = substType(n.T, env)
 		if n.Block != nil {
 			subst(n.Block, env)
+		}
+	case *LoopExpr:
+		n.T = substType(n.T, env)
+		if n.Body != nil {
+			subst(n.Body, env)
 		}
 	case *IfExpr:
 		n.T = substType(n.T, env)

--- a/internal/ir/validate.go
+++ b/internal/ir/validate.go
@@ -239,8 +239,11 @@ func (v *validator) validateStmt(s Stmt) {
 		if s.Value != nil {
 			v.validateExpr(s.Value)
 		}
-	case *BreakStmt, *ContinueStmt:
-		// leaves
+	case *BreakStmt:
+		if s.Value != nil {
+			v.validateExpr(s.Value)
+		}
+	case *ContinueStmt:
 	case *IfStmt:
 		if s.Cond == nil {
 			v.addf("IfStmt: nil Cond")
@@ -454,6 +457,10 @@ func (v *validator) validateExpr(e Expr) {
 		}
 	case *BlockExpr:
 		v.validateBlock(e.Block)
+	case *LoopExpr:
+		if e.Body != nil {
+			v.validateBlock(e.Body)
+		}
 	case *IfExpr:
 		v.validateExpr(e.Cond)
 		v.validateBlock(e.Then)

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -571,15 +571,10 @@ type loopFrame struct {
 	label         string
 	breakBlock    BlockID
 	continueBlock BlockID
-	// deferDepth records the defer-frame depth active at the top of
-	// the loop body. `break` and `continue` unwind inner frames
-	// *inclusive* of this one — every iteration enters the body
-	// scope fresh, so the body's defers run on both exit paths.
-	deferDepth int
-	// scopeDepth records the local-scope depth of the loop body so
-	// break/continue can retire loop-body locals before control jumps
-	// to the header/step/exit blocks.
-	scopeDepth int
+	deferDepth    int
+	scopeDepth    int
+	resultLocal   LocalID
+	resultType    Type
 }
 
 func newBodyState(l *lowerer, fn *Function) *bodyState {
@@ -1322,6 +1317,14 @@ func (bs *bodyState) lowerBreak(b *ir.BreakStmt) {
 			bs.l.noteIssue("break to undefined loop label")
 			return
 		}
+	}
+	if b.Value != nil && top.resultLocal != 0 {
+		rv := bs.lowerExprAsOperand(b.Value)
+		bs.emit(&AssignInstr{
+			Dest:  Place{Local: top.resultLocal},
+			Src:   &UseRV{Op: rv},
+			SpanV: b.SpanV,
+		})
 	}
 	bs.replayDefersFromDepth(top.deferDepth, b.SpanV)
 	bs.emitStorageDeadFromDepth(top.scopeDepth)
@@ -2496,6 +2499,9 @@ func (bs *bodyState) lowerExprIntoPlace(e ir.Expr, dest Place, destT Type) {
 		return
 	case *ir.IfExpr:
 		bs.lowerIfExprInto(x, dest, destT)
+		return
+	case *ir.LoopExpr:
+		bs.lowerLoopExprInto(x, dest, destT)
 		return
 	case *ir.IfLetExpr:
 		bs.lowerIfLetExprInto(x, dest, destT)
@@ -4131,7 +4137,47 @@ func (bs *bodyState) lowerBlockExprInto(be *ir.BlockExpr, dest Place, destT Type
 	bs.popScope()
 }
 
-// lowerIfLetExprInto handles `if let pat = scrut { … } else { … }`.
+func (bs *bodyState) lowerLoopExprInto(le *ir.LoopExpr, dest Place, destT Type) {
+	resultLocal := bs.newLocal("loop.result", destT, false, le.SpanV)
+	header := bs.newBlock(le.SpanV)
+	body := bs.newBlock(le.SpanV)
+	exit := bs.newBlock(le.SpanV)
+	bs.terminate(&GotoTerm{Target: header, SpanV: le.SpanV})
+	bs.cur = header
+	bs.terminate(&GotoTerm{Target: body, SpanV: le.SpanV})
+	bs.cur = body
+	bs.pushScope()
+	bs.pushDeferScope()
+	bs.loopStack = append(bs.loopStack, &loopFrame{
+		label:         le.Label,
+		breakBlock:    exit,
+		continueBlock: header,
+		deferDepth:    len(bs.deferFrames) - 1,
+		scopeDepth:    bs.currentScopeDepth(),
+		resultLocal:   resultLocal,
+		resultType:    destT,
+	})
+	if le.Body != nil {
+		for _, s := range le.Body.Stmts {
+			bs.lowerStmt(s)
+		}
+	}
+	bs.replayTopFrame(le.SpanV)
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.popDeferScope()
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: header, SpanV: le.SpanV})
+	bs.cur = exit
+	if destT != nil && !isPoisonType(destT) {
+		bs.emit(&AssignInstr{
+			Dest:  dest,
+			Src:   &UseRV{Op: &CopyOp{Place: Place{Local: resultLocal}, T: destT}},
+			SpanV: le.SpanV,
+		})
+	}
+}
+
+// lowerIfLetExprInto handles `if let pat = scrut { … } else { … }`. handles `if let pat = scrut { … } else { … }`.
 // It lowers into a discriminant test + payload binding for Option /
 // enum variants, and falls back to an unsupported note otherwise.
 func (bs *bodyState) lowerIfLetExprInto(ife *ir.IfLetExpr, dest Place, destT Type) {

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -273,12 +273,53 @@ func TestLowerWhileLoop(t *testing.T) {
 	})
 	mod := lowerHIR(t, fn)
 	text := Print(mod)
-	// Expect a branch on the condition and a back-edge goto.
 	if strings.Count(text, "goto -> bb") < 2 {
 		t.Fatalf("expected two gotos for while header/back-edge, got:\n%s", text)
 	}
 	if !strings.Contains(text, "branch ") {
 		t.Fatalf("expected branch for while cond, got:\n%s", text)
+	}
+}
+
+func TestLowerLoopExprBreakValue(t *testing.T) {
+	fn := mkFn("find", ir.TInt, &ir.Block{
+		Result: &ir.LoopExpr{
+			Body: &ir.Block{
+				Stmts: []ir.Stmt{
+					&ir.BreakStmt{Value: &ir.IntLit{Text: "42", T: ir.TInt}},
+				},
+			},
+			T: ir.TInt,
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "goto -> bb") {
+		t.Fatalf("expected goto for loop header, got:\n%s", text)
+	}
+	if !strings.Contains(text, "use const 42 Int") {
+		t.Fatalf("expected break value 42, got:\n%s", text)
+	}
+	if !strings.Contains(text, "_0 = use _1") {
+		t.Fatalf("expected copy from result to return slot, got:\n%s", text)
+	}
+}
+
+func TestLowerLoopExprNoValue(t *testing.T) {
+	fn := mkFn("spin", ir.TUnit, &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.ExprStmt{X: &ir.LoopExpr{
+				Body: &ir.Block{
+					Stmts: []ir.Stmt{},
+				},
+				T: ir.TUnit,
+			}},
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if strings.Count(text, "goto -> bb") < 2 {
+		t.Fatalf("expected gotos for infinite loop, got:\n%s", text)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `LoopExpr` to IR (`internal/ir/ir.go`) as a proper expression node with label, body, and result type (G22, §A.4)
- Add `Value Expr` field to `ir.BreakStmt` to carry the optional break expression
- Wire `ast.LoopExpr → ir.LoopExpr` lowering in `internal/ir/lower.go`, propagating break values
- Add MIR lowering for `LoopExpr` (`internal/mir/lower.go`): allocates result local, break-value stores into it, copies to destination after exit block
- Update `ir/clone.go`, `ir/subst.go`, `ir/validate.go`, `ir/print.go` for both new/changed types
- Add 2 new tests: `TestLowerLoopExprBreakValue` (break with value → result copy to return slot), `TestLowerLoopExprNoValue` (bare infinite loop as statement)

## Test plan
- [x] `go vet ./...` clean
- [x] `gofmt` clean
- [x] `go test ./internal/ir/... ./internal/mir/...` all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)