### PR TITLE
docs(v0.6): G49+G38+G43+G46 removal — fifth pass (sub-section refs)

### DIFF
--- a/LANG_SPEC_v0.6/02-type-system.md
+++ b/LANG_SPEC_v0.6/02-type-system.md
@@ -174,11 +174,6 @@ adds two interactions:
   This is acceptable inside `#[reproducible]` because the function
   contract concerns *successful* return values; aborts are a
   separate failure path that doesn't break determinism.
-- **`#[budget(allocs)]`** — `wrapping*` / `checked*` /
-  `saturating*` add no allocations (they're inlined into
-  arithmetic instruction sequences). The `instructions` budget may
-  reflect the slightly higher operation count for `checked*`
-  (overflow detection branch).
 
 The integer overflow contract holds across both backends (Go and
 LLVM); a v0.6 program that aborts on `Int.MAX + 1` does so with the

--- a/LANG_SPEC_v0.6/08-concurrency.md
+++ b/LANG_SPEC_v0.6/08-concurrency.md
@@ -107,21 +107,6 @@ behavior* (same input → same output). Worker assignment is
 implementation-detail; a `#[reproducible]` function produces the
 same result regardless of which worker happens to execute it.
 
-#### 8.0.2 Scheduler and `#[budget]`
-
-Runtime budget keys (`time_ms`, `p99_ms`) measure *wall-clock
-time* — the time elapsed regardless of worker placement. A
-function whose budget is `time_ms = 5` may run on a busy worker
-(blocked behind other tasks) or a free worker (executing
-immediately); the measurement is end-to-end, including any wait
-time.
-
-For deterministic budget testing, `osty bench --budget` runs each
-benchmark in isolation by default — no other tasks contend for
-workers during the timed loop. The flag `--bench-contention`
-allows simulating multi-task contention if a benchmark wants to
-measure that explicitly.
-
 ### 8.1 Structured Concurrency
 
 All concurrent tasks belong to a `taskGroup` scope. There is no detached
@@ -432,19 +417,6 @@ applies *only* to those two types — capability instances are not
 included, but the discipline of avoiding cross-scope capability
 sharing is recommended.
 
-#### 8.5.3 Channels and `#[budget]`
-
-A `thread.chan::<T>(capacity)` allocation counts as one allocation
-site for `#[budget(allocs)]` purposes. Each `ch <- value` and
-`ch.recv()` counts as one channel operation; a function that
-loops `ch.recv()` to drain a channel of `n` items counts `n`
-channel operations.
-
-The runtime's per-channel state (FIFO buffer, sender/receiver
-queues) is one allocation per channel; growing the buffer past its
-declared capacity is not supported (the channel rejects further
-sends until the receiver makes progress).
-
 ### 8.6 Select
 
 ```osty
@@ -519,18 +491,6 @@ If a `select` body needs to react to cancel separately from its
 ready branches, register an explicit `s.timeout(d, ...)` arm with
 a short duration — the timer fires before most blocking arms,
 giving the body a periodic point to check `thread.isCancelled()`.
-
-#### 8.6.3 Select and `#[budget]`
-
-Each registered branch counts as zero `io_calls` until it actually
-fires — `select` itself is the synchronization point. The `time`
-spent waiting in `select` is *not* counted toward `#[budget(time_ms
-= X)]`; only the active body's wall-clock time counts.
-
-For a function that loops over `select`, the budget applies to
-each iteration's *active branch body*, not to the number of
-iterations. Use `loop { ... }` exit conditions to bound iteration
-count separately if required.
 
 ### 8.7 Capabilities and Tasks
 

--- a/LANG_SPEC_v0.6/09-memory-management.md
+++ b/LANG_SPEC_v0.6/09-memory-management.md
@@ -94,23 +94,6 @@ Specifically:
 This is what lets flow tracking work without per-object metadata
 overhead.
 
-#### 9.3.3 `#[budget(allocs)]` and GC pressure
-
-The `allocs = N` budget (§3.15) counts allocation *sites* in the
-function's call graph, not *bytes* allocated. The relationship to
-GC pressure:
-
-- `allocs = 0` — no GC work attributable to this function.
-- `allocs = N` — at most N objects allocated per call. GC pressure
-  scales with N × call frequency.
-- `allocs = INF` — no budget; the function may allocate freely
-  (default for non-budgeted functions).
-
-The compiler proves the static count by walking the call graph;
-runtime allocation count under `osty bench --budget` should match.
-A discrepancy is a static-analysis bug or a runtime cost-model
-issue.
-
 ### 9.4 Defer cleanup patterns
 
 `defer` (§4.12) is the primary cleanup mechanism. The v0.6

--- a/LANG_SPEC_v0.6/11-testing.md
+++ b/LANG_SPEC_v0.6/11-testing.md
@@ -956,33 +956,6 @@ fn appCaps() -> AppCaps {
 pub fn loadConfig(path: String, caps: AppCaps) -> Result<Config, ConfigError> { ... }
 ```
 
-### 11.14 Property-based testing (v1 outlook)
-
-v0.6 baseline 은 `spec { example: }` 만 자동 실행. **v1 (Phase 5)** 에서
-`forall x in gen: ...` 형식의 property test 자동 등록 추가:
-
-```osty
-fn quicksort<T: Ordered>(xs: List<T>) -> List<T> {
-    spec {
-        forall xs in gen.list(gen.int(), 128):
-            result.toMultiset() == xs.toMultiset()
-
-        forall xs in gen.list(gen.int(), 128):
-            result.windowed(2).all(|w| w[0].le(w[1]))
-
-        example: quicksort([]) == []
-        example: quicksort([3, 1, 2]) == [1, 2, 3]
-    }
-    // ...impl
-}
-```
-
-`forall x in gen.list(gen.int(), 128)` 는 `gen.list(elemGen,
-maxLen)` 으로 `List<Int>` (길이 0..=128) 시퀀스 생성. v1 의 spec
-block runner 가 default 100 iterations 수행 + shrinking on failure.
-
-자세한 generator API 는 §10.5 (std.testing.gen) 참조.
-
 ### 11.15 Test 모드 통합
 
 ```sh
@@ -1198,36 +1171,3 @@ Guards against: regression in sanitization. The fake `Console`'s
 captured output is byte-equal to what the production `Console` would
 emit, so flow-tag bugs surface as observable failures.
 
-#### 11.18.7 Spec block + capability recipe
-
-`spec { example: ... }` clauses (§3.13) inside a capability-typed
-function run under the `--spec` mode. Capability instances that the
-function takes must be provided either by `#[example(uses = "name")]`
-referencing a fixture, or by explicit closure construction inside the
-example expression:
-
-```osty
-#[fixture(name = "frozenClock")]
-fn frozenClock() -> Clock {
-    std.capability.testing.FakeClock(epoch_ms = 0)
-}
-
-#[fixture(name = "seededRng")]
-fn seededRng() -> Rng {
-    std.capability.testing.FakeRng(seed = 42)
-}
-
-#[example(input = "()", uses = "frozenClock", uses = "seededRng",
-          output = "\"0-1608637542\"")]
-fn buildId(clock: Clock, rng: Rng) -> String {
-    spec {
-        example: buildId(frozenClock(), seededRng()) == "0-1608637542"
-    }
-    "{clock.now().toEpochMillis()}-{rng.next()}"
-}
-```
-
-The `uses = "name"` form composes; multiple `uses =` repeats inject
-each named fixture in order. v0.6 baseline runs the inline
-`example:` clause; the `#[example]` annotation form runs under
-`osty test --example`.

--- a/LANG_SPEC_v0.6/13-tooling.md
+++ b/LANG_SPEC_v0.6/13-tooling.md
@@ -647,9 +647,6 @@ suitable for security review and migration tracking.
     {"input": ["alice@example.com", "<Db>"], "output": "Ok(42)", "uses_fixture": "fakeDb"},
     {"input": ["invalid", "<Db>"], "output": "Err(UserCreateError.Format)", "uses_fixture": "fakeDb"}
   ],
-  "spec_refs": [
-    {"section": "§10.30.user.create", "title": "User creation"}
-  ],
   "error_contract": [
     {"variant": "UserCreateError.Format", "when": "missing @ or wrong format"},
     {"variant": "UserCreateError.DomainBlocked", "when": "domain in blocklist"},
@@ -687,7 +684,6 @@ suitable for security review and migration tracking.
 | `stability` | object \| null | `#[stability]` 데이터 |
 | `purpose` | `String` \| null | `#[purpose("...")]` |
 | `examples` | array | `#[example(input=, output=, uses=)]` 모두 |
-| `spec_refs` | array | `#[spec("§X.Y")]` + 동일 함수의 모든 spec ref |
 | `error_contract` | array | `#[error_contract]` entries |
 | `effects.capabilities_required` | array of capability type names | 함수 시그니처에서 capability 파라미터 추출 |
 | `effects.reproducible` | object \| null | `#[reproducible(scope=...)]` 데이터 |
@@ -798,9 +794,7 @@ fn computeDiff(prev: Manifest, curr: Manifest) -> DiffReport {
 | `#[reproducible]` 추가 | COMPAT-ADD (callee 보장 강화) |
 | `#[reproducible]` 제거 | BREAKING (callee 보장 약화) |
 | `#[error_contract]` variant 추가 | BREAKING (caller match exhaustiveness) |
-| `#[budget]` 강화 (allocs ↓, time_ms ↓) | BREAKING |
-| `#[budget]` 완화 | COMPAT-ADD |
-| body / `#[purpose]` / `#[spec]` 등 metadata | PATCH |
+| body / `#[purpose]` 등 metadata | PATCH |
 
 #### 13.10.4 Manifest 형식
 
@@ -901,7 +895,6 @@ legacy-globals util.timestamp
 | Mode | Discovers | Output |
 |---|---|---|
 | `osty test` | `#[test]` / `test_*` / `bench_*` (with `--bench`) | pass/fail summary |
-| `osty test --spec` | `spec { example: }` clause | per-clause pass/fail |
 | `osty test --example` | `#[example(input=, output=, uses=)]` | per-example pass/fail |
 | `osty test --golden` | `#[golden(path, mode)]` | snapshot 비교 결과 |
 | `osty test --update-golden` | (same) | snapshot 갱신 + report |

--- a/LANG_SPEC_v0.6/16-io-protocol.md
+++ b/LANG_SPEC_v0.6/16-io-protocol.md
@@ -267,10 +267,6 @@ cancellation point. The helper itself does not check cancel
 between calls; it relies on the underlying I/O to surface the
 signal.
 
-**Budget.** `io.readAll` allocates one growing `Bytes` buffer.
-Functions with `#[budget(allocs = 1)]` may use `io.readAll` for
-a single read; functions with `#[budget(allocs = 0)]` cannot.
-
 **Reproducibility.** `io.copy` and `io.readAll` are *not*
 deterministic — the exact byte sequence depends on the underlying
 stream's behavior (timing, partial reads). They cannot be used


### PR DESCRIPTION
## Summary

PR #1547 후속 — 본문 깊은 곳에 남은 `#[budget]` / `spec { }` / `spec_refs` /
`--spec` / spec block reference 정리. **-133 net LOC**, 6 파일.

### §02 type system

- §2.3.1 numeric overflow: `#[budget(allocs)]` 항목 제거

### §08 concurrency

- §8.0.2 Scheduler and `#[budget]` 섹션 삭제
- §8.5.3 Channels and `#[budget]` 섹션 삭제
- §8.6.3 Select and `#[budget]` 섹션 삭제

### §09 memory management

- §9.3.3 `#[budget(allocs)]` and GC pressure 섹션 삭제

### §11 testing

- §11.14 Property-based testing (v1 outlook) 섹션 삭제 (spec block forall 의존)
- §11.18.7 Spec block + capability recipe 섹션 삭제

### §13 tooling

- §13.9 osty context JSON: `spec_refs` field 삭제
- §13.10.3 Surface diff: `#[budget]` 강화/완화 행 삭제
- §13.13 Test subcommand 통합 reference: `--spec` 행 삭제

### §16 IO protocol

- §16.5 Buffered helpers: `#[budget(allocs = 1/0)]` 항목 삭제

이로써 v0.6 spec 본문의 `#[budget]` / spec block / spec_refs reference가
모두 정리됐다. 후속 batch: ERROR_CODES.md / §10 stdlib 잔여.

## Test plan

- [ ] `osty check LANG_SPEC_v0.6/` (markdown lint + cross-link)
- [ ] §13.9 osty context JSON 출력이 §3.12 / §3.14 / §7.5 와 정합
- [ ] §11 testing의 §11.18 capability recipes가 6개로 일치 (spec block recipe 제거됨)

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_