### PR TITLE
fix(toolchain): use List.len() instead of .length on cfg arg children

### DIFF
--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -2996,7 +2996,7 @@ fn srCheckCfgArg(
         let callee = srAstNode(file, arg.left)
         if callee.kind == AstNIdent && (callee.text == "all" || callee.text == "any" || callee.text == "not") {
             let mut out = result
-            if callee.text == "not" && arg.children.length != 1 {
+            if callee.text == "not" && arg.children.len() != 1 {
                 out.diagnostics.push(selfResolveDiagnosticHintAtNode(
                     "E0739",
                     "`not(...)` requires exactly one argument",
@@ -3101,7 +3101,7 @@ fn srCfgArgIdxPasses(file: AstFile, argIdx: Int, cfg: SelfResolveCfgEnv) -> Bool
                 return false
             }
             if callee.text == "not" {
-                if arg.children.length == 1 {
+                if arg.children.len() == 1 {
                     return !srCfgArgIdxPasses(file, arg.children[0], cfg)
                 }
                 return false


### PR DESCRIPTION
## Summary

\`arg.children\` is \`List<AstNodeIdx>\` but two sites in \`srCfgArgIdxPasses\` (toolchain/resolve.osty:2999, 3104) were calling \`.length\` (legacy / foreign field-style). The v0.6 checker now rejects this with \`E0702: no field 'length' on type 'List'\`, blocking \`osty install-self\` at the front-end stage before MIR is even handed to the LIR Proto subprocess.

\`\`\`osty
- if callee.text == "not" && arg.children.length != 1 {
+ if callee.text == "not" && arg.children.len() != 1 {

- if arg.children.length == 1 {
+ if arg.children.len() == 1 {
\`\`\`

Discovered while running the first-publish playbook §2.1 (darwin-arm64 native bootstrap seed) — the build host's checker rejected toolchain/ on type errors before stage1 lowering could start.

## Test plan

- [x] \`osty install-self\` reaches stage1 lowering after this fix (no more \`E0702\` on resolve.osty)
- [ ] CI green