### PR TITLE
fix(toolchain): repair check_gates.osty after G43 retract + helper signature bugs

### DIFF
--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -1509,7 +1509,7 @@ pub fn diagTaintSinkViolation(source: String, sink: String, requiredTag: String,
         end,
         [
             "LANG_SPEC §21.5.3 (T-Sink): tainted values must be sanitised before reaching a sink",
-            "hint: pass through a sanitiser that produces `{requiredTag}", or use the parametrised form",
+            "hint: pass through a sanitiser that produces `{requiredTag}`, or use the parametrised form",
         ],
     )
 }

--- a/toolchain/check_gates.osty
+++ b/toolchain/check_gates.osty
@@ -2427,7 +2427,7 @@ fn collectSealedStructInfo(arena: AstArena) -> List<SealedStructInfo> {
         }
         let sealedAnnots = collectAnnotationByName(arena, node.extra, "sealed_construct")
         for annot in sealedAnnots {
-            let constructorName = sealedConstructAnnotConstructor(annot)
+            let constructorName = sealedConstructAnnotConstructor(arena, annot)
             let mut methodNames: List<String> = []
             for memberIdx in node.children {
                 let member = astArenaNodeAt(arena, memberIdx)
@@ -2448,10 +2448,10 @@ fn collectSealedStructInfo(arena: AstArena) -> List<SealedStructInfo> {
     out
 }
 
-fn sealedConstructAnnotConstructor(annot: AstNode) -> String {
+fn sealedConstructAnnotConstructor(arena: AstArena, annot: AstNode) -> String {
     // The constructor name is stored as the first child's text.
     for argIdx in annot.children {
-        let arg = astArenaNodeAt(annot, argIdx)
+        let arg = astArenaNodeAt(arena, argIdx)
         if arg.text != "" {
             return arg.text
         }
@@ -2897,7 +2897,7 @@ fn collectFixtureNames(arena: AstArena) -> List<String> {
                 // We skip emitting here and do it in structuredIntentCheckFn.
             }
             // Extract fixture name from annotation args.
-            let name = fixtureAnnotName(annot)
+            let name = fixtureAnnotName(arena, annot)
             if name != "" {
                 out.push(name)
             } else {
@@ -2909,9 +2909,9 @@ fn collectFixtureNames(arena: AstArena) -> List<String> {
     out
 }
 
-fn fixtureAnnotName(annot: AstNode) -> String {
+fn fixtureAnnotName(arena: AstArena, annot: AstNode) -> String {
     for argIdx in annot.children {
-        let arg = astArenaNodeAt(annot, argIdx)
+        let arg = astArenaNodeAt(arena, argIdx)
         let text = arg.text
         // Look for `name = "..."` pattern.
         if strings.hasPrefix(text, "name") {
@@ -2924,7 +2924,7 @@ fn fixtureAnnotName(annot: AstNode) -> String {
             }
             // Check children for the value.
             for valIdx in arg.children {
-                let val = astArenaNodeAt(annot, valIdx)
+                let val = astArenaNodeAt(arena, valIdx)
                 if val.text != "" {
                     return val.text
                 }
@@ -3024,59 +3024,11 @@ fn fnParamCountExcludingSelf(arena: AstArena, fnNode: AstNode) -> Int {
 // ---------------------------------------------------------------------
 
 fn runSpecBlockGate(cx: ElabCx) {
-    let arena = cx.ast.arena
-    for declIdx in arena.decls {
-        let node = astArenaNodeAt(arena, declIdx)
-        match node.kind {
-            AstNFnDecl -> specBlockCheckFn(cx, arena, node),
-            AstNStructDecl -> specBlockCheckMethods(cx, arena, node),
-            AstNEnumDecl -> specBlockCheckMethods(cx, arena, node),
-            _ -> {},
-        }
-    }
-}
-
-fn specBlockCheckMethods(cx: ElabCx, arena: AstArena, parent: AstNode) {
-    for memberIdx in parent.children {
-        let member = astArenaNodeAt(arena, memberIdx)
-        if member.kind == AstNFnDecl {
-            specBlockCheckFn(cx, arena, member)
-        }
-    }
-}
-
-fn specBlockCheckFn(cx: ElabCx, arena: AstArena, fnNode: AstNode) {
-    if fnNode.right < 0 {
-        return
-    }
-    let body = astArenaNodeAt(arena, fnNode.right)
-    if body.kind != AstNBlock {
-        return
-    }
-    if body.children.len() == 0 {
-        return
-    }
-    // Check the first statement.
-    let firstStmt = astArenaNodeAt(arena, body.children[0])
-    if firstStmt.kind == AstNExprStmt {
-        let inner = astArenaNodeAt(arena, firstStmt.left)
-        if inner.kind == AstNSpecBlock {
-            return  // OK: spec block at first position.
-        }
-    }
-    // If there's a spec block anywhere, check if it's misplaced.
-    for stmtIdx in body.children {
-        let stmt = astArenaNodeAt(arena, stmtIdx)
-        if stmt.kind == AstNExprStmt {
-            let inner = astArenaNodeAt(arena, stmt.left)
-            if inner.kind == AstNSpecBlock {
-                cx.env.local.diagnostics.push(
-                    diagSpecBlockMisplaced(fnNode.text, inner.start, inner.end),
-                )
-                return
-            }
-        }
-    }
+    // G43 (spec block) was withdrawn in PRs #1542-#1549. The gate is
+    // kept as a no-op so the dispatcher's call-site stays stable;
+    // `AstNSpecBlock` is no longer part of the AST surface, so the
+    // previous walk was dead anyway. Reinstate when/if a successor
+    // gap revives the spec-block construct.
 }
 
 // ---------------------------------------------------------------------
@@ -3436,8 +3388,8 @@ fn taintCheckAnnotations(cx: ElabCx, arena: AstArena, node: AstNode, taintTags: 
     // W0901: #[trusted_declassify] — always emit audit warning.
     let declassifyAnnots = collectAnnotationByName(arena, node.extra, "trusted_declassify")
     for annot in declassifyAnnots {
-        let reason = declassifyAnnotReason(annot)
-        let fnName = node.text
+        let reason = declassifyAnnotReason(arena, annot)
+        let mut fnName = node.text
         if fnName == "" {
             fnName = "<unknown>"
         }
@@ -3447,9 +3399,9 @@ fn taintCheckAnnotations(cx: ElabCx, arena: AstArena, node: AstNode, taintTags: 
     }
 }
 
-fn declassifyAnnotReason(annot: AstNode) -> String {
+fn declassifyAnnotReason(arena: AstArena, annot: AstNode) -> String {
     for argIdx in annot.children {
-        let arg = astArenaNodeAt(annot, argIdx)
+        let arg = astArenaNodeAt(arena, argIdx)
         let text = arg.text
         if strings.hasPrefix(text, "reason") {
             let parts = strings.split(text, "=")
@@ -3457,7 +3409,7 @@ fn declassifyAnnotReason(annot: AstNode) -> String {
                 return strings.trimSpace(parts[parts.len() - 1])
             }
             for valIdx in arg.children {
-                let val = astArenaNodeAt(annot, valIdx)
+                let val = astArenaNodeAt(arena, valIdx)
                 if val.text != "" {
                     return val.text
                 }


### PR DESCRIPTION
## Summary

PR #1550 added 7 v0.6 self-host gates, then PRs #1542–#1549 withdrew **G43 (spec block)**, **G45 (golden)**, **G46 (budget)** — leaving **16 type errors** in \`toolchain/check_gates.osty\` that block \`osty install-self\` at the front-end check stage.

Discovered while running the first-publish playbook (\`docs/operations/first-publish-playbook.md\`); without this fix the bootstrap chain cannot reach the MIR stage even on stage0 99% audit coverage (#1551).

## Errors broken down

| Error | Count | Cause |
|---|---|---|
| E0500 (\`AstNSpecBlock\` undefined) | 3 | G43 retract removed the AST surface |
| E0700 (AstArena vs AstNode mismatch) | 6 | helper signatures missing \`arena: AstArena\` |
| E0745 (cannot find name) | 3 | same G43 retract chain |
| E0204 (parse error) | 2 | unbalanced \`\`\`\` / extra \`\"\` in string literal |
| E0725 (cannot assign to non-mut) | 1 | \`let fnName\` should be \`let mut\` |
| E0001 (newline in string literal) | 1 | same string literal |

## Fixes

- \`runSpecBlockGate\` body removed → stub. Dispatcher slot kept for any successor gap.
- \`sealedConstructAnnotConstructor\`, \`fixtureAnnotName\`, \`declassifyAnnotReason\` — added \`arena: AstArena\` to signatures + threaded through 6 call sites.
- \`let fnName\` → \`let mut fnName\` at line 3393.
- \`check_diag.osty:1512\` — closing backtick added, spurious \`\"\` removed.

## Validation

- [x] \`.bin/osty check toolchain/\` — **0 errors** (was 16)
- [ ] CI green
- [ ] Follow-up: MIR stage \`range literal in value position not lowered to MIR\` — separate diagnostic / lowering work, not in this PR