### PR TITLE
docs(v0.6): G49+G38+G43+G46 removal — second pass cleanup (-244 LOC)

### DIFF
--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -215,11 +215,6 @@ The v0.6 annotation surface composes with `const fn` as follows:
 - **`#[pure]`** — every `const fn` is implicitly pure (the body
   cannot consult any capability — capabilities are runtime
   values). Explicit `#[pure]` is permitted but redundant.
-- **`#[budget]`** — `const fn` calls in default-argument position
-  count for *zero* `allocs` / `io_calls` because the result is a
-  compile-time constant. They count for `instructions` only at the
-  runtime call site (when the `const fn` is called with non-const
-  arguments).
 - **`#[taint]`** — a `const fn` cannot receive a tainted input
   because tainted values are runtime constructs. The annotation is
   meaningless on a `const fn` parameter (`W0903`).
@@ -1862,7 +1857,6 @@ duplicate public/test helper name (`E0554`).
 #[example(input = ["invalid", "<Db>"],
           uses = "freshDb",
           output = "Err(SignupError.EmailFormat)")]
-#[spec("§10.30.user.signup")]
 #[since("0.6")]
 #[stability("stable")]
 #[error_contract(
@@ -1870,12 +1864,7 @@ duplicate public/test helper name (`E0554`).
     SignupError.DomainBlocked when "domain in deny-list",
     SignupError.DbConflict    when "email unique constraint",
 )]
-pub fn signup(email: String, db: Db) -> Result<UserId, SignupError> {
-    spec {
-        example: signup("alice@example.com", freshDb()) == Ok(UserId(1))
-    }
-    ...
-}
+pub fn signup(email: String, db: Db) -> Result<UserId, SignupError> { ... }
 
 #[fixture(name = "freshDb")]
 fn freshDb() -> Db { std.capability.testing.FakeDb() }
@@ -1890,11 +1879,10 @@ fn dbWithAlice() -> Db {
 
 This single declaration emits to:
 
-- `osty doc` page with purpose / spec link / failure modes / 3
-  example panels (each with the fixture body inlined).
+- `osty doc` page with purpose / failure modes / 3 example panels
+  (each with the fixture body inlined).
 - `osty context signup --format=json` with the full intent payload.
-- `osty test --spec --example --golden` runs all three examples + the
-  spec-block clause.
+- `osty test --example --golden` runs all three examples.
 - `osty publish` validates the API surface against `#[stability("stable")]`
   and the contract.
 - LSP hover shows the purpose + spec lead paragraph.
@@ -2064,7 +2052,6 @@ patterns 의 carry-forward 사례. 정식 의미는 각 sub-section.
     uses = "fakeDb",
     output = "Err(UserCreateError.Format)",
 )]
-#[spec("§10.30.user.create")]
 #[since("0.6")]
 #[stability("stable")]
 #[error_contract(
@@ -2072,7 +2059,6 @@ patterns 의 carry-forward 사례. 정식 의미는 각 sub-section.
     UserCreateError.DomainBlocked when "도메인 deny-list 등재",
     UserCreateError.DbConflict    when "이메일 unique 위반",
 )]
-#[budget(allocs = 8, io_calls = 1)]
 pub fn createUser(email: String, db: Db) -> Result<UserId, UserCreateError> {
     let parsed = Email.parse(email).orError(UserCreateError.Format)?
     if isDomainBlocked(parsed.domain()) {
@@ -2103,9 +2089,7 @@ fn fakeDb() -> Db { std.testing.db.inMemory() }
 ```osty
 #[purpose("Content-addressed hash of input bytes")]
 #[example(input = "<empty bytes>", output = "Bytes32.fromHex(\"e3b0c44...\")")]
-#[spec("§10.12.crypto")]
 #[reproducible(scope = "portable")]
-#[budget(allocs = 1, io_calls = 0)]
 pub fn computeKey(data: Bytes) -> Bytes32 {
     sha256(data)
 }
@@ -2115,33 +2099,12 @@ pub fn computeKey(data: Bytes) -> Bytes32 {
 `scope = "portable"` 는 가장 강한 scope — endianness / NaN bit /
 unordered iter 모두 거부 (§3.11.3).
 
-#### 3.16.3 Spec-block-driven validation
-
-```osty
-#[purpose("Normalize email — trim + lowercase")]
-fn normalizeEmail(s: String) -> String {
-    spec {
-        example: normalizeEmail(" Alice@EXAMPLE.COM ") == "alice@example.com"
-        example: normalizeEmail("") == ""
-        law: result == result.trim()
-        law: result == result.toLowerCase()
-        invariant: result.indexOf(" ") == -1
-    }
-    s.trim().toLowerCase()
-}
-```
-
-`spec { example: }` 는 `osty test --spec` 자동 실행. `law:` /
-`invariant:` 는 v0 (Phase 3) 에서 `osty doc` 만 — v1 (Phase 5) 에서
-property test 자동 생성.
-
-#### 3.16.4 Sealed type with structured intent
+#### 3.16.3 Sealed type with structured intent
 
 ```osty
 #[purpose("RFC 5322 email parser")]
 #[example(input = "alice@example.com", output = "Some(...)")]
 #[example(input = "no-at", output = "None")]
-#[spec("§10.30.email.parse")]
 #[since("0.6")]
 #[stability("stable")]
 #[sealed_construct(parse)]
@@ -2176,7 +2139,6 @@ struct literal `Email { local: ..., domain: ... }` 은 `E0420`. 이로써
     HandlerError.NotFound when "users 테이블에 없는 ID",
     HandlerError.DbDown   when "DB 연결 실패",
 )]
-#[budget(allocs = 4, io_calls = 1, time_ms = 50)]
 pub fn lookupUser(
     #[taint("user_input")] userId: String,
     db: Db,

--- a/LANG_SPEC_v0.6/13-tooling.md
+++ b/LANG_SPEC_v0.6/13-tooling.md
@@ -408,10 +408,10 @@ readers. To enumerate which hints actually affected codegen, use
 `osty context <symbol>` extracts a *machine-readable intent dossier*
 for a function, method, struct, enum, interface, or module. The
 output combines `#[purpose]` (§3.12), `#[example]` (§3.12),
-`#[spec]` (§3.10), `#[error_contract]` (§7.5), `#[stability]` /
-`#[since]` (§3.14), capability requirements (§20), and `#[budget]`
-(§3.15) into a single document. It is the canonical surface for AI
-agents, IDE hover, code-search tools, and external static analysis.
+`#[error_contract]` (§7.5), `#[stability]` / `#[since]` (§3.14),
+and capability requirements (§20) into a single document. It is the
+canonical surface for AI agents, IDE hover, code-search tools, and
+external static analysis.
 
 ```sh
 osty context <symbol>                          # default text
@@ -431,12 +431,10 @@ and includes:
 | `signature` | declared parameters / return type / generics |
 | `purpose` | `#[purpose]` |
 | `examples` | `#[example]` (auto-checked) |
-| `spec_refs` | `#[spec]` (anchor + section title) |
 | `error_contract` | `#[error_contract]` |
 | `effects.capabilities_required` | capability parameters in signature |
 | `effects.reproducible` | `#[reproducible(scope=...)]` |
 | `effects.taint_sources / sanitizes / sinks` | `#[taint]` / `#[sanitizes]` / `#[requires]` |
-| `budget.static / runtime` | `#[budget(...)]` |
 | `stability` / `since` | `#[stability]` / `#[since]` |
 | `fixtures_referenced` | `#[example(uses = "name")]` |
 | `callees` | `--recursive` only |
@@ -523,9 +521,9 @@ published manifest. It is the gate that enforces `#[stability]`
 struct fields and methods, enum variants and their payloads, interface
 methods, type alias RHS, public constants, and the following
 annotations: `#[stability]`, `#[error_contract]`, `#[since]`,
-`#[reproducible]`, `#[pure]`, `#[budget]`, parameter taint annotations.
+`#[reproducible]`, `#[pure]`, parameter taint annotations.
 *Excluded* from surface: function bodies, `#[purpose]` / `#[example]` /
-`#[fixture]` / `#[spec]`, `#[golden]`, line numbers, comments.
+`#[fixture]`, `#[golden]`, line numbers, comments.
 
 **Manifest format.** `target/manifest-{version}.json` (schema:
 `https://osty.dev/schemas/manifest/v1.json`) — `00-revision.md
@@ -542,15 +540,10 @@ fixed gate set before signing:
 | `osty audit --legacy-globals` | warns; promotes to abort if `[stability] default = "stable"` |
 | `osty audit --trusted-declassify` | warns; lists every declassify site for review |
 | `osty audit --trusted-construct` | same |
-| `osty validate-spec` (`#[spec]` resolution) | `E0790` aborts |
-| `osty test --example --spec` | example mismatch aborts |
-| `osty bench --budget` | `time_ms`/`p99_ms` regression beyond `regression-threshold` aborts |
+| `osty test --example` | example mismatch aborts |
 | `osty test --golden` | snapshot mismatch aborts |
 
-The gate sequence is intentional: cheap checks first, expensive
-benchmarks last. A `--no-bench` flag skips the budget gate for
-local previews; the registry-side acceptance still requires the
-full gate to have passed.
+The gate sequence is intentional: cheap checks first.
 
 #### 13.5.2 Workspace publish
 
@@ -615,13 +608,10 @@ suitable for security review and migration tracking.
 
 | Mode | Reads | Discovers |
 |---|---|---|
-| `osty test --spec` | `spec { example: }` clauses (§3.13) | per-clause boolean test |
 | `osty test --example` | `#[example(input=, output=, uses=)]` (§3.12) | input → output match |
 | `osty test --golden` | `#[golden(path, mode)]` (§11.5.2) | snapshot compare |
 | `osty test --update-golden` | (same) | overwrites snapshot |
 | `osty test --doc` | `///` doc-test blocks (baseline since v0.5) | runs as test |
-
-`osty bench --budget` (§3.15.2) gates runtime budget regressions.
 
 ### 13.9 `osty context` JSON schema
 
@@ -943,14 +933,11 @@ seed 로 reproducer 생성 가능.
 | `#[example]` | ✓ auto-test | | ✓ render | ✓ JSON | | |
 | `#[fixture]` | ✓ seed | | ✓ render | ✓ JSON | | |
 | `#[purpose]` | | | ✓ render | ✓ JSON | | |
-| `#[spec("§X.Y")]` | | ✓ validate | ✓ inline ref | ✓ JSON | | |
-| `spec { example: }` | ✓ auto-test | | ✓ render | ✓ JSON | | |
 | `#[error_contract]` | | ✓ enforce | ✓ table | ✓ JSON | ✓ surface diff | |
 | `#[reproducible]` | | ✓ enforce | | ✓ JSON | ✓ surface diff | |
 | `#[stability]` | | | ✓ banner | ✓ JSON | ✓ enforce | |
 | `#[since]` | | | ✓ render | ✓ JSON | ✓ surface diff | |
 | `#[match_compat]` | | ✓ enforce | | | | ✓ enumerate |
-| `#[budget]` | ✓ runtime check | ✓ static check | | ✓ JSON | ✓ surface diff | |
 | `#[ambient]` | | ✓ enforce | | | | |
 | `#[taint]` / `#[sanitizes]` | | ✓ enforce (Phase 5) | | ✓ JSON | ✓ surface diff | |
 | `#[trusted_declassify]` | | | | | | ✓ enumerate |
@@ -1024,182 +1011,3 @@ migrate by then. The migration path is documented in
 `MIGRATING_v0.5_to_v0.6.md` and §10.46 (Capability Migration
 Catalog).
 
-### 13.18 End-to-end v0.6 publishing workflow
-
-This section walks through the canonical release flow for a v0.6
-package — from local edit to published version — showing how each
-v0.6 surface (capability, stability, error contract, spec link,
-budget, golden) participates in the `osty` toolchain.
-
-The example package is `myapp.users` exposing one `pub fn`:
-
-```osty
-#[purpose("Create a user, validating email and respecting DB unique constraints")]
-#[example(input = "(\"alice@example.com\", fakeDb())", output = "Ok(42)")]
-#[example(input = "(\"alice@example.com\", seededFakeDb())", output = "Err(UserCreateError.DbConflict(1))")]
-#[spec("§10.30.user.create")]
-#[stability("stable")]
-#[since("0.6")]
-#[error_contract(
-    UserCreateError.EmailFormat   when "Email.parse failed",
-    UserCreateError.DomainBlocked when "domain is in deny-list",
-    UserCreateError.DbConflict    when "email unique constraint violated",
-)]
-#[budget(allocs = 4, io_calls = 1, time_ms = 5)]
-pub fn createUser(email: String, db: Db) -> Result<UserId, UserCreateError> {
-    spec {
-        example: createUser("alice@example.com", fakeDb()) == Ok(UserId(42))
-    }
-
-    let parsed = Email.parse(email).orError(UserCreateError.EmailFormat)?
-    if isBlocked(parsed.domain()) {
-        return Err(UserCreateError.DomainBlocked(parsed.domain()))
-    }
-    db.exec(sql.insertReturningId("users", [
-        ("email", sql.string(parsed.toString())),
-    ]))
-        .mapErr(|e| UserCreateError.DbConflict(e.code()))
-        .map(|id| UserId(id.toInt()))
-}
-```
-
-Step 1 — local check (`osty check`):
-
-```sh
-$ osty check
-0 errors, 0 warnings.
-```
-
-Step 2 — examples + spec block (`osty test --example --spec`):
-
-```sh
-$ osty test --example --spec --report=summary
-spec[createUser#example:1] PASS
-example[createUser#1] PASS
-example[createUser#2] PASS
-3/3 spec/example checks passed.
-```
-
-Step 3 — golden / structural tests (`osty test`):
-
-```sh
-$ osty test --report=summary
-12/12 tests passed.
-```
-
-Step 4 — performance budget (`osty bench --budget`):
-
-```sh
-$ osty bench --budget --report=summary
-bench createUser: avg=2.1ms p99=4.7ms allocs=3 io_calls=1
-budget OK (within 5ms / 5 allocs / 1 io_call).
-```
-
-Step 5 — capability + flow audit (`osty audit`):
-
-```sh
-$ osty audit --capabilities
-pkg myapp.users
-  pub fn createUser(email: String, db: Db)             [Db]
-  fn isBlocked(domain: String)                          (pure)
-
-$ osty audit --legacy-globals
-0 sites — package is fully migrated to v0.6 capability surface.
-```
-
-Step 6 — surface diff (`osty publish --check`):
-
-```sh
-$ osty publish --check
-api-surface unchanged from v0.6.0.
-proposed: v0.6.1 (patch — internal helper added).
-```
-
-Step 7 — actual publish:
-
-```sh
-$ osty publish
-publishing myapp.users v0.6.1
-  + new symbol: fn isAcceptableEmail (private)
-  api-surface diff: stable, additive only.
-released.
-```
-
-The `osty context` JSON for `createUser` (Step 4 / §13.9 schema)
-now contains the full intent payload — purpose, examples,
-fixtures referenced, spec link, error contract, stability, budget,
-capability set, sanitizer interactions — and is what an LLM agent
-or downstream tooling consumes to reason about the function.
-
-### 13.19 Release engineering with intent annotations
-
-`#[purpose]`, `#[example]`, `#[fixture]`, `#[spec]` (§3.12, G42) are
-the *machine-readable* layer underneath `osty doc` and
-`osty context`. Their interactions during release engineering:
-
-#### 13.19.1 `osty doc` rendering
-
-Annotations land in the rendered doc page in this order:
-
-1. Function signature + `#[since]` / `#[stability]` chip.
-2. `#[purpose]` text — primary one-liner.
-3. `#[spec]` anchor link — e.g. "§10.30.user.create" → resolved
-   markdown anchor in the rendered chapter.
-4. `#[error_contract]` — rendered as a "Failure modes" table.
-5. `#[example]` — rendered as runnable example panels, with the
-   referenced `#[fixture]` body inlined for context.
-6. `spec { example: }` clauses — rendered as `// example` comments
-   inside the function body in the page.
-7. `#[budget]` — rendered as a "Performance budget" callout.
-
-Authors who want a docstring on top of these annotations can keep
-using `///`; doc comments and intent annotations compose
-additively.
-
-#### 13.19.2 `osty context <symbol>`
-
-The CLI emits a single JSON object containing every intent
-annotation plus the resolved spec link, the contract variants, the
-fixture bodies, the example expressions, and the dependency
-capability set. The schema is §13.9.
-
-LLM-facing usage: a code-generation agent that wants to call
-`createUser` retrieves the JSON, reads the contract / examples /
-budget / spec, and constructs a semantically valid call site
-without needing to read the implementation.
-
-#### 13.19.3 `osty changelog` autogeneration
-
-`osty publish` writes a changelog entry per release based on the
-API-surface diff (§3.14.3) and the per-symbol intent payload:
-
-```
-v0.6.1 — 2026-05-08
-
-Added
-- `pub fn isAcceptableEmail` (private — no surface impact)
-
-No public API changes.
-```
-
-For a release with public-surface changes, the entry includes the
-`#[purpose]` text of each new / changed `pub` symbol so the
-changelog reads like a feature list rather than a raw diff.
-
-#### 13.19.4 `osty doc-test`
-
-A specialized mode of `osty test` that runs every `#[example]` and
-`spec { example: }` clause under a deterministic capability fake
-set. Failure here means *the published example claims do not match
-the implementation*, which would mislead documentation readers.
-This is the strictest gate before `osty publish`.
-
-```sh
-$ osty doc-test
-2 #[example] checks passed.
-1 spec { example: } check passed.
-```
-
-The doc-test mode shares the same fake registry as `osty test
---example --spec` but omits regular `#[test]` functions. Useful as
-a fast pre-commit or pre-publish gate.

--- a/LANG_SPEC_v0.6/ABRIDGED.md
+++ b/LANG_SPEC_v0.6/ABRIDGED.md
@@ -13,9 +13,8 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - 파일은 `.osty`, UTF-8, newline은 `\n`; `\r\n`은 정규화된다.
 - shebang은 byte offset 0에서만 한 번 허용된다.
 - 예약어: `fn struct enum interface type let mut pub if else match for break
-  continue return use defer while`. (`while` v0.6 추가, G49)
-- 문맥 식별자: `self Self true false Some None Ok Err loop const by spec
-  example law invariant`. (`spec` / `example` / `law` / `invariant` v0.6 추가, G43)
+  continue return use defer`.
+- 문맥 식별자: `self Self true false Some None Ok Err loop const by`.
 - v1 단계 추가 예정: `forall` (Phase 5).
 - identifier는 ASCII letter 또는 `_`로 시작한다. 단독 `_`는 wildcard이다.
 - 세미콜론은 없다. newline이 statement separator이다.
@@ -108,14 +107,14 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - `match`는 exhaustive여야 한다.
 - match guard는 arm 선택에는 참여하지만 exhaustiveness coverage에는 기여하지 않는다.
 - `for pattern in expr`은 iterable loop.
-- `for expr`은 while-style loop. **v0.6: `while expr` 도 같은 의미 (G49)**.
+- `for expr`은 while-style loop.
 - bare `for`는 infinite loop.
 - `loop { ... break value }`는 value-returning unbounded loop이다.
 - range step은 `a..b by step` / `a..=b by step`이다.
 - `for let pattern = expr`은 match 성공 동안 반복한다.
 - `break`/`continue`는 기본적으로 innermost loop에 적용된다. `'label: for/loop`와
   `break 'label` / `continue 'label`이 허용된다.
-- `Type { ... }` struct literal은 `if`/`match`/`for`/`while`/`if let`/`for let` head에서
+- `Type { ... }` struct literal은 `if`/`match`/`for`/`if let`/`for let` head에서
   괄호로 감싼다.
 - assignment는 statement이다. expression으로 쓰지 않는다.
 - channel send `<-`도 statement이다.
@@ -247,36 +246,24 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - v0.6 baseline sanitizer: `std.sql.escape`, `std.shell.quote`,
   `std.path.normalize`, `std.url.encode`, `std.html.escape`.
 
-## 11. Reproducibility (G39) and Performance (G46)
+## 11. Reproducibility (G39)
 
 - `#[reproducible(scope=...)]` — 환경독립 강제. scope 는 `"run"` / `"target"`
   (default) / `"portable"`.
 - 검사: non-deterministic capability 수신 금지, unordered iter 금지, pointer-id
   비교 금지, transitive callee 도 같거나 강한 scope 필수.
 - `#[pure]` 는 더 강함 — capability 수신 자체 금지.
-- `#[budget(...)]` static keys — `allocs`, `io_calls`, `stack_depth`,
-  `instructions`. 컴파일러가 *증명*. 위반 `E0795`.
-- `#[budget(...)]` runtime keys — `time_ms`, `p99_ms`. `osty bench --budget`
-  회귀 게이트.
 - `#[golden(path, mode=...)]` — snapshot 비교. mode `"text"` / `"ast"` / `"json"` /
   `"diag"`. text mode 는 BOM 제거 + LF 정규화 후 비교. `#[golden]` 은 암묵
   `#[reproducible(scope="target")]` — 위반 `E0444`.
 
-## 12. Spec Block (G43) and Intent (G42)
+## 12. Intent (G42)
 
-- `spec { ... }` top-level 함수 / method body 첫 statement 위치. clauses: `example:`, `law:`,
-  `invariant:`, `forall x in gen:` (v1).
-- v0 (Phase 3): `example:` 만 `osty test --spec` 실행, `law:` / `invariant:` 는
-  doc + LSP hover. `result` 는 `law:` / `invariant:` 안에서 함수 반환값 가리키는
-  virtual binding.
 - `#[purpose("...")]` — 자유 텍스트 의도 (doc / LSP / context).
 - `#[example(input=, output=, uses=)]` — 자동 검증. `uses` 는 fixture 이름.
 - `#[fixture(name=)]` — zero-arity 함수, 같은 type 의 canonical instance 제공.
-- `#[spec("§X.Y")]` — markdown anchor 검증 (`E0790` if missing). doc / LSP /
-  `osty explain` 에 spec 본문 인용.
-- `osty context <symbol> [--format=json]` — purpose / examples / spec_refs /
-  error_contract / fixtures / stability 단일 JSON 추출 (LSP / AI agent 첫
-  시민).
+- `osty context <symbol> [--format=json]` — purpose / examples / error_contract /
+  fixtures / stability 단일 JSON 추출 (LSP / AI agent 첫 시민).
 
 ## 13. API Evolution (G44) and Sealed Construction (G40)
 
@@ -302,12 +289,12 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 | **Existing (v0.5)** | `#[json]`, `#[deprecated]`, `#[op]`, `#[cfg]`, `#[test]`, `#[intrinsic]`, `#[pod]`, `#[repr]`, `#[export]`, `#[c_abi]`, `#[no_alloc]` | 기존 |
 | **Capability (G36)** | `#[ambient]`, `#[reproducible_capability]` | §9 |
 | **Information flow (G37)** | `#[taint]`, `#[sanitizes]`, `#[requires]`, `#[trusted_declassify]`, `#[taint_field]` | §10 |
-| **Spec / intent (G38, G42)** | `#[spec]`, `#[purpose]`, `#[example]`, `#[fixture]` | §12 |
+| **Intent (G42)** | `#[purpose]`, `#[example]`, `#[fixture]` | §12 |
 | **Construction (G40)** | `#[sealed_construct]`, `#[trusted_construct]`, `#[test_construct]` | §13 |
 | **Error (G41)** | `#[error_contract]` | §8 |
 | **Determinism (G39)** | `#[reproducible]` | §11 |
 | **Evolution (G44)** | `#[since]`, `#[stability]`, `#[match_compat]` | §13 |
-| **Testing / perf (G45, G46)** | `#[golden]`, `#[budget]` | §11 |
+| **Testing (G45)** | `#[golden]` | §11 |
 
 각 annotation 의 합법 위치는 `LANG_SPEC_v0.6/00-revision.md §7.6` 의 표가
 권위. 잘못된 위치는 `E0405`. annotation 인자는 항상 literal — 표현식 불가.
@@ -339,17 +326,16 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - `beforeEach`/`afterEach`는 없다. helper, `testing.context`, `defer`를 쓴다.
 - formatter는 설정이 없다. 생성 후 `osty fmt`, `osty check`, 필요하면 `osty lint`.
 - manifest는 `osty.toml`, lockfile은 `osty.lock`.
-- v0.6 신규 명령: `osty context <symbol>` (G47), `osty validate-spec` (G38),
-  `osty publish` (G44), `osty test --golden` / `--update-golden` (G45),
-  `osty test --spec` (G43), `osty test --example` (G42), `osty bench --budget`
-  (G46), `osty audit --trusted-declassify | --trusted-construct | --match-compat`.
+- v0.6 신규 명령: `osty context <symbol>` (G47), `osty publish` (G44),
+  `osty test --golden` / `--update-golden` (G45), `osty test --example` (G42),
+  `osty audit --trusted-declassify | --trusted-construct | --match-compat`.
 
 ## 17. Do Not Generate
 
 - `null`, `nil`, exceptions, `try`, `catch`, panic recovery.
 - inheritance, class, `impl`, macro, user-defined annotation.
 - function overloading, `[]`/`()`/bitwise/comparison operator overloading.
-- C-style `for`. (v0.6 부터 `while` 은 허용.)
+- C-style `for`. `while` 도 없음 — `for cond { }` 사용.
 - detached spawn, `async`, `await`, `WaitGroup`.
 - lifetime annotation, variance annotation, generic parameter default.
 - implicit narrowing/lossy numeric conversion, `as` conversion keyword.
@@ -372,7 +358,7 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 
 - No semicolons, no trailing-dot chains, no newline before `else`.
 - Use `T?`, not `Option<T>`, in formatted output.
-- Use `for cond` 또는 `while cond` (v0.6 동의어, §4.4). C-style for 는 금지.
+- Use `for cond` (§4.4). C-style for / `while` 키워드 모두 없다.
 - Use `match`/`if let` for enum destructuring, not plain `let`.
 - Parenthesize struct literals in control-flow heads.
 - Use `::<T>` only on calls and never with an empty type-argument list.
@@ -384,5 +370,5 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - v0.6: 라이브러리 코드에선 capability parameter 명시 — testability 강화.
 - v0.6: SQL/shell/path/url/html 데이터는 sanitizer 경유 후 sink 도달.
 - v0.6: stdlib sealed types 직접 literal 금지 — `Type.parse(...)`.
-- v0.6: 메타데이터가 풍부한 함수에 `#[purpose]` / `#[example]` / `#[spec]` 부착.
+- v0.6: 메타데이터가 풍부한 함수에 `#[purpose]` / `#[example]` 부착.
 - Run formatter/checker after edits.


### PR DESCRIPTION
## Summary

PR #1542 후속 — 첫 pass의 정의 섹션 삭제 후 남은 cross-reference 들을 정리.
**-244 net LOC**, 3 spec 파일.

### §3 declarations

- §3.1.1 const fn: `#[budget]` sub-bullet 제거
- §3.16.1-3 worked patterns: `signup` / `createUser` / `computeKey`에서
  `#[spec]` / `#[budget]` / `spec { }` block 제거
- §3.16.3 "Spec-block-driven validation" 섹션 자체 삭제
- §3.16.4-5 (이전 5/6): `#[spec]` / `#[budget]` 제거

### §13 tooling

- §13 chapter intro: validate-spec / spec_refs / spec / budget /
  `bench --budget` 언급 모두 제거
- §13.4 osty context: spec_refs / budget 필드 표에서 제거
- §13.5 surface diff: `#[budget]` / `#[spec]` 모두 표에서 제거
- §13.5.1 publish gates: validate-spec / `test --spec` / `bench --budget` 제거
- §13.8 test extensions: `--spec` 행 제거 + `bench --budget` 추가 제거
- §13.14 tool integration matrix: `#[spec("§X.Y")]` / `spec { example: }` /
  `#[budget]` 3 행 제거
- **§13.18 End-to-end publishing workflow 전체 삭제** (~107 LOC) — budget /
  spec block / spec link가 step마다 등장하던 worked example
- **§13.19 Release engineering with intent annotations 전체 삭제** (~73 LOC) —
  `#[spec]` / `#[budget]` / `spec { }` 의 osty doc / context / changelog 통합

### ABRIDGED

- §1 lexical: `while` 예약어 / `spec/example/law/invariant` 문맥 식별자 표시 제거
- §5 expressions: while-style synonym 언급 / `for/while` head 괄호 rule 정리
- §11 Reproducibility (G39+G46) → G39 only
- §12 Spec Block + Intent (G43+G42) → Intent (G42) only
- §13 surface 표: Spec/intent (G38, G42) → Intent (G42); Testing/perf (G45, G46)
  → Testing (G45)
- §16 도구 명령: validate-spec / `test --spec` / `bench --budget` 제거
- §17 Do Not Generate: `while` 허용 카멜레온 표시 제거
- §18 Agent Checklist: while cond 동의어 / `#[spec]` 부착 권고 제거

### 후속 batches

남은 정리:
- 00-revision.md (decision overview, decision count 14 → 10)
- 18-change-history.md (G49 / G38 / G43 / G46 entry 제거)
- SPEC_GAPS.md (open gap → withdrawn 마이그레이션)
- CHANGELOG_v0.6.md (Phase 진행 표 업데이트)
- README.md
- OSTY_GRAMMAR_v0.6.md (R1-R29 grammar update)
- CLAUDE.md 부록 C
- ERROR_CODES.md (E0440-E0446 / E0790 / E0795)
- §10 stdlib 잔여 references

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §13.4 context schema 가 §13.9 JSON schema 본문과 정합
- [ ] §13.5 surface definition 이 §3.14.3 publish algorithm과 정합
- [ ] §13.14 tool integration matrix가 §13.4-13.10 본문과 정합

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_