### PR TITLE
docs(v0.6): batch 16 — 21-file stdlib deep mechanics expansion (+1015 LOC)

### DIFF
--- a/LANG_SPEC_v0.6/10-standard-library/12-cryptography.md
+++ b/LANG_SPEC_v0.6/10-standard-library/12-cryptography.md
@@ -75,3 +75,57 @@ fn cacheKey(payload: Bytes) -> Bytes {
 `cacheKey` produces byte-identical hashes on every supported
 target. The hash output is ordinary `Bytes`; flow tags ride
 through (a tainted input produces a tainted hash output).
+
+#### 10.12.2 HMAC and constant-time comparison
+
+`crypto.hmac.sha256(key, message)` computes the keyed message
+authentication code. The function is *not* constant-time on the
+key — the `key` length affects the inner padding step. This is
+the standard HMAC contract; constant-time *comparison* of two
+HMAC outputs uses `crypto.constantTimeEq`:
+
+```osty
+fn verifySignature(secret: Bytes, payload: Bytes, sig: Bytes) -> Bool {
+    let computed = crypto.hmac.sha256(secret, payload)
+    crypto.constantTimeEq(computed, sig)
+}
+```
+
+The naive `computed == sig` is a timing attack — bytewise `==`
+short-circuits on the first mismatch, leaking position
+information that attackers can use to forge signatures one byte
+at a time. `constantTimeEq` always inspects every byte regardless
+of mismatches found.
+
+#### 10.12.3 Hash and information flow
+
+The hashing functions preserve flow tags — a tainted input
+produces a tainted hash output. The hash is *not* a sanitizer:
+
+- `crypto.sha256(taintedBytes)` returns tainted `Bytes`.
+- The hash output may flow into a sink only after appropriate
+  sanitization for that sink (e.g. `crypto.constantTimeEq` for
+  HMAC verification doesn't require sanitization since `Bool` is
+  primitive).
+
+This conservative approach catches a class of bugs where authors
+assume hashing "anonymizes" sensitive input — the hash output
+still carries the source's trust set, even though it does not
+carry the source bytes.
+
+#### 10.12.4 Hash algorithm policy
+
+The v0.6 stdlib provides:
+
+- **`sha256`, `sha512`** — recommended for new code. Collision-
+  resistant under cryptographic assumptions.
+- **`sha1`** — legacy compatibility only. SHA-1 is deprecated for
+  new use; collision attacks are practical. Available for
+  protocols that still require it (Git, older HMAC).
+- **`md5`** — legacy compatibility only. Cryptographically broken;
+  collision attacks are trivial. Use only for non-security
+  identifiers (cache keys where collision is acceptable).
+
+`osty lint` flags new uses of `sha1` and `md5` for security-
+sensitive contexts (`L0060`). The flag is a hint — author
+discretion overrides for known-safe cases.

--- a/LANG_SPEC_v0.6/10-standard-library/13-uuid.md
+++ b/LANG_SPEC_v0.6/10-standard-library/13-uuid.md
@@ -80,3 +80,36 @@ the input data, so flow tracking does not propagate.
 If a UUID is *parsed from* a tainted source string, however, the
 parsed `Uuid` carries the source's tag set — because `Uuid.parse`
 is a structural transformation of the input.
+
+#### 10.13.3 UUID v7 sortability
+
+`uuid.v7(clock, rng)` produces UUIDs that sort correctly by
+*timestamp first*, then random. This makes them useful as
+database row IDs:
+
+```osty
+let mut ids: List<Uuid> = [...]      // collected over time
+ids.sortBy(|a, b| a.cmp(b))          // chronological order
+```
+
+The sort is *byte-wise* over the UUID's 16-byte representation —
+v7's first 6 bytes are a millisecond timestamp big-endian, so
+byte comparison matches timestamp comparison. The remaining 10
+bytes are random; identical-millisecond UUIDs sort by their
+random suffix, which is acceptable for tiebreaking.
+
+#### 10.13.4 v4 vs v7 selection guide
+
+| Use case | Recommended | Why |
+|---|---|---|
+| Database row ID | v7 | Natural index ordering matches insertion |
+| Session ID | v4 | No timing information leak |
+| Cache key | v4 (or hash) | Collision concerns matter; ordering does not |
+| Distributed log entry | v7 | Multi-node logs merge in time order |
+| API token | v4 (or `CryptoRng.bytes`) | Unguessability is the priority |
+| File name in user-facing UI | v4 (full random) | v7's prefix leaks creation time |
+
+The "unguessability" criterion sits with `CryptoRng` — both v4
+and v7 use `CryptoRng` under the v0.6 baseline, so both are
+suitable for security-sensitive identifiers. v7 leaks the
+*creation timestamp* but not the random suffix.

--- a/LANG_SPEC_v0.6/10-standard-library/14-random.md
+++ b/LANG_SPEC_v0.6/10-standard-library/14-random.md
@@ -85,3 +85,38 @@ The seeded `Rng` is *not* received as a capability parameter —
 it's constructed locally from a deterministic seed, so the
 function takes the seed as a plain `Int64` rather than the `Rng`
 itself.
+
+#### 10.14.3 Rng method semantics
+
+| Method | Range | Notes |
+|---|---|---|
+| `Rng.int(min, max)` | `[min, max)` half-open | aborts if `min >= max` |
+| `Rng.intInclusive(min, max)` | `[min, max]` closed | aborts if `min > max` |
+| `Rng.float()` | `[0.0, 1.0)` | excludes 1.0 exactly |
+| `Rng.bool()` | `true`/`false` | 50/50 from underlying bit |
+| `Rng.bytes(n)` | n random bytes | aborts if `n < 0` |
+| `Rng.choice(items)` | one element of `items` | `None` if empty |
+| `Rng.shuffle(mut items)` | reorders in place | Fisher-Yates |
+
+`Rng.shuffle` mutates the input list in place; it requires `items`
+to be a `mut` binding. The shuffled order is determined by the
+seed.
+
+#### 10.14.4 Combining seeded and host RNGs
+
+A common pattern: derive a per-request seed from cryptographic
+randomness, then use seeded operations for reproducible per-
+request derivations:
+
+```osty
+fn deriveTokens(cryptoRng: CryptoRng, count: Int) -> List<Token> {
+    let seed = cryptoRng.bytes(8).toInt64BigEndian()
+    let rng = random.seeded(seed)
+    (0..count).map(|_| Token.fromBytes(rng.bytes(16))).toList()
+}
+```
+
+The outer `cryptoRng` provides cryptographic entropy (per request);
+the inner seeded `rng` is reproducible given that seed. This pattern
+is useful when tests want to fix the seed and replay the derivation
+without consulting the real `CryptoRng`.

--- a/LANG_SPEC_v0.6/10-standard-library/15-operating-system.md
+++ b/LANG_SPEC_v0.6/10-standard-library/15-operating-system.md
@@ -128,3 +128,49 @@ The path *sanitizer* is `std.path.normalize` / `Path.parse(...)?`
 — these registered with `#[sanitizes("user_input", into =
 "path_safe")]` and produce a `Path` value acceptable to `Fs.*`
 sinks.
+
+#### 10.15.3 Process exit and `defer`
+
+`Process.exit(code)` is an *immediate* termination — it bypasses
+`defer` cleanup (see §4.12 rule 7). For graceful shutdown, return
+from `main` instead of calling `exit`:
+
+```osty
+#[ambient(process)]
+fn main() -> Result<(), Error> {
+    let result = runApp()
+    match result {
+        Ok(_) -> Ok(()),                    // exit code 0, defer runs
+        Err(_) -> process.exit(1),          // exit code 1, defer SKIPS
+    }
+}
+```
+
+The asymmetry is the v0.5 baseline; v0.6 does not change it. For
+specific exit codes with cleanup, the recommended pattern is to
+return a `Result` from `main` and let the runtime translate it
+(see §6 scripts).
+
+#### 10.15.4 Signal handling
+
+`Process.onSignal(sig, handler)` registers a handler for OS
+signals (SIGINT, SIGTERM, SIGHUP). The handler runs on the Osty
+worker pool, not on a separate signal thread, so it has full
+access to the program's runtime (allocations, capability calls).
+
+The handler is *not* allowed to call `process.exit` — exit must
+happen through normal `main` return. Authors who want signal-
+triggered shutdown set a flag and let the main loop check it:
+
+```osty
+fn main(process: Process) -> Result<(), Error> {
+    let shutdownFlag = Atomic.new(false)
+    process.onSignal(Signal.Interrupt, || shutdownFlag.set(true))
+
+    while !shutdownFlag.get() {
+        processWork()?
+        thread.checkCancelled()?
+    }
+    Ok(())
+}
+```

--- a/LANG_SPEC_v0.6/10-standard-library/16-url.md
+++ b/LANG_SPEC_v0.6/10-standard-library/16-url.md
@@ -104,3 +104,34 @@ time. The build step is fallible — invalid combinations (e.g. a
 relative path without a scheme + host) return `Err`. Adding new
 required fields to the builder is a major SemVer event because
 existing builder chains will fail at compile time.
+
+#### 10.16.3 Query parameter handling
+
+`Url.query` is `Map<String, String>` — single-valued. URLs with
+repeated keys (`?key=a&key=b`) lose data on parse — only the last
+value survives. Multi-valued query strings should use
+`Url.queryValues(key)` which returns a `List<String>` parsed from
+the original raw string.
+
+The single-valued default is the common case (most APIs use
+unique query keys). Authors who need full multi-valued semantics
+parse the raw query string with `http.parseQuery` (§10.24).
+
+#### 10.16.4 URL join semantics
+
+`url.join(base: Url, relative: String) -> Result<Url, Error>`
+follows RFC 3986 reference resolution:
+
+| `base.toString()` | `relative` | Result |
+|---|---|---|
+| `https://example.com/a/` | `b/c` | `https://example.com/a/b/c` |
+| `https://example.com/a/` | `/b/c` | `https://example.com/b/c` |
+| `https://example.com/a/b` | `c` | `https://example.com/a/c` |
+| `https://example.com/a/b/` | `../c` | `https://example.com/a/c` |
+| `https://example.com/a/b` | `?q=1` | `https://example.com/a/b?q=1` |
+| `https://example.com/a/b` | `#frag` | `https://example.com/a/b#frag` |
+| `https://example.com/a/` | `https://other/x` | `https://other/x` (absolute wins) |
+
+The result is a sealed `Url` value; the join either succeeds
+fully (returning a validated URL) or fails with `Err`. There is
+no partial-result mode.

--- a/LANG_SPEC_v0.6/10-standard-library/20-time-extensions.md
+++ b/LANG_SPEC_v0.6/10-standard-library/20-time-extensions.md
@@ -194,4 +194,34 @@ fires, it cancels the group; the body's blocking calls return
 `clock.sleep(d)?` itself returns `Cancelled` (because the group is
 cancelled by the body's success).
 
+#### 10.20.3 Duration arithmetic
+
+`Duration` supports `+`, `-`, `*` (by Int), `/` (by Int):
+
+```osty
+let total = 5.minutes + 30.seconds        // 5:30
+let half = total / 2                       // 2:45
+let triple = total * 3                     // 16:30
+```
+
+Duration overflow follows the integer overflow rules (§2.3) — a
+`Duration` representing a value that exceeds `Int64` nanoseconds
+aborts. Practical durations (sub-century) never approach the
+limit.
+
+`Instant - Instant` returns a `Duration` (signed); `Instant +
+Duration` returns a new `Instant`. Adding a `Duration` to an
+`Instant` that would overflow `Int64` epoch nanoseconds aborts.
+
+#### 10.20.4 Timezone caveats
+
+`time.zone(name)` looks up an IANA tz database entry. The lookup
+is host-dependent — the runtime queries the system tz database.
+The set of valid `name` values is therefore platform-specific in
+edge cases (custom zones, unusual aliases).
+
+For maximum portability, use UTC (`time.utc()`) for all internal
+timestamps and apply zone conversion only at user-display
+boundaries.
+
 ---

--- a/LANG_SPEC_v0.6/10-standard-library/22-fmt.md
+++ b/LANG_SPEC_v0.6/10-standard-library/22-fmt.md
@@ -157,3 +157,34 @@ left-to-right pass that counts grapheme widths via §10.34
 `std.markdown` rules. This determinism is part of the v0.6
 contract; `tableAligned` is suitable for `#[golden]` snapshot
 output.
+
+#### 10.22.1 Format vs interpolation choice
+
+Osty's `"{expr}"` interpolation does not support inline format
+specifiers (§1.6.3). The decision is to keep the interpolation
+grammar trivial; non-default formatting goes through `std.fmt`:
+
+```osty
+"price: {fmt.fixed(price, 2)}"            // 2-decimal place
+"hex:   {fmt.base(n, 16)}"                // hex
+"width: {fmt.padLeft(name, 20)}"          // right-align in 20
+"comma: {fmt.commaInts(amount)}"          // 1,234,567
+```
+
+Each formatter is a regular function — its arguments and behavior
+are visible at the call site, not hidden inside an interpolation
+parser. The pattern is more verbose than format-specifier
+languages but always inspectable.
+
+#### 10.22.2 `compactNumber` and locale
+
+`fmt.compactNumber(n)` produces "1.2K", "3.4M", "5.6B" forms.
+The implementation is *locale-independent* — always English
+abbreviations, always `.` for the decimal separator. Locale-
+sensitive number formatting is not part of v0.6 baseline; a
+future stdlib `std.locale.fmt` is tracked for Phase 5.
+
+This locale-independence is a determinism feature: a
+`#[reproducible]` function calling `fmt.compactNumber` produces
+the same output across all targets. Locale-sensitive output would
+break that contract.

--- a/LANG_SPEC_v0.6/10-standard-library/23-net.md
+++ b/LANG_SPEC_v0.6/10-standard-library/23-net.md
@@ -164,3 +164,72 @@ output `#[taint("net_input")]`.
 For SSRF prevention, parse the resolved address through
 `std.security.checkUrl` or apply the address-block validation
 (§10.34 `std.security`) before opening a connection to it.
+
+#### 10.23.3 Read/write timeout discipline
+
+`TcpConn.setReadTimeout(d)` and `TcpConn.setWriteTimeout(d)` set
+operation deadlines. A timeout-expired call returns
+`Err(TimedOut { ... })` with the original duration in the cause.
+Subsequent calls on the same connection may proceed normally.
+
+Timeouts compose with `taskGroup` cancellation:
+
+```osty
+fn fetchOrCancel(net: Net, url: String) -> Result<Bytes, Error> {
+    taskGroup(|g| {
+        let conn = net.connect(url)?
+        defer conn.close()
+        conn.setReadTimeout(5.s)?       // 5s per-read deadline
+        let body = io.readAll(conn)?
+        // — read returns Err(TimedOut) after 5s, OR
+        // — read returns Err(Cancelled) on group cancel,
+        //   whichever fires first
+        Ok(body)
+    })
+}
+```
+
+The discipline: timeouts bound *individual* operations; the
+surrounding `taskGroup` provides the *whole-task* deadline via
+explicit cancel.
+
+#### 10.23.4 UDP packet boundaries
+
+UDP datagrams are delivered as units — `recv(maxBytes)` returns a
+single datagram up to `maxBytes` (or the full datagram if smaller).
+Truncation can occur if the actual datagram is larger than
+`maxBytes`; the truncation is silent (no error). Authors who need
+to detect truncation should size buffers conservatively.
+
+`recvFrom` additionally returns the sender's address. Both `recv`
+and `recvFrom` are cancellation points.
+
+#### 10.23.5 Concurrent connection patterns
+
+A `TcpListener` may accept multiple connections in parallel via
+`taskGroup`:
+
+```osty
+fn serveAll(net: Net, addr: String) -> Result<(), Error> {
+    let listener = net.listen(addr)?
+    defer listener.close()
+
+    taskGroup(|g| {
+        for {
+            let conn = listener.accept()?
+            g.spawn(|| {
+                defer conn.close()
+                handleConn(conn)
+            })
+        }
+    })
+}
+```
+
+Each spawned handler is independent; the listener's `accept` is
+cancellation-aware. When the surrounding task is cancelled,
+`accept` returns `Err(Cancelled)` and the loop exits.
+
+The non-escaping `Handle<T>` rule (§8.1) prevents leaking a
+spawned handler outside its `taskGroup`; the listener itself can
+outlive a single connection.

--- a/LANG_SPEC_v0.6/10-standard-library/24-http.md
+++ b/LANG_SPEC_v0.6/10-standard-library/24-http.md
@@ -369,3 +369,63 @@ fn handler(req: Request) -> Result<Response, Error> {
 The struct's fields all carry `user_input` because the parser
 preserves the input's tag set on each output field. Authors who
 need *per-field* tag narrowing use `#[taint_field]` (§21.5.8).
+
+#### 10.24.4 Router pattern matching
+
+`Router.find(req)` returns a `RouteMatch?` with extracted path
+parameters. The pattern grammar:
+
+| Pattern | Matches | Captures |
+|---|---|---|
+| `/users` | exact | none |
+| `/users/:id` | one segment after `/users/` | `id` → segment |
+| `/files/*rest` | one or more segments | `rest` → joined path |
+| `/users/:id/posts/:pid` | two-level params | `id`, `pid` |
+| `/static/*path` | catch-all suffix | `path` |
+
+Pattern matching is deterministic — the first matching route in
+registration order wins. Authors building dynamic routers should
+register more-specific patterns before catch-alls.
+
+Path parameters extracted from the URL carry
+`#[taint("user_input")]`. Authors must sanitize before passing
+into sinks. `params.get("id")` returns the raw string.
+
+#### 10.24.5 Cookie and header attacks
+
+The HTTP module does not implement automatic cookie sanitization.
+Setting a cookie value containing CRLF (`\r\n`) is a header-
+injection vulnerability — the request would split into two
+responses. The recommended pattern:
+
+```osty
+fn safeCookie(name: String, value: #[taint("user_input")] String) -> Result<Cookie, Error> {
+    if value.contains("\r") || value.contains("\n") {
+        return Err(Error.new("invalid cookie value"))
+    }
+    Ok(http.cookie(name, value))
+}
+```
+
+A future stdlib `std.http.cookieSafe` sanitizer is tracked for
+Phase 5; v0.6 baseline requires manual validation.
+
+#### 10.24.6 Server-side cancellation
+
+A handler invoked via `http.dispatch` runs in the request task.
+The task is cancelled when the client disconnects mid-request.
+Long-running handlers should check cancellation periodically or
+use cancellation-aware blocking calls:
+
+```osty
+fn slowHandler(req: HttpRequest) -> Result<HttpResponse, Error> {
+    for chunk in processChunks(req.body) {
+        thread.checkCancelled()?       // honor client disconnect
+        publishChunk(chunk)?
+    }
+    Ok(http.okText(""))
+}
+```
+
+`Net.read` and `Net.write` already honor cancellation; explicit
+`thread.checkCancelled()` is needed only for CPU-bound work.

--- a/LANG_SPEC_v0.6/10-standard-library/25-term.md
+++ b/LANG_SPEC_v0.6/10-standard-library/25-term.md
@@ -77,3 +77,32 @@ Legacy `term.open()` / `term.readKey()` / etc. (no capability args)
 desugar to `std.term.host.open()` / `std.term.host.readKey()` under
 `--legacy-globals` (v0.6.x only). Outside that mode, bare-arg form
 is `E0780`.
+
+#### 10.25.1 Cursor and screen restoration
+
+Programs that enter raw mode or switch to the alternate screen
+must restore the original state on exit. The recommended pattern
+is `defer term.restore()`:
+
+```osty
+fn runTui(console: Console) -> Result<(), Error> {
+    let term = console.terminal()?
+    term.setRawMode(true)?
+    defer term.restore()              // runs on every exit path
+
+    term.write(term.enterAltScreenSeq())?
+    term.flush()?
+    // ... interactive loop ...
+    Ok(())
+}
+```
+
+`term.restore()` is idempotent — calling it twice is safe. The
+implementation tracks which modes the program changed and reverses
+exactly those.
+
+If the program crashes (uncaught panic, signal-triggered abort)
+without running `defer`, the restore step is skipped — the host
+shell may need manual `reset` to recover the terminal. v0.6
+baseline does not provide a process-exit hook; signal handlers
+that want to restore must do so explicitly (§10.15.4).

--- a/LANG_SPEC_v0.6/10-standard-library/26-tui.md
+++ b/LANG_SPEC_v0.6/10-standard-library/26-tui.md
@@ -51,3 +51,86 @@ fn testLoginScreen() {
     testing.assertGolden(frame.renderAnsi())
 }
 ```
+
+#### 10.26.1 Frame composition patterns
+
+The pure-rendering / capability-presenting split lets TUI tests
+follow this layered shape:
+
+1. **Pure layer** — functions that take *application state* and
+   return a `Frame`. No capability, no I/O. `#[reproducible]`-
+   eligible.
+
+   ```osty
+   #[reproducible(scope = "target")]
+   fn renderState(state: AppState) -> Frame {
+       let frame = tui.frame(state.size)
+       frame.drawText(state.cursorPos, ">", styles.cursor)
+       frame.drawText(grid.point(0, 0), state.title, styles.heading)
+       frame
+   }
+   ```
+
+2. **Effectful layer** — receives `Terminal` and presents the
+   frame. This is the only place that consults capabilities.
+
+   ```osty
+   fn redraw(term: Terminal, screen: Screen, state: AppState) -> Result<(), Error> {
+       let frame = renderState(state)
+       screen.present(frame)
+   }
+   ```
+
+The split makes the pure layer testable in isolation against
+`#[golden]` snapshots; only the effectful layer needs `Terminal`-
+shaped fakes.
+
+#### 10.26.2 Diff-based rendering
+
+`Frame.diffAnsi(previous)` produces an ANSI sequence that updates
+the terminal from `previous` to the current frame. This is the
+primary pattern for low-flicker TUIs:
+
+```osty
+fn renderLoop(term: Terminal, screen: Screen) -> Result<(), Error> {
+    let mut prev: Frame? = None
+    for {
+        let state = readNextState()?
+        let curr = renderState(state)
+        let ansi = curr.diffAnsi(prev)
+        term.write(ansi)?
+        term.flush()?
+        prev = Some(curr)
+        thread.checkCancelled()?
+    }
+}
+```
+
+Diff output is deterministic given two frames — the sequence is
+always the same for the same `(prev, curr)` pair. This matters
+for `#[golden]` tests of diff output.
+
+#### 10.26.3 Frame and information flow
+
+Cell text in a `Frame` carries the flow tag set of its source
+string. Tainted text rendered into a frame produces a tainted
+ANSI string when serialized; writing that string to a terminal
+goes through the `Terminal` capability (not a registered sink),
+so no flow check is required at the present site.
+
+Authors who want sanitization before rendering apply it in the
+pure layer:
+
+```osty
+fn renderUserInput(input: #[taint("user_input")] String) -> Frame {
+    let safe = std.term.escapeAnsi(input)   // strips control sequences
+    let frame = tui.frame(grid.size(80, 1))
+    frame.drawText(grid.point(0, 0), safe, styles.normal)
+    frame
+}
+```
+
+`std.term.escapeAnsi` strips embedded ANSI control sequences from
+user input — preventing terminal-injection attacks where untrusted
+strings could move the cursor, change colors, or set the window
+title.

--- a/LANG_SPEC_v0.6/10-standard-library/27-grid.md
+++ b/LANG_SPEC_v0.6/10-standard-library/27-grid.md
@@ -68,3 +68,54 @@ fn render(grid: Grid<Cell>) -> String {
 `render` is `#[pure]`-eligible (capability-free). Side-effecting
 display happens via `Screen.present(frame)` (§10.26), which routes
 through `Terminal` (capability).
+
+#### 10.27.1 Grid coordinate determinism
+
+`Point` and `Rect` operations are deterministic given their
+inputs. Iteration helpers like `Grid.points()` traverse cells in
+a fixed (row-major) order — first row top-to-bottom, then column
+left-to-right within each row. This makes grid-based algorithms
+(BFS, A*, flood fill) acceptable inside `#[reproducible(scope =
+"portable")]` contexts.
+
+```osty
+#[reproducible(scope = "portable")]
+fn floodFill<T>(grid: Grid<T>, start: Point, target: T) -> Set<Point> {
+    let mut visited: Set<Point> = Set.empty()
+    let mut queue: List<Point> = [start]
+    while !queue.isEmpty() {
+        let p = queue.popFront()
+        if visited.contains(p) { continue }
+        if grid.get(p)? != target { continue }
+        visited.insert(p)
+        for n in grid.neighbors(p) {
+            queue.push(n)
+        }
+    }
+    visited.toListSorted()      // sorted for deterministic output
+}
+```
+
+The final `toListSorted()` is critical for reproducibility — `Set`
+iteration is hash-based and non-deterministic. `Set` *insertion
+order* is irrelevant; only the final sorted projection is.
+
+#### 10.27.2 Grid and information flow
+
+A `Grid<T>` cell carries `T`'s flow tag set. `Grid.map(f)`
+preserves tags through the transformation closure; `Grid.fill(t)`
+produces an untagged grid (the fill value is the source).
+
+For grid-of-text use cases (TUI map rendering), tainted text
+flowing into cells preserves the tag through to the rendered
+frame. Authors who want sanitization apply it in the cell
+construction step:
+
+```osty
+fn buildTainted(input: #[taint("user_input")] String) -> Grid<Cell> {
+    let escaped = std.term.escapeAnsi(input)
+    let g = grid.grid::<Cell>(grid.size(80, 1), Cell.empty())
+    g.set(grid.point(0, 0), Cell.text(escaped, styles.normal))
+    g
+}
+```

--- a/LANG_SPEC_v0.6/10-standard-library/28-sql.md
+++ b/LANG_SPEC_v0.6/10-standard-library/28-sql.md
@@ -110,3 +110,62 @@ Behavior:
 - `literal` and `debugSql` are for diagnostics, migrations, or generated SQL
   text. Runtime query execution should prefer `Query.params` over string
   interpolation.
+
+#### 10.28.1 SQL builder determinism
+
+Every builder in `std.sql` produces deterministic output —
+identical inputs yield byte-identical `Query` values. This is
+critical for:
+
+- **`#[reproducible]` cache keys**: a function that derives a SQL
+  fingerprint hashes the rendered query text and expects bit-
+  identical output across runs.
+- **Migration verification**: the same schema definition must
+  produce the same SQL across runs to validate migrations.
+- **`#[golden]` tests**: snapshot files of generated SQL can be
+  compared byte-exact.
+
+The determinism includes:
+
+- Column ordering (preserves `select(table, columns)` argument
+  order).
+- Conditions in `allOf`/`anyOf` join in argument order.
+- `orderBy` clauses join in argument order with the dialect's
+  default `NULLS FIRST` / `NULLS LAST` (Postgres convention is
+  preserved as-is; MySQL/SQLite emit no `NULLS` clause).
+- Placeholder numbering follows `Query.params` order.
+
+#### 10.28.2 SqlIdent and parameterization
+
+`SqlIdent` (returned from `sql.quoteIdent`) is sealed (§3.4.5) —
+external `SqlIdent { value: "..." }` literals are rejected
+(`E0420`). The seal ensures every identifier reaching a SQL sink
+has been validated against the `[A-Za-z_][A-Za-z0-9_]*` pattern.
+
+```osty
+fn buildOrderBy(col: String) -> Result<Order, Error> {
+    let ident = sql.quoteIdent(col)?      // validates the column name
+    Ok(sql.asc(ident)?)
+}
+```
+
+If `col` is tainted (`#[taint("user_input")]`), `sql.quoteIdent`
+acts as a sanitizer (`#[sanitizes("user_input", into = "sql_safe")]`)
+— the resulting `SqlIdent` carries `sql_safe`, acceptable for
+`Query` construction.
+
+#### 10.28.3 Dialect-specific render output
+
+`sql.render(query, dialect)` converts the internal placeholder
+form (`?`) to the dialect's expected form:
+
+| Dialect | Placeholder | Identifier quote | NULL ordering |
+|---|---|---|---|
+| `Generic` | `?` | `"name"` | dialect default |
+| `Postgres` | `$1, $2, ...` | `"name"` | explicit `NULLS FIRST`/`LAST` |
+| `MySql` | `?` | `` `name` `` | implicit |
+| `Sqlite` | `?` | `"name"` | implicit |
+
+The dialect choice is a runtime decision (typically inferred from
+the `db.Config`). Generated SQL text is byte-identical for the
+same `(query, dialect)` pair.

--- a/LANG_SPEC_v0.6/10-standard-library/29-db.md
+++ b/LANG_SPEC_v0.6/10-standard-library/29-db.md
@@ -180,3 +180,57 @@ Production code that wants reproducibility around DB writes uses
 `#[reproducible(scope = "target")]` for the *transformation*
 (input → SQL) and a separate non-reproducible function for the
 actual `db.exec` call.
+
+#### 10.29.4 FakeDb fidelity
+
+`std.capability.testing.FakeDb` provides an in-memory backend for
+testing. It supports:
+
+- **Schema mutation** (`db.exec(createTable)`).
+- **Insert / select / update / delete** with parameterized SQL.
+- **Transactions** (`beginTx`, `commit`, `rollback`) — including
+  nested transactions via savepoints.
+- **Indices and unique constraints** — duplicate-key violations
+  return `Err(DbError.Conflict(...))` matching production behavior.
+
+What it does *not* support:
+
+- **Vendor-specific SQL extensions** — `FakeDb` parses standard
+  ANSI SQL; PostgreSQL-only constructs (`RETURNING`, `JSONB`
+  operators, window functions) require a real DB.
+- **Concurrent access** — `FakeDb` is single-threaded; tests of
+  concurrent DB access must use a real backend or the
+  `FakeDb.serialize()` shim that simulates a single connection.
+- **Wire protocol details** — connection limits, network errors,
+  TLS handshakes are not modeled.
+
+The fidelity gap is an explicit trade-off — `FakeDb` covers the
+"normal" 95% of test cases; the remaining 5% (vendor-specific
+features, concurrency edge cases) require integration tests
+against a real DB instance.
+
+#### 10.29.5 Migration patterns
+
+`db.plan(currentVersion, migrations) -> MigrationPlan` returns the
+sorted list of pending migrations. The plan is *pure* — it does
+not run anything; the caller drives execution:
+
+```osty
+fn applyMigrations(db: Db, migrations: List<Migration>) -> Result<(), Error> {
+    let current = readCurrentVersion(db)?
+    let plan = db.plan(current, migrations)
+    for m in plan.pending {
+        let tx = db.beginTx(db.txOptions())?
+        defer tx.rollback()
+        tx.exec(m.upSql)?
+        tx.exec(db.recordMigrationSql(m))?
+        tx.commit()?
+    }
+    Ok(())
+}
+```
+
+The pattern uses `defer tx.rollback()` as a safety net — if
+`commit()` succeeds, the rollback is a no-op; if anything between
+`beginTx` and `commit` fails, the rollback runs. This is the
+canonical transactional shape for v0.6 DB code.

--- a/LANG_SPEC_v0.6/10-standard-library/30-smtp.md
+++ b/LANG_SPEC_v0.6/10-standard-library/30-smtp.md
@@ -103,3 +103,50 @@ encodes (base64 for AUTH PLAIN, etc.) but does not validate the
 semantic safety of payloads. Authors handling user-supplied email
 content must sanitize before constructing the `Envelope` if any
 sink-shaped semantics apply.
+
+#### 10.30.3 SMTP testing pattern
+
+Production SMTP code touches `Net` for the TCP connection. Tests
+inject `FakeNet` with canned server replies:
+
+```osty
+#[test]
+fn test_smtp_pipeline() {
+    let net = std.capability.testing.FakeNet.routes({
+        "smtp.example.com:587": std.capability.testing.cannedSmtpReplies([
+            "220 example.com ESMTP",
+            "250-example.com",
+            "250-AUTH PLAIN LOGIN",
+            "250 OK",
+            "235 Authentication successful",
+            "250 OK",
+            "250 OK",
+            "354 End data with <CR><LF>.<CR><LF>",
+            "250 OK queued as 12345",
+            "221 Bye",
+        ]),
+    })
+
+    let env = std.testing.email.envelope("from@x", "to@y", "Test", "Body")
+    sendOnce(net, smtpCfg(), env)?
+    testing.assertEq(net.dialedHosts(), ["smtp.example.com:587"])
+}
+```
+
+The `cannedSmtpReplies` helper returns a fake `TcpConn` that
+replays the given sequence on each `read` call. Ordered replies
+match the expected SMTP protocol flow.
+
+#### 10.30.4 STARTTLS handshake
+
+`std.smtp` represents STARTTLS in the command plan but does not
+itself perform the TLS handshake (TLS upgrade requires runtime
+support). The pattern is:
+
+1. Run the protocol up to and including the `STARTTLS` command.
+2. Caller invokes a TLS adapter on the existing `TcpConn` to
+   negotiate.
+3. Caller resumes the protocol with the upgraded connection.
+
+Phase 5 will add `Net.startTls(conn)` for inline upgrades; v0.6
+baseline keeps the protocol module purely focused on commands.

--- a/LANG_SPEC_v0.6/10-standard-library/34-deneb-utilities.md
+++ b/LANG_SPEC_v0.6/10-standard-library/34-deneb-utilities.md
@@ -156,3 +156,38 @@ pipeline.
 
 Parity audit: behavior-equivalent for increment/add/get/snapshot/key joining,
 with explicit value threading instead of lock-backed package globals.
+
+#### v0.6 surface summary
+
+The Deneb-derived utilities are *all pure*. None receives a
+capability parameter; each transforms input values into output
+values (or builds explicit state structs threaded by the caller).
+Acceptable inside `#[reproducible(scope = "portable")]` provided
+the caller's input is itself reproducible.
+
+| Module | Sanitizer registry | Capability needed |
+|---|---|---|
+| `std.redact` | not registered (best-effort masking, not a flow sanitizer) | none |
+| `std.security` | `sanitizeHtml` → `html_safe`, `checkUrl` → `url_safe` | none |
+| `std.search` | not a sanitizer | none |
+| `std.markdown` | `htmlToMarkdown` outputs untagged text from tagged HTML — noted as `#[trusted_declassify]`-equivalent for HTML→MD pipelines | none |
+| `std.media` | not a sanitizer | none |
+| `std.httpretry` | not a sanitizer | `Clock` (for backoff timer) |
+| `std.jsonl` | not a sanitizer | none |
+| `std.tokenest` | not a sanitizer | none |
+| `std.shortid` | not a sanitizer | `Rng` or `CryptoRng` (caller provides seed/source) |
+| `std.metrics` | not a sanitizer | none |
+
+The two registered sanitizers (`sanitizeHtml`, `checkUrl`) are
+documented under §10.34 `std.security`; their entries in the
+sanitizer registry (§21.18.2) make them recognized by the type
+checker for sink-routing.
+
+`std.shortid` is *capability-flexible* — the caller chooses
+between `Rng` (reproducible IDs from a seed) and `CryptoRng`
+(unguessable IDs). The shortid module itself is pure; the
+randomness comes from the passed-in source.
+
+`std.httpretry` consumes `Clock` for the backoff sleep and can be
+combined with the `taskGroup` cancellation contract — a backoff
+sleep returns `Err(Cancelled)` on cancel, propagating naturally.

--- a/LANG_SPEC_v0.6/10-standard-library/35-table.md
+++ b/LANG_SPEC_v0.6/10-standard-library/35-table.md
@@ -196,3 +196,51 @@ Behavior:
 - `inferTypes` ignores empty cells, promotes `IntColumn` plus
   `FloatColumn` to `FloatColumn`, treats any text cell as `TextColumn`,
   and returns `MixedColumn` for incompatible non-text mixes.
+
+#### 10.35.1 Table operations and v0.6 surfaces
+
+All `std.table` operations are pure transformations over `Table`
+values. They:
+
+- Return new `Table` values; mutations are local to the call.
+- Preserve flow tags element-wise — a tainted CSV input produces
+  tainted cells; transformations (`select`, `sortBy`, `coerce`)
+  preserve the tags.
+- Are acceptable inside `#[reproducible(scope = "portable")]`,
+  provided sort orders are deterministic (text comparison is
+  byte-wise; numeric comparison follows the IEEE-754 totalOrder
+  per §10.5).
+
+#### 10.35.2 Table aggregation determinism
+
+`countBy(column, name)` and `summarizeBy(groupBy, sumColumn)` use
+deterministic ordering — output rows appear in *first-occurrence*
+order from the input, not in hash order. This makes
+table-aggregation pipelines acceptable inside `#[reproducible]`
+without explicit `sortBy` afterward.
+
+```osty
+let counts = sales.countBy("city", "count")?
+// counts.rows order: ["seoul", "busan"] (first-occurrence in sales)
+```
+
+Authors who want a different output order apply explicit `sortBy`
+on the aggregated result. The first-occurrence default is the
+choice that maximizes reproducibility under typical usage.
+
+#### 10.35.3 Schema coercion and information flow
+
+`Table.coerce(schema)` parses each cell from text into the
+column's typed form. The parsed values inherit the source string's
+flow tag set:
+
+```osty
+let sales: Table = table.fromCsv(rawCsv)?    // cells tainted user_input
+let schema = table.schemaFrom(["amount"], [table.FloatColumn])?
+let typed = sales.coerce(schema)?
+// typed.row(0).floatAt("amount"): #[taint("user_input")] Float
+```
+
+Coercion is *not* a sanitizer — it does not validate semantic
+safety beyond type parsing. Sink-routing of typed cells still
+requires explicit sanitization.

--- a/LANG_SPEC_v0.6/10-standard-library/40-xlsx.md
+++ b/LANG_SPEC_v0.6/10-standard-library/40-xlsx.md
@@ -47,3 +47,44 @@ Primary surface:
 - `sheet`, `workbook`, `fromRows`, `fromTable`, `toTable`, `rows`
 - `encode`, `decode`, `encodeRows`, `decodeRows`, `encodeTable`
 - `sheetNames`, `isWorkbook`, `kindName`
+
+#### 10.40.1 XLSX and information flow
+
+XLSX files originating from external sources (uploads, email
+attachments) carry untrusted cell values. Decoded cells inherit
+the source's flow tag set:
+
+```osty
+fn ingest(fs: Fs, path: String) -> Result<List<Row>, Error> {
+    let raw: #[taint("fs_input")] Bytes = fs.read(path)?
+    let rows: List<Row> = xlsx.decodeRows(raw, "Sheet1")?
+    // each row's cells: #[taint("fs_input")] String
+    Ok(rows)
+}
+```
+
+Cells flowing into SQL, shell, or HTML sinks must pass the
+appropriate sanitizer first.
+
+#### 10.40.2 XLSX deterministic encoding
+
+`xlsx.encodeRows(name, rows)` produces deterministic output —
+identical inputs yield byte-identical XLSX archives. This is
+necessary for `#[golden]` tests of XLSX-generating code:
+
+```osty
+#[golden("fixtures/report.xlsx", mode = "binary")]
+#[reproducible(scope = "portable")]
+fn testReport() {
+    let bytes = xlsx.encodeRows("Report", [
+        ["name", "score"],
+        ["Ada", "42"],
+    ])?
+    testing.assertGolden(bytes)
+}
+```
+
+The deterministic property covers cell ordering, sheet metadata,
+and the underlying ZIP container's internal byte layout. ZIP
+timestamps are pinned to a fixed epoch (2000-01-01) to avoid
+non-determinism from build-time clocks.

--- a/LANG_SPEC_v0.6/10-standard-library/43-supabase.md
+++ b/LANG_SPEC_v0.6/10-standard-library/43-supabase.md
@@ -207,3 +207,49 @@ supabase.requireSuccess(response) -> Result<http.Response, Error>
 
 `ApiError` extracts the common Supabase/PostgREST JSON fields `code`,
 `message`, `details`, and `hint`, while preserving the raw body for logs.
+
+#### 10.43.1 Supabase capability surface
+
+Production Supabase code touches three v0.6 capability points:
+
+1. **`Env` for credential lookup** — `supabase.fromEnv(env)` reads
+   `SUPABASE_URL` and `SUPABASE_ANON_KEY` (or
+   `SUPABASE_SERVICE_ROLE_KEY` for service role).
+2. **`Net` for HTTP transport** — `supabase.send*` consumes a
+   `Net` capability to issue the actual request.
+3. **No `Clock`/`Rng` directly** — Supabase request building is
+   pure; ID generation (e.g. UUIDs for new rows) is delegated to
+   `std.uuid` and routed through whichever `Rng`/`CryptoRng` the
+   caller chooses.
+
+Tests inject `FakeEnv` (with the API URL/key set) and `FakeNet`
+(with canned PostgREST responses). The pure builder layer
+(`supabase.from`, `q.select`, `q.eq`, etc.) is acceptable inside
+`#[reproducible(scope = "target")]`; only the `send*` calls are
+non-reproducible.
+
+#### 10.43.2 Supabase and information flow
+
+PostgREST query results carry `#[taint("net_input")]` on each row
+field, like any other network response. When echoing a row back
+into a sink (HTML, SQL via different DB, shell), apply the
+appropriate sanitizer:
+
+```osty
+fn renderTodo(net: Net, sb: Client, id: Int) -> Result<String, Error> {
+    let q = supabase.from("todos")?.select("title").eq("id", "{id}")?
+    let row = supabase.sendSelectOne::<Todo>(net, sb, q)??
+    Ok(std.html.escape(row.title))             // sanitize for html_safe sink
+}
+```
+
+#### 10.43.3 Service role caveat
+
+A `Client` configured with `serviceRoleFromEnv()` bypasses Row
+Level Security (RLS). Service-role requests must be carefully
+audited; `osty audit --supabase-service-role` enumerates every
+client construction site that uses service role.
+
+For tests, prefer `FakeNet` over real service-role calls — service
+role compromises are common attack vectors when leaked into CI
+logs.

--- a/LANG_SPEC_v0.6/10-standard-library/44-github.md
+++ b/LANG_SPEC_v0.6/10-standard-library/44-github.md
@@ -185,3 +185,62 @@ github.requireSuccess(response) -> Result<http.Response, Error>
 
 `ApiError` extracts GitHub's common `message` and `documentation_url` fields
 while preserving the raw body for logs and agent transcripts.
+
+#### 10.44.1 GitHub capability surface
+
+Production GitHub code routes through:
+
+1. **`Env`** for token lookup — `env.require("GITHUB_TOKEN")`.
+2. **`Net`** for HTTP transport — `client.send(net, req)`.
+3. **`std.crypto`** for webhook signature verification — pure,
+   no capability needed.
+
+Pure builder functions (`github.repo`, `github.issueQuery`,
+`github.pullRequestDraft`, etc.) build request values and are
+acceptable inside `#[reproducible(scope = "target")]`. Only the
+actual `send*` call is non-reproducible.
+
+#### 10.44.2 Webhook verification flow
+
+GitHub webhooks use HMAC-SHA256 signature verification. The
+verification function:
+
+```osty
+fn verifyWebhook(secret: String, body: Bytes, sigHeader: String) -> Bool {
+    let expected = crypto.hmac.sha256(secret.toBytes(), body)
+    let actual = parseSig(sigHeader)
+    crypto.constantTimeEq(expected, actual)
+}
+```
+
+is *pure* — no capability required. The `constantTimeEq` is
+critical: a vanilla `==` on byte sequences leaks timing
+information that attackers can exploit to forge signatures.
+
+The full webhook intake combines verification + replay window +
+payload parsing — covered by `std.webhook` (§10.45).
+
+#### 10.44.3 Rate limit handling
+
+GitHub returns rate-limit headers (`X-RateLimit-Remaining`,
+`X-RateLimit-Reset`) on every response. Client code that wants to
+respect these should:
+
+1. Read the headers from the `Response`.
+2. Sleep until reset if remaining is 0.
+3. Retry the request.
+
+`std.httpretry` (§10.34) provides the backoff infrastructure;
+`Clock.sleep` honors cancellation so a long-running rate-limit
+wait does not block `taskGroup` shutdown.
+
+#### 10.44.4 Token scope and `#[stability]`
+
+A `pub fn` that takes `github.Client` exposes the underlying token
+*usage* — code that wraps GitHub calls should document the minimum
+required token scope (e.g. `repo`, `repo:read`, `workflow`).
+
+Documenting scope is a `#[purpose]` / `#[doc-comment]` choice, not
+a v0.6 type-level feature. A future audit subcommand
+(`osty audit --github-scope`) is tracked for Phase 5 to
+auto-extract scope hints from doc comments.

--- a/LANG_SPEC_v0.6/10-standard-library/45-webhook.md
+++ b/LANG_SPEC_v0.6/10-standard-library/45-webhook.md
@@ -137,3 +137,77 @@ webhook.clearInFlight(store, key) -> Store
 `Store` is intentionally value-shaped. Small applications can keep it in memory;
 larger services should persist the same `idempotencyKey(event)` in a database or
 queue table before performing side effects.
+
+#### 10.45.1 Webhook input flow tag
+
+The bytes received from a webhook callback carry
+`#[taint("user_input")]` because the sender is not authenticated
+beyond signature verification. Even after signature passes, the
+*payload* is still controlled by an external party.
+
+```osty
+fn handle(env: Env, clock: Clock, req: HttpRequest) -> Result<HttpResponse, Error> {
+    let policy = webhook.stripe(env.require("STRIPE_WEBHOOK_SECRET")?)
+    let store = webhook.emptyStore()
+
+    let outcome = webhook.dispatch(req, policy, clock, store, fn(event) {
+        // event.payload: #[taint("user_input")] Bytes
+        // — process under the same trust assumption as any HTTP body
+        webhook.ack()
+    })
+    Ok(outcome.response)
+}
+```
+
+The signature check is a *replay-prevention* guarantee, not a
+declassification of the payload. Code processing the event payload
+must apply the same flow-tag rules as ordinary user input.
+
+#### 10.45.2 Replay window and Clock determinism
+
+The `webhook.policy` configures an acceptable replay window (e.g.
+"timestamps older than 5 minutes are rejected"). The check uses
+`clock.now()` against the event's signed timestamp; deterministic
+testing requires `FakeClock`:
+
+```osty
+#[test]
+fn test_replay_rejected() {
+    let env = std.capability.testing.FakeEnv(vars = {"STRIPE_WEBHOOK_SECRET": "test"})
+    let clock = std.capability.testing.FakeClock(epoch_ms = 1_700_000_000_000)
+    let req = std.capability.testing.fakeStripeWebhook(timestamp = 1_699_999_900_000)  // 100s old
+
+    let outcome = handle(env, clock, req)?
+    testing.assert(outcome.response.status == 400)  // replay rejected
+}
+```
+
+The replay window is part of the package's policy, not a v0.6
+language feature; the `Clock` capability is the v0.6 mechanism
+that makes the policy testable.
+
+#### 10.45.3 Webhook and `#[error_contract]`
+
+A handler returning `Result<HttpResponse, WebhookError>` carries
+contract entries for each verification failure mode:
+
+```osty
+pub enum WebhookError {
+    SignatureMismatch,
+    Replay,
+    PayloadParseFailed,
+    HandlerFailed(Error),
+}
+
+#[error_contract(
+    WebhookError.SignatureMismatch when "signature did not verify",
+    WebhookError.Replay when "timestamp outside replay window",
+    WebhookError.PayloadParseFailed when "payload was not valid JSON",
+    WebhookError.HandlerFailed when "business handler returned Err",
+)]
+pub fn handle(env: Env, clock: Clock, req: HttpRequest) -> Result<HttpResponse, WebhookError> { ... }
+```
+
+Each variant maps to a distinct HTTP response shape; the contract
+makes the mapping explicit at the type level, and the handler
+function's match exhaustiveness benefits from the contract pruning.


### PR DESCRIPTION
## Summary

PR #1533 후속 — 남은 stdlib chapter의 capability / flow / determinism
sub-section들을 한 batch에 묶어 1000+ LOC PR threshold 달성.
**+1015 LOC**, 21 spec 파일.

### §10 stdlib chapters (21)

| Chapter | Topics |
|---|---|
| §10.12 crypto | HMAC + `constantTimeEq` / hash + flow / sha1+md5 deprecation lint |
| §10.13 UUID | v7 sortability / v4 vs v7 selection guide 표 |
| §10.14 Random | Rng method semantics 표 / combining seeded + host RNGs |
| §10.15 OS | `Process.exit` + defer skip / signal handling pattern |
| §10.16 URL | query parameter handling / RFC 3986 join semantics 표 |
| §10.20 Time | Duration arithmetic / timezone caveats |
| §10.22 fmt | format vs interpolation choice / compactNumber locale |
| §10.23 Net | timeout discipline / UDP packet boundaries / concurrent connections |
| §10.24 HTTP | router pattern matching 표 / cookie+header attacks / server-side cancel |
| §10.25 Terminal | cursor + screen restoration pattern |
| §10.26 TUI | composition patterns / diff-based rendering / Frame + flow |
| §10.27 Grid | coordinate determinism / flow |
| §10.28 SQL | builder determinism / SqlIdent + parameterization / dialect render 표 |
| §10.29 DB | FakeDb fidelity / migration patterns |
| §10.30 SMTP | testing pattern (FakeNet + cannedSmtpReplies) / STARTTLS handshake |
| §10.34 Deneb | v0.6 surface summary 표 (10 sub-modules) |
| §10.35 Table | operations + v0.6 / aggregation determinism / schema coercion + flow |
| §10.40 XLSX | information flow / deterministic encoding (golden test) |
| §10.43 Supabase | capability / flow / service role caveat |
| §10.44 GitHub | capability / webhook verification / rate limit / token scope |
| §10.45 Webhook | input flow tag / replay window + Clock / error_contract integration |

이로써 v0.6 spec의 모든 stdlib chapter가 capability / flow / 결정성 / SemVer
정합 sub-section reference를 가진다.

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §10.* sub-sections이 §20.18 capability matrix와 정합
- [ ] §10.12.4 sha1/md5 deprecation이 `osty lint L0060` 본문과 정합
- [ ] §10.16.4 join semantics 표가 §10.16 본문과 정합
- [ ] §10.45.3 webhook error_contract가 §7.5 본문과 정합

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_