### PR TITLE
test(toolchain): lock nested struct binding path

### DIFF
--- a/LLVM_BACKEND_GAP_PLAN.md
+++ b/LLVM_BACKEND_GAP_PLAN.md
@@ -177,6 +177,7 @@ Go MIR emitter 미러는 PR #1405에서 제거됐다 (`internal/llvmgen` 112K LO
 **C3 — Nested struct binding pattern** (GAP-INSTR-006) — Tier A (d)
 - `match user { User { addr: Address { city } } -> ... }` recursive `extractvalue` + `name @ pattern` alias.
 - 진행: `source_nested_struct_binding` source parity fixture가 `let whole @ User { addr: Address { city, zip }, score } = u`를 통해 whole-scrutinee alias + nested field extraction을 고정한다.
+- 진행: Go MIR lowering 회귀도 같은 shape를 `whole` alias store + `.addr.city`/`.addr.zip`/`.score` projected reads로 잠근다. LIR Proto catalog sentinel은 current-generator fixture set에 이 source parity fixture가 계속 포함되는지도 확인한다.
 - 회귀: `TestRunCoversNestedStructBindingPattern` (cmd/osty-native-llvmgen).
 - 의존성: A1 진단 가시화 권장.
 
@@ -272,7 +273,7 @@ F3 (별개): TestBundledRuntimeMap* link
 
 ## 8. 추후 audit 추가 항목
 
-- (TODO) cmd/osty-native-llvmgen 측 nested binding 회귀 (Tier A (d)) 정확한 코드 위치
+- cmd/osty-native-llvmgen 측 nested binding binary 회귀는 `osty-self` artifact가 있는 환경에서만 활성화한다. 로컬 기본 잠금은 Go MIR shape + LIR Proto source parity catalog로 유지.
 - (TODO) `MIRDirect` 라우트가 항상 `tryNativeOwnedMIRPayloadLLVMIRText`로 fallback하는 현재 로직 재검토 — 이중 호출 비효율
 - (TODO) 진짜 Tier B (pkgmgr 셀프-컴파일) 갭은 별도 audit. 현재 본 문서는 Tier A 범위.
 

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -481,6 +481,91 @@ func TestLowerStructLiteralAndField(t *testing.T) {
 	}
 }
 
+func TestLowerNestedStructBindingPatternKeepsAliasAndLeaves(t *testing.T) {
+	addressT := &ir.NamedType{Name: "Address"}
+	userT := &ir.NamedType{Name: "User"}
+	addressDecl := &ir.StructDecl{
+		Name: "Address",
+		Fields: []*ir.Field{
+			{Name: "city", Type: ir.TInt},
+			{Name: "zip", Type: ir.TInt},
+		},
+	}
+	userDecl := &ir.StructDecl{
+		Name: "User",
+		Fields: []*ir.Field{
+			{Name: "addr", Type: addressT},
+			{Name: "score", Type: ir.TInt},
+		},
+	}
+	fn := &ir.FnDecl{
+		Name:   "check",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "u", Type: userT}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Type: userT,
+					Pattern: &ir.BindingPat{Name: "whole", Pattern: &ir.StructPat{
+						TypeName: "User",
+						Fields: []ir.StructPatField{
+							{Name: "addr", Pattern: &ir.StructPat{
+								TypeName: "Address",
+								Fields: []ir.StructPatField{
+									{Name: "city"},
+									{Name: "zip"},
+								},
+							}},
+							{Name: "score"},
+						},
+					}},
+					Value: &ir.Ident{Name: "u", Kind: ir.IdentParam, T: userT},
+				},
+			},
+			Result: &ir.BinaryExpr{
+				Op: ir.BinAdd,
+				Left: &ir.BinaryExpr{
+					Op: ir.BinAdd,
+					Left: &ir.BinaryExpr{
+						Op: ir.BinAdd,
+						Left: &ir.FieldExpr{
+							X:    &ir.Ident{Name: "whole", Kind: ir.IdentLocal, T: userT},
+							Name: "score",
+							T:    ir.TInt,
+						},
+						Right: &ir.Ident{Name: "city", Kind: ir.IdentLocal, T: ir.TInt},
+						T:     ir.TInt,
+					},
+					Right: &ir.Ident{Name: "zip", Kind: ir.IdentLocal, T: ir.TInt},
+					T:     ir.TInt,
+				},
+				Right: &ir.Ident{Name: "score", Kind: ir.IdentLocal, T: ir.TInt},
+				T:     ir.TInt,
+			},
+		},
+	}
+	out := Lower(&ir.Module{Package: "main", Decls: []ir.Decl{addressDecl, userDecl, fn}})
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	for _, want := range []string{
+		"fn check(_1: User) -> Int",
+		"_3 = use _2",
+		".addr.city",
+		".addr.zip",
+		".score",
+		"+",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("lowered MIR missing %q:\n%s", want, text)
+		}
+	}
+	if out.Layouts == nil || out.Layouts.Structs["Address"] == nil || out.Layouts.Structs["User"] == nil {
+		t.Fatalf("expected nested struct layouts, got %#v", out.Layouts)
+	}
+}
+
 func TestLowerEnumMatch(t *testing.T) {
 	// enum Maybe { Some(Int), None }
 	// fn score(m: Maybe) -> Int { match m { Some(x) -> x, None -> 0 } }

--- a/toolchain/lir_proto_test.osty
+++ b/toolchain/lir_proto_test.osty
@@ -531,6 +531,7 @@ fn testLirProtoParityCatalogIsOstyOwned() {
     let currentNames = strings.join(lirParityFixtureNames(current), ",")
     assertLirContains(currentNames, "source_scalar_arithmetic")
     assertLirContains(currentNames, "source_projected_intrinsic_result")
+    assertLirContains(currentNames, "source_nested_struct_binding")
     testing.assert(!(strings.contains(currentNames, "source_println_int_runtime_abi")))
 }
 fn testLirProtoParityCatalogFindsMissingNeedles() {


### PR DESCRIPTION
## Summary
- add a Go MIR regression for `whole @ User { addr: Address { city, zip }, score }` so the alias store and nested field projections stay visible
- pin `source_nested_struct_binding` in the LIR Proto current-generator parity catalog sentinel
- update the Tier A gap plan with the C3 follow-up lock and the remaining binary-gated note

## Validation
- git diff --check
- go test -count=1 -vet=off ./internal/mir -run 'TestLower(BuildsInterfaceLayouts|NestedStructBindingPatternKeepsAliasAndLeaves)'\n- go test -count=1 -vet=off ./cmd/osty-native-lirproto ./cmd/osty-native-llvmgen -run 'TestRun(InvokesOstySelfWithRequestArgs|EmitsLLVMIRForMIRPayload|MIRPayloadPrefersLIRProtoWhenSelected)'\n- go test -count=1 -vet=off ./internal/selfhost -run TestCheckSnapshot\n\nNote: direct `.bin/osty check --no-airepair toolchain/lir_proto_test.osty` is not a valid standalone gate for this helper file because it depends on sibling toolchain modules; it reports missing LIR/MIR symbols when run alone.