### PR TITLE
docs(v0.6): remove G49 + G38 + G43 + G46 (first pass, -626 LOC)

### DIFF
--- a/LANG_SPEC_v0.6/01-lexical-structure.md
+++ b/LANG_SPEC_v0.6/01-lexical-structure.md
@@ -30,21 +30,17 @@ A shebang is recognized **only at byte offset 0** of the source file and
 **only once**. Any `#` appearing elsewhere is the start of an annotation
 (§1.9) or, in any other context, a lex error.
 
-### 1.2 Keywords (18)
+### 1.2 Keywords (17)
 
 ```
 fn  struct  enum  interface  type
 let  mut  pub
 if  else  match
-for  while  break  continue  return
+for  break  continue  return
 use  defer
 ```
 
 These are reserved and may not be used as identifiers.
-
-`while` (G49) is reserved. `while cond { body }` is equivalent in
-lowering and meaning to `for cond { body }` — provided as ergonomics
-for callers who expect a distinct conditional-loop keyword.
 
 ### 1.3 Contextual Identifiers
 
@@ -59,12 +55,6 @@ The following have special meaning in context but are not reserved words:
 - `loop` — `loop { ... }` expression head (§4.4.1)
 - `const` — `const fn` declaration prefix (§3.1.1)
 - `by` — range step marker in range expressions (§4.4)
-- `spec` — spec block opener at function-body first-statement position
-  (§3.13). G43.
-- `example`, `law`, `invariant` — clause keywords inside `spec { ... }`
-  (§3.13). G43.
-- `forall` — *(reserved for v1, Phase 5)* property-test clause keyword
-  inside `spec { ... }` (§3.13.3).
 
 ### 1.4 Identifiers
 
@@ -534,30 +524,17 @@ position, or with arguments of the wrong type, is a compile error.
 
 #### 1.10.1 Reserved keyword 변경
 
-v0.5 → v0.6 에서 reserved keyword 가 17 → 18 로 +1 — `while` (G49).
-`while cond { body }` 와 `for cond { body }` 는 *동의어* — 두 form
-모두 같은 IR 로 lower (§4.4).
-
-| v0.5 | v0.6 | 변경 |
-|---|---|---|
-| 17 reserved | 18 reserved | +`while` |
+v0.5 → v0.6 에서 reserved keyword 가 17 → 17 로 *변경 없음*.
 
 #### 1.10.2 Contextual keyword 변경
 
 v0.5 의 contextual identifier set (`self`, `Self`, `true`, `false`,
-`Some`, `None`, `Ok`, `Err`, `loop`, `const`, `by`) 위에 v0.6 은
-4 추가 — `spec`, `example`, `law`, `invariant` (G43, §3.13).
-
-`spec` 은 top-level `fn` / method body 의 첫 statement 위치에서만
-keyword. `example`, `law`, `invariant` 는 *spec block 내부* 에서만
-keyword. 그 외 위치 (변수 이름, struct field 이름) 에서는 식별자.
-
-`forall` 은 v1 (Phase 5) 단계에서 추가 예정 — v0.6.0 baseline 에는
-없음.
+`Some`, `None`, `Ok`, `Err`, `loop`, `const`, `by`) 가 v0.6 에서도
+변경 없음.
 
 #### 1.10.3 Annotation set 변경
 
-v0.5 의 11 fixed annotation 위에 v0.6 은 20 신규 annotation 추가.
+v0.5 의 11 fixed annotation 위에 v0.6 은 16 신규 annotation 추가.
 모든 v0.6 annotation 의 합법 위치 표는 `00-revision.md §7.6` 가
 권위.
 
@@ -565,14 +542,12 @@ v0.5 의 11 fixed annotation 위에 v0.6 은 20 신규 annotation 추가.
 |---|---|
 | Capabilities (G36) | `#[ambient]`, `#[reproducible_capability]` |
 | Information flow (G37) | `#[taint]`, `#[sanitizes]`, `#[trusted_declassify]`, `#[taint_field]` (parameter `#[requires]` 는 v0.5 reuse) |
-| Spec link (G38) | `#[spec]` |
 | Reproducibility (G39) | `#[reproducible]` |
 | Sealed construct (G40) | `#[sealed_construct]`, `#[trusted_construct]`, `#[test_construct]` |
 | Error contract (G41) | `#[error_contract]` |
 | Structured intent (G42) | `#[purpose]`, `#[example]`, `#[fixture]` |
 | API evolution (G44) | `#[since]`, `#[stability]`, `#[match_compat]` |
 | Golden tests (G45) | `#[golden]` |
-| Performance (G46) | `#[budget]` |
 
 annotation 인자는 v0.5 와 동일 — *literal 만* (string / int / bool /
 ident / `key = literal`). expression 인자 불가.
@@ -580,26 +555,19 @@ ident / `key = literal`). expression 인자 불가.
 #### 1.10.4 Lexer token 변경
 
 v0.5 에서 v0.6 으로 *새 token kind 0 추가*. 모든 v0.6 신규 syntax
-(spec block / parameter-position annotation / capability parameter)
-는 기존 token 으로 표현 가능.
+(parameter-position annotation / capability parameter) 는 기존
+token 으로 표현 가능.
 
 #### 1.10.5 ASI 영향
 
-`while` keyword 추가는 `for` / `loop` 와 동일한 ASI suppression
-패턴. `while cond { body }` 는 `if cond { body }` 와 같은 token
-flow 로 처리.
-
-`spec { }` block 은 top-level `fn` / method body 의 *첫 statement
-위치* 에서 lex — `fn foo() {` 다음 `spec` 식별자 발견 시 spec block
-시작 token 으로 승격. closure body, `if` arm, `match` arm, nested block
-안에서는 일반 식별자.
+v0.6 추가 surface 는 ASI 규칙에 영향 없음.
 
 #### 1.10.6 Diagnostic 영향
 
 v0.6 lexical 영역에 *신규 진단 코드 0* — 모든 신규 surface 가 기존
 band 의 코드 재사용 또는 §3.8 / §20 / §21 의 의미론 진단으로 처리.
 
-`E0400` (CodeUnknownAnnotation) 는 v0.6 의 20 추가 annotation 모두
+`E0400` (CodeUnknownAnnotation) 는 v0.6 의 16 추가 annotation 모두
 recognize — `internal/ast/ast.go::annotationRules` 와
 `toolchain/resolve.osty::srAnnotAllowedTargets`, checked-in selfhost
 generated mirror 가 sync.

--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -3,33 +3,31 @@
 This chapter defines Osty v0.6 declaration forms — functions (§3.1),
 variables (§3.2), multiple assignment (§3.3), structs (§3.4) including
 the v0.6 sealed-construct rule (§3.4.5, G40), enums (§3.5), interfaces
-(§3.6), type aliases (§3.7), and annotations (§3.8). Sections §3.10
-through §3.15 specify the v0.6 *hidden-dependency-surface*
-annotations (G36–G46) — `#[spec]` for spec-link traceability,
-`#[reproducible]` for environment-independence, `#[purpose]` /
-`#[example]` / `#[fixture]` for structured intent, `spec { ... }`
-blocks for executable specification, `#[since]` / `#[stability]` /
-`#[match_compat]` for API evolution, and `#[budget]` for performance
-contracts.
+(§3.6), type aliases (§3.7), and annotations (§3.8). Sections §3.11,
+§3.12, and §3.14 specify the v0.6 *hidden-dependency-surface*
+annotations (G36, G39, G42, G44) — `#[reproducible]` for
+environment-independence, `#[purpose]` / `#[example]` / `#[fixture]`
+for structured intent, and `#[since]` / `#[stability]` /
+`#[match_compat]` for API evolution.
 
 The v0.6 design north star (*hidden dependency is forbidden*) is
 realized in this chapter: every external dependency, intent,
 contract, or evolution rule that affects a declaration is expressible
-at the declaration site. The annotation surface in §3.10 – §3.15
-makes that visibility *machine-readable* so that diagnostics
-(§3.10.4 spec link, §7.5 error contract), enforcement (§3.11
-reproducibility, §3.4.5 sealed construct), and tooling (§13.4 `osty
-context`, §13.5 `osty publish`) all share one source of truth.
+at the declaration site. The annotation surface in §3.11, §3.12,
+§3.14 makes that visibility *machine-readable* so that diagnostics
+(§7.5 error contract), enforcement (§3.11 reproducibility, §3.4.5
+sealed construct), and tooling (§13.4 `osty context`, §13.5 `osty
+publish`) all share one source of truth.
 
-The annotation set is finite — 31 compiler-recognized annotations as
+The annotation set is finite — 27 compiler-recognized annotations as
 of v0.6 (§3.8). Three sub-categories sit on top of the underlying
 declaration grammar:
 
 | Category | Annotations | Purpose |
 |---|---|---|
 | **Effect & flow** | `#[ambient]`, `#[reproducible]`, `#[reproducible_capability]`, `#[taint]`, `#[sanitizes]`, `#[requires]`, `#[trusted_declassify]` | Make capability use, reproducibility scope, and information-flow tags explicit at the declaration boundary. |
-| **Intent & contract** | `#[purpose]`, `#[example]`, `#[fixture]`, `#[spec]`, `spec { }` block, `#[error_contract]`, `#[golden]` | Author-visible, machine-readable record of *what a declaration is for* and *what it must produce*. |
-| **Evolution & budget** | `#[since]`, `#[stability]`, `#[match_compat]`, `#[deprecated]`, `#[budget]` | Promises about API surface stability and performance regression bounds, enforced by `osty publish` and `osty bench --budget`. |
+| **Intent & contract** | `#[purpose]`, `#[example]`, `#[fixture]`, `#[error_contract]`, `#[golden]` | Author-visible, machine-readable record of *what a declaration is for* and *what it must produce*. |
+| **Evolution** | `#[since]`, `#[stability]`, `#[match_compat]`, `#[deprecated]` | Promises about API surface stability, enforced by `osty publish`. |
 
 Declarations without these annotations behave per the underlying
 grammar — the annotations are *opt-in attestations*, not new syntactic
@@ -644,22 +642,24 @@ Stdlib v0.6 sealed types (`Email`, `Url`, `Path`, `SqlIdent`,
 `Duration`, `Uuid`) maintain the contract `parse(value.toString())?
 == Some(value)` for every value the constructor produces. User code
 that defines a sealed type **should** uphold the same round-trip;
-formalizing it via a `spec { law: ... }` clause (§3.13) gives the
-checker a target:
+documenting the law in a doc comment and asserting it in tests
+covers the contract:
 
 ```osty
 #[sealed_construct(parse)]
 pub struct Slug {
     text: String,
 
-    pub fn parse(s: String) -> Slug? {
-        spec {
-            law: result.map(|sl| Slug.parse(sl.toString())) == Some(Some(result))
-        }
-        ...
-    }
+    /// Round-trip: `parse(slug.toString())? == Some(slug)`.
+    pub fn parse(s: String) -> Slug? { ... }
 
     pub fn toString(self) -> String { self.text }
+}
+
+#[test]
+fn test_slug_roundtrip() {
+    let s = Slug.parse("hello-world").unwrap()
+    testing.assertEq(Slug.parse(s.toString()), Some(s))
 }
 ```
 
@@ -1572,26 +1572,19 @@ which keeps the *interactions* between annotations bounded. The table
 below catalogues the meaningful pairings — empty cells mean the
 annotations are orthogonal (no special rule applies).
 
-| Caller annotation | `#[reproducible]` | `#[pure]` | `#[error_contract]` | `#[budget]` | `#[golden]` |
-|---|---|---|---|---|---|
-| `#[ambient]` | rejected (only in entry-point) | rejected | OK | OK | OK |
-| `#[reproducible]` | scope ≤ caller | implied stronger | OK | OK | implicit `#[reproducible]` |
-| `#[pure]` | implies all scopes | (self) | OK | OK | OK |
-| `#[error_contract]` | OK | OK | (only for `Result<_, E>`) | OK | OK |
-| `#[budget(static)]` | OK | OK | OK | (self) | OK |
-| `#[budget(runtime)]` | warned (perf measurement is non-deterministic) | warned | OK | (self) | warned |
-| `#[golden]` | implicit `#[reproducible(scope = "target")]` | OK | OK | OK | (self) |
+| Caller annotation | `#[reproducible]` | `#[pure]` | `#[error_contract]` | `#[golden]` |
+|---|---|---|---|---|
+| `#[ambient]` | rejected (only in entry-point) | rejected | OK | OK |
+| `#[reproducible]` | scope ≤ caller | implied stronger | OK | implicit `#[reproducible]` |
+| `#[pure]` | implies all scopes | (self) | OK | OK |
+| `#[error_contract]` | OK | OK | (only for `Result<_, E>`) | OK |
+| `#[golden]` | implicit `#[reproducible(scope = "target")]` | OK | OK | (self) |
 
 Reading examples:
 
 - `#[ambient(clock)]` + `#[reproducible]`: rejected. `#[ambient]` is
   permitted only on entry-point functions, which are not
   reproducible. `E0782`.
-- `#[golden]` + `#[budget(time_ms = 5)]`: warned. The golden
-  comparison runs in the test harness; mixing it with runtime
-  budget measurement makes the budget signal noisy. The recommended
-  pattern is to keep `#[budget(runtime)]` on the production
-  function and `#[golden]` on the test fixture that drives it.
 - `#[error_contract]` + `#[pure]`: OK. A pure function may return
   `Result<_, E>` and carry an error contract.
 - `#[reproducible(scope = "portable")]` + transitively-called
@@ -1610,125 +1603,19 @@ sequence (top to bottom):
    appears in the slot)
 2. **Intent** — `#[purpose]`
 3. **Examples** — `#[example]` (one or more)
-4. **Spec link** — `#[spec]`
-5. **Error contract** — `#[error_contract]`
-6. **Reproducibility / purity** — `#[reproducible]` / `#[pure]`
-7. **Budget** — `#[budget]`
-8. **Stability / since** — `#[stability]`, `#[since]`, `#[deprecated]`
-9. **Performance hints** — `#[inline]`, `#[hot]` / `#[cold]`,
+4. **Error contract** — `#[error_contract]`
+5. **Reproducibility / purity** — `#[reproducible]` / `#[pure]`
+6. **Stability / since** — `#[stability]`, `#[since]`, `#[deprecated]`
+7. **Performance hints** — `#[inline]`, `#[hot]` / `#[cold]`,
    `#[target_feature]`, `#[noalias]`, `#[parallel]`,
    `#[vectorize]`, `#[unroll]`, `#[no_vectorize]`
-10. **Compatibility** — `#[match_compat]`
-11. **Information flow** — `#[taint]` / `#[sanitizes]` / `#[trusted_declassify]` (function-level)
-12. **Capability marker** — `#[reproducible_capability]` (interfaces)
+8. **Compatibility** — `#[match_compat]`
+9. **Information flow** — `#[taint]` / `#[sanitizes]` / `#[trusted_declassify]` (function-level)
+10. **Capability marker** — `#[reproducible_capability]` (interfaces)
 
 The formatter normalizes to this ordering on save. Authors who
 prefer a different sequence should set `formatter.annotation_order =
 "as-written"` in `osty.toml`.
-
-### 3.10 `#[spec("§X.Y")]` — Spec link (G38)
-
-A declaration may carry `#[spec("§X.Y")]` to register a checked link
-into the language specification. The compiler verifies the target
-markdown anchor exists; missing anchors produce `E0790`. The compiler
-includes the section's lead paragraph in `osty doc` output and LSP
-hover.
-
-```osty
-#[spec("§2.2")]
-fn checkNumericWidening(from: Type, to: Type) -> CheckResult { ... }
-
-#[spec("§10.30.user")]
-pub fn createUser(email: String, db: Db) -> Result<UserId, Error> { ... }
-```
-
-`#[spec]` may be applied to functions, methods, structs, enums, and
-interfaces. Use is encouraged for compiler-internal code
-(`internal/check`, `toolchain/*.osty`) and stdlib modules; user code
-may use it for self-documentation. Osty has no `impl` blocks (§14) —
-methods live in struct / enum bodies, where `#[spec]` applies
-directly.
-
-#### 3.10.1 Anchor resolution
-
-The `§X.Y` form is resolved against the spec markdown corpus (the
-files in `LANG_SPEC_v0.6/`) at compile time. Resolution rules:
-
-1. The argument must be a *string literal* matching the regex
-   `§\d+(\.\d+)*(\.\w+)*` (Unicode `§` is required — `&sect;` /
-   `§` are not accepted).
-2. The trailing path beyond `§X.Y` (e.g. `§10.30.user.create`)
-   names a markdown anchor *under* §10.30 — the resolver looks for
-   `<a id="user-create">` or a heading whose slugified form matches
-   `user-create`.
-3. Missing anchor → `E0790` with the suggested anchor list (the
-   resolver fuzzy-matches and offers up to 3 alternatives).
-4. Moved anchor (the file no longer contains the named heading but
-   the corpus still has the anchor elsewhere) → `W0790` — the
-   diagnostic suggests the new path. Tooling can auto-rewrite via
-   `osty fix --spec-links`.
-
-```osty
-#[spec("§10.30.user.create")]   // resolves to LANG_SPEC_v0.6/10-standard-library/30-...
-                                //   under heading "user.create"
-pub fn createUser(...) -> ... { ... }
-```
-
-#### 3.10.2 Spec link inheritance
-
-A `#[spec]` annotation on a `struct` or `enum` is *not* inherited by
-its methods — each method declares its own link. This is intentional:
-the struct's spec link describes the *type*, while a method's spec
-link points at the specific method's contract. Tools resolve both
-when generating documentation.
-
-```osty
-#[spec("§10.30.user")]
-pub struct User {
-    pub email: Email,
-    ...
-
-    #[spec("§10.30.user.toString")]
-    pub fn toString(self) -> String { ... }
-
-    // No #[spec] — `osty doc` falls back to "see User type spec".
-    pub fn isVerified(self) -> Bool { self.verified }
-}
-```
-
-#### 3.10.3 Spec link in `osty context` JSON
-
-`osty context <symbol> --format=json` emits the resolved spec link
-as a structured object containing the anchor, the file path, the
-heading text, and the lead paragraph (first non-empty paragraph
-after the heading). This lets agents read the spec body without
-fetching and parsing markdown themselves.
-
-```json
-{
-  "spec": {
-    "anchor": "§10.30.user.create",
-    "file": "LANG_SPEC_v0.6/10-standard-library/30-user.md",
-    "heading": "user.create",
-    "lead": "Create a user, validating email format..."
-  }
-}
-```
-
-#### 3.10.4 `#[spec]` and capability surface
-
-A function with `#[spec("§X.Y")]` is *not* implicitly required to
-match the capability surface declared in the spec target. The
-checker verifies the anchor's *existence*, not its semantic
-agreement with the function. Authors who want the stronger
-guarantee can use `#[reproducible]` / `#[error_contract]` /
-`#[budget]` together — those *do* enforce a contract — and use
-`#[spec]` only as a documentation breadcrumb.
-
-A future revision may add `osty validate-spec --strict` (§13.6)
-that runs LLM-driven semantic comparison between the spec text and
-the implementation — that gate is opt-in and not part of the v0.6
-baseline.
 
 ### 3.11 `#[reproducible(scope=...)]` — Determinism contract (G39)
 
@@ -2017,134 +1904,6 @@ declaration: every external dependency, every failure mode, every
 test fixture, every API stability promise — all surfaced explicitly
 at the function's signature.
 
-### 3.13 `spec { ... }` — Executable Spec Block (G43)
-
-A top-level function or method body may begin with a `spec { ... }`
-block stating executable specifications colocated with the implementation. The
-block has no runtime cost — `example:` clauses run as tests under
-`osty test --spec`, while `law:` and `invariant:` clauses are surfaced
-in `osty doc` and LSP hover.
-
-```osty
-fn normalizeEmail(s: String) -> String {
-    spec {
-        example: normalizeEmail(" Alice@EXAMPLE.COM ") == "alice@example.com"
-        example: normalizeEmail("") == ""
-        law: result == result.trim()
-        law: result == result.toLowerCase()
-        invariant: result.indexOf(" ") == -1
-    }
-    s.trim().toLowerCase()
-}
-```
-
-**Clauses.**
-
-| Clause | v0.6 (Phase 3) | v1 (Phase 5) |
-|---|---|---|
-| `example: expr` | Run as test under `osty test --spec`; expected `Bool` (`E0441`) | (same) |
-| `law: expr`, `invariant: expr` | Doc / LSP only; `result` is virtual binding for return value (`E0442`) | (same) |
-| `forall x, y in gen: expr` | Reserved (parser allows; runtime defers) | Auto property test |
-
-The `spec` block must be the top-level function or method body's
-*first* statement (`E0440`). It is not an expression; it produces no
-value. Closure bodies, `if` arms, `match` arms, and nested blocks cannot
-host a `spec` block even when `spec` appears first inside that block.
-
-#### 3.13.1 `result` virtual binding
-
-Inside `law:` and `invariant:` clauses, the identifier `result`
-refers to the function's return value as if it had already been
-computed. The binding is *virtual* — it does not exist at runtime,
-and the clauses themselves are not executed in v0.6 baseline (Phase
-3 runs `example:` only). The checker uses `result` to type-check
-the clause body so authors can reference it without `let result =
-...` boilerplate.
-
-```osty
-fn parseInt(s: String) -> Result<Int, Error> {
-    spec {
-        example: parseInt("42") == Ok(42)
-        example: parseInt("foo").isErr()
-        law: result.isOk() == s.bytes().all(|b| b >= '0' && b <= '9') || s == ""
-        invariant: !result.isOk() || result.unwrap() >= 0 || s.startsWith("-")
-    }
-    ...
-}
-```
-
-`result` is in scope only inside `law:` / `invariant:` clauses.
-Inside `example:` clauses, the function is called explicitly with
-the example's input — there is no implicit `result` because the
-runner needs to know which arguments to pass.
-
-#### 3.13.2 Determinism rules for `example:` clauses
-
-An `example:` clause is run as a test under `osty test --spec`.
-The test harness applies these rules:
-
-1. The clause body must evaluate to `Bool`. Anything else is `E0441`.
-2. The clause is run with the surrounding function's `#[fixture]` set
-   inlined as `let` bindings — every `name` in `#[example(uses =
-   "name")]` is bound to the fixture body's return value.
-3. The clause cannot consult non-deterministic capabilities directly.
-   To exercise `Clock` / `Rng` / `Net` / `Fs`, route through
-   `std.capability.testing.Fake*` via a `#[fixture]`.
-4. Multiple `example:` clauses run independently — each gets a fresh
-   fixture instance, so state mutations don't leak between examples.
-
-```osty
-#[fixture(name = "fakeClock")]
-fn fakeClock() -> Clock {
-    std.capability.testing.FakeClock(epoch_ms = 1_000_000)
-}
-
-fn timestampLine(clock: Clock, msg: String) -> String {
-    spec {
-        example: timestampLine(fakeClock(), "ready") == "1000000:ready"
-    }
-    "{clock.now().toEpochMillis()}:{msg}"
-}
-```
-
-#### 3.13.3 Composing with `#[example]`
-
-`spec { example: }` and `#[example]` are *additive* surfaces, not
-substitutes:
-
-| Surface | Best for |
-|---|---|
-| `spec { example: ... }` (inside body) | Examples that read naturally as code; "the parser accepts these inputs" |
-| `#[example(input = ..., output = ..., uses = ...)]` (annotation) | Machine-readable input/output pairs; consumed by `osty doc` and `osty context` JSON |
-
-A function may carry both. `osty test --spec` runs the spec-block
-clauses; `osty test --example` runs the annotation entries; `osty
-test --spec --example` runs both. They share the same `#[fixture]`
-registry.
-
-#### 3.13.4 Spec block and reproducibility
-
-A spec block does not by itself make its enclosing function
-`#[reproducible]` — that's a separate annotation (§3.11). However,
-spec blocks compose well with reproducibility:
-
-```osty
-#[reproducible(scope = "target")]
-fn merkleRoot(leaves: List<Bytes32>) -> Bytes32 {
-    spec {
-        example: merkleRoot([]) == Bytes32.zero()
-        example: merkleRoot([Bytes32.zero()]).isHashOf(Bytes32.zero())
-        law: result == merkleRoot(leaves)   // determinism
-    }
-    ...
-}
-```
-
-The `law: result == merkleRoot(leaves)` clause is documentation in
-v0.6 baseline; Phase 5 turns it into an enforced property test
-(`forall leaves in gen.list(gen.bytes32(), 16): result ==
-merkleRoot(leaves)`).
-
 ### 3.14 API Evolution — `#[since]`, `#[stability]`, `#[match_compat]` (G44)
 
 Three annotations cooperate to make API versioning a first-class
@@ -2286,139 +2045,10 @@ Authors who follow this pattern get *zero silent fallthroughs* across
 the upgrade — the compiler-enforced fallback in v0.6 anchors the
 behavior, and the explicit handler in v0.7 replaces it.
 
-### 3.15 `#[budget]` — Performance Contract (G46)
-
-A function may declare static and runtime performance budgets.
-
-```osty
-#[budget(allocs = 0, io_calls = 0, stack_depth = 100)]
-fn pureCompute(data: Bytes) -> Bytes32 { ... }
-
-#[budget(time_ms = 5, p99_ms = 20)]
-fn routeRequest(req: Request) -> Response { ... }
-```
-
-**Static keys** (compiler-proven; violation `E0795`):
-
-| Key | Meaning |
-|---|---|
-| `allocs = N` | Maximum GC allocation sites in transitive call graph |
-| `io_calls = N` | Maximum capability-method calls |
-| `stack_depth = N` | Maximum recursive depth |
-| `instructions = N` | LLVM-cost-model estimate |
-
-**Runtime keys** (measured by `osty bench --budget`; violation `W0795`):
-
-| Key | Meaning |
-|---|---|
-| `time_ms = X` | Mean wall-clock time |
-| `p99_ms = X` | p99 wall-clock time |
-
-Static and runtime keys may coexist on the same annotation —
-the compiler partitions them by category.
-
-#### 3.15.1 Static-key proof rules
-
-`allocs = N` is proved by counting allocation sites in the
-function's transitive call graph. The checker walks every callee
-reachable from the function body and sums the worst-case
-allocations per call site. A function calling `List<Int>.append(x)`
-in a loop with bound `n` counts `n` allocations (one per `append`),
-so `#[budget(allocs = 0)]` on such a function is `E0795`.
-
-`io_calls = N` counts capability-method calls. A function that takes
-`Net` and calls `net.connect(...)` once carries `io_calls = 1`. A
-helper that *transitively* calls `net.connect` through 3 wrapper
-functions still counts the single underlying call.
-
-`stack_depth = N` is proved by the maximum simple-cycle path in the
-call graph. Recursive functions can carry `stack_depth = N` only
-when the recursion has a structural bound (e.g. tree height); the
-checker conservatively rejects unbounded recursion under any finite
-budget.
-
-`instructions = N` uses the LLVM IR cost model; the budget is
-matched against the function's lowered IR instruction count. Tight
-loops with `#[unroll]` raise the count; the budget should be set
-based on observed values from `osty bench --instructions`.
-
-#### 3.15.2 Runtime-key measurement
-
-`time_ms` and `p99_ms` are sampled by `osty bench --budget` over a
-large iteration count (default 1000, configurable via
-`--benchtime`). The sampling rules:
-
-- The benchmark warm-up phase (`max(N/10, 100)` iterations) is
-  excluded from the budget check.
-- Wall-clock time uses the monotonic clock; clock skew during the
-  run does not affect the budget.
-- Cancellation paths (`Err(Cancelled { ... })` returned mid-run) are
-  counted as failed iterations; budget violations apply to
-  successful iterations only.
-- A regression of more than 20% over the previous published version
-  promotes `W0795` (warning) to `E0795` (error) on `osty publish`,
-  blocking release until fixed or the budget is intentionally
-  loosened (which itself is a SemVer-relevant change — see §3.14).
-
-#### 3.15.3 Worked budget patterns
-
-**Hot pure helper** — zero alloc, zero IO, bounded depth:
-
-```osty
-#[budget(allocs = 0, io_calls = 0, stack_depth = 1)]
-#[reproducible(scope = "portable")]
-fn xorBytes(a: Bytes, b: Bytes) -> Bytes {
-    let mut out = Bytes.zeros(a.len())
-    for i in 0..a.len() {
-        out[i] = a[i] ^ b[i]
-    }
-    out
-}
-```
-
-The single output buffer is the lone allocation; `Bytes.zeros` is a
-single allocation site. Adjusting to `allocs = 1` reflects the
-honest cost.
-
-**HTTP handler** — bounded time, bounded p99:
-
-```osty
-#[budget(time_ms = 5, p99_ms = 20)]
-fn routeUserLookup(req: HttpRequest, db: Db) -> Result<HttpResponse, Error> {
-    let id = req.queryParam("id") ?? ""
-    match db.queryOne::<User>("SELECT * FROM users WHERE id = ?", [id])? {
-        Some(u) -> Ok(http.okJson(u)),
-        None -> Ok(http.notFound("")),
-    }
-}
-```
-
-`time_ms = 5` says the *mean* response is under 5ms; `p99_ms = 20`
-says even the slowest 1% stays under 20ms. The benchmark drives
-the function with synthetic input under `osty bench --budget`; CI
-fails on regression.
-
-**Combined static + runtime**:
-
-```osty
-#[budget(
-    allocs = 4,
-    io_calls = 1,
-    time_ms = 5,
-    p99_ms = 20,
-)]
-pub fn createUser(email: String, db: Db) -> Result<UserId, UserCreateError> { ... }
-```
-
-The compiler proves `allocs ≤ 4` and `io_calls ≤ 1` at compile
-time; `osty bench --budget` measures `time_ms` and `p99_ms`. Both
-gates run independently — a static violation blocks at `osty
-check`, a runtime violation blocks at `osty publish`.
-
 ### 3.16 Combined v0.6 declaration patterns
 
-이 섹션은 §3.10–§3.15 의 v0.6 어노테이션을 *함께* 사용하는 patterns
-의 carry-forward 사례. 정식 의미는 각 sub-section.
+이 섹션은 §3.11 / §3.12 / §3.14 의 v0.6 어노테이션을 *함께* 사용하는
+patterns 의 carry-forward 사례. 정식 의미는 각 sub-section.
 
 #### 3.16.1 Library function — full v0.6 surface
 

--- a/LANG_SPEC_v0.6/04-expressions.md
+++ b/LANG_SPEC_v0.6/04-expressions.md
@@ -4,9 +4,8 @@ Osty v0.6 is an expression-oriented language. Block (§4.1), `if`
 (§4.2), `match` (§4.3), and `loop` are all expressions that produce
 values when used in value position, and statements when used at
 statement position. This chapter defines expression syntax and
-semantics: blocks, conditionals, pattern matching, loops including
-the v0.6-introduced `while cond { }` synonym for `for cond { }`
-(G49, §4.4), error propagation (§4.5), optional chaining and
+semantics: blocks, conditionals, pattern matching, loops (§4.4),
+error propagation (§4.5), optional chaining and
 nil-coalescing (§4.6), closures (§4.7), string interpolation (§4.8),
 member access (§4.9), indexing (§4.10), block scope (§4.11), `defer`
 semantics including cancellation interaction (§4.12), and assignment
@@ -26,13 +25,6 @@ grammar:
   expression form (`if`, `match`, `?`, closures, indexing,
   interpolation) preserving the tag set; sanitization is the only way
   to drop a tag, and it must be explicit (§21.5).
-- **Spec block.** A function's `spec { }` block (§3.13, G43) sits in
-  *declaration position* — `spec { example: ... }` is not an
-  expression. It must be the top-level function or method body's first
-  statement; placing it elsewhere is `E0440`.
-
-The v0.6 keyword addition is `while cond { }` as a synonym for
-`for cond { }` (G49, §4.4) — both lower to the same IR.
 
 ### 4.1 Block Expressions
 
@@ -300,8 +292,7 @@ for i in 0..100 by 2 { ... }
 for item in xs { ... }
 for (k, v) in map { ... }
 
-for cond { ... }                 // while-style (legacy form)
-while cond { ... }               // while-style (G49 — same lowering)
+for cond { ... }                 // while-style
 for { ... }                      // infinite
 
 let winner = loop {
@@ -379,7 +370,6 @@ The complete catalogue of v0.6 loop forms:
 |---|---|---|---|
 | `for x in iterable { }` | Each-iteration over an `Iterable<T>` | `()` | No (use `thread.checkCancelled()`) |
 | `for cond { }` | While-style loop | `()` | No |
-| `while cond { }` | While-style synonym (G49) | `()` | No |
 | `for { }` | Infinite, no value | `()` | No |
 | `for let Some(x) = expr { }` | Loop while pattern matches | `()` | No |
 | `loop { ... break value }` | Value-returning loop | type of `break value` | No |

--- a/LANG_SPEC_v0.6/11-testing.md
+++ b/LANG_SPEC_v0.6/11-testing.md
@@ -5,10 +5,8 @@ in `_test.osty` files or as `#[test]`-annotated functions in
 production sources; the runner is `osty test`, with assertions
 provided by `std.testing`. The v0.6 surface adds: declarative golden
 tests via `#[golden]` (§11.5.2, G45) which reuse the v0.5 snapshot
-on-disk format, executable specification clauses through `spec { }`
-blocks (§3.13, G43) which run as tests under `osty test --spec`, and
-the `#[example]` annotation (§3.12, G42) which auto-checks
-`input → output` declarations under `osty test --example`.
+on-disk format, and the `#[example]` annotation (§3.12, G42) which
+auto-checks `input → output` declarations under `osty test --example`.
 
 Test files use the `_test.osty` suffix and live alongside code in the
 same package. Functions whose names begin with lowercase `test` and
@@ -266,37 +264,6 @@ In bench mode:
   flag uses Go-style durations (`500ms`, `2s`, `1m`) and requires
   `--bench`.
 
-#### 11.4.1 `#[budget]` integration
-
-A bench function may target a specific function carrying
-`#[budget(time_ms = X, p99_ms = Y)]` (§3.15). When `osty bench
---budget` is run, the bench harness records the measured `time_ms`
-/ `p99_ms` and compares against the declared budget:
-
-```osty
-#[budget(time_ms = 5, p99_ms = 20)]
-pub fn createUser(email: String, db: Db) -> Result<UserId, Error> { ... }
-
-fn benchCreateUser() {
-    let db = std.capability.testing.FakeDb()
-    testing.benchmark(1000, || {
-        let _ = createUser("alice@example.com", db)?
-        Ok(())
-    })
-}
-```
-
-`osty bench --budget` output:
-
-```
-bench benchCreateUser: avg=2.1ms p99=4.7ms
-budget OK (within 5ms / 20ms).
-```
-
-Regression beyond the manifest's `regression-threshold` (§13.2.1)
-promotes the warning to error and blocks `osty publish`.
-
-#### 11.4.2 Capability fakes inside benchmarks
 
 A benchmark of capability-typed code uses fake instances
 (§11.18.1-7). Fakes are intentionally low-overhead: `FakeClock` /
@@ -806,69 +773,6 @@ fn test_cancel_propagates_through_sleep() {
 
 `FakeClock.sleep()` 은 즉시 반환하지만 `taskGroup` cancel 이 도달
 하면 `Err(Cancelled)` 로 응답.
-
-### 11.10 `spec { }` block as tests
-
-`spec { example: ... }` 절은 `osty test --spec` 모드에서 *자동 등록
-테스트* 가 된다 (G43, §3.13). spec block 의 example 은 `assertEq`
-호출 없이 boolean expression 으로 작성되며, runner 가 결과를 평가.
-
-#### 11.10.1 Example clauses
-
-```osty
-fn normalizeEmail(s: String) -> String {
-    spec {
-        example: normalizeEmail(" Alice@EXAMPLE.COM ") == "alice@example.com"
-        example: normalizeEmail("") == ""
-    }
-    s.trim().toLowerCase()
-}
-```
-
-`osty test --spec` 호출 시 두 example 이 자동 테스트로 등록 — 출력은
-`spec[normalizeEmail#example:1] PASS` 형식.
-
-#### 11.10.2 Law / invariant clauses
-
-```osty
-fn normalizeEmail(s: String) -> String {
-    spec {
-        example: normalizeEmail(" Hi ") == "hi"
-        law: result == result.trim()
-        law: result == result.toLowerCase()
-        invariant: result.indexOf(" ") == -1
-    }
-    s.trim().toLowerCase()
-}
-```
-
-`law:` / `invariant:` 는 v0 (Phase 3) 에선 *문서화 + LSP hover* 만 —
-실행되지 않는다. v1 (Phase 5) 에서 `forall` property test 자동
-생성과 함께 enforcement.
-
-`result` 는 함수 반환값을 가리키는 *virtual binding* — `law:` /
-`invariant:` 안에서만 의미를 가진다.
-
-#### 11.10.3 Spec block 와 일반 test 의 공존
-
-```osty
-fn normalize(s: String) -> String {
-    spec {
-        example: normalize("HI") == "hi"
-        law: result.length() <= s.length()
-    }
-    s.toLowerCase().trim()
-}
-
-// 같은 함수에 일반 test
-#[test]
-fn test_normalize_preserves_alpha() {
-    testing.assertEq(normalize("hello"), "hello")
-}
-```
-
-두 형식 모두 등록 — `spec { example: }` 는 `osty test --spec` 시,
-`#[test]` 는 `osty test` 시 (`--spec` 도 spec example 포함).
 
 ### 11.11 `#[example]` annotation as tests
 

--- a/LANG_SPEC_v0.6/13-tooling.md
+++ b/LANG_SPEC_v0.6/13-tooling.md
@@ -4,15 +4,13 @@ Osty v0.6 tooling exposes the spec surface through commands. The CLI
 (§13.1), package manifest format (§13.2), and zero-config formatter
 (§13.3) carry forward from v0.5 unchanged. v0.6 adds: `osty context`
 (§13.4, G47) for machine-readable intent extraction (purpose,
-example, spec_refs, error_contract, capabilities, taint, budget) as
-a single JSON document; `osty publish` (§13.5, G44) for SemVer
-enforcement against `#[stability]` declarations through API surface
-diff; `osty validate-spec` (§13.6, G38) for `#[spec(...)]` anchor
-validation; audit subcommands (§13.7) for trusted-declassify /
-trusted-construct / match-compat / legacy-globals enumeration; and
-test-subcommand extensions (§13.8) for `--spec`, `--example`,
-`--golden`, `--update-golden`, and `--doc` modes alongside `osty
-bench --budget` runtime gates.
+example, error_contract, capabilities, taint) as a single JSON
+document; `osty publish` (§13.5, G44) for SemVer enforcement against
+`#[stability]` declarations through API surface diff; audit
+subcommands (§13.7) for trusted-declassify / trusted-construct /
+match-compat / legacy-globals enumeration; and test-subcommand
+extensions (§13.8) for `--example`, `--golden`, `--update-golden`,
+and `--doc` modes.
 
 ### 13.1 CLI
 
@@ -594,77 +592,6 @@ The fingerprint excludes line numbers, formatting, and comments —
 reformatting source code does not change the fingerprint. This is
 why `osty fmt` is safe to run before `osty publish`.
 
-### 13.6 `osty validate-spec` (G38)
-
-`osty validate-spec` walks the workspace looking for `#[spec("§X.Y")]`
-annotations and verifies each anchor exists in
-`LANG_SPEC_v0.6/`. Missing anchors become `E0790`; anchors that have
-moved between sections produce `W0790` with a suggested replacement.
-
-```sh
-osty validate-spec                          # workspace
-osty validate-spec ./toolchain              # specific dir
-osty validate-spec --strict                 # treat W0790 as error
-osty validate-spec --update                 # apply suggested rewrites
-```
-
-The command is run automatically by `osty check --strict` and by
-the `just prepush` recipe.
-
-#### 13.6.1 Anchor resolution algorithm
-
-`osty validate-spec` walks the spec corpus once at startup, building
-an index of `(file, heading) → anchor`. The walk follows these
-rules:
-
-1. **Section heading** (`## §X.Y Title`, `### §X.Y.Z Title`) — the
-   anchor is `§X.Y` or `§X.Y.Z`. The title becomes the lead text.
-2. **Sub-anchor** (`<a id="X.Y.user.create"></a>` immediately
-   before a heading) — the anchor is the explicit `id`.
-3. **Inline anchor** (text immediately following a heading) — the
-   anchor is the heading's slugified title, with the parent
-   section as prefix.
-
-The index is rebuilt only when the spec corpus changes, so repeated
-`osty validate-spec` invocations are fast.
-
-For `#[spec("§X.Y")]` annotations whose argument matches a known
-anchor, the resolver records the `(file, heading, lead)` triple and
-caches it in `target/spec-links.json` for use by `osty doc` and
-`osty context`.
-
-#### 13.6.2 `--update` rewrite policy
-
-When invoked with `--update`, `osty validate-spec` applies
-suggested rewrites in three categories:
-
-1. **Anchor renamed** — `§X.Y` is replaced by the target section's
-   new anchor. The replacement is exact-string in the source file.
-2. **Anchor moved** — `§X.Y.foo` becomes `§A.B.foo` if the named
-   sub-anchor moved across sections. The resolver maintains a
-   *moved-anchor history* across spec versions to enable this.
-3. **Anchor removed** — emits `E0790` (no rewrite). The author
-   must manually choose a replacement.
-
-The rewrite mode is opt-in because changing spec links can have
-publish-surface implications (§3.14.3 includes `#[spec]` arguments
-in the API hash for `stable` symbols). CI typically runs
-`osty validate-spec --strict` (no `--update`) and asks the author
-to apply the rewrite locally with review.
-
-#### 13.6.3 Cross-package spec validation
-
-A workspace with multiple packages may reference spec anchors from
-each. `osty validate-spec` resolves *all* anchors against a single
-spec corpus snapshot — the workspace declares its target spec
-version in `osty.toml` (`[package].edition = "0.6"`).
-
-Mixed-edition workspaces (rare; transitional) resolve each package
-against its own edition's corpus. The compiler does not allow
-`edition = "0.5"` and `edition = "0.6"` to share a workspace
-directly — use a `[workspace.member]` boundary with explicit
-edition pin.
-
 ### 13.7 Audit subcommands
 
 Several v0.6 annotations grant *audit-marked escapes* — places where
@@ -933,51 +860,6 @@ osty publish --dry-run --report=summary
 #   1 PATCH
 #   Current bump: 0.6.0 → 0.6.1 (patch)
 #   ❌ Insufficient bump — major required
-```
-
-### 13.11 `osty validate-spec` algorithm
-
-`#[spec("§X.Y")]` 어노테이션의 anchor 가 `LANG_SPEC_v0.6/` 안에
-존재하는지 검증.
-
-#### 13.11.1 Workflow
-
-```
-1. 워크스페이스 walk → 모든 #[spec(...)] anchor 수집
-2. LANG_SPEC_v0.6/ 의 모든 markdown 파일 walk → heading anchor 카탈로그
-3. 각 #[spec] anchor 가 카탈로그에 있는지 확인
-4. 누락 → E0790
-5. 카탈로그에서 다른 chapter 로 이동했으면 (heading text 일치) → W0790 +
-   suggested replacement
-6. 모든 anchor 통과 → 0 errors
-```
-
-#### 13.11.2 Anchor 형식
-
-`#[spec("§X.Y")]` 의 `§X.Y` 는 다음 패턴 매치:
-
-- `§N` → `## N. <title>` heading
-- `§N.M` → `### N.M <title>` heading
-- `§N.M.K` → `#### N.M.K <title>` heading
-- `§10.X.<id>` → `LANG_SPEC_v0.6/10-standard-library/<NN>-<id>.md` 의 `## 10.X` heading
-
-#### 13.11.3 CLI
-
-```sh
-osty validate-spec                          # 전체 워크스페이스
-osty validate-spec ./toolchain              # 특정 디렉토리
-osty validate-spec --strict                 # W0790 도 error 처리
-osty validate-spec --update                 # suggested replacement 자동 적용
-```
-
-`osty check --strict` 와 `just prepush` 가 자동 호출.
-
-#### 13.11.4 CI 통합
-
-```yaml
-- name: Validate spec links
-  run: osty validate-spec --strict
-  # PR 가 spec section 을 옮기면 #[spec] 어노테이션도 함께 갱신해야 통과
 ```
 
 ### 13.12 Audit workflow


### PR DESCRIPTION
## Summary

사용자 결정 — 실용성이 낮은 v0.6 추가 4개를 v0.6 baseline 에서 철회.
**v0.6 결정 14개 → 10개로 축소**. 첫 pass: 정의 섹션 / 핵심 cross-reference 정리.
**-626 net LOC**, 5 spec 파일.

### 제거된 surface

| Gap | 기능 | 제거 이유 |
|---|---|---|
| **G49** | `while` keyword | `for cond { }` 와 동의어였음. 순수 cosmetic. 예약어 1개 회수. |
| **G38** | `#[spec("§X.Y")]` | 언어 spec 챕터 가리키는 annotation. user use case narrow. doc comment 대체 가능. |
| **G43** | `spec { example: / law: / invariant: }` block | `example:` 은 `#[example]` 과 기능 중복. `law:` / `invariant:` 는 v0 doc-only. |
| **G46** | `#[budget(...)]` | static + runtime keys. `#[pure]` 가 effect bound covers; perf bound 는 외부 벤치/CI 로 충분. |

### 본 commit 변경 (5 files, -626 LOC)

| Section | Change |
|---|---|
| §1.2 keywords | 18 → 17 (`while` 제거) |
| §1.3 contextual identifiers | `spec` / `example` / `law` / `invariant` 제거 |
| §1.10 lexical surface summary | 변경 없음 명시 |
| §3 chapter intro | 31 → 27 annotations |
| §3.4.5.2 round-trip | spec block law → doc comment + test |
| §3.8.13 annotation interaction matrix | `budget` 열 제거 |
| §3.8.14 ordering | spec link / budget 슬롯 제거 |
| §3.10 `#[spec]` (전체 삭제) | -104 LOC |
| §3.13 `spec { }` (전체 삭제) | -128 LOC |
| §3.15 `#[budget]` (전체 삭제) | -129 LOC |
| §3.16 worked patterns intro | §3.10–§3.15 → §3.11/§3.12/§3.14 |
| §4 chapter intro | while / spec block 언급 제거 |
| §4.4 loops form 표 | while 행 제거 |
| §11 chapter intro | spec block 언급 제거 |
| §11.4.1 `#[budget]` integration | -30 LOC |
| §11.10 spec block as tests | -63 LOC |
| §13 chapter intro | validate-spec / `bench --budget` 언급 제거 |
| §13.6 `osty validate-spec` (전체 삭제) | -71 LOC |
| §13.11 validate-spec algorithm | -45 LOC |

### 후속 batches

남은 cross-reference 정리는 follow-up batch들에서:
- §3.16 worked patterns 의 `#[spec]` / `#[budget]` / `spec { }` 사용 제거
- §13.4 osty context schema의 `spec_refs` / `budget` 필드 제거
- §13.5.1 publish gates 표의 budget 항목 제거
- §13.18 publish workflow 7-step 의 budget step 제거
- §10 stdlib 잔여 references
- 00-revision.md / 18-change-history.md / SPEC_GAPS.md / CHANGELOG_v0.6.md
- ABRIDGED.md / README.md
- OSTY_GRAMMAR_v0.6.md
- CLAUDE.md 부록 C
- ERROR_CODES.md (E0440-E0446 / E0790-E0790 / E0795)

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §3 chapter intro의 27 annotations 카운트가 §3.8 본문과 정합
- [ ] §3.16/§3.17 worked patterns에 남은 G38/G43/G46 사용 follow-up 에서 제거
- [ ] §13 본문이 §13.6 / §13.11 삭제 후 cross-link 깨지지 않음

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_