### PR TITLE
docs(v0.6): G49+G38+G43+G46 removal — fourth pass (grammar + CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,8 @@
   - `LANG_SPEC_v0.6/00-revision.md` — v0.5 → v0.6 결정 overview
   - `LANG_SPEC_v0.6/18-change-history.md §18.0` — v0.5 → v0.6 변경 이력
   - `LANG_SPEC_v0.6/20-capabilities.md`, `21-information-flow.md` — v0.6 신규 챕터
-- **`OSTY_GRAMMAR_v0.6.md`** — EBNF 문법 + R1–R29 decision log. 스펙과 구현이 충돌하면 **스펙이 기준**
-- `SPEC_GAPS.md` — 해결된 갭 아카이브 (v0.6 시점 G36-G49 추가됨, open gap 0)
+- **`OSTY_GRAMMAR_v0.6.md`** — EBNF 문법 + R1–R27 decision log. 스펙과 구현이 충돌하면 **스펙이 기준**
+- `SPEC_GAPS.md` — 해결된 갭 아카이브 (v0.6 시점 10 결정: G36, G37, G39-G42, G44, G45, G47, G48; G38/G43/G46/G49 withdrawn; open gap 0)
 - `CHANGELOG_v0.6.md` — v0.6 implementation 진행도 (spec 와 분리)
 - `BREAKING_v0.6.md` — v0.5 → v0.6 breaking change 카탈로그
 - `MIGRATING_v0.5_to_v0.6.md` — 사용자 마이그레이션 가이드
@@ -193,13 +193,13 @@ winget install --id LLVM.LLVM                              # clang/lld/llc (머�
 
 **규칙**:
 - 새 구문/키워드/어노테이션 추가는 `LANG_SPEC_v0.6/` 개정 없이는 **금지**. 정식 버전 업(minor/major)과 함께만 surface 변경.
-- v0.6 결정 (G36–G49) 은 baseline 동결. 새 결정은 `SPEC_GAPS.md` Open Gaps 섹션에 G50+ 으로 등재 후 다음 minor/major 에 일괄 수용.
+- v0.6 결정 (10 개: G36, G37, G39-G42, G44, G45, G47, G48) 은 baseline 동결. G38/G43/G46/G49 는 pre-release withdrawn (low utility). 새 결정은 `SPEC_GAPS.md` Open Gaps 섹션에 G50+ 으로 등재 후 다음 minor/major 에 일괄 수용.
 - 문법 모호성 발견 → 컴파일러가 아니라 `SPEC_GAPS.md` 에 먼저 기록.
 - 공개 백엔드는 `--backend llvm` 만. 새 백엔드 플래그 추가 금지.
 
 ### v0.5 → v0.6 transition 정책
 
-**Spec 단계 (완료)**: PR #1469 / #1471 / #1472 / #1473 / #1474 / #1475 / #1476 으로 14 결정 (G36-G49) baseline 동결. 22 main chapter + 46 stdlib subchapter, OSTY_GRAMMAR_v0.6, BREAKING / MIGRATING 가이드, CLAUDE.md 부록 C 모두 land.
+**Spec 단계 (완료)**: 10 결정 (G36, G37, G39-G42, G44, G45, G47, G48) baseline 동결. 22 main chapter + 46 stdlib subchapter, OSTY_GRAMMAR_v0.6, BREAKING / MIGRATING 가이드, CLAUDE.md 부록 C 모두 land.
 
 **Implementation phase 진행**: `CHANGELOG_v0.6.md` 가 phase 진행도의 권위.
 
@@ -207,11 +207,10 @@ winget install --id LLVM.LLVM                              # clang/lld/llc (머�
 |---|---|---|
 | 0 | Self-host 자력 사이클 (Tier A 갭) | (v0.5 follow-up) |
 | 1 | Capability + ambient + stdlib migration | G36 |
-| 2 | Spec link + structured intent + osty context | G38, G42, G47 |
-| 3 | Reproducible + spec block v0 + golden | G39, G43 (v0), G45 |
-| 4 | Sealed + ErrorContract + Evolution + Budget(static) | G40, G41, G44, G46 (static) |
-| 5 | Taint + Budget(runtime) + spec block v1 | G37, G46 (runtime), G43 (v1) |
-| Pre-1.0 | While ergonomics | G49 |
+| 2 | Structured intent + osty context | G42, G47 |
+| 3 | Reproducible + golden | G39, G45 |
+| 4 | Sealed + ErrorContract + Evolution | G40, G41, G44 |
+| 5 | Taint / sanitize | G37 |
 
 **호환성**:
 - `--legacy-globals` (v0.6.x 한정 — v0.7 제거): v0.5 의 전역 effect 함수 (`time.now()` / `random.next()` / `env.get(k)` / `fs.read(p)` / `os.exec(...)` / `net.dial(...)`) 가 자동 desugar 됨. 사용 시 manifest stability 가 자동 `experimental` 로 강제.
@@ -1072,7 +1071,7 @@ fn benchParseConfig() {
 
 ---
 
-# 부록 C. v0.6 신규 패턴 (G36-G49)
+# 부록 C. v0.6 신규 패턴 (G36, G37, G39-G42, G44, G45, G47, G48)
 
 > **v0.6 design north star**: *Hidden dependency is forbidden* — 시간, 난수, 환경, 보안 흐름, API 진화, 성능 계약, 의도, 명세 어느 것도 암묵으로 두지 않는다.
 >
@@ -1233,47 +1232,23 @@ pub fn createUser(email: String, db: Db) -> Result<UserId, UserCreateError> { ..
 
 **Erased `Error` interface 에는 `#[error_contract(any)]`** (검증 없음, 문서용).
 
-## C.5 Spec link + structured intent (G38, G42)
+## C.5 Structured intent (G42)
 
-**규칙**: public API / 컴파일러 internal 함수에 `#[spec("§X.Y")]` + `#[purpose]` + `#[example]` 로 machine-readable intent 노출.
+**규칙**: public API / 컴파일러 internal 함수에 `#[purpose]` + `#[example]`
+로 machine-readable intent 노출.
 
 ```osty
 #[purpose("이메일 검증 후 DB에 사용자 저장")]
 #[example(input = "alice@example.com", uses = "sampleDb", output = "Ok(42)")]
 #[example(input = "invalid",            uses = "sampleDb", output = "Err(UserCreateError.EmailFormat)")]
-#[spec("§10.30.user.create")]
 pub fn createUser(email: String, db: Db) -> Result<UserId, UserCreateError> { ... }
 
 #[fixture(name = "sampleDb")]
 fn fakeDb() -> Db { std.testing.db.inMemory() }
 ```
 
-**소비**: `osty doc` (문서 생성), `osty test --example` (자동 검증), `osty context` (LLM agent payload), LSP hover.
-
-**`#[spec]` 컴파일러 검증**: markdown anchor 존재 확인 — 누락 `E0790`, 이동 `W0790` (suggested replacement).
-
-## C.6 Spec block — 실행 가능한 명세 (G43, §3.13)
-
-**v0 Phase 3** (현재 baseline): `example:` 만 자동 실행. `law:` / `invariant:` 는 doc + LSP hover.
-
-```osty
-fn normalizeEmail(s: String) -> String {
-    spec {
-        example: normalizeEmail(" Alice@EXAMPLE.COM ") == "alice@example.com"
-        example: normalizeEmail("") == ""
-        law: result == result.trim()
-        law: result == result.toLowerCase()
-        invariant: result.indexOf(" ") == -1
-    }
-    s.trim().toLowerCase()
-}
-```
-
-**제약**:
-- top-level 함수 / method body 의 *첫 statement* 위치만 (`E0440`)
-- `example:` 는 boolean (`E0441`), `law:` / `invariant:` 는 boolean — `result` 는 함수 반환값 가리키는 virtual binding
-
-**v1 Phase 5** (예정): `forall x in gen.list(gen.int(), 128): result.toMultiset() == x.toMultiset()` 형식의 property test.
+**소비**: `osty doc` (문서 생성), `osty test --example` (자동 검증),
+`osty context` (LLM agent payload), LSP hover.
 
 ## C.7 Reproducibility (G39, §3.11)
 
@@ -1297,21 +1272,6 @@ fn migrationId(name: String, sequence: Int) -> Int64 {
 - `"portable"` — 플랫폼 간 byte-equal
 
 **금지**: non-deterministic capability 수신 (`E0784`), unordered iter (`E0786`), pointer-id 비교, 더 약한 scope callee 호출 (`E0787`).
-
-## C.8 Performance contract (G46, §3.15)
-
-**규칙**: hot path / public API 에 `#[budget(...)]` 명시.
-
-```osty
-#[budget(allocs = 0, io_calls = 0, stack_depth = 100)]
-fn pureCompute(data: Bytes) -> Bytes32 { ... }
-
-#[budget(time_ms = 5, p99_ms = 20)]
-fn routeRequest(req: Request, db: Db) -> Response { ... }
-```
-
-**Static keys** (컴파일러 증명, `E0795`): `allocs` / `io_calls` / `stack_depth` / `instructions`.
-**Runtime keys** (`osty bench --budget` 회귀 게이트, `W0795`): `time_ms` / `p99_ms`.
 
 ## C.9 API evolution (G44)
 
@@ -1372,28 +1332,7 @@ fn testNumericNarrowingDiag() {
 
 **Update**: `osty test --update-golden` 로 일괄 갱신.
 
-## C.11 `while` keyword (G49, §4.4)
-
-**규칙**: `while cond { body }` 와 `for cond { body }` 는 *동의어*. 둘 다 컴파일러가 같은 IR 생성. 가독성 / mental model 따라 선택.
-
-```osty
-// 둘 다 같은 의미
-while !queue.isEmpty() {
-    process(queue.pop()?)
-}
-
-for !queue.isEmpty() {
-    process(queue.pop()?)
-}
-```
-
-**그 외 loop 형식 (v0.5 와 동일)**:
-- `for x in iter { ... }` — iterable
-- `for { ... }` — infinite
-- `loop { ... break value }` — value-returning
-- `for let Some(x) = q.pop() { ... }` — Some/Ok 패턴
-
-## C.12 부록 C 빠른 참조 표
+## C.11 부록 C 빠른 참조 표
 
 | 영역 | Annotation | 주 사용처 |
 |---|---|---|
@@ -1401,13 +1340,10 @@ for !queue.isEmpty() {
 | **Information flow** (C.2) | `#[taint]`, `#[sanitizes]`, `#[requires]`, `#[trusted_declassify]` | HTTP / DB / shell / path / URL 경계 |
 | **Sealed construct** (C.3) | `#[sealed_construct(parse)]` | parse-don't-validate 타입 (Email/Url/Path/Uuid/...) |
 | **Error contract** (C.4) | `#[error_contract(... when ...)]` | public API의 concrete enum error |
-| **Spec / intent** (C.5) | `#[spec]`, `#[purpose]`, `#[example]`, `#[fixture]` | public API / compiler internal |
-| **Spec block** (C.6) | `spec { example: / law: / invariant: }` | 명세-주도 함수 |
+| **Intent** (C.5) | `#[purpose]`, `#[example]`, `#[fixture]` | public API / compiler internal |
 | **Reproducibility** (C.7) | `#[reproducible(scope=...)]` | 캐시 키 / 해시 / migration ID |
-| **Budget** (C.8) | `#[budget(allocs=, time_ms=, ...)]` | hot path / public API |
 | **Evolution** (C.9) | `#[stability]`, `#[since]`, `#[match_compat]` | public API surface |
 | **Golden** (C.10) | `#[golden(path, mode=)]` | 컴파일러 / formatter / docgen 자가 테스트 |
-| **While** (C.11) | `while cond { }` | 가독성 선호 시 `for cond` 대신 |
 
 ---
 

--- a/OSTY_GRAMMAR_v0.6.md
+++ b/OSTY_GRAMMAR_v0.6.md
@@ -4,37 +4,35 @@ v0.5 의 R1–R26 결정과 EBNF 를 baseline 으로, v0.6 에서 추가/변경�
 만 본 문서에 명시한다. v0.5 grammar 의 본문은
 [`OSTY_GRAMMAR_v0.5.md`](./OSTY_GRAMMAR_v0.5.md) 가 계속 권위.
 
-> **Status**: v0.6 spec revision 동기 (G36–G49). spec 본문은
+> **Status**: v0.6 spec revision 동기 (G36, G37, G39-G42, G44, G45,
+> G47, G48). spec 본문은
 > [`LANG_SPEC_v0.6/00-revision.md`](./LANG_SPEC_v0.6/00-revision.md).
+>
+> **Withdrawn from v0.6 baseline**: G38 (spec link), G43 (spec block),
+> G46 (`#[budget]`), G49 (while keyword) — pre-release low-utility
+> withdrawal. SPEC_GAPS.md 의 Withdrawn 섹션 참조.
 
 ---
 
 ## 결정 이력 (v0.5 → v0.6)
 
-### 새 reserved keyword 1 개 (R27)
+### 새 reserved keyword 0 개
 
-- **`while`** (G49) — `while cond { }` 형식의 conditional loop. v0.5 의
-  `for cond { }` 와 동의어 — 둘 다 같은 lowering. 식별자로 사용했던 코드는
-  rename 필요 (사용자 0 단계에서의 acceptable break).
+(G49 `while` keyword 는 withdrawn — reserved keyword 17 → 17 변경 없음.)
 
-### 새 v0 contextual keyword 4 개 (R28)
+### 새 v0 contextual keyword 0 개
 
-- **`spec`** — top-level `fn` / method body 첫 statement 위치에서만
-  keyword. 그 외 위치 식별자.
-- **`example`** — `spec { }` block 안에서만 keyword.
-- **`law`** — `spec { }` block 안에서만 keyword.
-- **`invariant`** — `spec { }` block 안에서만 keyword.
-- **`forall`** *(v1 — Phase 5 reserved)* — `spec { }` block 안에서만
-  keyword. v0 단계는 식별자.
+(G43 spec block contextual keywords `spec` / `example` / `law` /
+`invariant` 는 withdrawn.)
 
 ### 새 lexer 토큰 0 개
 
 신규 syntax 는 모두 기존 token 조합으로 표현. `{`, `}`, `:`, `,` 재사용.
 
-### Annotation set 확장 +20
+### Annotation set 확장 +16
 
 §5 of [`LANG_SPEC_v0.6/00-revision.md`](./LANG_SPEC_v0.6/00-revision.md)
-참조 — 31 개 fixed annotation 으로 확장. `#[name(args)]` 형식 그대로.
+참조 — 27 개 fixed annotation 으로 확장. `#[name(args)]` 형식 그대로.
 
 ### Annotation parameter position (R29)
 
@@ -45,47 +43,6 @@ v0.5 의 R1–R26 결정과 EBNF 를 baseline 으로, v0.6 에서 추가/변경�
 ---
 
 ## EBNF — 전체 신규 production
-
-### G43 — spec block
-
-```ebnf
-SpecBlock      ::= 'spec' '{' SpecClause+ '}'
-
-SpecClause     ::= ExampleClause
-                 | LawClause
-                 | InvariantClause
-                 | ForallClause            (* v1 — Phase 5 *)
-
-ExampleClause  ::= 'example' ':' Expr LineEnd
-
-LawClause      ::= 'law' ':' Expr LineEnd
-
-InvariantClause::= 'invariant' ':' Expr LineEnd
-
-ForallClause   ::= 'forall' Ident (',' Ident)* 'in' Expr ':' Expr LineEnd
-
-LineEnd        ::= NEWLINE
-                 | (다음 SpecClause 시작 token 직전 — ASI 적용)
-```
-
-위치 제약 (R28):
-- `SpecBlock` 은 top-level `FnDecl` 또는 method declaration body 의
-  *첫 statement* 위치에만 출현 가능. closure body, `if` arm,
-  `match` arm, nested block 에는 출현할 수 없다.
-- `'spec'` 토큰은 그 위치에서만 keyword. 그 외 위치 (예: `let spec = 1`)
-  에서는 일반 식별자.
-- `'example'` / `'law'` / `'invariant'` 는 `SpecBlock` 본문 안에서만
-  keyword.
-
-### G49 — while loop
-
-```ebnf
-WhileStmt      ::= 'while' Expr Block
-
-(* 의미: 'while' Expr Block ≡ 'for' Expr Block — same lowering, same type *)
-```
-
-`'while'` 은 fully reserved (R27). 식별자 자리에 사용 불가.
 
 ### G37 — annotation on parameter
 
@@ -132,13 +89,6 @@ SanitizeAnno  ::= '#[sanitizes' '(' StringLit ',' 'into' '=' StringLit ')' ']'
 RequiresAnno  ::= '#[requires' '(' StringLit ')' ']'
 DeclassifyAnno::= '#[trusted_declassify' '(' 'reason' '=' StringLit ')' ']'
 TaintFieldAnno::= '#[taint_field' '(' StringLit ')' ']'
-```
-
-### G38 — spec link
-
-```ebnf
-SpecAnno      ::= '#[spec' '(' StringLit ')' ']'
-                  (* StringLit 는 markdown anchor (예: "§2.2", "§10.30.user") *)
 ```
 
 ### G39 — reproducibility
@@ -215,22 +165,6 @@ GoldenMode   ::= '"text"' | '"ast"' | '"json"' | '"diag"'
                  (* 미지정 시 default = "text" *)
 ```
 
-### G46 — performance contract
-
-```ebnf
-BudgetAnno   ::= '#[budget' '(' BudgetField (',' BudgetField)* ','? ')' ']'
-
-BudgetField  ::= 'allocs' '=' IntLit
-               | 'io_calls' '=' IntLit
-               | 'stack_depth' '=' IntLit
-               | 'instructions' '=' IntLit
-               | 'time_ms' '=' (IntLit | FloatLit)
-               | 'p99_ms' '=' (IntLit | FloatLit)
-
-(* 같은 어노테이션에 static (allocs/io_calls/stack_depth/instructions) 와
-   runtime (time_ms/p99_ms) 키가 혼재 가능 — 컴파일러가 분리 처리 *)
-```
-
 ### Annotation 위치 enforcement
 
 각 annotation 의 합법 위치는 `LANG_SPEC_v0.6/00-revision.md §7.6` 의 표가
@@ -240,26 +174,7 @@ BudgetField  ::= 'allocs' '=' IntLit
 
 ## R-rule 추가
 
-### R27. `while` 키워드 (G49)
-
-`while` 은 fully reserved keyword. parser 에서 `'while' Expr Block` 를
-`'for' Expr Block` 와 동등하게 lower. expression / type / control flow
-의미 완전 동일. v0.5 의 `for cond {}` 도 deprecate 안 함 — 양쪽 모두
-컴파일러가 같은 IR 생성.
-
-### R28. spec block 위치 (G43)
-
-`spec { ... }` block 은 top-level `fn` / method body 의 *첫 statement*
-위치에만 허용. closure body, `if` arm, `match` arm, nested block 의
-첫 위치라도 허용하지 않는다. 그 외 위치는 `E0440`. block 은 expression 이
-아니다 — 결과 type 없음, 마지막 expression 평가 안 됨. spec block 본문은
-*순수 메타데이터*: `example:` 는 test runner 가 따로 실행, `law:` /
-`invariant:` 는 doc generator 가 추출.
-
-`'spec'` keyword 는 그 위치에서만 keyword 로 lex. 그 외 위치 (예: 변수
-이름, struct field 이름) 에서는 식별자.
-
-### R29. annotation 위치 확장 (G37)
+### R27. annotation 위치 확장 (G37)
 
 `Annotation*` 가 새로 허용되는 위치:
 
@@ -274,23 +189,12 @@ field, enum variant) 는 변경 없음.
 
 ## R7 보강 — 키워드 vs 문맥 식별자 (v0.6 갱신)
 
-v0.5 의 R7 는 contextual keyword 7+ 개 (`self`, `Self`, `true`, `false`,
-`Some`, `None`, `Ok`, `Err`, `loop`, `const`, `by`) 를 정의. v0.6 은:
+v0.5 의 R7 는 contextual keyword 11 개 (`self`, `Self`, `true`, `false`,
+`Some`, `None`, `Ok`, `Err`, `loop`, `const`, `by`) 를 정의. v0.6 은
+변경 없음 — withdrawn G43 의 spec block contextual keywords 와 G49 의
+`while` reserved keyword 는 baseline 에 포함되지 않는다.
 
-- **추가 contextual**: `spec`, `example`, `law`, `invariant` — spec
-  block 컨텍스트에서만 keyword.
-- **추가 reserved**: `while` — 모든 위치에서 keyword.
-- **`forall`**: v1 (Phase 5) 단계에서 contextual keyword 추가. v0
-  단계에서는 식별자 그대로.
-
-R7 에 다음 추가:
-
-> **spec block scope**: `spec { ... }` block 안에서 `example`, `law`,
-> `invariant` 는 keyword. 그 외 위치 (block 외부) 에서는 식별자.
-
-> **block 시작 위치**: top-level `fn` / method body 첫 statement 위치에서 `spec` 가 keyword.
-> 여기서 함수 본문은 top-level `fn` / method declaration body 만 뜻한다.
-> 그 외 위치에서는 식별자. R28 참조.
+R7 에 추가되는 항목:
 
 > **label vs char literal**: lexer 는 single quote 다음이 one scalar or
 > escape + closing quote 이면 `CHAR_LIT`, single quote 다음이 identifier 이고
@@ -303,10 +207,10 @@ R7 에 다음 추가:
 
 | 항목 | v0.4 | v0.5 | v0.6 | Δ (v0.5→v0.6) |
 |---|---:|---:|---:|---:|
-| Reserved keywords | 17 | 17 | **18** | +1 (`while`) |
-| Contextual keywords | 7 | 10 | **14** | +4 (`forall` 은 v1 단계 추가 시 15) |
-| Fixed annotation set | 8 | 11 | **31** | +20 |
-| EBNF productions | 180 | 191 | **199** | +8 |
+| Reserved keywords | 17 | 17 | **17** | 0 |
+| Contextual keywords | 7 | 11 | **11** | 0 |
+| Fixed annotation set | 8 | 11 | **27** | +16 |
+| EBNF productions | 180 | 191 | **192** | +1 (parameter annotation) |
 | Lexer token classes | 34 | 36 | **36** | 0 |
 | Diagnostic bands used | E0001-E0779 + E0405 | 동일 | E0001-E0949 + E2149 + W0949 | +5 bands |
 
@@ -317,9 +221,7 @@ R7 에 다음 추가:
 | 번호 | 이름 | 영역 |
 |---|---|---|
 | R1–R26 | (v0.5 와 동일) | — |
-| R27 | `while` 키워드 | G49 |
-| R28 | spec block 위치 + `spec`/`example`/`law`/`invariant` 컨텍스트 | G43 |
-| R29 | annotation 위치 확장 (parameter 두 위치) | G37 |
+| R27 | annotation 위치 확장 (parameter 두 위치) | G37 |
 
 ---
 


### PR DESCRIPTION
## Summary

PR #1546 후속 — **OSTY_GRAMMAR_v0.6.md** 와 **CLAUDE.md** (부록 C) cleanup.
**-162 net LOC**, 2 파일.

### OSTY_GRAMMAR_v0.6.md

- Status header: G36-G49 → G36, G37, G39-G42, G44, G45, G47, G48 (10 결정 + 4
  withdrawn)
- 새 reserved keyword 1 → 0 (G49 withdrawn)
- 새 contextual keyword 4 → 0 (G43 withdrawn)
- Annotation set 확장 +20 → +16
- EBNF 신규 production 제거: `SpecBlock`, `WhileStmt`, `SpecAnno`, `BudgetAnno`
- R-rule: R27 (while), R28 (spec block) 제거. 기존 R29 → R27 renumber
- R7 보강: spec block scope 항목 제거
- Grammar 규모 표: keywords 17→17, annotations 27, EBNF productions 192 (+1
  parameter annotation only)

### CLAUDE.md

- 필독 문서 / baseline 규칙: SPEC_GAPS / Phase 표 갱신
- 부록 C header: "G36-G49" → "G36, G37, G39-G42, G44, G45, G47, G48"
- §C.5: "Spec link + structured intent (G38, G42)" → "Structured intent (G42)"
- §C.6 spec block / §C.8 budget / §C.11 while 전체 삭제
- §C.12 빠른 참조 표 → §C.11 로 renumber, withdrawn 행 제거

이로써 v0.6의 핵심 dev reference (CLAUDE.md 부록 C + OSTY_GRAMMAR EBNF)가
G38/G43/G46/G49 withdrawal을 정합. 후속 batch: ERROR_CODES.md / §10 stdlib
잔여.

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] OSTY_GRAMMAR keywords 17/11/27 카운트가 §1.10 lexical surface와 정합
- [ ] CLAUDE.md 부록 C 빠른 참조 표가 §C.1-C.10 sub-sections와 정합

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_