### PR TITLE
docs(v0.6): G49+G38+G43+G46 removal — third pass (meta-docs)

### DIFF
--- a/CHANGELOG_v0.6.md
+++ b/CHANGELOG_v0.6.md
@@ -9,9 +9,9 @@ authority on what v0.6 *is* right now. v0.5 의 분리 패턴
 ([`CHANGELOG_v0.5.md`](./CHANGELOG_v0.5.md)) 을 그대로 따른다.
 
 See [`LANG_SPEC_v0.6/00-revision.md`](./LANG_SPEC_v0.6/00-revision.md)
-for the full v0.5 → v0.6 decision log (14 resolved gaps, G36 – G49)
-and [`SPEC_GAPS.md`](./SPEC_GAPS.md) §"Resolved in v0.6" for per-gap
-rationale.
+for the v0.5 → v0.6 decision log (10 resolved gaps after G38/G43/
+G46/G49 withdrawal) and [`SPEC_GAPS.md`](./SPEC_GAPS.md) §"Resolved
+in v0.6" for per-gap rationale.
 
 ## Implementation phases
 
@@ -22,11 +22,10 @@ rationale.
 |---|---|---|
 | Phase 0 | Self-host 자력 사이클 (Tier A 5 개) | (v0.5 follow-up) |
 | Phase 1 | Capability + ambient + stdlib migration | G36 |
-| Phase 2 | Spec link + structured intent + osty context | G38, G42, G47 |
-| Phase 3 | Reproducible + spec block v0 + golden | G39, G43 (v0), G45 |
-| Phase 4 | Sealed + ErrorContract + Evolution + Budget(static) | G40, G41, G44, G46 (static) |
-| Phase 5 | Taint + Budget(runtime) + spec block v1 | G37, G46 (runtime), G43 (v1) |
-| Pre-1.0 | While ergonomics | G49 |
+| Phase 2 | Structured intent + osty context | G42, G47 |
+| Phase 3 | Reproducible + golden | G39, G45 |
+| Phase 4 | Sealed + ErrorContract + Evolution | G40, G41, G44 |
+| Phase 5 | Taint / sanitize | G37 |
 
 ## Shipped in the compiler
 
@@ -37,10 +36,8 @@ rationale.
 
 | Form | Status | Notes |
 |---|---|---|
-| `while cond { body }` | **planned** (G49) | `for cond { body }` 와 동등 lowering. 사용자 0 단계의 breaking change — 식별자 `while` 사용했던 코드는 rename. |
-| `spec { example: ... }` block | **planned** (G43, v0) | example: 만 v0 에 실행, law:/invariant: 는 doc only |
 | Parameter annotation `fn f(#[taint("...")] x: T)` | **planned** (G37) | parameter 위치 annotation 신규 허용 |
-| v0.6 declaration annotation vocabulary | **partial** (G36-G46) | Go parser/resolver and selfhost resolver both recognize the declaration/field/method/variant annotation names. Per-feature semantic gates and parameter-position annotations still land by phase. |
+| v0.6 declaration annotation vocabulary | **partial** (G36, G37, G39-G42, G44, G45, G47) | Go parser/resolver and selfhost resolver both recognize the declaration/field/method/variant annotation names. Per-feature semantic gates and parameter-position annotations still land by phase. |
 
 ### Capabilities (G36 — Phase 1, blocking everything else)
 
@@ -64,16 +61,14 @@ rationale.
 | `#[trusted_declassify(reason)]` FFI escape | **planned** | audit 가능 |
 | stdlib sink catalog (`db.query`, `process.exec`, `fs.path*`, `http.redirect`, `template.render`) | **planned** | Phase 5 baseline |
 
-### Spec / Intent
+### Intent
 
 | Item | Status | Notes |
 |---|---|---|
-| `#[spec("§X.Y")]` annotation | **partial** (G38, Phase 2) | active check now rejects missing `LANG_SPEC_v0.6/` section links (`E0790`). `osty doc`/LSP lead-paragraph surfacing remains planned. |
 | `#[purpose("...")]` | **planned** (G42, Phase 2) | doc / context only |
 | `#[example(input=, output=, uses=)]` | **planned** (G42, Phase 2) | auto-test |
 | `#[fixture(name=)]` | **planned** (G42, Phase 2) | 공유 canonical instance |
 | `osty context <symbol>` | **planned** (G47, Phase 2) | JSON output |
-| `osty validate-spec` | **planned** (G38, Phase 2) | CI gate |
 
 ### Determinism / Construction / Errors
 
@@ -95,8 +90,6 @@ rationale.
 | `osty publish` API surface diff | **planned** (G44, Phase 4) | major bump 강제 |
 | `#[golden("path", mode="text"|"ast")]` | **planned** (G45, Phase 3) | reproducible 결합 |
 | `osty test --golden` / `--update-golden` | **planned** (G45, Phase 3) | |
-| `#[budget(allocs, io_calls, stack_depth, instructions)]` static | **planned** (G46, Phase 4) | 컴파일러 증명 |
-| `#[budget(time_ms, p99_ms)]` runtime | **planned** (G46, Phase 5) | osty bench 게이트 |
 
 ## Migration path from v0.5
 
@@ -117,9 +110,8 @@ rationale.
 
 - `#[since]` / `#[stability]` / `#[match_compat]` — 옵션 어노테이션, 미사용
   코드 영향 없음
-- `while` keyword — 신규 surface, 기존 코드 영향 없음 (식별자 `while` 사용 코드만 rename)
-- `#[spec]` / `#[purpose]` / `#[example]` / `#[fixture]` — 메타데이터, 옵션
-- `#[reproducible]` / `#[golden]` / `#[budget]` — 옵션, 미사용 영향 없음
+- `#[purpose]` / `#[example]` / `#[fixture]` — 메타데이터, 옵션
+- `#[reproducible]` / `#[golden]` — 옵션, 미사용 영향 없음
 
 ## Spec corpus 확장
 
@@ -129,10 +121,10 @@ rationale.
 | Phase | Positive 케이스 추가 | Negative 케이스 추가 |
 |---|---|---|
 | 1 | capability typed signature | E0780-E0789 (capability misuse) |
-| 2 | `#[spec]` 검증 통과, `osty context` 출력 | E0790, W0790 |
+| 2 | `osty context` 출력 | (intent annotations metadata only) |
 | 3 | `#[reproducible]` 통과, golden snapshot | E0784-E0788, E0444-E0445 |
 | 4 | sealed/ErrorContract/Evolution | E0410-E0451, E2100-E2101 |
-| 5 | taint flow, budget runtime | E0900-E0903, E0795-E0796 |
+| 5 | taint flow | E0900-E0903 |
 
 각 phase 의 `LLVM E2E` 통과까지 확인 후 phase 종료.
 
@@ -141,8 +133,6 @@ rationale.
 v0.7 에서 다룰 예정 (현 시점 미결정):
 
 - **Implicit information flow** (covert channel) — opt-in `#[strict_flow]`
-- **`#[budget(time_ms)]` static 증명** — LLVM cost model 기반
-- **`spec { forall }` SMT solver 통합** — Z3/CVC5 backend
 - **Row-polymorphic error union** — `Result<T, EmailError | DbError | ...>` 의
   open form
 - **Cross-capability flow analysis** — `Clock` 결과가 `Rng` seed 가 되는 패턴

--- a/LANG_SPEC_v0.6/00-revision.md
+++ b/LANG_SPEC_v0.6/00-revision.md
@@ -1,17 +1,22 @@
 # Osty v0.6 — Revision Document
 
-> **Status**: 제안 (draft). 14 개 결정 (G36–G49) 을 v0.5 baseline 위에 추가하는 spec 개정.
+> **Status**: baseline (frozen). 10 개 결정 (G36, G37, G39, G40, G41, G42,
+> G44, G45, G47, G48) 을 v0.5 baseline 위에 추가하는 spec 개정.
 > v0.5 의 모든 결정은 v0.6 에서도 유효. 본 문서는 *delta* 만 기술하며, 변경 없는 챕터는
 > [`../LANG_SPEC_v0.5/`](../LANG_SPEC_v0.5/) 가 계속 권위.
+>
+> **Withdrawn from v0.6 baseline** (low-utility, removed pre-release):
+> G38 (`#[spec]` link), G43 (spec block), G46 (`#[budget]`), G49 (`while`
+> keyword). 자세한 사유는 SPEC_GAPS.md 의 "Withdrawn" 섹션.
 >
 > **Companion**: [`SPEC_GAPS.md`](../SPEC_GAPS.md) §"Resolved in v0.6", [`OSTY_GRAMMAR_v0.6.md`](../OSTY_GRAMMAR_v0.6.md), [`CHANGELOG_v0.6.md`](../CHANGELOG_v0.6.md).
 
 ## 0. Overview
 
-v0.5 의 외부 사용 corpus 와 셀프호스트 운영 (100 PR / 4 일 sprint) 에서 도출된 13 개
-*hidden-dependency-surface* 결정 + 1 개 *ergonomics* 정정 (`while` 키워드) 을 v0.6 에
-batch 로 수용한다. 사용자 0 인 단계의 마지막 큰 surface revision — 이후 v0.7 부터는
-stable API rule (G44) 이 적용된다.
+v0.5 의 외부 사용 corpus 와 셀프호스트 운영 (100 PR / 4 일 sprint) 에서 도출된
+*hidden-dependency-surface* 결정 10 개를 v0.6 에 batch 로 수용한다. 사용자 0 인
+단계의 마지막 큰 surface revision — 이후 v0.7 부터는 stable API rule (G44) 이
+적용된다.
 
 v0.5 의 §14 *anonymous structural record* 금지 정책은 그대로 유지된다 — ad-hoc
 labeled data 는 nominal `struct` 또는 tuple 로 표현한다.
@@ -20,24 +25,14 @@ labeled data 는 nominal `struct` 또는 tuple 로 표현한다.
 |---|---|---|
 | G36 | Capabilities (§20) | 환경 effect 를 capability 값으로 명시 |
 | G37 | Information flow (§21) | `#[taint]` / `#[sanitizes]` 정적 IFC |
-| G38 | Spec link (§3.10) | `#[spec("§X.Y")]` checked spec ↔ impl 링크 |
 | G39 | Reproducibility (§3.11) | `#[reproducible(scope=...)]` 환경독립 강제 |
 | G40 | Construction discipline (§3.4.5) | `#[sealed_construct]` parse-don't-validate |
 | G41 | Error contract (§7.5) | `#[error_contract(... when ...)]` failure mode 명세 |
 | G42 | Structured intent (§3.12) | `#[purpose]` / `#[example]` / `#[fixture]` |
-| G43 | Executable spec (§3.13) | `spec { example: / law: / invariant: }` 블록 |
 | G44 | API evolution (§3.14) | `#[since]` / `#[stability]` / `#[match_compat]` |
 | G45 | Golden tests (§11.5) | `#[golden]` AST-aware 스냅샷 |
-| G46 | Performance contract (§3.15) | `#[budget(allocs/io/time)]` static + runtime 분리 |
 | G47 | Machine-readable context (§13.4) | `osty context <symbol>` 구조화 추출 |
 | G48 | Annotation surface | 위 신규 어노테이션의 grammar 통합 |
-| **G49** | `while` keyword (§4.4) | `for cond {}` 와 동의어. mental-model 일치 |
-
-> **G49 design review note**: G36–G48 (13 개) 가 직전 사용 corpus 분석에서
-> 합의된 결정. **G49 는 본 spec 작성 과정에서 추가된 ergonomics 정정**으로
-> 작은 surface (1 keyword, 새 의미 0) 라 포함. 한때 같이 검토됐던 *G50 anonymous
-> structural record* 는 v0.5 §14 의 "named types are nominal" discipline 유지를
-> 위해 *제외*. ad-hoc labeled data 는 nominal `struct` 또는 tuple 로.
 
 ## 1. Design North Star — *Hidden Dependency Is Forbidden*
 
@@ -45,39 +40,35 @@ v0.5 까지의 결정이 (a) safety-by-construction, (b) type system simplicity,
 discipline 세 축이었다면, v0.6 은 네 번째 축을 추가한다:
 
 > **모든 hidden dependency 는 surface 로 끌어올린다 — 시간, 난수, 환경, 보안 흐름,
-> 진화 규칙, 성능 계약, 의도, 명세 — 어느 것도 "암묵"으로 두지 않는다.**
+> 진화 규칙, 의도 — 어느 것도 "암묵"으로 두지 않는다.**
 
-이 원칙으로 v0.6 의 13 결정이 4 카테고리로 묶인다:
+이 원칙으로 v0.6 의 10 결정이 4 카테고리로 묶인다:
 
 | 카테고리 | 명시 대상 | 결정 |
 |---|---|---|
 | **Effectful** | 런타임 환경 의존 (시간/난수/IO) | G36 (Capability), G39 (Reproducible) |
 | **Security** | 정보 흐름 (sources → sinks) | G37 (Taint/Sanitize) |
 | **Temporal** | API 진화 / 호환성 | G44 (Since/Stability/MatchCompat) |
-| **Intent + Determinism** | 의도, 명세, 성능, 실패 양태 | G38 (Spec), G40 (SealedConstruct), G41 (ErrorContract), G42 (Intent), G43 (SpecBlock), G45 (Golden), G46 (Budget), G47 (Context) |
+| **Intent + Determinism** | 의도, 명세, 실패 양태 | G40 (SealedConstruct), G41 (ErrorContract), G42 (Intent), G45 (Golden), G47 (Context) |
 
-**Capability (G36) 은 base layer.** G39 / G37 / G46 의 검사가 capability 시그니처 위에서
-*allow-list 기반*으로 sound 해진다. 따라서 구현 순서는 G36 → G38 → G39 → G37 순.
+**Capability (G36) 은 base layer.** G39 / G37 의 검사가 capability 시그니처 위에서
+*allow-list 기반*으로 sound 해진다. 따라서 구현 순서는 G36 → G39 → G37 순.
 
 ## 2. Implementation Phases
 
-스펙 결정은 v0.6 baseline 으로 한 번에 동결하지만, 구현은 5 단계로 분리한다.
+스펙 결정은 v0.6 baseline 으로 한 번에 동결하지만, 구현은 단계로 분리한다.
 각 phase 종료 시 `spec corpus`, `STDLIB_MATRIX`, `CHANGELOG_v0.6` 갱신.
 
 ```
 Phase 1   G36 Capability + #[ambient] + stdlib capability migration
           (가장 큰 리팩터, base layer 이므로 선행 필수)
-Phase 2   G38 #[spec("§X.Y")] + G42 #[fixture] / #[purpose] / #[example]
+Phase 2   G42 #[fixture] / #[purpose] / #[example]
           + G47 osty context (작고 dogfood 가치 ↑)
 Phase 3   G39 #[reproducible(scope=...)] (capability 위에 sound)
-          + G43 spec { } v0 (example: 만)
           + G45 #[golden] AST-aware
 Phase 4   G40 #[sealed_construct] + G41 #[error_contract]
           + G44 #[since] / #[stability] / #[match_compat]
-          + G46 #[budget(static)]
 Phase 5   G37 #[taint] / #[sanitizes] (가장 무거움, 시그니처급 임팩트)
-          + G46 #[budget(runtime)]
-          + G43 spec { } v1 (forall property test 자동 생성)
 ```
 
 ## 3. New Chapters

--- a/LANG_SPEC_v0.6/18-change-history.md
+++ b/LANG_SPEC_v0.6/18-change-history.md
@@ -5,15 +5,17 @@ versions. The latest release is at the top.
 
 ### 18.0 v0.5 → v0.6
 
-v0.6 is the release that closes 14 gaps (G36–G49) accumulated during
-the v0.5 use corpus and the 100-PR self-host sprint. The release is
-governed by a single design principle:
+v0.6 is the release that closes 10 gaps (G36, G37, G39-G42, G44, G45,
+G47, G48) accumulated during the v0.5 use corpus and the 100-PR self-
+host sprint. Four originally-proposed gaps (G38, G43, G46, G49) were
+withdrawn pre-release as low-utility — see SPEC_GAPS.md "Withdrawn"
+for sub-rationale. The release is governed by a single design
+principle:
 
 > **Hidden dependency is forbidden.**
 > Time, randomness, environment, filesystem, network, security flow,
-> API evolution rules, performance contracts, intent, and
-> specification — all surfaced through type signatures or annotations,
-> never implicit.
+> API evolution rules, intent — all surfaced through type signatures
+> or annotations, never implicit.
 
 Four annotation families implement the principle:
 
@@ -22,41 +24,39 @@ Four annotation families implement the principle:
 | **Effectful** (env / IO) | Capability parameters (§20), `#[ambient]`, `#[reproducible]`, `#[reproducible_capability]` |
 | **Security** (sources → sinks) | `#[taint]`, `#[sanitizes]`, `#[requires]`, `#[trusted_declassify]`, `#[taint_field]` (§21) |
 | **Temporal** (versioning) | `#[since]`, `#[stability]`, `#[match_compat]`, `osty publish` (§3.14) |
-| **Intent + Determinism** | `#[spec]`, `#[purpose]`, `#[example]`, `#[fixture]`, `spec { }`, `#[error_contract]`, `#[sealed_construct]`, `#[golden]`, `#[budget]`, `osty context` (§3.10–§3.15, §7.5, §11.5, §13.4) |
+| **Intent + Determinism** | `#[purpose]`, `#[example]`, `#[fixture]`, `#[error_contract]`, `#[sealed_construct]`, `#[golden]`, `osty context` (§3.12, §3.4.5, §7.5, §11.5, §13.4) |
 
-**Resolved gaps (G36–G49).**
+**Resolved gaps (10).**
 
 | ID | 영역 | 한 줄 |
 |---|---|---|
 | G36 | Capabilities (§20) | 환경 effect 를 capability 값으로 명시 |
 | G37 | Information flow (§21) | `#[taint]` / `#[sanitizes]` 정적 IFC |
-| G38 | Spec link (§3.10) | `#[spec("§X.Y")]` checked link |
 | G39 | Reproducibility (§3.11) | `#[reproducible(scope=...)]` 환경독립 강제 |
 | G40 | Sealed construct (§3.4.5) | `#[sealed_construct]` parse-don't-validate |
 | G41 | Error contract (§7.5) | `#[error_contract(... when ...)]` failure mode 명세 |
 | G42 | Structured intent (§3.12) | `#[purpose]` / `#[example]` / `#[fixture]` |
-| G43 | Executable spec (§3.13) | `spec { example: / law: / invariant: }` 블록 |
 | G44 | API evolution (§3.14) | `#[since]` / `#[stability]` / `#[match_compat]` |
 | G45 | Golden tests (§11.5) | `#[golden]` AST-aware 스냅샷 |
-| G46 | Performance contract (§3.15) | `#[budget(allocs/io/time)]` static + runtime |
 | G47 | Machine-readable context (§13.4) | `osty context <symbol>` 구조화 추출 |
-| G48 | Annotation surface | 위 신규 어노테이션의 grammar 통합 (+20 fixed annotations) |
-| G49 | `while` keyword (§4.4) | `for cond {}` 와 동의어. mental-model 일치 |
+| G48 | Annotation surface | 위 신규 어노테이션의 grammar 통합 (+16 fixed annotations) |
 
-`G50` (anonymous structural record) 은 본 batch 검토 중 빠졌다 — v0.5 §14
-의 "named types are nominal" discipline 유지를 위해 ad-hoc labeled data 는
-nominal `struct` 또는 tuple 로 표현한다.
+**Withdrawn from v0.6 baseline (4).**
 
-**Additions — grammar (G48 + G49).**
+G38 `#[spec]` link / G43 `spec { }` block / G46 `#[budget]` /
+G49 `while` keyword — pre-release withdrawal. SPEC_GAPS.md 의
+Withdrawn 섹션 참조. `G50` (anonymous structural record) 도 본
+batch 검토 중 빠졌다 — v0.5 §14 의 "named types are nominal"
+discipline 유지를 위해 ad-hoc labeled data 는 nominal `struct`
+또는 tuple 로 표현한다.
 
-- *Reserved keyword + 1*: `while` (G49) — `while cond { body }` ≡
-  `for cond { body }`. 식별자 `while` 사용 코드는 rename (사용자 0
-  단계의 acceptable break).
-- *Contextual keyword + 4*: `spec`, `example`, `law`, `invariant`
-  (G43 — spec block 컨텍스트만). `forall` 은 v1 (Phase 5) 단계.
-- *Fixed annotation set*: 11 → 31 (+20 신규).
-- *EBNF productions*: 191 → 199 (+8). 새 grammar surface 는 §3.13
-  spec block 과 parameter 위치 annotation 두 곳.
+**Additions — grammar (G48).**
+
+- *Reserved keyword*: 변경 없음 (17 → 17).
+- *Contextual keyword*: 변경 없음.
+- *Fixed annotation set*: 11 → 27 (+16 신규).
+- *EBNF productions*: 변경 없음. 새 grammar surface 는 parameter 위치
+  annotation (§21) 한 곳.
 
 **Additions — capabilities (G36, §20).**
 

--- a/LANG_SPEC_v0.6/README.md
+++ b/LANG_SPEC_v0.6/README.md
@@ -3,18 +3,19 @@
 Osty is a general-purpose, statically-typed, garbage-collected programming language.
 This directory holds the specification, split into per-section files for easier navigation and editing.
 
-**Status.** v0.6 — current spec baseline. Supersedes v0.5. Closes 14 gaps
-(G36–G49) accumulated during the v0.5 use corpus and the 100-PR
-self-host sprint: capability parameters, information flow tracking,
-spec link, reproducibility, sealed construction, error contract,
-structured intent, executable spec block, API evolution rules, golden
-tests, performance contract, machine-readable context export, plus a
-single ergonomics fix (`while` keyword).
+**Status.** v0.6 — current spec baseline. Supersedes v0.5. Closes 10 gaps
+(G36, G37, G39, G40, G41, G42, G44, G45, G47, G48) accumulated during
+the v0.5 use corpus and the 100-PR self-host sprint: capability
+parameters, information flow tracking, reproducibility, sealed
+construction, error contract, structured intent, API evolution rules,
+golden tests, machine-readable context export. Four originally-proposed
+gaps (G38, G43, G46, G49) were withdrawn pre-release as low-utility —
+see SPEC_GAPS.md "Withdrawn" for sub-rationale.
 
 The v0.6 design north star is *Hidden dependency is forbidden* —
 time, randomness, environment, security flow, evolution rules,
-performance contracts, intent, and specification are all surfaced
-explicitly through the type system or the annotation surface.
+intent are all surfaced explicitly through the type system or the
+annotation surface.
 
 See [`18-change-history.md`](./18-change-history.md) for the full
 v0.1 → v0.2 → v0.3 → v0.4 → v0.5 → v0.6 evolution and per-version
@@ -117,4 +118,4 @@ Four annotation families implement this principle:
 | **Effectful** (env / IO) | Capability parameters, `#[ambient]`, `#[reproducible]`, `#[pure]` | §20, §3.11 |
 | **Security** (sources → sinks) | `#[taint]`, `#[sanitizes]`, `#[requires]` | §21 |
 | **Temporal** (versioning) | `#[since]`, `#[stability]`, `#[match_compat]`, `osty publish` | §3.14 |
-| **Intent + Determinism** | `#[spec]`, `#[purpose]`, `#[example]`, `#[fixture]`, `spec { }`, `#[error_contract]`, `#[sealed_construct]`, `#[golden]`, `#[budget]`, `osty context` | §3.10, §3.12, §3.13, §3.15, §3.4.5, §7.5, §11.5, §13.4 |
+| **Intent + Determinism** | `#[purpose]`, `#[example]`, `#[fixture]`, `#[error_contract]`, `#[sealed_construct]`, `#[golden]`, `osty context` | §3.12, §3.4.5, §7.5, §11.5, §13.4 |

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -250,20 +250,27 @@ v0.6.x 에서만 제공 후 v0.7 에서 제거. 자세한 spec 본문은
 |---|---|---|---|
 | **G36** | Capabilities (§20) | 환경 effect (`Clock`, `Rng`, `Env`, `Fs`, `Net`, `Process`, `Console`) 를 stdlib interface 로 정의하고 함수 파라미터로 전달. 값의 interface 만족은 structural 이지만 effect/determinism 분류는 parameter 의 resolved interface identity 기준. `#[ambient(...)]` 어노테이션이 script / `main` / test 진입점에서 process-singleton default instance 를 scope 에 주입. `#[reproducible_capability]` 가 사용자 정의 deterministic capability 등록. `#[reproducible]` / `#[pure]` 검사가 capability 시그니처 기반 *allow-list* 로 sound. v0.5 의 전역 함수 (`time.now()` / `random.next()` 등) 는 `--legacy-globals` 로 v0.6.x 호환, v0.7 제거. | decided |
 | **G37** | Information flow (§21) | `#[taint("source")]` source 표시, `#[sanitizes("source", into = "trust")]` sanitizer, `#[requires("trust")]` sink 요구. 1-bit + N-tag value-flow tracking 을 checker 에 추가하되 tag 는 type identity / monomorphization key 에 포함하지 않는다. Generic / closure 통한 propagation 자동. Implicit flow 는 *explicit-only* 정책 (Jif 와 동일). FFI/opaque 경계는 sibling `#[sanitizes]` + `#[trusted_declassify(reason)]` 로 audit. stdlib sink catalog 는 baseline 이며 user-defined sink 는 sanitizer-produced tag 에 한해 허용. mainstream 산업언어 첫 정적 IFC. | decided |
-| **G38** | Spec link (§3.10) | `#[spec("§X.Y")]` 어노테이션. 컴파일러가 markdown anchor 존재 검증 (`E0790`), section 이동 시 `W0790`. `osty doc` 가 spec 본문 첫 단락 inline 표시, LSP hover 동일. 운영 discipline 을 언어 feature 로 승급. | decided |
 | **G39** | Reproducibility (§3.11) | `#[reproducible(scope=...)]` — `"run"` / `"target"` / `"portable"` 3-tier. `target` 이 default. capability deny rule 기반 검증. unordered iter 금지 (`E0786`), pointer-id 비교 금지, transitive callee 도 같거나 강한 scope 필수 (`E0787`). `portable` 추가 제약 (endianness, NaN bit, …). `#[golden]` 함수는 암묵적으로 `#[reproducible(scope="target")]`. | decided |
 | **G40** | Sealed construct (§3.4.5) | `#[sealed_construct(name)]` — 명시한 constructor 만 허용. 외부 struct literal / spread update / 직접 mutation / generic deserialize / FFI default 모두 차단. `#[trusted_construct(reason)]` stdlib escape, `#[test_construct]` test profile escape. parse-don't-validate 패턴을 언어 primitive 로. v0.6 baseline 에서 stdlib `Email` / `Url` / `Path` / `SqlIdent` / `Duration` / `Uuid` 등 sealed 화. | decided |
 | **G41** | Error contract (§7.5) | `#[error_contract(Variant when "condition", ...)]` — concrete enum error 의 failure mode catalog. Contract inclusion 은 `(EnumTypeIdentity, VariantName)` 정확 일치. `Err(...)` return path 정합성 정적 검증 (`E0410`), 미발화 variant `W0411`, `?` propagation subset mismatch 는 `E0414`. 호출자 측 match exhaustiveness 가 contract variant 기반. erased `Error` 에는 `#[error_contract(any)]` 만 가능하며 concrete caller superset 을 자동 만족하지 않는다. | decided |
 | **G42** | Structured intent (§3.12) | `#[purpose("...")]` 자유 텍스트 의도, `#[example(input=, output=, uses=)]` 자동 검증 예시, `#[fixture(name=)]` canonical instance. 모두 `osty doc` / `osty context` / LSP / property test seed 가 공유. AI hype 비의존 framing — *machine-readable intent*. | decided |
-| **G43** | Executable spec block (§3.13) | `spec { example: / law: / invariant: / forall x in gen: }` 함수 본문 첫 위치 블록. v0 (Phase 3) 는 `example:` 만 실행, `law:` / `invariant:` 는 doc/hover. v1 (Phase 5) 는 `forall` property test 자동 생성. `result` virtual binding (`law:` / `invariant:` 안에서). | decided |
 | **G44** | API evolution (§3.14) | `#[since("X.Y")]` 도입 버전, `#[stability(level, until?, since?, remove?)]` 에서 level ∈ {`stable`, `experimental`, `deprecated`, `internal`}. `osty publish` 가 stable API breaking change 시 major bump 강제 (`E2100`). `#[match_compat("X.Y", fallback=)]` 로 enum shape pin — silent fallback 금지 (`E0450`), `unsafe_silent` 명시 시 `W0902`. | decided |
 | **G45** | Golden tests (§11.5) | `#[golden("path", mode="text"|"ast"|"json"|"diag")]` snapshot 비교. text mode 는 BOM 제거 + CRLF/CR→LF 정규화 후 byte 비교(trailing newline 보존). AST mode 는 reparse 후 비교 (whitespace/comment 무시). `osty test --golden` / `--update-golden`. 함수는 reproducible 검증 통과 필수 (`E0444`). | decided |
-| **G46** | Performance contract (§3.15) | `#[budget(allocs=, io_calls=, stack_depth=, instructions=)]` static — 컴파일러 증명, 위반 `E0795`. `#[budget(time_ms=, p99_ms=)]` runtime — `osty bench --budget` 회귀 게이트. static 과 runtime 이 같은 어노테이션 키 namespace 공유. | decided |
-| **G47** | Machine-readable context (§13.4 / §13.9) | `osty context <symbol> [--format=json] [--recursive]` — purpose / examples / spec_refs / error_contract / fixtures / stability / since 단일 JSON 으로 추출. LSP `textDocument/hover` 통합. AI agent 첫 시민. | decided |
-| **G48** | Annotation surface 통합 | 신규 어노테이션 20 개 (G36-G47 합계) 가 기존 fixed annotation set 에 추가, `#[name(args)]` form 그대로 — 신규 grammar 0. parameter 위치 annotation (`#[taint]` / `#[requires]`) 은 v0.6 grammar 변경. spec block 만 신규 syntax. 추가 contextual keyword 4 (v0): `spec`, `example`, `law`, `invariant`. | decided |
-| **G49** | `while` keyword (§4.4) | `for cond {}` 외에 `while cond {}` 동의어 추가. v0.5 의 keyword economy taste 는 유지하되 *mental model 일치*를 위해 더 흔한 surface 도 받아들임. `for cond` 도 deprecate 안 함 — 양쪽 모두 컴파일러가 같은 lowering. | decided |
+| **G47** | Machine-readable context (§13.4 / §13.9) | `osty context <symbol> [--format=json] [--recursive]` — purpose / examples / error_contract / fixtures / stability / since 단일 JSON 으로 추출. LSP `textDocument/hover` 통합. AI agent 첫 시민. | decided |
+| **G48** | Annotation surface 통합 | 신규 어노테이션 16 개 (G36, G37, G39-G42, G44, G45, G47 합계) 가 기존 fixed annotation set 에 추가, `#[name(args)]` form 그대로 — 신규 grammar 0. parameter 위치 annotation (`#[taint]` / `#[requires]`) 은 v0.6 grammar 변경. | decided |
 
-이 14 개 결정 (G36-G49) 은 [`LANG_SPEC_v0.6/00-revision.md`](LANG_SPEC_v0.6/00-revision.md)
+#### Withdrawn from v0.6 baseline
+
+다음 4 결정은 v0.6 release 전에 *low utility* 사유로 withdraw:
+
+| ID | 영역 | 철회 사유 |
+|---|---|---|
+| **G38** | Spec link `#[spec("§X.Y")]` | user-code use case narrow. doc comment + 외부 link checker 로 충분. |
+| **G43** | Spec block `spec { example: / law: / invariant: }` | `example:` 은 `#[example]` 과 기능 중복. `law:` / `invariant:` 는 v0 doc-only 였음. |
+| **G46** | Performance contract `#[budget(...)]` | `#[pure]` 가 effect bound covers. perf bound 는 외부 벤치/CI 로 충분. |
+| **G49** | `while` keyword | `for cond { }` 와 동의어. 순수 cosmetic. |
+
+이 10 개 결정 (G36, G37, G39-G42, G44, G45, G47, G48) 은 [`LANG_SPEC_v0.6/00-revision.md`](LANG_SPEC_v0.6/00-revision.md)
 가 권위. 구현 phase 는 동 문서 §2 참조. 호환성 영향이 있는 항목 — G36 (capability
 migration, breaking in v0.7), G37 (taint sink rollout, breaking for unsanitized
 code), G40 (stdlib sealed types) — 은 `--legacy-globals` 또는 `--legacy-construct`


### PR DESCRIPTION
## Summary

PR #1544 후속 — meta-doc cleanup. **00-revision / 18-change-history / SPEC_GAPS /
CHANGELOG / README** 의 14 결정 → 10 결정 narrative 업데이트. **5 파일**.

### 00-revision.md

- Status header: "14 개 결정" → "10 개 결정 + 4 withdrawn"
- Decision summary 표: G38 / G43 / G46 / G49 행 제거
- Design north star intro: 7 축 → 6 축 (성능 계약 / 명세 제거)
- 4 카테고리 표: G38 / G43 / G46 from "Intent + Determinism" 제거
- Implementation phases: G38 (Phase 2) / G43 (Phase 3, 5) / G46 (Phase 4, 5) /
  G49 (pre-1.0) 제거

### 18-change-history.md

- §18.0 v0.5 → v0.6 intro: "14 gaps" → "10 gaps + 4 withdrawn"
- Resolved gaps 표: G38 / G43 / G46 / G49 행 제거
- Withdrawn section 추가
- Grammar additions: 11 → 27 (+16), EBNF productions 변경 없음

### SPEC_GAPS.md

- §"Resolved in v0.6" 표: G38 / G43 / G46 / G49 4 행 제거
- "Withdrawn from v0.6 baseline" section 추가 (4 entry + 철회 사유)

### CHANGELOG_v0.6.md

- Phase 표: G38 / G43 / G46 / G49 entry 제거
- Spec / Intent → Intent (G42) 만
- `#[budget]` static / runtime 행 / `osty validate-spec` / `--spec` 명령 제거
- Forecast: budget / spec block 제거
- Spec corpus phase 표 정리

### LANG_SPEC_v0.6/README.md

- Status: 14 → 10 gaps + withdrawn 4 명시
- Design north star: performance / specification 항목 제거
- 4 annotation families 표: `#[spec]` / `spec { }` / `#[budget]` 제거

이로써 v0.6 spec의 핵심 narrative가 모두 G38/G43/G46/G49 withdrawal 반영.
후속 batch: OSTY_GRAMMAR_v0.6.md / CLAUDE.md 부록 C / ERROR_CODES.md / §10
stdlib 잔여.

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] CHANGELOG / SPEC_GAPS / 00-revision / 18-change-history 모두 G36/G37/
  G39-G42/G44/G45/G47/G48 10 결정과 정합
- [ ] README의 4-family 표가 §3 chapter intro와 정합
- [ ] Withdrawn 섹션이 SPEC_GAPS에 정확히 4 entry 등록

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_