### PR TITLE
chore(mir): include source span in range-literal-value-position diagnostic

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3693,7 +3693,11 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 		return bs.lowerVariantLit(x, hint)
 	case *ir.RangeLit:
 		// Range values — unsupported in value position for MIR stage 1.
-		bs.l.noteIssue("range literal in value position not lowered to MIR")
+		// Surface the source span so toolchain authors can find the
+		// blocking site quickly; see docs/osty_self_b2_1_audit.md for
+		// the in-progress range-value lowering plan.
+		span := x.At()
+		bs.l.noteIssue("range literal in value position not lowered to MIR (span %d-%d)", span.Start.Offset, span.End.Offset)
 		return &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}}
 	case *ir.Closure:
 		return bs.lowerClosure(x, hint)

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -4907,7 +4907,7 @@ pub fn mirLowerRangeLitInto(
     let span = mirSpanFromHir(e.span)
     mirLowerNoteIssue(
         bs.l,
-        "mir_lower: range literal in value position not lowered to MIR",
+        "mir_lower: range literal in value position not lowered to MIR (HIR span offset {e.span.start.offset}-{e.span.end.offset}, line {e.span.start.line})",
     )
     mirLowerEmitInstr(
         bs,


### PR DESCRIPTION
## Summary

\`internal/mir/lower.go:3696\` emits \"range literal in value position not lowered to MIR\" when an \`ir.RangeLit\` reaches a value-position lowering slot the MIR generator does not yet support. The diagnostic carried no source location, which made it hard to find the offending toolchain site during bootstrap-chain diagnosis — every \`install-self\` attempt got the same opaque message.

Added the HIR span as a byte-offset pair to the message so callers can map back to a file:line via existing span-lookup tooling. Mirrored the same change in the Osty-side helper (\`toolchain/mir_lower.osty\`) so the self-hosted MIR lowerer keeps message parity with the host.

## Validation

- [x] \`go build ./cmd/osty\` clean
- [ ] CI green

Diagnostic-only change. No new lowering, no behaviour change for callers that don't read the issue text. Real Range<T> support is tracked under the MIR emitter's Range<T> whitelist.