### PR TITLE
feat(diag): Phase 1 closeout — --legacy-globals + W0750

### DIFF
--- a/CHANGELOG_v0.6.md
+++ b/CHANGELOG_v0.6.md
@@ -47,7 +47,7 @@ in v0.6" for per-gap rationale.
 | Deterministic capability test fakes | **partial** | `std.capability.testing` 에 `FakeClock` / `FakeRng` / `FakeEnv` / `FakeFs` / `FakeNet` / `FakeProcess` / `FakeConsole` 추가. `examples/v06_capability_fakes` 로 fake injection proof 추가. |
 | `#[ambient(...)]` annotation | **partial** | active checker gate now rejects non-entry usage (`E0780`), unknown canonical names (`E0781`), and user-defined ambient capabilities (`E0789`). Positive/negative spec corpus plus `examples/v06_ambient_boundaries` pin the boundary; auto-forward/desugar remains follow-up. |
 | `#[reproducible_capability]` annotation | **partial** | active checker gate now rejects non-`#[reproducible]` methods in reproducible capability interfaces (`E0783`). Deeper transitive reproducibility analysis remains follow-up. |
-| `--legacy-globals` 호환 모드 | **planned** | v0.6.x 에서만, v0.7 제거 |
+| `--legacy-globals` 호환 모드 | **partial** | CLI flag (`cli.CliFlags.LegacyGlobals`) + W0750 deprecation pass land — `osty check/typecheck/resolve/lint --legacy-globals` 가 v0.5 글로벌 호출 (`time.now()`, `random.next()`, `env.get(...)`, `fs.read(...)`, `os.exec(...)`, `net.dial(...)` 등) 마다 W0750 발화. Auto-desugar to capability host adapters + manifest stability=experimental 강제 는 follow-up. v0.6.x 에서만, v0.7 제거. |
 | stdlib `time.*` → `clock.*` migration | **partial** | migration catalog (`capability.legacyGlobalRewriteRules`) 와 host-boundary factories가 landing. 전역 호출 warning/desugar 는 compiler phase 후속. |
 
 ### Information flow (G37 — Phase 5)

--- a/cmd/osty/legacy_globals_test.go
+++ b/cmd/osty/legacy_globals_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLegacyGlobals_FlagOnEmitsW0750 pins the end-to-end wiring: a DIR
+// `osty check` invocation with `--legacy-globals` set must surface the
+// W0750 deprecation warning at every legacy-global call site without
+// failing the build (Warning severity → exit 0). This is the
+// authoritative front-end behaviour test for the v0.6.x transition
+// flag.
+func TestLegacyGlobals_FlagOnEmitsW0750(t *testing.T) {
+	dir := t.TempDir()
+	src := []byte(`fn main() {
+    let _ = time.now()
+    let _ = fs.read("/etc/hosts")
+}
+`)
+	if err := os.WriteFile(filepath.Join(dir, "main.osty"), src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stderr := captureStderr(t, func() int {
+		flags := cliFlags{noColor: true, native: true, legacyGlobals: true}
+		return runCheckPackageNative(dir, flags)
+	})
+
+	if c := strings.Count(stderr, "warning[W0750]"); c != 2 {
+		t.Fatalf("W0750 warning count in stderr = %d, want 2\nstderr:\n%s", c, stderr)
+	}
+	if !strings.Contains(stderr, "time.now") {
+		t.Errorf("stderr missing `time.now` reference:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "fs.read") {
+		t.Errorf("stderr missing `fs.read` reference:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "Clock") {
+		t.Errorf("stderr missing `Clock` capability hint:\n%s", stderr)
+	}
+}
+
+// TestLegacyGlobals_FlagOffStaysSilent guarantees the default
+// behaviour: without `--legacy-globals`, no W0750 should fire at any
+// legacy-global call site. This pins the opt-in contract — v0.6.0
+// users that don't pass the flag should not see migration noise.
+func TestLegacyGlobals_FlagOffStaysSilent(t *testing.T) {
+	dir := t.TempDir()
+	src := []byte(`fn main() {
+    let _ = time.now()
+}
+`)
+	if err := os.WriteFile(filepath.Join(dir, "main.osty"), src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stderr := captureStderr(t, func() int {
+		// No legacyGlobals: false default — explicitly omit it.
+		flags := cliFlags{noColor: true, native: true}
+		return runCheckPackageNative(dir, flags)
+	})
+	if strings.Contains(stderr, "W0750") {
+		t.Fatalf("stderr emitted W0750 without --legacy-globals:\n%s", stderr)
+	}
+}
+
+// captureStderr redirects os.Stderr to a pipe, runs body, and returns
+// what was written. Mirrors the pipe pattern from
+// check_native_test.go but encapsulated so the legacy-globals tests
+// stay readable. Stdout is silenced to keep the suite quiet.
+func captureStderr(t *testing.T, body func() int) string {
+	t.Helper()
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	rout, wout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	rerr, werr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stdout = wout
+	os.Stderr = werr
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	})
+	drained := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
+	stderrCh := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(rerr)
+		stderrCh <- string(b)
+		drained <- struct{}{}
+	}()
+
+	_ = body()
+
+	_ = wout.Close()
+	_ = werr.Close()
+	<-drained
+	<-drained
+	return <-stderrCh
+}

--- a/cmd/osty/lint_cmd.go
+++ b/cmd/osty/lint_cmd.go
@@ -100,6 +100,7 @@ func runLintLoadedPackage(
 	}
 	all := append([]*diag.Diagnostic{}, frontendDiags...)
 	all = append(all, lr.Diags...)
+	all = append(all, legacyGlobalsDiags(pkg, flags)...)
 	printPackageDiags(pkg, all, flags)
 	if flags.fix || flags.fixDryRun {
 		applyPackageFixes(pkg, lr.Diags, flags)
@@ -200,6 +201,7 @@ func runLintFile(path string, src []byte, formatter *diag.Formatter, flags cliFl
 	}
 	all := append([]*diag.Diagnostic{}, chk.Diags...)
 	all = append(all, lr.Diags...)
+	all = append(all, legacyGlobalsDiagsFromRun(run, path, flags)...)
 	printDiags(formatter, all, flags)
 	if flags.fix || flags.fixDryRun {
 		newSrc, applied, skipped := lint.ApplyFixes(src, lr.Diags)

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -105,6 +105,16 @@ type cliFlags struct {
 	// afterwards, so multi-file failures don't emit a summary line per
 	// file. Never surfaced as a CLI flag.
 	suppressSummary bool
+	// legacyGlobals enables the v0.5 → v0.6 transition compatibility
+	// mode. When true, the front-end emits W0750 deprecation warnings
+	// at every legacy-global call site (`time.now()`, `random.next()`,
+	// `env.get(...)`, `fs.read(...)`, `os.exec(...)`, `net.dial(...)`,
+	// etc.) so users can enumerate migration work via
+	// `osty check --legacy-globals --warnings-as-errors`. Auto-desugar
+	// to capability host adapters is a follow-up PR. v0.6.x only —
+	// v0.7 removes the flag (BREAKING_v0.6.md §3, LANG_SPEC_v0.6
+	// §20.15).
+	legacyGlobals bool
 }
 
 func main() {
@@ -456,6 +466,7 @@ func main() {
 			switch cmd {
 			case "check":
 				diags := append(append([]*diag.Diagnostic{}, selected.res.Diags...), selected.chk.Diags...)
+				diags = append(diags, legacyGlobalsDiags(selected.pkg, flags)...)
 				printPackageDiags(selected.pkg, diags, flags)
 				if flags.inspect && selected.file != nil && selected.file.File != nil {
 					runInspectPackageInput(nativePackageCheckInput(selected.pkg, nil), selected.file.Path, flags)
@@ -469,6 +480,7 @@ func main() {
 				return
 			case "typecheck":
 				diags := append(append([]*diag.Diagnostic{}, selected.res.Diags...), selected.chk.Diags...)
+				diags = append(diags, legacyGlobalsDiags(selected.pkg, flags)...)
 				printPackageDiags(selected.pkg, diags, flags)
 				printTypes(selected.chk)
 				if hasError(diags) {
@@ -480,6 +492,7 @@ func main() {
 				if nativeDiags, err := nativeResolvePackageDiagnostics(selected.pkg); err == nil {
 					diags = append(packageParseDiags(selected.pkg), nativeDiags...)
 				}
+				diags = append(diags, legacyGlobalsDiags(selected.pkg, flags)...)
 				printPackageDiags(selected.pkg, diags, flags)
 				if rows, err := nativeResolvePackageRows(selected.pkg, selected.file.Path); err == nil && len(rows) > 0 {
 					fmt.Printf("# %s\n", selected.file.Path)
@@ -591,6 +604,7 @@ func convertFlags(cf clicmd.CliFlags) cliFlags {
 	}
 	f.dumpNativeDiags = cf.DumpNativeDiags
 	f.native = cf.Native
+	f.legacyGlobals = cf.LegacyGlobals
 	return f
 }
 
@@ -612,6 +626,7 @@ func parseFlags() cliFlags {
 	flag.BoolVar(&f.inspect, "inspect", false, "check: emit one record per expression showing the inference rule, type, and hint (see LANG_SPEC_v0.6/02a-type-inference.md)")
 	flag.BoolVar(&f.dumpNativeDiags, "dump-native-diags", false, "check/typecheck: after the run, print the native checker's per-context error histogram to stderr")
 	flag.BoolVar(&f.native, "native", true, "check/typecheck: backwards-compat no-op since Phase 1c.5. The self-host arena pipeline is the only path; this flag is accepted so old scripts keep working")
+	flag.BoolVar(&f.legacyGlobals, "legacy-globals", false, "check/lint/build: enable the v0.5 → v0.6 transition compat mode. Each legacy-global call site (time.now / random.next / env.get / fs.read / os.exec / net.dial …) emits W0750. v0.6.x only; v0.7 removes the flag")
 	flag.Usage = usage
 	flag.Parse()
 	return f
@@ -655,6 +670,7 @@ func runResolvePackageInner(dir string, flags cliFlags) int {
 		r := ensureGoResolve()
 		diags = r.Diags
 	}
+	diags = append(diags, legacyGlobalsDiags(pkg, flags)...)
 	printPackageDiags(pkg, diags, flags)
 	nativeRowsUsed := false
 	nativeErrored := false

--- a/cmd/osty/native_check.go
+++ b/cmd/osty/native_check.go
@@ -12,12 +12,37 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/legacyglobals"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/stdlib"
 )
+
+// legacyGlobalsDiags returns W0750 deprecation diagnostics for every
+// v0.5 legacy global call site in pkg when --legacy-globals is set.
+// Returns nil otherwise (the flag is opt-in; default behaviour stays
+// silent so old code paths keep their current shape until the user
+// opts in to the migration warning surface).
+func legacyGlobalsDiags(pkg *resolve.Package, flags cliFlags) []*diag.Diagnostic {
+	if !flags.legacyGlobals {
+		return nil
+	}
+	return legacyglobals.Detect(pkg)
+}
+
+// legacyGlobalsDiagsFromRun is the single-file sibling of
+// legacyGlobalsDiags. Used by `osty lint FILE` / `osty check FILE`
+// outside a containing package — those paths feed a selfhost
+// FrontendRun directly and never build a resolve.Package.
+func legacyGlobalsDiagsFromRun(run *selfhost.FrontendRun, path string, flags cliFlags) []*diag.Diagnostic {
+	if !flags.legacyGlobals || run == nil {
+		return nil
+	}
+	file := selfhost.LowerPublicFileFromRun(run)
+	return legacyglobals.DetectAST(file, path)
+}
 
 // runCheckPackage runs lex + parse + resolve over dir. Two modes:
 //
@@ -165,6 +190,9 @@ func runResolveFile(path string, src []byte, formatter *diag.Formatter, flags cl
 	all := append([]*diag.Diagnostic{}, parseDiags...)
 	nativeDiags := nativeResolveDiagnosticsFromResolved(resolved, src, path)
 	all = append(all, nativeDiags...)
+	if flags.legacyGlobals {
+		all = append(all, legacyglobals.DetectAST(ensureLoweredFile(), path)...)
+	}
 	printDiags(formatter, all, flags)
 	if rows := nativeResolveRowsFromResolved(resolved, src, path); len(rows) > 0 {
 		printNativeResolutionRows(rows)
@@ -210,6 +238,7 @@ func runTypecheckPackageNative(dir string, flags cliFlags) int {
 	}
 	diags := packageParseDiags(pkg)
 	diags = append(diags, nativePackageCheckDiags(checked.Diagnostics, input.Files)...)
+	diags = append(diags, legacyGlobalsDiags(pkg, flags)...)
 	printPackageDiags(pkg, diags, flags)
 	printNativePackageTypes(checked, input.Files)
 	if flags.inspect {
@@ -287,6 +316,7 @@ func runCheckPackageNative(dir string, flags cliFlags) int {
 	}
 	diags := packageParseDiags(pkg)
 	diags = append(diags, nativePackageCheckDiags(checked.Diagnostics, input.Files)...)
+	diags = append(diags, legacyGlobalsDiags(pkg, flags)...)
 	printPackageDiags(pkg, diags, flags)
 	if flags.inspect {
 		runInspectPackageInput(input, "", flags)
@@ -323,6 +353,7 @@ func runNativeWorkspaceCheck(dir, mode string, flags cliFlags, emitTypes bool) i
 		}
 		diags := packageParseDiags(pkg)
 		diags = append(diags, nativePackageCheckDiags(checked.Diagnostics, input.Files)...)
+		diags = append(diags, legacyGlobalsDiags(pkg, flags)...)
 		printPackageDiags(pkg, diags, flags)
 		if emitTypes {
 			printNativePackageTypes(checked, input.Files)
@@ -503,6 +534,9 @@ func runTypecheckFileNative(path string, src []byte, formatter *diag.Formatter, 
 	}
 	all := append([]*diag.Diagnostic{}, parseDiags...)
 	all = append(all, checkDiags...)
+	if flags.legacyGlobals {
+		all = append(all, legacyGlobalsDiagsFromRun(selfhost.Run(src), path, flags)...)
+	}
 	printDiags(formatter, all, flags)
 	printNativeTypes(src, checked)
 	if flags.inspect {
@@ -596,6 +630,9 @@ func runCheckFileNative(path string, src []byte, formatter *diag.Formatter, flag
 	}
 	all := append([]*diag.Diagnostic{}, parseDiags...)
 	all = append(all, checkDiags...)
+	if flags.legacyGlobals {
+		all = append(all, legacyGlobalsDiagsFromRun(selfhost.Run(src), path, flags)...)
+	}
 	printDiags(formatter, all, flags)
 	if flags.inspect {
 		runInspectSource(path, src, flags)

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -21,6 +21,16 @@ type CliFlags struct {
 	AiMode          string
 	DumpNativeDiags bool
 	Native          bool
+	// LegacyGlobals enables the v0.5 → v0.6 transition compatibility
+	// mode for legacy global effect functions (`time.now()`,
+	// `random.next()`, `env.get(k)`, `fs.read(p)`, `os.exec(...)`,
+	// `net.dial(...)`). When set, the front-end emits W0750
+	// deprecation warnings at every legacy-global call site so users
+	// can enumerate migration work; auto-desugar to capability host
+	// adapters lands in a follow-up PR. v0.6.x only — v0.7 removes
+	// the flag entirely (BREAKING_v0.6.md §3, LANG_SPEC_v0.6
+	// §20.15).
+	LegacyGlobals bool
 }
 
 func DefaultCliFlags() CliFlags {
@@ -321,6 +331,9 @@ func applyBoolFlag(flags *CliFlags, name string) bool {
 		return true
 	case "native":
 		flags.Native = true
+		return true
+	case "legacy-globals":
+		flags.LegacyGlobals = true
 		return true
 	case "airepair", "repair":
 		flags.AiRepair = true

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import "testing"
+
+// TestParseArgs_LegacyGlobalsFlagPropagates pins that
+// `--legacy-globals` is recognised at the global pre-subcommand
+// position and lifts into CliFlags.LegacyGlobals = true. The flag is
+// the v0.6.x → v0.7 transition handle for v0.5 effect-global
+// deprecations (LANG_SPEC_v0.6 §20.15, BREAKING_v0.6.md §3) — every
+// front-end command needs to see it.
+func TestParseArgs_LegacyGlobalsFlagPropagates(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"check FILE", []string{"--legacy-globals", "check", "main.osty"}},
+		{"resolve DIR", []string{"--legacy-globals", "resolve", "."}},
+		{"lint DIR", []string{"--legacy-globals", "lint", "."}},
+		{"typecheck FILE", []string{"--legacy-globals", "typecheck", "main.osty"}},
+		{"build", []string{"--legacy-globals", "build"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed := ParseArgs(tc.args)
+			if !parsed.IsOk() {
+				t.Fatalf("ParseArgs returned errors: %v", parsed.Errors)
+			}
+			if !parsed.Flags.LegacyGlobals {
+				t.Fatalf("Flags.LegacyGlobals = false, want true; raw args = %v", tc.args)
+			}
+		})
+	}
+}
+
+// TestParseArgs_LegacyGlobalsDefaultsFalse keeps the default behaviour
+// honest: the flag must be explicitly opted into; v0.6.0 users that
+// don't pass it should see no W0750 noise.
+func TestParseArgs_LegacyGlobalsDefaultsFalse(t *testing.T) {
+	parsed := ParseArgs([]string{"check", "main.osty"})
+	if !parsed.IsOk() {
+		t.Fatalf("ParseArgs returned errors: %v", parsed.Errors)
+	}
+	if parsed.Flags.LegacyGlobals {
+		t.Fatalf("Flags.LegacyGlobals = true without --legacy-globals; want false (opt-in only)")
+	}
+}

--- a/internal/legacyglobals/catalog.go
+++ b/internal/legacyglobals/catalog.go
@@ -1,0 +1,92 @@
+package legacyglobals
+
+// legacyRule maps one v0.5 legacy global call to its v0.6 capability
+// replacement. The catalog mirrors `BREAKING_v0.6.md` §3 (the broader
+// list) and `LANG_SPEC_v0.6/20-capabilities.md` §20.15 (the canonical
+// rewrite table). The Osty side at
+// `internal/stdlib/modules/capability.osty::legacyGlobalRewriteRules`
+// keeps a sample of the same data — we deliberately keep both surfaces
+// because:
+//
+//   - The Osty catalog drives docgen / migration tooling and is the
+//     authority for *user-facing* migration messages.
+//   - This Go-side catalog drives the front-end W0750 detector and
+//     stays small enough to pin without an interpreter shim, so the
+//     compiler boundary keeps working before the LLVM self-host path
+//     can re-emit the lookup table.
+//
+// Drift between the two is policed by the parity test in
+// `internal/stdlib/capability_test.go` (it exercises the Osty-side
+// helper names) and the unit tests in this package (which exercise
+// the Go-side lookup behaviour). When a new entry is added one place,
+// add it to the other in the same PR.
+type legacyRule struct {
+	// module is the bare-Ident head of the selector at the call site
+	// (e.g., `time` in `time.now()`).
+	module string
+	// method is the method name on the legacy module (e.g., `now`).
+	method string
+	// capability is the canonical v0.6 capability that should now be
+	// passed as a parameter (e.g., `Clock`).
+	capability string
+	// replacement is the canonical migration form for the user. It
+	// reads as the body of the `Hint:` line — terse, no period.
+	replacement string
+}
+
+// legacyRules is the static catalog. Indexed via lookupRule by
+// (module, method) lower-case match.
+var legacyRules = []legacyRule{
+	// time → Clock
+	{module: "time", method: "now", capability: "Clock", replacement: "clock.now()"},
+	{module: "time", method: "monotonic", capability: "Clock", replacement: "clock.monotonic()"},
+	{module: "time", method: "sleep", capability: "Clock", replacement: "clock.sleep(d)"},
+
+	// random → Rng
+	{module: "random", method: "next", capability: "Rng", replacement: "rng.next()"},
+	{module: "random", method: "nextBytes", capability: "Rng", replacement: "rng.nextBytes(n)"},
+	{module: "random", method: "default", capability: "Rng", replacement: "rng parameter"},
+
+	// env → Env
+	{module: "env", method: "args", capability: "Env", replacement: "env.args()"},
+	{module: "env", method: "get", capability: "Env", replacement: "env.get(k)"},
+	{module: "env", method: "require", capability: "Env", replacement: "env.require(k)"},
+	{module: "env", method: "set", capability: "Env", replacement: "env.set(k, v)"},
+	{module: "env", method: "unset", capability: "Env", replacement: "env.unset(k)"},
+	{module: "env", method: "vars", capability: "Env", replacement: "env.vars()"},
+
+	// fs → Fs
+	{module: "fs", method: "read", capability: "Fs", replacement: "fs.read(p)"},
+	{module: "fs", method: "readToString", capability: "Fs", replacement: "fs.readToString(p)"},
+	{module: "fs", method: "write", capability: "Fs", replacement: "fs.write(p, b)"},
+	{module: "fs", method: "writeString", capability: "Fs", replacement: "fs.writeString(p, s)"},
+	{module: "fs", method: "exists", capability: "Fs", replacement: "fs.exists(p)"},
+	{module: "fs", method: "create", capability: "Fs", replacement: "fs.create(p)"},
+	{module: "fs", method: "remove", capability: "Fs", replacement: "fs.remove(p)"},
+	{module: "fs", method: "mkdir", capability: "Fs", replacement: "fs.mkdir(p)"},
+	{module: "fs", method: "mkdirAll", capability: "Fs", replacement: "fs.mkdirAll(p)"},
+
+	// net → Net
+	{module: "net", method: "dial", capability: "Net", replacement: "net.connect(addr)"},
+	{module: "net", method: "connect", capability: "Net", replacement: "net.connect(addr)"},
+	{module: "net", method: "listen", capability: "Net", replacement: "net.listen(addr)"},
+
+	// os/process → Process
+	{module: "os", method: "exec", capability: "Process", replacement: "process.exec(c, a)"},
+	{module: "os", method: "exit", capability: "Process", replacement: "process.exit(code)"},
+	{module: "os", method: "hostname", capability: "Process", replacement: "process.hostname()"},
+	{module: "os", method: "pid", capability: "Process", replacement: "process.pid()"},
+}
+
+// lookupRule returns the catalog entry that matches a (module, method)
+// pair, or zero+false when no entry applies. The first matching rule
+// wins; the catalog is small enough that linear scan is the simplest
+// correct answer and avoids the init-order coupling a map would add.
+func lookupRule(module, method string) (legacyRule, bool) {
+	for _, r := range legacyRules {
+		if r.module == module && r.method == method {
+			return r, true
+		}
+	}
+	return legacyRule{}, false
+}

--- a/internal/legacyglobals/legacyglobals.go
+++ b/internal/legacyglobals/legacyglobals.go
@@ -1,0 +1,314 @@
+// Package legacyglobals implements the v0.6.x compatibility detector for
+// v0.5 legacy global effect functions.
+//
+// When the front-end is invoked with `--legacy-globals`, this package
+// walks each parsed file's AST, finds calls that match the v0.5 legacy
+// global surface (`time.now()`, `random.next()`, `env.get(...)`,
+// `fs.read(...)`, `os.exec(...)`, `net.dial(...)`, etc.), and emits
+// `W0750` deprecation warnings pointing at every call site. The
+// detector is intentionally textual (selector head names + leaf method
+// name) so it stays useful for sources where the resolver cannot bind
+// the legacy callee to a stdlib symbol — that is the whole point of
+// `--legacy-globals`: today the legacy modules are not exposed as
+// callable globals, so the resolver would only emit `E0500
+// (UnknownName)` and the user has no way to enumerate migration work.
+//
+// Authority for the migration catalog is the spec table in
+// `LANG_SPEC_v0.6/20-capabilities.md` §20.15 plus the broader call list
+// in `BREAKING_v0.6.md` §3. The legacy module list also lives in
+// `internal/stdlib/modules/capability.osty::legacyGlobalModules` so the
+// stdlib registry's parity test pins drift between the two surfaces.
+//
+// Auto-desugar (rewrite to `time.systemClock.now()` / etc.) is a
+// follow-up PR — `CHANGELOG_v0.6.md` line 50 stays at "partial" until
+// then. The `[stability] = experimental` enforcement on packages that
+// trigger any W0750 is also planned but not in this commit.
+//
+// v0.6.x only — v0.7 removes the flag and the desugar. After v0.7 each
+// legacy global call becomes `E0701 (unknown name in this scope)`.
+package legacyglobals
+
+import (
+	"fmt"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// Detect walks pkg's parsed files (after EnsureFile) and returns one
+// W0750 deprecation diagnostic per legacy-global call site.
+//
+// Files that fail to materialize (Run-only packages where EnsureFile
+// errors) are skipped silently — the parse-error path will already
+// surface the failure.
+func Detect(pkg *resolve.Package) []*diag.Diagnostic {
+	if pkg == nil {
+		return nil
+	}
+	var out []*diag.Diagnostic
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		out = append(out, detectFile(pf)...)
+	}
+	return out
+}
+
+// DetectFile is Detect for a single PackageFile.
+func DetectFile(pf *resolve.PackageFile) []*diag.Diagnostic {
+	if pf == nil {
+		return nil
+	}
+	return detectFile(pf)
+}
+
+// DetectAST runs the detector over a parsed *ast.File directly. Used by
+// the single-file front-end paths (`osty lint FILE`,
+// `osty check FILE` without a containing package) where building a
+// resolve.PackageFile would be unnecessary ceremony.
+func DetectAST(file *ast.File, path string) []*diag.Diagnostic {
+	if file == nil {
+		return nil
+	}
+	visitor := newCallVisitor(path)
+	for _, decl := range file.Decls {
+		visitor.visitDecl(decl)
+	}
+	for _, stmt := range file.Stmts {
+		visitor.visitStmt(stmt)
+	}
+	return visitor.diags
+}
+
+func detectFile(pf *resolve.PackageFile) []*diag.Diagnostic {
+	file := materializeFile(pf)
+	if file == nil {
+		return nil
+	}
+	visitor := newCallVisitor(pf.Path)
+	for _, decl := range file.Decls {
+		visitor.visitDecl(decl)
+	}
+	for _, stmt := range file.Stmts {
+		visitor.visitStmt(stmt)
+	}
+	return visitor.diags
+}
+
+// materializeFile pulls the public AST out of the PackageFile, calling
+// EnsureFile only when the package was loaded via the native arena
+// path. The detector tolerates a nil result — native-only packages
+// without a public AST simply skip the W0750 pass.
+func materializeFile(pf *resolve.PackageFile) *ast.File {
+	if pf == nil {
+		return nil
+	}
+	if pf.File != nil {
+		return pf.File
+	}
+	if pf.Run == nil {
+		return nil
+	}
+	return pf.EnsureFile()
+}
+
+// callVisitor accumulates W0750 diagnostics for one file.
+type callVisitor struct {
+	path  string
+	diags []*diag.Diagnostic
+}
+
+func newCallVisitor(path string) *callVisitor {
+	return &callVisitor{path: path}
+}
+
+func (v *callVisitor) visitDecl(decl ast.Decl) {
+	if decl == nil {
+		return
+	}
+	switch d := decl.(type) {
+	case *ast.FnDecl:
+		v.visitBlock(d.Body)
+	case *ast.LetDecl:
+		v.visitExpr(d.Value)
+	case *ast.StructDecl:
+		for _, m := range d.Methods {
+			v.visitDecl(m)
+		}
+	case *ast.EnumDecl:
+		for _, m := range d.Methods {
+			v.visitDecl(m)
+		}
+	case *ast.InterfaceDecl:
+		for _, m := range d.Methods {
+			v.visitDecl(m)
+		}
+	}
+}
+
+func (v *callVisitor) visitStmt(stmt ast.Stmt) {
+	if stmt == nil {
+		return
+	}
+	switch s := stmt.(type) {
+	case *ast.ExprStmt:
+		v.visitExpr(s.X)
+	case *ast.LetStmt:
+		v.visitExpr(s.Value)
+	case *ast.AssignStmt:
+		for _, t := range s.Targets {
+			v.visitExpr(t)
+		}
+		v.visitExpr(s.Value)
+	case *ast.ReturnStmt:
+		v.visitExpr(s.Value)
+	case *ast.ForStmt:
+		v.visitExpr(s.Iter)
+		v.visitBlock(s.Body)
+	case *ast.DeferStmt:
+		v.visitExpr(s.X)
+	case *ast.ChanSendStmt:
+		v.visitExpr(s.Channel)
+		v.visitExpr(s.Value)
+	case *ast.Block:
+		v.visitBlock(s)
+	case *ast.BreakStmt:
+		v.visitExpr(s.Value)
+	case *ast.ContinueStmt:
+		// no expressions
+	}
+}
+
+func (v *callVisitor) visitBlock(block *ast.Block) {
+	if block == nil {
+		return
+	}
+	for _, stmt := range block.Stmts {
+		v.visitStmt(stmt)
+	}
+}
+
+func (v *callVisitor) visitExpr(expr ast.Expr) {
+	if expr == nil {
+		return
+	}
+	switch e := expr.(type) {
+	case *ast.CallExpr:
+		v.checkCall(e)
+		v.visitExpr(e.Fn)
+		for _, arg := range e.Args {
+			if arg != nil {
+				v.visitExpr(arg.Value)
+			}
+		}
+	case *ast.FieldExpr:
+		v.visitExpr(e.X)
+	case *ast.IndexExpr:
+		v.visitExpr(e.X)
+		v.visitExpr(e.Index)
+	case *ast.UnaryExpr:
+		v.visitExpr(e.X)
+	case *ast.BinaryExpr:
+		v.visitExpr(e.Left)
+		v.visitExpr(e.Right)
+	case *ast.QuestionExpr:
+		v.visitExpr(e.X)
+	case *ast.TurbofishExpr:
+		v.visitExpr(e.Base)
+	case *ast.RangeExpr:
+		v.visitExpr(e.Start)
+		v.visitExpr(e.Stop)
+	case *ast.ParenExpr:
+		v.visitExpr(e.X)
+	case *ast.TupleExpr:
+		for _, x := range e.Elems {
+			v.visitExpr(x)
+		}
+	case *ast.ListExpr:
+		for _, x := range e.Elems {
+			v.visitExpr(x)
+		}
+	case *ast.MapExpr:
+		for _, entry := range e.Entries {
+			if entry != nil {
+				v.visitExpr(entry.Key)
+				v.visitExpr(entry.Value)
+			}
+		}
+	case *ast.StructLit:
+		for _, f := range e.Fields {
+			if f != nil {
+				v.visitExpr(f.Value)
+			}
+		}
+		v.visitExpr(e.Spread)
+	case *ast.IfExpr:
+		v.visitExpr(e.Cond)
+		v.visitBlock(e.Then)
+		v.visitExpr(e.Else)
+	case *ast.LoopExpr:
+		v.visitBlock(e.Body)
+	case *ast.MatchExpr:
+		v.visitExpr(e.Scrutinee)
+		for _, arm := range e.Arms {
+			if arm != nil {
+				v.visitExpr(arm.Guard)
+				v.visitExpr(arm.Body)
+			}
+		}
+	case *ast.ClosureExpr:
+		v.visitExpr(e.Body)
+	case *ast.Block:
+		v.visitBlock(e)
+	case *ast.StringLit:
+		for _, part := range e.Parts {
+			if !part.IsLit {
+				v.visitExpr(part.Expr)
+			}
+		}
+	}
+}
+
+// checkCall classifies a single CallExpr as a legacy global if the
+// callee selector matches the migration catalog. Bare `Ident` callees
+// (e.g., `println("...")`) are *not* flagged: the catalog entry for
+// console output is the explicit `console.println` host call form, and
+// flagging the bare prelude `println` would warn on every test file.
+func (v *callVisitor) checkCall(call *ast.CallExpr) {
+	if call == nil || call.Fn == nil {
+		return
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok {
+		return
+	}
+	head, ok := field.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+	rule, ok := lookupRule(head.Name, field.Name)
+	if !ok {
+		return
+	}
+	v.diags = append(v.diags, buildDiagnostic(call, rule, v.path))
+}
+
+func buildDiagnostic(call *ast.CallExpr, rule legacyRule, path string) *diag.Diagnostic {
+	span := diag.Span{Start: call.Pos(), End: call.End()}
+	msg := fmt.Sprintf(
+		"v0.5 legacy global `%s.%s` is deprecated — pass a `%s` capability parameter (LANG_SPEC_v0.6 §20.15)",
+		rule.module, rule.method, rule.capability,
+	)
+	hint := fmt.Sprintf("migrate to `%s` (capability parameter); see CLAUDE.md 부록 C.1", rule.replacement)
+	b := diag.New(diag.Warning, msg).
+		Code(diag.CodeDeprecatedUse).
+		Primary(span, "legacy global call site").
+		Note("`--legacy-globals` is v0.6.x only — v0.7 removes the flag and the desugar; this call site becomes E0701 (unknown name)").
+		Hint(hint)
+	if path != "" {
+		b = b.File(path)
+	}
+	return b.Build()
+}

--- a/internal/legacyglobals/legacyglobals_test.go
+++ b/internal/legacyglobals/legacyglobals_test.go
@@ -1,0 +1,234 @@
+package legacyglobals_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/legacyglobals"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+// TestDetectAST_FlagsLegacyGlobalCallSites verifies the detector walks a
+// representative file and emits one W0750 per legacy-global call site,
+// covering every capability bucket on the v0.6 catalog (Clock, Rng,
+// Env, Fs, Net, Process). Calls that look similar but are not in the
+// catalog (e.g., `cap.now()` on a passed Clock parameter) must NOT
+// fire — the detector is selector-head-keyed by module name so user
+// idents shadowing those names would also trigger; that is intended
+// since the whole point of `--legacy-globals` is to enumerate every
+// call site that needs migration.
+func TestDetectAST_FlagsLegacyGlobalCallSites(t *testing.T) {
+	src := []byte(`fn main() {
+    let _ = time.now()
+    let _ = random.next()
+    let _ = env.get("HOME")
+    let _ = fs.read("/etc/passwd")
+    let _ = net.dial("example.com", 443)
+    let _ = os.exec("ls", [])
+    println("hello")
+}
+`)
+	run := selfhost.Run(src)
+	file := selfhost.LowerPublicFileFromRun(run)
+	if file == nil {
+		t.Fatalf("selfhost lower returned nil file (parse diags: %v)", run.Diagnostics())
+	}
+	diags := legacyglobals.DetectAST(file, "test.osty")
+	if got := len(diags); got != 6 {
+		t.Fatalf("DetectAST W0750 count = %d, want 6\n%s", got, formatDiags(diags))
+	}
+	// Every diagnostic must carry the W0750 code at Warning severity.
+	for i, d := range diags {
+		if d == nil {
+			t.Fatalf("diagnostic[%d] is nil", i)
+		}
+		if d.Code != diag.CodeDeprecatedUse {
+			t.Errorf("diagnostic[%d].Code = %q, want %q", i, d.Code, diag.CodeDeprecatedUse)
+		}
+		if d.Severity != diag.Warning {
+			t.Errorf("diagnostic[%d].Severity = %v, want Warning", i, d.Severity)
+		}
+		if d.File != "test.osty" {
+			t.Errorf("diagnostic[%d].File = %q, want %q", i, d.File, "test.osty")
+		}
+	}
+
+	// Spot-check that the message names the legacy form and the
+	// capability bucket. The first emission corresponds to
+	// `time.now()` so the message has both `time.now` and `Clock`.
+	first := diags[0]
+	if !strings.Contains(first.Message, "time.now") {
+		t.Errorf("first diagnostic message = %q, want it to mention `time.now`", first.Message)
+	}
+	if !strings.Contains(first.Message, "Clock") {
+		t.Errorf("first diagnostic message = %q, want it to mention `Clock`", first.Message)
+	}
+	// Hint must reference CLAUDE.md 부록 C.1 so users know where to
+	// learn the capability migration pattern.
+	if !strings.Contains(first.Hint, "capability parameter") {
+		t.Errorf("first diagnostic hint = %q, want it to mention capability parameter", first.Hint)
+	}
+}
+
+// TestDetectAST_BareIdentCallsAreSilent guards against the
+// false-positive that would scrub every test file: bare-Ident callees
+// like `println("...")` are *not* in the catalog (which is selector
+// shaped), so they must not produce W0750 even though the migration
+// table mentions a `console.println` capability form.
+func TestDetectAST_BareIdentCallsAreSilent(t *testing.T) {
+	src := []byte(`fn main() {
+    println("hello")
+    let n = 42
+    let _ = n
+}
+`)
+	run := selfhost.Run(src)
+	file := selfhost.LowerPublicFileFromRun(run)
+	if file == nil {
+		t.Fatalf("selfhost lower returned nil file")
+	}
+	diags := legacyglobals.DetectAST(file, "test.osty")
+	if len(diags) != 0 {
+		t.Fatalf("DetectAST emitted %d diagnostic(s) for bare-Ident calls; want 0\n%s",
+			len(diags), formatDiags(diags))
+	}
+}
+
+// TestDetectAST_NestedCallSitesAreVisited walks calls inside nested
+// expressions (closures, if-then bodies, struct-lit field values) so
+// the visitor's coverage of the AST shape is pinned. Without this the
+// detector might silently miss legacy calls inside e.g. `let _ = if c
+// { time.now() } else { 0 }`.
+func TestDetectAST_NestedCallSitesAreVisited(t *testing.T) {
+	src := []byte(`fn main() {
+    let cb = || time.now()
+    let _ = cb
+    let _ = if true { random.next() } else { 0 }
+    for x in [1, 2, 3] {
+        let _ = x + env.get("X").len()
+    }
+}
+`)
+	run := selfhost.Run(src)
+	file := selfhost.LowerPublicFileFromRun(run)
+	if file == nil {
+		t.Fatalf("selfhost lower returned nil file (parse diags: %v)", run.Diagnostics())
+	}
+	diags := legacyglobals.DetectAST(file, "test.osty")
+	if got := len(diags); got != 3 {
+		t.Fatalf("nested-walk W0750 count = %d, want 3\n%s", got, formatDiags(diags))
+	}
+}
+
+// TestLookupRule_CatalogContainsCanonicalEntries pins the catalog
+// surface so a refactor that drops a row breaks fast. The rules tested
+// here are the ones called out by name in BREAKING_v0.6.md §3 and
+// LANG_SPEC_v0.6 §20.15.
+func TestLookupRule_CatalogContainsCanonicalEntries(t *testing.T) {
+	cases := []struct {
+		module, method string
+	}{
+		{"time", "now"},
+		{"time", "monotonic"},
+		{"time", "sleep"},
+		{"random", "next"},
+		{"random", "default"},
+		{"env", "get"},
+		{"env", "set"},
+		{"env", "args"},
+		{"fs", "read"},
+		{"fs", "readToString"},
+		{"fs", "write"},
+		{"net", "dial"},
+		{"net", "listen"},
+		{"os", "exec"},
+		{"os", "exit"},
+	}
+	for _, tc := range cases {
+		src := []byte("fn main() {\n    let _ = " + tc.module + "." + tc.method + "()\n}\n")
+		run := selfhost.Run(src)
+		file := selfhost.LowerPublicFileFromRun(run)
+		if file == nil {
+			t.Errorf("%s.%s: selfhost lower returned nil", tc.module, tc.method)
+			continue
+		}
+		diags := legacyglobals.DetectAST(file, "test.osty")
+		if len(diags) != 1 {
+			t.Errorf("%s.%s: emitted %d diags, want 1", tc.module, tc.method, len(diags))
+		}
+	}
+}
+
+// TestDetectPackage_StampsFilePath builds a real *resolve.Package with
+// two source files and asserts (a) every emitted W0750 carries the
+// owning file path so multi-file diagnostics route correctly, and (b)
+// passing a nil Package is a quiet no-op (the package resolver may
+// hand a nil to downstream phases when load itself fails).
+func TestDetectPackage_StampsFilePath(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.osty")
+	b := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(a, []byte(`fn first() {
+    let _ = time.now()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte(`fn second() {
+    let _ = fs.read("/etc/passwd")
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := resolve.LoadPackageForNative(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageForNative: %v", err)
+	}
+	diags := legacyglobals.Detect(pkg)
+	if got := len(diags); got != 2 {
+		t.Fatalf("Detect produced %d diagnostics, want 2\n%s",
+			got, formatDiags(diags))
+	}
+	files := map[string]bool{}
+	for _, d := range diags {
+		files[d.File] = true
+	}
+	if !files[a] {
+		t.Errorf("expected diagnostic stamped %q, got files = %v", a, keys(files))
+	}
+	if !files[b] {
+		t.Errorf("expected diagnostic stamped %q, got files = %v", b, keys(files))
+	}
+
+	if got := legacyglobals.Detect(nil); got != nil {
+		t.Errorf("Detect(nil) = %v, want nil", got)
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func formatDiags(diags []*diag.Diagnostic) string {
+	var b strings.Builder
+	for _, d := range diags {
+		if d == nil {
+			b.WriteString("(nil)\n")
+			continue
+		}
+		b.WriteString(d.Code)
+		b.WriteString(": ")
+		b.WriteString(d.Message)
+		b.WriteString("\n")
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

`CHANGELOG_v0.6.md` line 50: **planned → partial.**

- Adds `--legacy-globals` to the global flag surface (`cli.CliFlags.LegacyGlobals`).
- Wires every front-end subcommand (check / typecheck / resolve / lint, both FILE and DIR modes; native + selectedPackageEntry paths) to emit `W0750` deprecation warnings at v0.5 legacy-global call sites when the flag is set.
- New `internal/legacyglobals` package: pure AST walker keyed by `(module, method)` selector head of `CallExpr.Fn`. Catalog mirrors `BREAKING_v0.6.md` §3 + `LANG_SPEC_v0.6/20-capabilities.md` §20.15. Bare-Ident calls (e.g. `println(...)`) are intentionally not in the catalog (would warn on every test file).

### What's NOT in this PR (follow-up TODOs)

- Auto-desugar `time.now()` → `time.systemClock.now()` etc. (rewrite to capability host adapters).
- Manifest `[stability] = experimental` strict gate when any W0750 fires.
- Spec corpus addition — the negative corpus driver is `Exxxx`-only by regex; the positive corpus is parser-only and the legacy syntax already parses cleanly.

The changelog entry stays "partial" until those land.

## Behaviour

```text
$ osty --legacy-globals --no-color check ./demo
warning[W0750]: v0.5 legacy global `time.now` is deprecated — pass a `Clock` capability parameter (LANG_SPEC_v0.6 §20.15)
 --> demo/main.osty:2:13
    |
  2 |     let _ = time.now()
    |             ^^^^^^^^^^ legacy global call site
    |
 = note: `--legacy-globals` is v0.6.x only — v0.7 removes the flag and the desugar; this call site becomes E0701 (unknown name)
 = help: migrate to `clock.now()` (capability parameter); see CLAUDE.md 부록 C.1
```

Without the flag, no W0750 fires (default-silent opt-in).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [x] `internal/legacyglobals` unit tests (catalog spot-checks, nested AST walks, bare-Ident silence, `*resolve.Package` file-path stamping)
- [x] `internal/cli` flag-parsing tests (every front-end subcommand sees the flag; default-false)
- [x] `cmd/osty/legacy_globals_test.go` integration test of `runCheckPackageNative` with flag toggled on/off
- [x] Affected packages: `./internal/cli/...`, `./internal/legacyglobals/...`, `./internal/check/...`, `./internal/resolve/...`, `./internal/diag/...`, `./internal/stdlib/...`, `./internal/speccorpus/...`, `./internal/lsp/...` — all green
- [x] `./cmd/osty/...` short tests green
- [x] Manual smoke test of `osty check --legacy-globals` against demo source — W0750 emits, exit 1 only when other errors present, `--no-color` honoured
- [ ] CI green confirmation

Pre-existing failures `TestParseMatchArmAllowsBareAssignmentBody` and `TestParseSnapshot/word_freq` are unrelated to this PR.

## Files changed

- `internal/cli/dispatch.go` + `dispatch_test.go` — flag plumbing
- `cmd/osty/main.go`, `cmd/osty/native_check.go`, `cmd/osty/lint_cmd.go` — front-end wiring
- `cmd/osty/legacy_globals_test.go` — in-process integration test
- `internal/legacyglobals/{catalog.go,legacyglobals.go,legacyglobals_test.go}` — detector package
- `CHANGELOG_v0.6.md` — line 50 status update

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_