### PR TITLE
perf(airepair): tag-type fast path + skip .length rewrite (3.8× on mir_generator)

### DIFF
--- a/internal/airepair/semantic.go
+++ b/internal/airepair/semantic.go
@@ -356,6 +356,11 @@ func parseAppendCall(expr string) (string, string, bool) {
 }
 
 func rewriteLengthProperties(src []byte) ([]byte, []repair.Change, bool) {
+	// validLengthFieldOffsets runs the full lex/lower/resolve/check
+	// pipeline; skip it when the source has no `.length` to rewrite.
+	if !bytes.Contains(src, []byte(".length")) {
+		return src, nil, false
+	}
 	toks := lexer.New(src).Lex()
 	protected := validLengthFieldOffsets(src)
 	var edits []semanticEdit

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -170,11 +170,51 @@ func resultMapErr[T any, E any, F any](r Result[T, E], f func(E) F) Result[T, F]
 	return resultErr[T, F](f(r.Error))
 }
 
+// ostyTagTypeCache caches the result of ostyIsTagType per reflect.Type.
+// Tag-discriminant types (single `_ref byte` field) are the bulk of the
+// ostyEqual call shape `ostyEqual(value, KindType(&KindType_Variant{}))`,
+// and the lookup is hit ~25M times on big self-host inputs.
+var ostyTagTypeCache sync.Map // reflect.Type -> bool
+
+// ostyIsTagType reports whether t is a pointer to a single-field
+// `_ref byte` tag struct. The selfhost code generator emits these for
+// every sum-type variant; their `_ref` is always zero, so two values of
+// the same dynamic type are always equal.
+func ostyIsTagType(t reflect.Type) bool {
+	if t == nil || t.Kind() != reflect.Pointer {
+		return false
+	}
+	if v, ok := ostyTagTypeCache.Load(t); ok {
+		return v.(bool)
+	}
+	elem := t.Elem()
+	isTag := elem.Kind() == reflect.Struct &&
+		elem.NumField() == 1 &&
+		elem.Field(0).Name == "_ref"
+	ostyTagTypeCache.Store(t, isTag)
+	return isTag
+}
+
 func ostyEqual(a, b any) bool {
 	av := reflect.ValueOf(a)
 	bv := reflect.ValueOf(b)
 	if !av.IsValid() || !bv.IsValid() {
 		return ostyIsNilValue(av) && ostyIsNilValue(bv)
+	}
+	at, bt := av.Type(), bv.Type()
+	// Fast path: differing dynamic types skip the seen-map allocation.
+	// Mirrors ostyEqualValue's type-mismatch fall-through.
+	if at != bt {
+		return ostyIsNilValue(av) && ostyIsNilValue(bv)
+	}
+	// Fast path: tag-discriminant types are equal whenever their dynamic
+	// types match (the `_ref` field is always zero). Saves ~57% of CPU
+	// on self-host inputs by short-circuiting deep reflect.
+	if ostyIsTagType(at) {
+		if av.IsNil() || bv.IsNil() {
+			return av.IsNil() == bv.IsNil()
+		}
+		return true
 	}
 	return ostyEqualValue(av, bv, map[ostyEqualVisit]bool{})
 }


### PR DESCRIPTION
## Summary

Two surgical fixes that drop `osty repair --check toolchain/mir_generator.osty` from **99s → ~26s (3.8×)** on the biggest `.osty` file in the tree.

### 1. `ostyEqual` tag-type fast path ([internal/selfhost/generated.go](internal/selfhost/generated.go))

The selfhost generator emits sum-type variants as `*Variant{_ref byte}` pointers and compares them with the shape:

```go
ostyEqual(value, Kind(&Kind_Variant{}))
```

The reflect-driven deep walk allocates a `seen` map and recurses for what is morally a one-byte type-tag check. The cached fast path returns true whenever both args share the same dynamic type and that type is a single-`_ref byte` struct pointer. The `_ref` field is **always zero** (`grep -E "_ref:\s*[1-9]" generated.go` → 0 matches), so this is sound.

**Impact**: 99s → 38s.

### 2. Skip `rewriteLengthProperties` when source has no `.length` ([internal/airepair/semantic.go](internal/airepair/semantic.go))

`rewriteLengthProperties` calls `validLengthFieldOffsets`, which runs the full lex/lower/resolve/check pipeline to learn which `.length` reads are real struct fields and shouldn't be rewritten to `.len()`. On `toolchain/mir_generator.osty`:
- `.length` occurrences: **0**
- `len(...)` occurrences: 202

The existing `wantsSemanticRepair` gate fires on `len(`, but the length rewriter still ran a full pipeline pass for nothing. A `bytes.Contains(src, []byte(".length"))` short-circuit fixes it.

**Impact**: 38s → 26s.

## Profile (before vs after)

| Top consumer | Before (99s) | After (~26s) |
|---|---:|---:|
| `selfhost.ostyJoinDocLines` (via `ostyEqual`) | 29.85s | 6.6s |
| `selfhost.ostyEqual` cum | 27.64s | 5.2s |
| `airepair.validLengthFieldOffsets` | 13.52s | ~0s |
| `airepair.diagnosticSemanticSource` | 21.87s | ~0s on this file |

Profile captured via a small standalone driver (not committed) calling `airepair.Analyze` directly with `runtime/pprof`. The `osty pipeline --cpuprofile` flag in main is currently broken (the dispatch flag specs in [internal/cli/dispatch.go](internal/cli/dispatch.go) are missing `--per-decl`, `--cpuprofile`, `--memprofile`, `--diagnostics`, `--gen`, `--emit`); fixing that is out of scope here.

## Why this is safe

- **Tag fast path soundness**: tag types have a single `_ref byte` field that is never assigned (zero matches in `generated.go` for `_ref: <nonzero>`). Two values of the same dynamic type therefore have identical fields and are reflect-equal. The fast path triggers only when both args have the same dynamic type AND the type is a `*<struct{_ref byte}>`.
- **Length-rewrite gate soundness**: `bytes.Contains(src, []byte(".length"))` is a strict superset of any sequence the rewriter would touch — without `.length` in source there is no possible edit to make. The skip preserves `(src, nil, false)`, the same return shape `rewriteLengthProperties` already uses on a no-edit path.

## Verification

Sanity check across files (errors counts and `changed` flag identical with and without the patch):

| File | size | elapsed (after) | errors_before | errors_after | changed |
|---|---:|---:|---:|---:|---:|
| `testdata/hello.osty` | 179 B | 18ms | 2 | 2 | false |
| `examples/regex_find_all/main.osty` | 1.9 KB | 39ms | 8 | 8 | true (passes=1) |
| `toolchain/check_env.osty` | 144 KB | 968ms | 504 | 504 | false |
| `toolchain/mir_generator.osty` | 868 KB | 26s | 588 | 588 | false |

## Pre-existing test failures (NOT introduced by this PR)

Verified by re-running on `origin/main` without these changes:

- `TestParseSnapshot/word_freq` (parse snapshot drift) — already failing on main.
- `TestParseMatchArmAllowsBareAssignmentBody` — already failing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)