### PR TITLE
docs+code(v0.6): migrate v0.5 spec references to v0.6

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 - **Scope**: Compiler pipeline design — pass-level architecture, error recovery, diagnostic flow
 - **Type**: Design doc
 High-level map of the Osty front-end. For spec decisions see
-`OSTY_GRAMMAR_v0.5.md`; this document covers **implementation** layout.
+`OSTY_GRAMMAR_v0.6.md`; this document covers **implementation** layout.
 
 ## Pipeline
 
@@ -321,7 +321,7 @@ tracked outside spec gaps.
 Bidirectional typing with local unification and monomorphization on
 generic instantiation. The full specification, including the rule
 table and a line-level mapping to the self-hosted implementation,
-lives at `LANG_SPEC_v0.5/02a-type-inference.md`. The reference
+lives at `LANG_SPEC_v0.6/02a-type-inference.md`. The reference
 implementation is `toolchain/check.osty`; `host_boundary.go` is a
 pure adapter that materializes the checker's output as
 `Result.Types`, `Result.LetTypes`, `Result.SymTypes`, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,9 @@
 - `ERROR_CODES.md` — 진단 카탈로그 (생성물, `internal/diag/codes.go`에서 자동 생성)
 - `RUNTIME_GC.md` — 런타임/GC 구현 경로
 
-> v0.5 spec 은 `LANG_SPEC_v0.5/` / `OSTY_GRAMMAR_v0.5.md` 에 historical snapshot 으로 보존. v0.6 코드 작성에는 v0.6 docs 만 참조.
-
 ## graphify 지식 그래프
 
-`graphify-out/`에 AST + 시맨틱 병합 그래프 존재 (13.6k 노드 / 44.9k 엣지 / 159 커뮤니티). 스코프: `internal/` + `LANG_SPEC_v0.5/` + `toolchain/`. `cmd/`·`benchmarks/`·`examples/`는 미인덱스.
+`graphify-out/`에 AST + 시맨틱 병합 그래프 존재 (13.6k 노드 / 44.9k 엣지 / 159 커뮤니티). 스코프: `internal/` + `LANG_SPEC_v0.6/` + `toolchain/`. `cmd/`·`benchmarks/`·`examples/`는 미인덱스.
 
 ### 언제 쓸지
 - 아키텍처/파이프라인 질문 → **먼저 `graphify-out/GRAPH_REPORT.md`** 읽고 god 노드 + 커뮤니티 구조 파악
@@ -268,7 +266,7 @@ prefix는 `feat` / `fix` / `chore` / `docs` / `refactor` / `test` / `perf` 중 �
 
 # 부록 A. 언어 핵심 문법·의미론 + canonical 예시 (v0.4)
 
-> **이 부록은 에이전트가 실제로 Osty 코드를 작성할 때 참조하는 작업 레퍼런스다.** 모든 권위는 `LANG_SPEC_v0.5/`와 `OSTY_GRAMMAR_v0.5.md`에 있으나, 아래 예시들은 Osty다운 스타일의 baseline — 그대로 따라 쓸 수 있는 기준이다. 예시 코드는 스펙 내에서 확실한 구문만 사용한다.
+> **이 부록은 에이전트가 실제로 Osty 코드를 작성할 때 참조하는 작업 레퍼런스다.** 모든 권위는 `LANG_SPEC_v0.6/`와 `OSTY_GRAMMAR_v0.6.md`에 있으나, 아래 예시들은 Osty다운 스타일의 baseline — 그대로 따라 쓸 수 있는 기준이다. 예시 코드는 스펙 내에서 확실한 구문만 사용한다.
 
 ## A.1 프로그램 구조 / 렉시컬
 

--- a/LANG_SPEC_v0.6/00-revision.md
+++ b/LANG_SPEC_v0.6/00-revision.md
@@ -2,8 +2,8 @@
 
 > **Status**: baseline (frozen). 10 개 결정 (G36, G37, G39, G40, G41, G42,
 > G44, G45, G47, G48) 을 v0.5 baseline 위에 추가하는 spec 개정.
-> v0.5 의 모든 결정은 v0.6 에서도 유효. 본 문서는 *delta* 만 기술하며, 변경 없는 챕터는
-> [`../LANG_SPEC_v0.5/`](../LANG_SPEC_v0.5/) 가 계속 권위.
+> v0.5 의 모든 결정은 v0.6 에서도 유효 — 변경 없는 챕터는 본 디렉토리
+> [`./`](./) 의 같은-번호 파일이 계속 권위. 본 문서는 *delta* 만 기술한다.
 >
 > **Withdrawn from v0.6 baseline** (low-utility, removed pre-release):
 > G38 (`#[spec]` link), G43 (spec block), G46 (`#[budget]`), G49 (`while`

--- a/LANG_SPEC_v0.6/README.md
+++ b/LANG_SPEC_v0.6/README.md
@@ -33,7 +33,6 @@ gap closure tables.
   *one-document overview*.
 - `../OSTY_GRAMMAR_v0.6.md` — formal grammar (R1–R29 + EBNF). The
   lexer/parser ground truth.
-- `../OSTY_GRAMMAR_v0.5.md` and earlier — historical grammar snapshots.
 - `../SPEC_GAPS.md` — archive of resolved gaps per version.
 - `../CHANGELOG_v0.6.md` — implementation status (what is *shipped*
   vs what is *spec*).

--- a/OSTY_GRAMMAR_v0.6.md
+++ b/OSTY_GRAMMAR_v0.6.md
@@ -1,8 +1,9 @@
 # Osty Grammar — Rules & EBNF (v0.6)
 
-v0.5 의 R1–R26 결정과 EBNF 를 baseline 으로, v0.6 에서 추가/변경된 rule
-만 본 문서에 명시한다. v0.5 grammar 의 본문은
-[`OSTY_GRAMMAR_v0.5.md`](./OSTY_GRAMMAR_v0.5.md) 가 계속 권위.
+R1–R26 결정과 EBNF baseline 위에서 v0.6 에서 추가/변경된 rule 만
+본 문서에 *delta* 로 명시한다. 통합 grammar 는 별도 파일
+`OSTY_GRAMMAR_v0.6_FULL.md` (Phase 1 종료 시 생성) 참조 — 본 문서는
+*delta only*.
 
 > **Status**: v0.6 spec revision 동기 (G36, G37, G39-G42, G44, G45,
 > G47, G48). spec 본문은

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 - **Type**: README
 A work-in-progress implementation of the **Osty** programming language — a
 general-purpose, statically-typed, GC'd language specified in
-[`LANG_SPEC_v0.5/`](./LANG_SPEC_v0.5/README.md) with grammar fixed in
-[`OSTY_GRAMMAR_v0.5.md`](./OSTY_GRAMMAR_v0.5.md).
+[`LANG_SPEC_v0.6/`](./LANG_SPEC_v0.6/README.md) with grammar fixed in
+[`OSTY_GRAMMAR_v0.6.md`](./OSTY_GRAMMAR_v0.6.md).
 
 The target is a self-hosted native runtime and LLVM backend. Current scope:
 front-end (lex → parse → resolve → type-check), multi-file packages and
@@ -33,7 +33,7 @@ native-only through the LLVM backend.
 | Diagnostics (`error[E0002]:` with caret, hints, notes) | done |
 | Name resolution (single + multi-file, workspace, typo suggestions) | done |
 | Formatter (`internal/format`) | done |
-| Type checker (`internal/check`) | done for the shipped v0.5 front-end core — generic instantiation, structural interface checks, exhaustiveness, builder protocol, function-value arity, closure pattern params. Algorithm: bidirectional + local unification, spec in [`LANG_SPEC_v0.5/02a-type-inference.md`](./LANG_SPEC_v0.5/02a-type-inference.md); `osty check --inspect` observes it at runtime |
+| Type checker (`internal/check`) | done for the shipped v0.6 front-end core — generic instantiation, structural interface checks, exhaustiveness, builder protocol, function-value arity, closure pattern params. Algorithm: bidirectional + local unification, spec in [`LANG_SPEC_v0.6/02a-type-inference.md`](./LANG_SPEC_v0.6/02a-type-inference.md); `osty check --inspect` observes it at runtime |
 | Linter (`internal/lint`, 28 codes across L0001–L0070 spanning unused / dead-code / naming / simplify / complexity / docs, `--fix` / `--fix-dry-run`, policy via `[lint]` in `osty.toml`) | done |
 | Multi-file packages (`resolve` loader/package/workspace) | done |
 | LSP (`internal/lsp`, wired as `osty lsp`) | done — hover, definition, formatting, documentSymbol, lint diagnostics, editor policy backed by toolchain sources |
@@ -138,8 +138,8 @@ parity.
 
 ```
 osty/
-├── LANG_SPEC_v0.5/          # Current spec prose / design target
-├── OSTY_GRAMMAR_v0.5.md     # Current EBNF grammar + decision log
+├── LANG_SPEC_v0.6/          # Current spec prose / design target
+├── OSTY_GRAMMAR_v0.6.md     # Current EBNF grammar + decision log
 ├── SPEC_GAPS.md             # Resolved-gap archive by language version
 ├── LLVM_MIGRATION_PLAN.md   # Native backend migration history/plan
 ├── LLVM_PHASE1_BASELINE.md  # Legacy Go-backend baseline for LLVM migration
@@ -396,7 +396,7 @@ osty parse FILE        # parse to AST, emit JSON
 osty resolve FILE|DIR  # name resolution; directory = package mode (--scopes for tree)
 osty check FILE|DIR    # lex + parse + resolve + type-check (diagnostics only)
                        # --inspect prints one record per expression with the
-                       # inference rule applied (see LANG_SPEC_v0.5/02a-type-inference.md)
+                       # inference rule applied (see LANG_SPEC_v0.6/02a-type-inference.md)
 osty typecheck FILE    # same as check, plus a per-expression type dump
 osty lint FILE|DIR     # style + correctness warnings (L0xxx codes)
 osty fmt FILE          # airepair + format to canonical style (see --check, --write, --engine)
@@ -434,7 +434,7 @@ Global flags (precede the subcommand):
   unique code; applies to `check`, `typecheck`, `resolve`, `lint`, `parse`, `tokens`
 - `--inspect` — `check`-only: emit one record per expression naming the
   inference rule and the type/hint the checker used. Pairs with `--json` for
-  NDJSON output. See [`LANG_SPEC_v0.5/02a-type-inference.md`](./LANG_SPEC_v0.5/02a-type-inference.md).
+  NDJSON output. See [`LANG_SPEC_v0.6/02a-type-inference.md`](./LANG_SPEC_v0.6/02a-type-inference.md).
 
 `fmt`-specific flags (after the subcommand):
 
@@ -811,8 +811,8 @@ regenerations.
 
 ## Contributing
 
-Spec work in this repo is tracked under **v0.5**
-(`LANG_SPEC_v0.5/`, `OSTY_GRAMMAR_v0.5.md`), and the shipped project
+Spec work in this repo is tracked under **v0.6**
+(`LANG_SPEC_v0.6/`, `OSTY_GRAMMAR_v0.6.md`), and the shipped project
 edition is **0.5** today: `osty new` / `osty init` write
 `edition = "0.5"`, while manifest validation still accepts the
 historical `0.3` / `0.4` range for existing projects. Future surface

--- a/RUNTIME_SCHEDULER.md
+++ b/RUNTIME_SCHEDULER.md
@@ -2,7 +2,7 @@
 
 - **Scope**: Runtime scheduler design — task groups, structured concurrency, cancel state
 - **Type**: Design doc
-> **Status (2026-04-22):** **Phase 2 착륙.** thread-per-task pthread 모델이 워커 풀 + 워커별 Chase-Lev work-stealing deque + linked-list FIFO 인젝트 큐로 교체됨. 워커 수는 기본 `min(CPUs, 8)` (Darwin 은 `sysctlbyname("hw.ncpu")`, 그 외 POSIX 는 `sysconf(_SC_NPROCESSORS_ONLN)`, Windows 는 `GetSystemInfo`), `OSTY_SCHED_WORKERS` 환경변수로 `[1, 256]` 오버라이드. Elastic worker는 **블로킹 cv_wait 진입 직전에만** on-demand 생성 (상한 `OSTY_SCHED_ELASTIC_MAX = 256`) — CPU-bound 워크로드는 오버섭스크립션 없이 fixed pool 로 스케일. 관찰된 speedup: 16 xorshift task × `workers=1 → 4` 에서 **3.97x**. ThreadSanitizer clean (Chase-Lev slot publication 을 release/acquire atomic 으로 게시). 공개 ABI (`osty_rt_task_spawn/group_spawn/handle_join/group/group_cancel/...`) 는 Phase 1B에서 그대로 유지 — MIR/백엔드 재컴파일 불필요. `parallel` / `race` / `collectAll` / `thread.select` (recv/send/timeout/default) 은 Phase 1B에서 추가된 형태 그대로 풀 위에서 동작하며, Phase 1B부터 남아있던 `race` / `collectAll` 의 `list trace-kind mismatch` 버그는 이 마이그레이션 중에 함께 수정. 이 문서는 `LANG_SPEC_v0.5/08-concurrency.md` §8.0과 `LANG_SPEC_v0.5/19-runtime-primitives.md` §19.1 "GC × scheduler interaction" 절에 대응하는 **구현 레퍼런스**다. 스펙은 관찰 가능한 계약만 고정하고, 이 문서는 공개 LLVM 백엔드의 참조 런타임이 어떤 단계로 그 계약을 만족하는지 기술한다.
+> **Status (2026-04-22):** **Phase 2 착륙.** thread-per-task pthread 모델이 워커 풀 + 워커별 Chase-Lev work-stealing deque + linked-list FIFO 인젝트 큐로 교체됨. 워커 수는 기본 `min(CPUs, 8)` (Darwin 은 `sysctlbyname("hw.ncpu")`, 그 외 POSIX 는 `sysconf(_SC_NPROCESSORS_ONLN)`, Windows 는 `GetSystemInfo`), `OSTY_SCHED_WORKERS` 환경변수로 `[1, 256]` 오버라이드. Elastic worker는 **블로킹 cv_wait 진입 직전에만** on-demand 생성 (상한 `OSTY_SCHED_ELASTIC_MAX = 256`) — CPU-bound 워크로드는 오버섭스크립션 없이 fixed pool 로 스케일. 관찰된 speedup: 16 xorshift task × `workers=1 → 4` 에서 **3.97x**. ThreadSanitizer clean (Chase-Lev slot publication 을 release/acquire atomic 으로 게시). 공개 ABI (`osty_rt_task_spawn/group_spawn/handle_join/group/group_cancel/...`) 는 Phase 1B에서 그대로 유지 — MIR/백엔드 재컴파일 불필요. `parallel` / `race` / `collectAll` / `thread.select` (recv/send/timeout/default) 은 Phase 1B에서 추가된 형태 그대로 풀 위에서 동작하며, Phase 1B부터 남아있던 `race` / `collectAll` 의 `list trace-kind mismatch` 버그는 이 마이그레이션 중에 함께 수정. 이 문서는 `LANG_SPEC_v0.6/08-concurrency.md` §8.0과 `LANG_SPEC_v0.6/19-runtime-primitives.md` §19.1 "GC × scheduler interaction" 절에 대응하는 **구현 레퍼런스**다. 스펙은 관찰 가능한 계약만 고정하고, 이 문서는 공개 LLVM 백엔드의 참조 런타임이 어떤 단계로 그 계약을 만족하는지 기술한다.
 
 ## 배경
 
@@ -257,8 +257,8 @@ void osty_rt_gc_collect_concurrent_incremental_v1(
 - `internal/backend/runtime/osty_runtime.c` — GC + collection intrinsics + (Phase 1A부터) task/thread/chan/select 심볼.
 - `internal/llvmgen/mir_generator.go` — 심볼 lowering. 변경 시 이 문서 ABI 섹션 동기화.
 - `internal/backend/llvm_runtime.go` — 런타임 소스 embed. 파일 분리 시 두 번째 embed 추가.
-- `LANG_SPEC_v0.5/08-concurrency.md` §8.0 — 스케줄러 모델 고정.
-- `LANG_SPEC_v0.5/19-runtime-primitives.md` §19.1 "GC × scheduler interaction" — 수집기와 스케줄러 상호작용.
+- `LANG_SPEC_v0.6/08-concurrency.md` §8.0 — 스케줄러 모델 고정.
+- `LANG_SPEC_v0.6/19-runtime-primitives.md` §19.1 "GC × scheduler interaction" — 수집기와 스케줄러 상호작용.
 
 ## 비-목표
 

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -2,13 +2,14 @@
 
 - **Scope**: Resolved spec gaps — v0.4 edge-case decisions, archived by language version
 - **Type**: Decision log
-`LANG_SPEC_v0.5/` + `OSTY_GRAMMAR_v0.5.md` 기준.
+`LANG_SPEC_v0.6/` + `OSTY_GRAMMAR_v0.6.md` 기준.
 
-**v0.5 시점 open gap: 없음.** v0.4 사용 코퍼스에서 관찰된 15 개
-개선점(G20-G34) 을 v0.5 에서 일괄 결정했다.
+**v0.6 시점 open gap: 없음.** v0.4 사용 코퍼스에서 관찰된 15 개
+개선점(G20-G34) 을 v0.5 에서 일괄 결정했고, v0.6 에서는 G36-G48 중
+G36/G37/G39-G42/G44/G45/G47/G48 (10 결정) 을 baseline 동결했다.
 
-스펙은 v0.2 부터 폴더 구조이다. §X (X = 1..18) 는 `LANG_SPEC_v0.5/NN-*.md`
-파일. §10 의 서브섹션은 `LANG_SPEC_v0.5/10-standard-library/NN-*.md`.
+스펙은 v0.2 부터 폴더 구조이다. §X (X = 1..21) 는 `LANG_SPEC_v0.6/NN-*.md`
+파일. §10 의 서브섹션은 `LANG_SPEC_v0.6/10-standard-library/NN-*.md`.
 §19 는 v0.4 additive minor 로 도입된 toolchain-only 서브언어.
 
 ---

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -8,7 +8,7 @@ Osty 표준 라이브러리 모듈별 실행 가능성 / 스펙 정합 매트릭
 > - `internal/stdlib/modules/*.osty` (Phase B / surface)
 > - `internal/stdlib/primitives/*.osty` (intrinsic methods)
 > - `internal/backend/runtime/osty_runtime.c` (23,895 LOC / 638 `osty_rt_*` 함수 / Phase A / C runtime)
-> - `LANG_SPEC_v0.5/10-standard-library/*.md` (스펙 권위)
+> - `LANG_SPEC_v0.6/10-standard-library/*.md` (스펙 권위)
 >
 > **기준일**: 2026-05-05 (HEAD `b640a833` 대조).
 > **이전 매트릭스 (94% Production 주장) 전면 재평가됨** —
@@ -110,7 +110,7 @@ partial 모듈 3개 (crypto / option / result) 는 **호출 패턴 한정 동작
 | net | §10.23 / §20 | 972 | 94 + HostNet | 11% | net 40 runtime | TCP/UDP는 백엔드 풍부, IPv6 zone parsing 등 일부 미검증. v0.6 bridge `HostNet` adapter 추가 |
 | thread | §8 | 76 | 16 | 50% | thread 16 + chan 10 + select 22 + task 19 | ~~`thread.Duration{}` 빈 struct~~ → commit `23f4568c`에서 제거. 현재는 `use std.time` + `time.Duration` 단일 사용 |
 | sync | §10.2 | 96 | 17 | 17% | mu 5 + rmu 5 + cond 6 + once 3 | spec tier-2 = "Mutex, RwLock, atomics". Once는 spec 외인데 백엔드는 갖춤 |
-| time | §10.20 / §20 | 94 | 25 + HostClock | 64% | monotonic + sleep + format 일부 | `systemClock` adapter 추가. ~~`Int.s/ms/h/min/days/ns/us/weeks` 부재~~ → 2026-05-02 재확인 결과 8개 모두 ([primitives/int.osty:76-83](internal/stdlib/primitives/int.osty)) + Float 8개 ([primitives/float.osty:61-68](internal/stdlib/primitives/float.osty)) 선언됨. 체커 등록은 [`primitive_arith_register.go:131`](internal/selfhost/primitive_arith_register.go) (8개 loop), LLVM 백엔드는 [`duration_constructors_test.go`](internal/llvmgen/duration_constructors_test.go) 8개 테스트 통과. spec 이름 `minutes` (≠ `min`, `Int.min(self, other)`와 충돌 회피, [spec §10.20](LANG_SPEC_v0.5/10-standard-library/20-time-extensions.md) line 111-112) |
+| time | §10.20 / §20 | 94 | 25 + HostClock | 64% | monotonic + sleep + format 일부 | `systemClock` adapter 추가. ~~`Int.s/ms/h/min/days/ns/us/weeks` 부재~~ → 2026-05-02 재확인 결과 8개 모두 ([primitives/int.osty:76-83](internal/stdlib/primitives/int.osty)) + Float 8개 ([primitives/float.osty:61-68](internal/stdlib/primitives/float.osty)) 선언됨. 체커 등록은 [`primitive_arith_register.go:131`](internal/selfhost/primitive_arith_register.go) (8개 loop), LLVM 백엔드는 [`duration_constructors_test.go`](internal/llvmgen/duration_constructors_test.go) 8개 테스트 통과. spec 이름 `minutes` (≠ `min`, `Int.min(self, other)`와 충돌 회피, [spec §10.20](LANG_SPEC_v0.6/10-standard-library/20-time-extensions.md) line 111-112) |
 | testing | §11 | 88 | 14 | 100% | bench 7 + test 6 + snapshot 7 + parallel 6 | assertion/benchmark/snapshot 백엔드 인터셉트로 동작. property는 스펙 §11 G33 |
 | testing_gen | §11 | 168 | 18 | 0% | pure Osty | int/intRange/bool/float/string/list 등 generator |
 | term | §10.25 | 320 | 39 | 17% | term 14 runtime + shim | isTerminal/size/write/flush/setRawMode 백엔드. **readKey/pollKey/readEvent는 미구현** (모듈 헤더 자백) |
@@ -291,7 +291,7 @@ partial 모듈 3개 (crypto / option / result) 는 **호출 패턴 한정 동작
 
 | # | 항목 | 작업 |
 |---|---|---|
-| 14 | unspec 모듈 (62개) | LANG_SPEC_v0.5/10-standard-library/에 챕터 추가하거나 community-package 라벨 |
+| 14 | unspec 모듈 (62개) | LANG_SPEC_v0.6/10-standard-library/에 챕터 추가하거나 community-package 라벨 |
 | 15 | OSTY_STDLIB_BODY_LOWER | default-on flip + 게이트 제거 (memory `project_stdlib_injection_hang`) |
 | 16 | `Set` 빈약 / `Deque`/`PriorityQueue` 부재 | spec §10.6 확장 제안 (v0.6 minor) |
 

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -609,7 +609,7 @@ func parseFlags() cliFlags {
 	flag.BoolVar(&f.showScopes, "scopes", false, "resolve: also dump the nested scope tree")
 	flag.BoolVar(&f.trace, "trace", false, "stream per-phase timing to stderr (single-file front-end commands)")
 	flag.BoolVar(&f.explain, "explain", false, "after diagnostics, print the `osty explain CODE` text for each unique code")
-	flag.BoolVar(&f.inspect, "inspect", false, "check: emit one record per expression showing the inference rule, type, and hint (see LANG_SPEC_v0.5/02a-type-inference.md)")
+	flag.BoolVar(&f.inspect, "inspect", false, "check: emit one record per expression showing the inference rule, type, and hint (see LANG_SPEC_v0.6/02a-type-inference.md)")
 	flag.BoolVar(&f.dumpNativeDiags, "dump-native-diags", false, "check/typecheck: after the run, print the native checker's per-context error histogram to stderr")
 	flag.BoolVar(&f.native, "native", true, "check/typecheck: backwards-compat no-op since Phase 1c.5. The self-host arena pipeline is the only path; this flag is accepted so old scripts keep working")
 	flag.Usage = usage

--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -59,7 +59,7 @@ host osty (Go 부트스트랩)
 `osty-self`가 없을 때만 켜지는, 의도적으로 좁은 stage0 emitter를 Go 측에 둔다. 범위:
 
 - **포함**: `toolchain/*.osty` 자기 자신을 한번 컴파일하기에 충분한 MIR 패턴 — 함수 정의, 분기, 산술, struct/enum 기본 lowering, runtime ABI 호출 (`osty.gc.*`, `osty_rt_*`).
-- **제외**: vectorize 힌트, parallel access groups, target_feature, hot/cold 섹션, advanced unroll. 즉 v0.5 spec의 **컴파일러를 컴파일할 수 있는 핵심만**.
+- **제외**: vectorize 힌트, parallel access groups, target_feature, hot/cold 섹션, advanced unroll. 즉 v0.6 spec의 **컴파일러를 컴파일할 수 있는 핵심만**.
 
 stage0 emitter는 명시적으로 **deprecated-on-arrival** — fast path가 아니라 부트스트랩용. Production 빌드 (`osty-self` 사용 가능 시)는 LIR Proto 경로 그대로.
 
@@ -84,12 +84,12 @@ func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options
 ```
 
 `stage0EmitMIR` 본체는:
-- **새 패키지 `internal/backend/stage0/`** 에 격리. ~5K 줄을 넘지 않도록 v0.5 spec 핵심 구문만 다룸.
+- **새 패키지 `internal/backend/stage0/`** 에 격리. ~5K 줄을 넘지 않도록 v0.6 spec 핵심 구문만 다룸.
 - 매 회 `toolchain/*.osty`가 stage0 surface를 벗어나지 않는지 CI에서 검증 (`TestStage0CoversToolchainMIR` 같은 게이트).
 - 출력은 LIR Proto 경로와 byte-equivalent일 필요 **없음**. `verify-self-rebuild`의 stage2/3 parity는 stage1의 결과물 (`osty-self-1`)이 stage1을 사용해서 다시 빌드되는 것이므로, stage0 IR이 stage1 IR과 다른 건 정상.
 
 장점:
-- v0.5 spec ON, 부트스트랩 가능.
+- v0.6 spec ON, 부트스트랩 가능.
 - stage0이 모든 emit을 처리하지 않으므로 surface 폭주 위험 제어됨.
 - LIR Proto 경로가 default — stage0 retire는 osty-self 광범위 가용 시점에 가능.
 
@@ -147,9 +147,9 @@ func TestStage0CoversToolchainMIR(t *testing.T) {
 
 retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통째로 삭제 + 본 design doc도 archive로 이동.
 
-### 3.5 v0.5 spec 영향
+### 3.5 v0.6 spec 영향
 
-없음. stage0는 emitter level에서만 작동하며 surface 추가 0건. `LANG_SPEC_v0.5/`, `OSTY_GRAMMAR_v0.5.md`는 변경 안 함.
+없음. stage0는 emitter level에서만 작동하며 surface 추가 0건. `LANG_SPEC_v0.6/`, `OSTY_GRAMMAR_v0.6.md`는 변경 안 함.
 
 ## 4. 구현 단계 (제안)
 

--- a/docs/post_1405_coverage_audit_design.md
+++ b/docs/post_1405_coverage_audit_design.md
@@ -67,7 +67,7 @@ PR #1406이 그 위에 추가로 12개 backend 테스트를 obsolete 처리 (del
 
 테스트: 자유변수 캡처 → 환경 struct 생성 → indirect call.
 
-- v0.5 spec 핵심 (B.5).
+- v0.6 spec 핵심 (B.5).
 - 현황: 자기-호스트 컴파일 자체가 closure를 사용하므로 `verify-self-rebuild` 가 indirect로 잡음. 단 specific shape (재귀, mutable capture 등)는 미보장.
 - **Action**: backend 측 통합 테스트 5-10개 정도로 회복. skip-on-no-osty-self.
 
@@ -75,7 +75,7 @@ PR #1406이 그 위에 추가로 12개 backend 테스트를 obsolete 처리 (del
 
 테스트: `Error.downcast::<T>()` lowering, vtable lookup.
 
-- v0.5 spec 핵심 (A.6).
+- v0.6 spec 핵심 (A.6).
 - 현황: 자기-호스트 컴파일러가 downcast 안 쓰면 `verify-self-rebuild` 로 잡히지 않음.
 - **Action**: 회복 필요. 우선순위 중.
 
@@ -91,7 +91,7 @@ PR #1406이 그 위에 추가로 12개 backend 테스트를 obsolete 처리 (del
 
 테스트: 모든 패턴 종류 (literal / range / or / binding / guard / payload destructure) lowering.
 
-- v0.5 spec A.5.
+- v0.6 spec A.5.
 - 자기-호스트가 일부 패턴만 사용 → 광범위 indirect coverage 불가.
 - **Action**: spec corpus 와 결합. 우선순위 중-높음.
 
@@ -99,7 +99,7 @@ PR #1406이 그 위에 추가로 12개 backend 테스트를 obsolete 처리 (del
 
 테스트: defer LIFO + `?` propagation 시 실행 + cancel 시 실행 + `panic`/`unreachable`/`todo`/`abort` skip.
 
-- v0.5 spec A.6 (특히 panic 시 skip vs cancel 시 실행 — 미묘함).
+- v0.6 spec A.6 (특히 panic 시 skip vs cancel 시 실행 — 미묘함).
 - 자기-호스트가 defer를 사용하지만 defer × cancel × panic 조합은 안 씀.
 - **Action**: 회복 필요. 우선순위 중.
 

--- a/internal/backend/stage0/doc.go
+++ b/internal/backend/stage0/doc.go
@@ -15,6 +15,6 @@
 //
 // See docs/osty_self_bootstrap_design.md for the bootstrap plan,
 // retirement conditions, and the roadmap from P1 (this skeleton)
-// through P5 (CI matrix). v0.5 spec surface is unchanged — stage0
+// through P5 (CI matrix). v0.6 spec surface is unchanged — stage0
 // operates entirely below the front-end.
 package stage0

--- a/internal/check/inspect.go
+++ b/internal/check/inspect.go
@@ -21,7 +21,7 @@ type InspectRecord struct {
 	End token.Pos
 	// NodeKind is the syntactic category, e.g. "IntLit", "CallExpr", "If".
 	NodeKind string
-	// Rule is the label from LANG_SPEC_v0.5/02a-type-inference.md.
+	// Rule is the label from LANG_SPEC_v0.6/02a-type-inference.md.
 	Rule string
 	// Type is retained for compatibility with callers that already consume
 	// types.Type values. New formatting code prefers TypeName so it never has

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -17,7 +17,7 @@ import (
 //
 // Generic fns that are never called are dropped entirely — matching the
 // language spec's "header-like" demand-driven framing
-// (LANG_SPEC_v0.5/02-type-system.md §2.7.3).
+// (LANG_SPEC_v0.6/02-type-system.md §2.7.3).
 //
 // The returned []error collects non-fatal issues (unresolved type
 // parameters, arity mismatches). A nil module yields (nil, nil).

--- a/internal/resolve/helpers.go
+++ b/internal/resolve/helpers.go
@@ -20,7 +20,7 @@ func lastSeg(s string, sep byte) string {
 
 // stringArg extracts a literal string from an annotation argument
 // expression. Returns ok=false for interpolated or non-string forms —
-// annotations require literal arguments per the v0.5 spec.
+// annotations require literal arguments per the v0.6 spec.
 func stringArg(e ast.Expr) (string, bool) {
 	lit, ok := e.(*ast.StringLit)
 	if !ok {

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -21405,7 +21405,7 @@ func opTryParsePostfix(p *OstyParser, lhs int) int {
 	// Osty: /tmp/selfhost_merged.osty:7962:5
 	if ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontIdent{})) && tok.text == "as" && ostyEqual(opPeekAt(p, 1).kind, FrontTokenKind(&FrontTokenKind_FrontQuestion{})) {
 		// Osty: /tmp/selfhost_merged.osty:7966:9
-		opErrorFull(p, "`as?` must be written without whitespace between `as` and `?`", "write `as?` as a single token (no space)", "OSTY_GRAMMAR_v0.5 §28", "E0202")
+		opErrorFull(p, "`as?` must be written without whitespace between `as` and `?`", "write `as?` as a single token (no space)", "OSTY_GRAMMAR_v0.6 §28", "E0202")
 		// Osty: /tmp/selfhost_merged.osty:7967:9
 		_ = opAdvance(p)
 		// Osty: /tmp/selfhost_merged.osty:7968:9

--- a/internal/selfhost/testdata/parse_snapshots/testdata_spec_negative_reject.txt
+++ b/internal/selfhost/testdata/parse_snapshots/testdata_spec_negative_reject.txt
@@ -39,5 +39,5 @@ error E0600 "`break` outside of loop" ^[132:16-132:17] hint="move inside a `for`
 error E0601 "`continue` outside of loop" ^[136:19-136:20] hint="move inside a `for` loop"
 error E0607 "annotation on the wrong kind of declaration" ^[163:1-163:4] hint="annotations are not permitted on `use` statements"
 error E0608 "`defer` is not allowed at the top level of a script" ^[168:1-168:6] hint="move this `defer` inside a function body — it binds to the enclosing function's return"
-error E0202 "`as?` must be written without whitespace between `as` and `?`" ^[260:9-260:11] hint="write `as?` as a single token (no space)" note="OSTY_GRAMMAR_v0.5 §28"
+error E0202 "`as?` must be written without whitespace between `as` and `?`" ^[260:9-260:11] hint="write `as?` as a single token (no space)" note="OSTY_GRAMMAR_v0.6 §28"
 error E0004 "unterminated block comment" ^[375:1-376:1]

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -4,7 +4,7 @@
 // Stdlib modules are authored as .osty stub files under `modules/`
 // (and, once primitive method stubs land, `primitives/`). Each stub
 // declares types, interfaces, and body-less `fn` signatures that mirror
-// the language specification in `LANG_SPEC_v0.5/10-standard-library/`.
+// the language specification in `LANG_SPEC_v0.6/10-standard-library/`.
 // The stubs are embedded at build time and parsed by the existing
 // compiler front-end so the stdlib uses the same syntax rules as user
 // code.

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2727,7 +2727,7 @@ pub fn llvmUnsupportedDiagnostic(kind: String, detail: String) -> LlvmUnsupporte
             code: "LLVM001",
             kind: "foreign-ffi",
             message: "Go FFI import {target} is not supported by the self-hosted native backend",
-            hint: "rewrite the binding as `use runtime.cabi.<lib>` with an item block for extern C symbols, or `use runtime.<surface>` with an item block for an osty_rt_* runtime ABI helper (LANG_SPEC_v0.5 §12.8)",
+            hint: "rewrite the binding as `use runtime.cabi.<lib>` with an item block for extern C symbols, or `use runtime.<surface>` with an item block for an osty_rt_* runtime ABI helper (LANG_SPEC_v0.6 §12.8)",
         }
     }
     if kind == "runtime-ffi" {

--- a/toolchain/monomorph.osty
+++ b/toolchain/monomorph.osty
@@ -41,7 +41,7 @@ pub struct MonomorphTypeRequest {
 /// monomorphPrimCode maps an Osty primitive source name to its Itanium
 /// ABI builtin-type code. Returns "" for non-primitives so callers can
 /// fall back to the nested / template encodings. The table mirrors
-/// LANG_SPEC_v0.5/02-type-system.md §2.2 plus the relevant C++ ABI
+/// LANG_SPEC_v0.6/02-type-system.md §2.2 plus the relevant C++ ABI
 /// encodings; Osty's canonical `Int` is platform-independent i64 and
 /// maps to `l` (C `long`) to distinguish it from explicit `Int64` (`x`).
 pub fn monomorphPrimCode(name: String) -> String {

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -1542,8 +1542,8 @@ fn opTryParsePostfix(p: OstyParser, lhs: Int) -> Int {
     if tok.kind == FrontIdent && tok.text == "as" && opPeekAt(p, 1).kind == FrontQuestion {
         // After lexer fusion `as?` should arrive as FrontAsQuestion. If
         // we still see IDENT(`as`) + QUESTION it must have whitespace in
-        // between, which v0.5 rejects with E0202.
-        opErrorFull(p, "`as?` must be written without whitespace between `as` and `?`", "write `as?` as a single token (no space)", "OSTY_GRAMMAR_v0.5 §28", "E0202")
+        // between, which the grammar rejects with E0202.
+        opErrorFull(p, "`as?` must be written without whitespace between `as` and `?`", "write `as?` as a single token (no space)", "OSTY_GRAMMAR_v0.6 §28", "E0202")
         let _ = opAdvance(p)
         let _ = opAdvance(p)
         let _ = opParseType(p)


### PR DESCRIPTION
## Summary

v0.6 baseline 동결 후 follow-up — 코드/문서의 `LANG_SPEC_v0.5` /
`OSTY_GRAMMAR_v0.5` / "v0.5 spec" 인용 26 곳을 v0.6 으로 일괄 이관.
**22 파일 / +52 / -53 LOC.**

v0.5 historical artifact (CHANGELOG_v0.5.md, MIGRATING_v0.5_to_v0.6.md,
BREAKING_v0.6.md, LANG_SPEC_v0.5/, OSTY_GRAMMAR_v0.5.md, 18-change-history,
00-revision §3.10/§3.13/§3.15/§4.4 의 withdrawn-callout 본문) 은
의도적 보존.

### top-level docs
- `CLAUDE.md`: historical-snapshot 안내 + graphify scope + 부록 A authority
  3 곳 v0.6 으로 이관.
- `README.md`: spec lead, type checker status, layout tree, `--inspect` doc
  link, contributing 절 6 곳.
- `ARCHITECTURE.md`: grammar 인용 + 02a-type-inference 인용 2 곳.

### spec/grammar/runtime docs
- `OSTY_GRAMMAR_v0.6.md`: lead 의 v0.5 grammar cross-link 제거
  ("delta over baseline" 표현 유지).
- `SPEC_GAPS.md`: v0.5 → v0.6 baseline 으로, open gap callout + folder
  structure note 갱신 (§X = 1..21).
- `STDLIB_MATRIX.md`: spec authority + time-extensions cross-ref +
  unspec module action.
- `RUNTIME_SCHEDULER.md`: §8.0 / §19.1 cross-ref 2 곳.
- `LANG_SPEC_v0.6/README.md`: "../OSTY_GRAMMAR_v0.5 historical snapshot"
  bullet 제거.
- `LANG_SPEC_v0.6/00-revision.md`: "변경 없는 챕터는 ../LANG_SPEC_v0.5/ 가
  계속 권위" → 본 디렉토리 같은-번호 파일이 권위.
- `docs/osty_self_bootstrap_design.md`: 4 곳 v0.6 으로.
- `docs/post_1405_coverage_audit_design.md`: 4 곳 v0.6 으로.

### Go source / toolchain
- `cmd/osty/main.go`: `--inspect` flag help.
- `internal/{check/inspect, ir/monomorph, stdlib, resolve/helpers, backend/stage0/doc}`
  의 doc 코멘트 + spec cross-ref.
- `toolchain/{parser, llvmgen, monomorph}.osty`: error note + hint +
  doc 코멘트.
- `internal/selfhost/generated.go` (frozen seed): `parser.osty` 의 E0202
  error note 미러 동기화.
- `internal/selfhost/testdata/.../testdata_spec_negative_reject.txt`
  스냅샷 동기화.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] 영향 패키지 (`selfhost/check/resolve/ir/stdlib/speccorpus/cmd/osty/backend/stage0`) 테스트 통과
- [x] `TestParseSnapshot/word_freq` 는 본 변경 이전부터 실패 (offset drift) — 본 PR 무관
- [ ] CI on push

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_