### PR TITLE
feat(check): Phase 4 entry — #[since] format gate

### DIFF
--- a/CHANGELOG_v0.6.md
+++ b/CHANGELOG_v0.6.md
@@ -83,7 +83,7 @@ in v0.6" for per-gap rationale.
 
 | Item | Status | Notes |
 |---|---|---|
-| `#[since("X.Y")]` | **planned** (G44, Phase 4) | metadata only |
+| `#[since("X.Y")]` | **partial** (G44, Phase 4) | format gate landed: SemVer-shape regex enforced (`E0452`); arg must be exactly one non-interpolated string literal. `osty publish` API surface gate is still pending. |
 | `#[stability("level", until/since/remove)]` | **planned** (G44, Phase 4) | osty publish 게이트 |
 | `#[match_compat("X.Y", fallback=)]` | **planned** (G44, Phase 4) | non-silent fallback 강제 |
 | `osty publish` API surface diff | **planned** (G44, Phase 4) | major bump 강제 |

--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -1513,6 +1513,14 @@ Spec: v0.6 §3.14.4
 
 **Fix**: use a known version, or update the compiler.
 
+### E0452 — `CodeSinceBadFormat`
+
+CodeSinceBadFormat: `#[since(...)]` did not receive exactly one SemVer-shaped string literal. Accepted shapes are `"X.Y"`, `"X.Y.Z"`, and `"X.Y.Z-pre"` where each `X` / `Y` / `Z` is an ASCII digit run and the optional pre-release tail is `[A-Za-z0-9.-]+`. Interpolated strings, integer literals, identifiers, prefixes such as `"v0.6"`, and wildcard tails such as `"0.6.x"` are rejected.
+
+Spec: v0.6 §3.14.1
+
+**Fix**: pass exactly one string literal whose contents match `^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$` (e.g. `"0.6"`, `"1.0.0"`, `"2.0.0-rc.1"`).
+
 ---
 
 ## Manifest — TOML syntax (E2000–E2004)

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -1391,6 +1391,17 @@ const (
 	// Fix: use a known version, or update the compiler.
 	CodeMatchCompatUnknownVersion = "E0451"
 
+	// CodeSinceBadFormat: `#[since(...)]` did not receive exactly one
+	// SemVer-shaped string literal. Accepted shapes are `"X.Y"`,
+	// `"X.Y.Z"`, and `"X.Y.Z-pre"` where each `X` / `Y` / `Z` is an ASCII
+	// digit run and the optional pre-release tail is `[A-Za-z0-9.-]+`.
+	// Interpolated strings, integer literals, identifiers, prefixes such
+	// as `"v0.6"`, and wildcard tails such as `"0.6.x"` are rejected.
+	//
+	// Spec: v0.6 §3.14.1
+	// Fix: pass exactly one string literal whose contents match `^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$` (e.g. `"0.6"`, `"1.0.0"`, `"2.0.0-rc.1"`).
+	CodeSinceBadFormat = "E0452"
+
 	// Manifest — TOML syntax.
 
 	// Fallback TOML syntax error in `osty.toml`.

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -55656,6 +55656,10 @@ func srCheckAnnotationArgs(file *AstFile, ann *AstNode, target int, result *Self
 		// Osty: /tmp/selfhost_merged.osty:28452:32
 		return srCheckNoaliasArgs(file, ann, result)
 	}
+	// v0.6 G44 — `#[since("X.Y")]` format gate (§3.14.1).
+	if ann.text == "since" {
+		return srCheckSinceArgs(file, ann, result)
+	}
 	return result
 }
 
@@ -56454,6 +56458,169 @@ func srPushBadArgHint(result *SelfResolveResult, message string, start int, end 
 		return struct{}{}
 	}()
 	return out
+}
+
+// srPushSinceBadFormat — v0.6 G44, mirrors toolchain/resolve.osty.
+func srPushSinceBadFormat(result *SelfResolveResult, message string, start int, end int, hint string) *SelfResolveResult {
+	out := result
+	_ = out
+	out.diagnostics = append(out.diagnostics, selfResolveDiagnosticHintAtNode("E0452", message, "", start, end, -1, hint))
+	return out
+}
+
+// srCheckSinceArgs — v0.6 G44 #[since("X.Y")] format gate (§3.14.1).
+// Mirrors toolchain/resolve.osty::srCheckSinceArgs.
+func srCheckSinceArgs(file *AstFile, ann *AstNode, result *SelfResolveResult) *SelfResolveResult {
+	argCount := len(ann.children)
+	if argCount == 0 {
+		return srPushSinceBadFormat(
+			result,
+			"`#[since(...)]` requires one SemVer-shaped string literal",
+			ann.start,
+			ann.end,
+			"example: `#[since(\"0.6\")]`, `#[since(\"1.0.0\")]`, or `#[since(\"2.0.0-rc.1\")]`",
+		)
+	}
+	if argCount > 1 {
+		extra := srAnnotArgView(file, ann.children[1])
+		return srPushSinceBadFormat(
+			result,
+			"`#[since(...)]` accepts exactly one argument",
+			extra.start,
+			extra.end,
+			"remove the extra arguments; only one SemVer string is allowed",
+		)
+	}
+	view := srAnnotArgView(file, ann.children[0])
+	if view.isFlag || view.key != "" {
+		return srPushSinceBadFormat(
+			result,
+			"`#[since(...)]` takes a positional string literal, not a key/flag",
+			view.start,
+			view.end,
+			"example: `#[since(\"0.6\")]`",
+		)
+	}
+	if view.valueIdx < 0 {
+		return srPushSinceBadFormat(
+			result,
+			"`#[since(...)]` requires a SemVer-shaped string literal",
+			view.start,
+			view.end,
+			"example: `#[since(\"0.6\")]`",
+		)
+	}
+	valueNode := srAstNode(file, view.valueIdx)
+	if !ostyEqual(valueNode.kind, AstNodeKind(&AstNodeKind_AstNStringLit{})) {
+		return srPushSinceBadFormat(
+			result,
+			"`#[since(...)]` argument must be a string literal",
+			view.start,
+			view.end,
+			"example: `#[since(\"0.6\")]`",
+		)
+	}
+	if len(valueNode.children) != 0 {
+		return srPushSinceBadFormat(
+			result,
+			"`#[since(...)]` argument must be a non-interpolated string literal",
+			view.start,
+			view.end,
+			"use a plain literal like `\"0.6\"` — interpolation is not allowed",
+		)
+	}
+	raw := srStringLitContent(valueNode.text)
+	if !srIsSemVerShape(raw) {
+		return srPushSinceBadFormat(
+			result,
+			"`#[since(\""+raw+"\")]` is not a SemVer-shape version",
+			view.start,
+			view.end,
+			"accepted shapes: `\"X.Y\"`, `\"X.Y.Z\"`, or `\"X.Y.Z-pre\"` with digit components and an optional `[A-Za-z0-9.-]+` pre-release tail",
+		)
+	}
+	return result
+}
+
+// srIsSemVerShape mirrors toolchain/resolve.osty's hand-rolled
+// implementation of `^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$`.
+func srIsSemVerShape(s string) bool {
+	chars := []rune(s)
+	n := len(chars)
+	if n == 0 {
+		return false
+	}
+	i := 0
+	majorEnd := srSemVerDigitRunEnd(chars, i)
+	if majorEnd == i {
+		return false
+	}
+	i = majorEnd
+	if i >= n {
+		return false
+	}
+	if chars[i] != '.' {
+		return false
+	}
+	i = i + 1
+	minorEnd := srSemVerDigitRunEnd(chars, i)
+	if minorEnd == i {
+		return false
+	}
+	i = minorEnd
+	if i < n && chars[i] == '.' {
+		i = i + 1
+		patchEnd := srSemVerDigitRunEnd(chars, i)
+		if patchEnd == i {
+			return false
+		}
+		i = patchEnd
+	}
+	if i < n && chars[i] == '-' {
+		i = i + 1
+		if i >= n {
+			return false
+		}
+		for j := i; j < n; j++ {
+			if !srSemVerPreReleaseChar(chars[j]) {
+				return false
+			}
+		}
+		i = n
+	}
+	return i == n
+}
+
+func srSemVerDigitRunEnd(chars []rune, start int) int {
+	n := len(chars)
+	j := start
+	for k := start; k < n; k++ {
+		c := chars[k]
+		if c < '0' || c > '9' {
+			return j
+		}
+		j = k + 1
+	}
+	return j
+}
+
+func srSemVerPreReleaseChar(c rune) bool {
+	if c >= '0' && c <= '9' {
+		return true
+	}
+	if c >= 'a' && c <= 'z' {
+		return true
+	}
+	if c >= 'A' && c <= 'Z' {
+		return true
+	}
+	if c == '.' {
+		return true
+	}
+	if c == '-' {
+		return true
+	}
+	return false
 }
 
 // Osty: /tmp/selfhost_merged.osty:29191:1

--- a/internal/selfhost/since_format_gate_test.go
+++ b/internal/selfhost/since_format_gate_test.go
@@ -1,0 +1,181 @@
+package selfhost
+
+import "testing"
+
+// G44 — `#[since("X.Y")]` format gate (v0.6 §3.14.1).
+// Phase 4 entry. Implementation lives in toolchain/resolve.osty
+// (mirrored in internal/selfhost/generated.go); these tests pin the
+// exact diagnostic surface the resolver produces.
+
+func countSinceFormatCode(result ResolveResult, code string) int {
+	count := 0
+	for _, d := range result.Diagnostics {
+		if d.Code == code {
+			count++
+		}
+	}
+	return count
+}
+
+func TestSinceFormatGateAcceptsXY(t *testing.T) {
+	src := []byte(`#[since("0.6")]
+fn ok() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 0 {
+		t.Fatalf("E0452 count = %d, want 0; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateAcceptsXYZ(t *testing.T) {
+	src := []byte(`#[since("1.0.0")]
+fn ok() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 0 {
+		t.Fatalf("E0452 count = %d, want 0; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateAcceptsPreRelease(t *testing.T) {
+	src := []byte(`#[since("2.0.0-rc.1")]
+fn ok() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 0 {
+		t.Fatalf("E0452 count = %d, want 0; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateAcceptsPreReleaseHyphenOnly(t *testing.T) {
+	src := []byte(`#[since("1.0.0-alpha")]
+fn ok() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 0 {
+		t.Fatalf("E0452 count = %d, want 0; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateRejectsVPrefix(t *testing.T) {
+	src := []byte(`#[since("v0.6")]
+fn bad() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 1 {
+		t.Fatalf("E0452 count = %d, want 1; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateRejectsWildcardTail(t *testing.T) {
+	src := []byte(`#[since("0.6.x")]
+fn bad() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 1 {
+		t.Fatalf("E0452 count = %d, want 1; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateRejectsEmptyString(t *testing.T) {
+	src := []byte(`#[since("")]
+fn bad() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 1 {
+		t.Fatalf("E0452 count = %d, want 1; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateRejectsAbcLiteral(t *testing.T) {
+	src := []byte(`#[since("abc")]
+fn bad() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 1 {
+		t.Fatalf("E0452 count = %d, want 1; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateRejectsIntegerLiteral(t *testing.T) {
+	src := []byte(`#[since(42)]
+fn bad() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 1 {
+		t.Fatalf("E0452 count = %d, want 1; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateRejectsBareFlag(t *testing.T) {
+	// `#[since]` with no parens — no args at all.
+	src := []byte(`#[since]
+fn bad() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 1 {
+		t.Fatalf("E0452 count = %d, want 1; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateRejectsTwoArgs(t *testing.T) {
+	src := []byte(`#[since("0.6", "0.7")]
+fn bad() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 1 {
+		t.Fatalf("E0452 count = %d, want 1; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateRejectsKeywordArg(t *testing.T) {
+	src := []byte(`#[since(version = "0.6")]
+fn bad() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 1 {
+		t.Fatalf("E0452 count = %d, want 1; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+func TestSinceFormatGateRejectsInterpolatedString(t *testing.T) {
+	src := []byte(`fn bad() {
+    let x = 1
+    let _ = x
+}
+
+#[since("v{x}")]
+fn other() {}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 1 {
+		t.Fatalf("E0452 count = %d, want 1; diagnostics=%#v", got, result.Diagnostics)
+	}
+}
+
+// Verify position coverage: #[since] is permitted on fn / struct /
+// enum variant / interface method / field. Valid SemVer strings on
+// each site must produce zero E0452.
+func TestSinceFormatGateAcceptsAllPermittedTargets(t *testing.T) {
+	src := []byte(`#[since("0.6")]
+struct A {
+    #[since("0.6.1")]
+    a: Int,
+}
+
+#[since("0.7")]
+enum B {
+    #[since("0.7.0")]
+    Variant,
+}
+
+interface C {
+    #[since("1.0")]
+    fn m(self) -> Int
+}
+`)
+	result := ResolveSourceStructured(src)
+	if got := countSinceFormatCode(result, "E0452"); got != 0 {
+		t.Fatalf("E0452 count = %d, want 0; diagnostics=%#v", got, result.Diagnostics)
+	}
+}

--- a/testdata/spec/negative/reject.osty
+++ b/testdata/spec/negative/reject.osty
@@ -363,6 +363,46 @@ fn badPureCapability(hash: PureHashCap, value: String) -> String {
 }
 // === END
 
+// === CASE: E0452 === since with v-prefix (not SemVer)
+#[since("v0.6")]
+fn badSinceVPrefix() {}
+// === END
+
+// === CASE: E0452 === since with wildcard tail
+#[since("0.6.x")]
+fn badSinceWildcard() {}
+// === END
+
+// === CASE: E0452 === since with empty string
+#[since("")]
+fn badSinceEmpty() {}
+// === END
+
+// === CASE: E0452 === since with abc literal
+#[since("abc")]
+fn badSinceAbc() {}
+// === END
+
+// === CASE: E0452 === since with integer arg
+#[since(42)]
+fn badSinceInt() {}
+// === END
+
+// === CASE: E0452 === since with no arguments
+#[since]
+fn badSinceBareFlag() {}
+// === END
+
+// === CASE: E0452 === since with two arguments
+#[since("0.6", "0.7")]
+fn badSinceTwoArgs() {}
+// === END
+
+// === CASE: E0452 === since with keyword argument
+#[since(version = "0.6")]
+fn badSinceKwarg() {}
+// === END
+
 // === CASE: E0004 === unterminated block comment (MUST remain last — the
 // unclosed /* is intentional and swallows every byte to EOF).
 /* never closes

--- a/testdata/spec/positive/17-v06-since.osty
+++ b/testdata/spec/positive/17-v06-since.osty
@@ -1,0 +1,49 @@
+// v0.6 Phase 4 entry — `#[since("X.Y")]` format gate (G44, §3.14.1).
+//
+// All declaration sites accept SemVer-shape strings:
+//   `"X.Y"`, `"X.Y.Z"`, `"X.Y.Z-pre"`, `"X.Y-pre"`.
+// Pre-release tail allows `[A-Za-z0-9.-]+`.
+
+#[since("0.6")]
+fn introducedAtMinorOnly() -> Int {
+    0
+}
+
+#[since("1.0.0")]
+fn introducedAtPatch() -> Int {
+    0
+}
+
+#[since("2.0.0-rc.1")]
+fn introducedWithPreRelease() -> Int {
+    0
+}
+
+#[since("3.0.0-alpha")]
+fn preReleaseHyphenOnly() -> Int {
+    0
+}
+
+#[since("0.7.1-beta.2")]
+fn preReleaseDottedTail() -> Int {
+    0
+}
+
+#[since("0.7")]
+struct VersionedStruct {
+    #[since("0.7.1")]
+    pub field: Int,
+}
+
+#[since("0.8")]
+enum VersionedEnum {
+    Original,
+
+    #[since("0.8.0")]
+    Added,
+}
+
+interface VersionedInterface {
+    #[since("1.0")]
+    fn method(self) -> Int
+}

--- a/toolchain/diag_manifest.osty
+++ b/toolchain/diag_manifest.osty
@@ -191,6 +191,7 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
     // G44 — API evolution (§3.14)
     if code == "E0450" { return FamilyAnnotation }
     if code == "E0451" { return FamilyAnnotation }
+    if code == "E0452" { return FamilyAnnotation }
     // Manifest — TOML syntax (E2000–E2004)
     if code == "E2000" { return FamilyManifest }
     if code == "E2001" { return FamilyManifest }

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -2929,6 +2929,8 @@ fn srCheckAnnotationArgs(
     if ann.text == "vectorize" { return srCheckVectorizeArgs(file, ann, result) }
     if ann.text == "target_feature" { return srCheckTargetFeatureArgs(file, ann, result) }
     if ann.text == "noalias" { return srCheckNoaliasArgs(file, ann, result) }
+    // v0.6 G44 — `#[since("X.Y")]` format gate (§3.14.1).
+    if ann.text == "since" { return srCheckSinceArgs(file, ann, result) }
     result
 }
 
@@ -3798,6 +3800,164 @@ fn srPushBadArgHint(
     let mut out = result
     out.diagnostics.push(selfResolveDiagnosticHintAtNode("E0739", message, "", start, end, -1, hint))
     out
+}
+
+fn srPushSinceBadFormat(
+    result: SelfResolveResult,
+    message: String,
+    start: Int,
+    end: Int,
+    hint: String,
+) -> SelfResolveResult {
+    let mut out = result
+    out.diagnostics.push(selfResolveDiagnosticHintAtNode("E0452", message, "", start, end, -1, hint))
+    out
+}
+
+/// srCheckSinceArgs validates `#[since("X.Y")]` (v0.6 G44, §3.14.1).
+/// Accepts exactly one argument: a non-interpolated string literal whose
+/// inner content matches the SemVer-shape regex
+/// `^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$`. Anything else
+/// (interpolated string, integer, identifier, prefix like `"v0.6"`,
+/// wildcard tail like `"0.6.x"`, empty string) yields E0452. Spec
+/// authority: LANG_SPEC_v0.6/00-revision.md §3.14.1.
+fn srCheckSinceArgs(
+    file: AstFile,
+    ann: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let argCount = ann.children.len()
+    if argCount == 0 {
+        return srPushSinceBadFormat(
+            result,
+            "`#[since(...)]` requires one SemVer-shaped string literal",
+            ann.start,
+            ann.end,
+            "example: `#[since(\"0.6\")]`, `#[since(\"1.0.0\")]`, or `#[since(\"2.0.0-rc.1\")]`",
+        )
+    }
+    if argCount > 1 {
+        let extra = srAnnotArgView(file, ann.children[1])
+        return srPushSinceBadFormat(
+            result,
+            "`#[since(...)]` accepts exactly one argument",
+            extra.start,
+            extra.end,
+            "remove the extra arguments; only one SemVer string is allowed",
+        )
+    }
+    let view = srAnnotArgView(file, ann.children[0])
+    if view.isFlag || view.key != "" {
+        return srPushSinceBadFormat(
+            result,
+            "`#[since(...)]` takes a positional string literal, not a key/flag",
+            view.start,
+            view.end,
+            "example: `#[since(\"0.6\")]`",
+        )
+    }
+    if view.valueIdx < 0 {
+        return srPushSinceBadFormat(
+            result,
+            "`#[since(...)]` requires a SemVer-shaped string literal",
+            view.start,
+            view.end,
+            "example: `#[since(\"0.6\")]`",
+        )
+    }
+    let valueNode = srAstNode(file, view.valueIdx)
+    if valueNode.kind != AstNStringLit {
+        return srPushSinceBadFormat(
+            result,
+            "`#[since(...)]` argument must be a string literal",
+            view.start,
+            view.end,
+            "example: `#[since(\"0.6\")]`",
+        )
+    }
+    if valueNode.children.len() != 0 {
+        return srPushSinceBadFormat(
+            result,
+            "`#[since(...)]` argument must be a non-interpolated string literal",
+            view.start,
+            view.end,
+            "use a plain literal like `\"0.6\"` — interpolation is not allowed",
+        )
+    }
+    let raw = srStringLitContent(valueNode.text)
+    if !srIsSemVerShape(raw) {
+        return srPushSinceBadFormat(
+            result,
+            "`#[since(\"" + raw + "\")]` is not a SemVer-shape version",
+            view.start,
+            view.end,
+            "accepted shapes: `\"X.Y\"`, `\"X.Y.Z\"`, or `\"X.Y.Z-pre\"` with digit components and an optional `[A-Za-z0-9.-]+` pre-release tail",
+        )
+    }
+    result
+}
+
+/// srIsSemVerShape mirrors the regex
+/// `^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$` used by
+/// `#[since(...)]` (v0.6 §3.14.1). Implemented as a hand-rolled parser
+/// rather than depending on a regex engine — the shape is small and
+/// has fixed positions: digit run, dot, digit run, optional dot+digits,
+/// optional dash+pre-release tail. The pre-release tail must contain
+/// at least one character; allowed tail chars are ASCII letters,
+/// digits, dot, and dash.
+fn srIsSemVerShape(s: String) -> Bool {
+    let chars = s.chars()
+    let n = chars.len()
+    if n == 0 { return false }
+    let mut i = 0
+    // Major: [0-9]+
+    let majorEnd = srSemVerDigitRunEnd(chars, i)
+    if majorEnd == i { return false }
+    i = majorEnd
+    if i >= n { return false }
+    if chars[i] != '.' { return false }
+    i = i + 1
+    // Minor: [0-9]+
+    let minorEnd = srSemVerDigitRunEnd(chars, i)
+    if minorEnd == i { return false }
+    i = minorEnd
+    // Optional patch: \.[0-9]+
+    if i < n && chars[i] == '.' {
+        i = i + 1
+        let patchEnd = srSemVerDigitRunEnd(chars, i)
+        if patchEnd == i { return false }
+        i = patchEnd
+    }
+    // Optional pre-release: -[A-Za-z0-9.-]+
+    if i < n && chars[i] == '-' {
+        i = i + 1
+        if i >= n { return false }
+        for j in i..n {
+            if !srSemVerPreReleaseChar(chars[j]) { return false }
+        }
+        i = n
+    }
+    i == n
+}
+
+fn srSemVerDigitRunEnd(chars: List<Char>, start: Int) -> Int {
+    let n = chars.len()
+    let mut j = start
+    for k in start..n {
+        let c = chars[k]
+        if c < '0' || c > '9' { return j }
+        j = k + 1
+    }
+    j
+}
+
+fn srSemVerPreReleaseChar(c: Char) -> Bool {
+    if c >= '0' && c <= '9' { return true }
+    if c >= 'a' && c <= 'z' { return true }
+    if c >= 'A' && c <= 'Z' { return true }
+    if c == '.' { return true }
+    if c == '-' { return true }
+    false
 }
 
 /// srAnnotIntValue extracts a non-negative integer literal from an

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -522,6 +522,72 @@ fn testSelfResolverAcceptsValidAnnotations() {
     testing.assertEq(selfResolveCodeCount(result, "E0609"), 0)
 }
 
+fn testSelfResolverAcceptsValidSinceAnnotations() {
+    // v0.6 G44 — `#[since("X.Y")]` format gate (§3.14.1). Each shape
+    // accepted by the SemVer-shape regex must produce no E0452.
+    let result = selfResolveSource(
+        r"""
+            #[since("0.6")]
+            fn introducedAtMinorOnly() -> Int { 0 }
+
+            #[since("1.0.0")]
+            fn introducedAtPatch() -> Int { 0 }
+
+            #[since("2.0.0-rc.1")]
+            fn introducedWithPreRelease() -> Int { 0 }
+
+            #[since("3.0.0-alpha")]
+            fn preReleaseHyphenOnly() -> Int { 0 }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0452"), 0)
+}
+
+fn testSelfResolverRejectsMalformedSinceVersion() {
+    // Malformed SemVer strings — `v0.6` (prefix), `0.6.x` (wildcard),
+    // empty string, plain text — each must fire one E0452.
+    let result = selfResolveSource(
+        r"""
+            #[since("v0.6")]
+            fn badPrefix() {}
+
+            #[since("0.6.x")]
+            fn badWildcard() {}
+
+            #[since("")]
+            fn badEmpty() {}
+
+            #[since("abc")]
+            fn badText() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0452"), 4)
+}
+
+fn testSelfResolverRejectsSinceWithWrongArgShape() {
+    // `#[since]` (no args), `#[since(42)]` (integer), `#[since("0.6", "0.7")]`
+    // (two args), `#[since(version = "0.6")]` (kwarg) — each fires E0452.
+    let result = selfResolveSource(
+        r"""
+            #[since]
+            fn badBare() {}
+
+            #[since(42)]
+            fn badInt() {}
+
+            #[since("0.6", "0.7")]
+            fn badTwoArgs() {}
+
+            #[since(version = "0.6")]
+            fn badKwarg() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0452"), 4)
+}
+
 fn testSelfResolverChecksAnnotationsOnStructMembers() {
     // `#[json]` on a method is wrong target (methods aren't in json's
     // allow-set). `#[op]` on a field is wrong target too.


### PR DESCRIPTION
## Summary

Phase 4 entry: enforce the **format shape** of `#[since("X.Y")]` (G44, v0.6 §3.14.1) at resolver time. The annotation must carry **exactly one non-interpolated string literal** whose contents match `^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$`. Anything else (interpolated string, integer literal, identifier, prefixes like `"v0.6"`, wildcard tails like `"0.6.x"`, empty string, missing or extra args, keyword args) yields a new diagnostic **E0452** (`CodeSinceBadFormat`).

The `osty publish` API surface gate stays out of scope of this PR — only metadata ingestion + format check land here.

## Changes

- **`internal/diag/codes.go`**: add `CodeSinceBadFormat = "E0452"` with doc comment. `go generate ./internal/diag/...` regenerates `ERROR_CODES.md` and `toolchain/diag_manifest.osty`.
- **`toolchain/resolve.osty`**: register `since` in `srCheckAnnotationArgs` dispatch; add `srCheckSinceArgs` plus a hand-rolled SemVer-shape validator (`srIsSemVerShape` / `srSemVerDigitRunEnd` / `srSemVerPreReleaseChar`) — no regex engine dependency.
- **`internal/selfhost/generated.go`**: mirror the Osty implementation in the frozen seed so the runtime resolver actually fires the gate today (without waiting for an LLVM self-host rebuild).
- **`testdata/spec/positive/17-v06-since.osty`**: positive corpus covering `"X.Y"`, `"X.Y.Z"`, pre-release variants, and every permitted target site (fn / struct / field / enum / variant / interface method).
- **`testdata/spec/negative/reject.osty`**: 8 new E0452 CASE blocks (v-prefix, wildcard tail, empty, plain text, integer arg, bare flag, two args, keyword arg).
- **`internal/selfhost/since_format_gate_test.go`**: 14 Go-side tests exercising the gate via `ResolveSourceStructured`.
- **`toolchain/resolve_test.osty`**: 3 new self-host `selfResolveSource` assertions for when the LLVM self-host catches up.
- **`CHANGELOG_v0.6.md` line 86**: `#[since]` `planned` → `partial`, noting `osty publish` follow-up.

## Diagnostic surface

E0452 — `#[since(...)]` did not receive exactly one SemVer-shaped string literal. Accepted shapes: `"X.Y"`, `"X.Y.Z"`, `"X.Y.Z-pre"`. The pre-release tail allows `[A-Za-z0-9.-]+`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/selfhost/ -run TestSinceFormatGate -count=1` — 14 / 14 PASS
- [x] `go test ./internal/speccorpus/ -run TestSpecNegative/cases/E0452 -count=1` — 8 / 8 PASS
- [x] `go test ./internal/speccorpus/ -run TestSpecPositive -count=1` — full corpus PASS, including new `17-v06-since.osty`
- [x] Pre-existing test failures (`TestParseSnapshot`, `TestParseMatchArmAllowsBareAssignmentBody`) are unrelated to this PR (verified via baseline stash).

## Follow-up

- `osty publish` semantic gate (E2100+ surface diff) — separate PR.
- `#[since]` cross-version validity (e.g. checking that `since` ≤ current compiler version) — placeholder, similar to E0451's "unknown version" scaffolding.
- Rebake `internal/selfhost/generated.go` from the LLVM self-host once the periodic regen cycle picks up. The Osty source already carries the implementation in `toolchain/resolve.osty`; the seed mirror is the bridge until then.

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_