### PR TITLE
feat(check): Phase 2 entry — #[purpose]/#[example]/#[fixture] semantic gates

### DIFF
--- a/CHANGELOG_v0.6.md
+++ b/CHANGELOG_v0.6.md
@@ -64,9 +64,9 @@ in v0.6" for per-gap rationale.
 
 | Item | Status | Notes |
 |---|---|---|
-| `#[purpose("...")]` | **planned** (G42, Phase 2) | doc / context only |
-| `#[example(input=, output=, uses=)]` | **planned** (G42, Phase 2) | auto-test |
-| `#[fixture(name=)]` | **planned** (G42, Phase 2) | 공유 canonical instance |
+| `#[purpose("...")]` | **partial** (G42, Phase 2) | active checker gate now rejects non-string-literal arguments (`E0434`). Interpolated, raw, triple-quoted, and `key = value` forms are caught with a structured detail message. |
+| `#[example(input=, output=, uses=)]` | **partial** (G42, Phase 2) | active checker gate enforces the `input` / `output` / `uses` key catalog (`E0435`); preserves the `input` arity (`E0431`) and `uses` fixture (`E0433`) gates. Runtime `osty test --example` execution and output mismatch (`E0430`) remain follow-up. |
+| `#[fixture(name=)]` | **partial** (G42, Phase 2) | active checker gate restricts `#[fixture]` to function declarations (`E0436`) and keeps the zero-arity rule (`E0432`). Gate runs at struct / enum / interface / type alias / let / variant / field positions. |
 | `osty context <symbol>` | **planned** (G47, Phase 2) | JSON output |
 
 ### Determinism / Construction / Errors

--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -1447,6 +1447,34 @@ Spec: v0.6 §3.12.3
 
 **Fix**: declare the fixture, or correct the name.
 
+### E0434 — `CodePurposeNotStringLiteral`
+
+CodePurposeNotStringLiteral: `#[purpose("...")]` accepts exactly one string-literal argument. Interpolated, raw, or triple-quoted strings, concatenations, identifiers, and any other expression form are rejected so tooling can extract the purpose verbatim.
+
+Spec: v0.6 §3.12.1
+
+**Fix**: replace the argument with a single plain string literal.
+
+### E0435 — `CodeExampleUnknownKey`
+
+CodeExampleUnknownKey: `#[example(...)]` was passed a keyword argument whose name is not in the {`input`, `output`, `uses`} catalog defined by §3.12.2.
+
+drop the unrecognised argument.
+
+Spec: v0.6 §3.12.2
+
+**Fix**: rename the key to one of `input` / `output` / `uses`, or
+
+### E0436 — `CodeFixtureNonFunction`
+
+CodeFixtureNonFunction: `#[fixture(name = "...")]` was applied to a declaration that is not a function (e.g. struct, enum, interface, or top-level `let`). Fixtures are runnable factories; only `fn` declarations qualify.
+
+that returns the value, and reference it via the fixture's registered name.
+
+Spec: v0.6 §3.12.3
+
+**Fix**: move the annotation to a fresh zero-arity factory function
+
 ---
 
 ## G45 — Golden tests (§11.5)

--- a/LANG_SPEC_v0.6/00-revision.md
+++ b/LANG_SPEC_v0.6/00-revision.md
@@ -432,6 +432,9 @@ JSON 스키마는 `LANG_SPEC_v0.6/13-tooling.md §13.9` 에서 정의.
 | `E0431` | `#[example]` 의 input arity 가 함수 arity 와 불일치 |
 | `E0432` | `#[fixture]` 함수가 인자를 받음 (must be zero-arity) |
 | `E0433` | `#[example(uses = "X")]` 의 X 가 fixture 가 아님 |
+| `E0434` | `#[purpose]` 인자가 plain string literal 이 아님 |
+| `E0435` | `#[example]` 가 `input` / `output` / `uses` 외 키 사용 |
+| `E0436` | `#[fixture]` 가 fn 외 위치 (struct / enum / field / variant ...) 에 부착 |
 
 ---
 
@@ -969,7 +972,7 @@ Phase 2 에서 *category-prefix 옵션* 도입 검토:
 
 | Range | 영역 | 신규 |
 |---|---|---|
-| `E0410–E0429` | Annotation/intent (G41, G42) | E0410, E0411, E0412, E0414, E0420, E0421, E0422, E0423, E0424, E0430, E0431, E0432, E0433 |
+| `E0410–E0436` | Annotation/intent (G41, G42) | E0410, E0411, E0412, E0414, E0420, E0421, E0422, E0423, E0424, E0430, E0431, E0432, E0433, E0434, E0435, E0436 |
 | `E0440–E0449` | Golden / evolution (G44, G45) | E0444, E0445, E0450, E0451 |
 | `E0780–E0799` | Capability / Reproducible (G36, G39) | E0780-E0789 |
 | `E0900–E0949` | Information flow (G37) | E0900, E0901, E0902, E0903 |

--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -1744,8 +1744,9 @@ fn aliceUser() -> Email { Email.parse("alice@example.com")? }
 declaration exists. Unlike a doc comment (`///`), the purpose:
 
 - Has a fixed syntactic shape — easy for tooling to extract.
-- Is required to be a single string literal, not a concatenation
-  or expression. `E0431`.
+- Is required to be a single plain string literal, not a concatenation,
+  interpolated string, raw / triple-quoted form, or any other
+  expression. `E0434`.
 - Is rendered as the *primary one-liner* in `osty doc`, separate
   from longer explanatory prose in `///` comments.
 
@@ -1795,6 +1796,8 @@ pub fn signup(email: String, db: Db) -> Result<UserId, SignupError> { ... }
   order; capability placeholders in `input` are resolved against
   the fixture set.
 
+Keys outside `{ input, output, uses }` are rejected as `E0435`.
+
 **Verification.** `osty test --example` runs each `#[example]` as
 an independent test. Output mismatch is a test failure. Missing
 fixture (named in `uses` but no matching `#[fixture]`) is `E0433`.
@@ -1820,11 +1823,14 @@ fn fakeDb() -> Db {
 
 **Composition rules.**
 
-1. Zero arity is mandatory (`E0432`). A fixture takes no parameters.
-2. Fixtures may call other fixtures by name. Cycles are `E0433`.
-3. Each call to a fixture function returns a *fresh instance* —
+1. `#[fixture]` is restricted to function declarations. Applying it
+   to a struct, enum, interface, type alias, field, variant, or
+   top-level `let` is `E0436`.
+2. Zero arity is mandatory (`E0432`). A fixture takes no parameters.
+3. Fixtures may call other fixtures by name. Cycles are `E0433`.
+4. Each call to a fixture function returns a *fresh instance* —
    tests never share fixture state.
-4. Fixtures are package-local by default; `pub fn` annotated with
+5. Fixtures are package-local by default; `pub fn` annotated with
    `#[fixture]` is exported for downstream packages but is rare in
    practice (most fixtures are test-local).
 

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -1334,6 +1334,35 @@ const (
 	// Fix: declare the fixture, or correct the name.
 	CodeExampleUnknownFixture = "E0433"
 
+	// CodePurposeNotStringLiteral: `#[purpose("...")]` accepts exactly one
+	// string-literal argument. Interpolated, raw, or triple-quoted strings,
+	// concatenations, identifiers, and any other expression form are
+	// rejected so tooling can extract the purpose verbatim.
+	//
+	// Spec: v0.6 §3.12.1
+	// Fix: replace the argument with a single plain string literal.
+	CodePurposeNotStringLiteral = "E0434"
+
+	// CodeExampleUnknownKey: `#[example(...)]` was passed a keyword
+	// argument whose name is not in the {`input`, `output`, `uses`}
+	// catalog defined by §3.12.2.
+	//
+	// Spec: v0.6 §3.12.2
+	// Fix: rename the key to one of `input` / `output` / `uses`, or
+	//      drop the unrecognised argument.
+	CodeExampleUnknownKey = "E0435"
+
+	// CodeFixtureNonFunction: `#[fixture(name = "...")]` was applied to a
+	// declaration that is not a function (e.g. struct, enum, interface,
+	// or top-level `let`). Fixtures are runnable factories; only `fn`
+	// declarations qualify.
+	//
+	// Spec: v0.6 §3.12.3
+	// Fix: move the annotation to a fresh zero-arity factory function
+	//      that returns the value, and reference it via the fixture's
+	//      registered name.
+	CodeFixtureNonFunction = "E0436"
+
 	// G45 — Golden tests (§11.5)
 
 	// CodeGoldenNotReproducible: a function carrying `#[golden]` does

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -49960,6 +49960,7 @@ func runCheckGates(cx *ElabCx) {
 	runAmbientGate(cx)
 	runReproducibleCapabilityGate(cx)
 	runCapabilitySignatureGate(cx)
+	runStructuredIntentGate(cx)
 }
 
 // Osty: /tmp/selfhost_merged.osty:24554:1
@@ -70955,4 +70956,457 @@ func isNonDeterministicCapabilityName(name string) bool {
 	default:
 		return false
 	}
+}
+
+// ---------------------------------------------------------------------
+// G42 — structured intent gate (E0430–E0436, v0.6 §3.12).
+// Mirror of toolchain/check_gates.osty::runStructuredIntentGate so the
+// host-side generated checker emits the same diagnostics as the LLVM
+// self-host until the bootstrapped seed catches up.
+// ---------------------------------------------------------------------
+
+func checkCodePurposeNotStringLiteral() string { return "E0434" }
+func checkCodeExampleUnknownKey() string       { return "E0435" }
+func checkCodeFixtureNonFunction() string      { return "E0436" }
+func checkCodeExampleArityMismatch() string    { return "E0431" }
+func checkCodeFixtureNonZeroArity() string     { return "E0432" }
+func checkCodeExampleUnknownFixture() string   { return "E0433" }
+
+func diagPurposeNotStringLiteral(detail string, start int, end int) *CheckDiagnostic {
+	return checkDiagWithNotes(
+		checkCodePurposeNotStringLiteral(),
+		fmt.Sprintf("`#[purpose]` argument must be a plain string literal (%s)", ostyToString(detail)),
+		start,
+		end,
+		[]string{
+			"LANG_SPEC §3.12.1: `#[purpose]` accepts exactly one plain `\"...\"` literal",
+			"hint: replace the argument with a single non-interpolated string literal",
+		},
+	)
+}
+
+func diagExampleUnknownKey(fnName string, key string, start int, end int) *CheckDiagnostic {
+	return checkDiagWithNotes(
+		checkCodeExampleUnknownKey(),
+		fmt.Sprintf("`#[example]` on `%s` uses unknown key `%s`", ostyToString(fnName), ostyToString(key)),
+		start,
+		end,
+		[]string{
+			"LANG_SPEC §3.12.2: `#[example]` keys are `input`, `output`, `uses`",
+			"hint: rename the key to one of the catalog entries, or drop it",
+		},
+	)
+}
+
+func diagFixtureNonFunction(declName string, kind string, start int, end int) *CheckDiagnostic {
+	return checkDiagWithNotes(
+		checkCodeFixtureNonFunction(),
+		fmt.Sprintf("`#[fixture]` cannot be applied to %s `%s`; only functions are eligible", ostyToString(kind), ostyToString(declName)),
+		start,
+		end,
+		[]string{
+			"LANG_SPEC §3.12.3: `#[fixture]` registers a zero-arity factory function",
+			"hint: move `#[fixture]` to a `fn` that returns the value",
+		},
+	)
+}
+
+func diagFixtureNonZeroArity(fnName string, paramCount int, start int, end int) *CheckDiagnostic {
+	return checkDiagWithNotes(
+		checkCodeFixtureNonZeroArity(),
+		fmt.Sprintf("`#[fixture]` function `%s` has %d parameter(s); fixtures must be zero-arity", ostyToString(fnName), paramCount),
+		start,
+		end,
+		[]string{
+			"LANG_SPEC §3.12.3: fixtures must be zero-arity to be sharable across docs / tests / context",
+			"hint: remove the parameters, or drop `#[fixture]`",
+		},
+	)
+}
+
+func diagExampleArityMismatch(fnName string, expected int, got int, start int, end int) *CheckDiagnostic {
+	return checkDiagWithNotes(
+		checkCodeExampleArityMismatch(),
+		fmt.Sprintf("`#[example]` on `%s`: expected %d input(s), got %d", ostyToString(fnName), expected, got),
+		start,
+		end,
+		[]string{
+			"LANG_SPEC §3.12.2: example input count must match the function's positional arity",
+			"hint: adjust the input list to match the function's parameters",
+		},
+	)
+}
+
+func diagExampleUnknownFixture(fnName string, fixtureName string, start int, end int) *CheckDiagnostic {
+	return checkDiagWithNotes(
+		checkCodeExampleUnknownFixture(),
+		fmt.Sprintf("`#[example]` on `%s` references unknown fixture `%s`", ostyToString(fnName), ostyToString(fixtureName)),
+		start,
+		end,
+		[]string{
+			"LANG_SPEC §3.12.3: fixture names must resolve to a `#[fixture]` declaration",
+			"hint: declare the fixture, or correct the name",
+		},
+	)
+}
+
+// runStructuredIntentGate validates `#[purpose]` / `#[example]` /
+// `#[fixture]` annotations against §3.12.
+func runStructuredIntentGate(cx *ElabCx) {
+	if cx == nil || cx.ast == nil || cx.ast.arena == nil {
+		return
+	}
+	arena := cx.ast.arena
+	fixtureNames := collectFixtureNames(arena)
+	for _, declIdx := range arena.decls {
+		node := astArenaNodeAt(arena, declIdx)
+		if node == nil {
+			continue
+		}
+		switch node.kind.(type) {
+		case *AstNodeKind_AstNFnDecl:
+			structuredIntentCheckFn(cx, arena, node, fixtureNames)
+		case *AstNodeKind_AstNStructDecl:
+			structuredIntentCheckPurposeAt(cx, arena, node.extra)
+			structuredIntentCheckFixtureNonFn(cx, arena, node.text, "struct", node.extra)
+			structuredIntentCheckStructMembers(cx, arena, node, fixtureNames)
+		case *AstNodeKind_AstNEnumDecl:
+			structuredIntentCheckPurposeAt(cx, arena, node.extra)
+			structuredIntentCheckFixtureNonFn(cx, arena, node.text, "enum", node.extra)
+			structuredIntentCheckEnumMembers(cx, arena, node, fixtureNames)
+		case *AstNodeKind_AstNInterfaceDecl:
+			structuredIntentCheckPurposeAt(cx, arena, node.extra)
+			structuredIntentCheckFixtureNonFn(cx, arena, node.text, "interface", node.extra)
+			structuredIntentCheckMethodsList(cx, arena, node, fixtureNames)
+		case *AstNodeKind_AstNTypeAlias:
+			structuredIntentCheckPurposeAt(cx, arena, node.extra)
+			structuredIntentCheckFixtureNonFn(cx, arena, node.text, "type alias", node.extra)
+		case *AstNodeKind_AstNLet, *AstNodeKind_AstNLetDecl:
+			structuredIntentCheckPurposeAt(cx, arena, node.extra)
+			structuredIntentCheckFixtureNonFn(cx, arena, node.text, "let", node.extra)
+		}
+	}
+}
+
+func structuredIntentCheckMethodsList(cx *ElabCx, arena *AstArena, parent *AstNode, fixtureNames []string) {
+	if parent == nil {
+		return
+	}
+	for _, memberIdx := range parent.children {
+		member := astArenaNodeAt(arena, memberIdx)
+		if member == nil {
+			continue
+		}
+		if _, ok := member.kind.(*AstNodeKind_AstNFnDecl); ok {
+			structuredIntentCheckFn(cx, arena, member, fixtureNames)
+		}
+	}
+}
+
+func structuredIntentCheckStructMembers(cx *ElabCx, arena *AstArena, parent *AstNode, fixtureNames []string) {
+	if parent == nil {
+		return
+	}
+	for _, memberIdx := range parent.children {
+		member := astArenaNodeAt(arena, memberIdx)
+		if member == nil {
+			continue
+		}
+		switch member.kind.(type) {
+		case *AstNodeKind_AstNFnDecl:
+			structuredIntentCheckFn(cx, arena, member, fixtureNames)
+		case *AstNodeKind_AstNField_:
+			structuredIntentCheckPurposeAt(cx, arena, member.extra)
+			structuredIntentCheckFixtureNonFn(cx, arena, member.text, "field", member.extra)
+		}
+	}
+}
+
+func structuredIntentCheckEnumMembers(cx *ElabCx, arena *AstArena, parent *AstNode, fixtureNames []string) {
+	if parent == nil {
+		return
+	}
+	for _, memberIdx := range parent.children {
+		member := astArenaNodeAt(arena, memberIdx)
+		if member == nil {
+			continue
+		}
+		switch member.kind.(type) {
+		case *AstNodeKind_AstNFnDecl:
+			structuredIntentCheckFn(cx, arena, member, fixtureNames)
+		case *AstNodeKind_AstNVariant:
+			structuredIntentCheckPurposeAt(cx, arena, member.extra)
+			structuredIntentCheckFixtureNonFn(cx, arena, member.text, "enum variant", member.extra)
+		}
+	}
+}
+
+func structuredIntentCheckFn(cx *ElabCx, arena *AstArena, fnNode *AstNode, fixtureNames []string) {
+	if fnNode == nil || fnNode.extra < 0 {
+		return
+	}
+	structuredIntentCheckPurposeAt(cx, arena, fnNode.extra)
+	fixtureAnnots := structuredIntentCollectAnnotations(arena, fnNode.extra, "fixture")
+	for range fixtureAnnots {
+		paramCount := fnParamCountExcludingSelf(arena, fnNode)
+		if paramCount > 0 {
+			cx.env.local.diagnostics = append(cx.env.local.diagnostics, diagFixtureNonZeroArity(fnNode.text, paramCount, fnNode.start, fnNode.end))
+		}
+	}
+	exampleAnnots := structuredIntentCollectAnnotations(arena, fnNode.extra, "example")
+	for _, annot := range exampleAnnots {
+		structuredIntentCheckExample(cx, arena, annot, fnNode, fixtureNames)
+	}
+}
+
+func structuredIntentCheckPurposeAt(cx *ElabCx, arena *AstArena, annotIdx int) {
+	if annotIdx < 0 {
+		return
+	}
+	purposeAnnots := structuredIntentCollectAnnotations(arena, annotIdx, "purpose")
+	for _, annot := range purposeAnnots {
+		structuredIntentValidatePurposeArgs(cx, arena, annot)
+	}
+}
+
+func structuredIntentValidatePurposeArgs(cx *ElabCx, arena *AstArena, annot *AstNode) {
+	if annot == nil {
+		return
+	}
+	argCount := len(annot.children)
+	if argCount == 0 {
+		cx.env.local.diagnostics = append(cx.env.local.diagnostics, diagPurposeNotStringLiteral("missing argument", annot.start, annot.end))
+		return
+	}
+	if argCount > 1 {
+		cx.env.local.diagnostics = append(cx.env.local.diagnostics, diagPurposeNotStringLiteral(fmt.Sprintf("expected exactly one argument, got %d", argCount), annot.start, annot.end))
+	}
+	first := astArenaNodeAt(arena, annot.children[0])
+	issue := classifyPurposeArg(first)
+	if issue != "" {
+		cx.env.local.diagnostics = append(cx.env.local.diagnostics, diagPurposeNotStringLiteral(issue, first.start, first.end))
+	}
+}
+
+func classifyPurposeArg(arg *AstNode) string {
+	if arg == nil {
+		return "missing argument"
+	}
+	if _, ok := arg.kind.(*AstNodeKind_AstNField_); ok {
+		return "argument has `key = value` form; use a plain string literal"
+	}
+	if _, ok := arg.kind.(*AstNodeKind_AstNStringLit); !ok {
+		return "argument is not a string literal"
+	}
+	if strings.HasPrefix(arg.text, "r\"") {
+		return "raw string literals are not accepted"
+	}
+	if strings.HasPrefix(arg.text, "\"\"\"") {
+		return "triple-quoted strings are not accepted"
+	}
+	if len(arg.children) > 0 {
+		return "interpolated strings are not accepted"
+	}
+	if containsInterpolation(arg.text) {
+		return "interpolated strings are not accepted"
+	}
+	return ""
+}
+
+func structuredIntentCheckFixtureNonFn(cx *ElabCx, arena *AstArena, declName string, kind string, annotIdx int) {
+	if annotIdx < 0 {
+		return
+	}
+	fixtureAnnots := structuredIntentCollectAnnotations(arena, annotIdx, "fixture")
+	for _, annot := range fixtureAnnots {
+		cx.env.local.diagnostics = append(cx.env.local.diagnostics, diagFixtureNonFunction(declName, kind, annot.start, annot.end))
+	}
+}
+
+func structuredIntentCheckExample(cx *ElabCx, arena *AstArena, annot *AstNode, fnNode *AstNode, fixtureNames []string) {
+	if annot == nil || fnNode == nil {
+		return
+	}
+	fnParamCount := fnParamCountExcludingSelf(arena, fnNode)
+	inputCount := 0
+	sawInput := false
+	usesFixture := ""
+	for _, argIdx := range annot.children {
+		arg := astArenaNodeAt(arena, argIdx)
+		if arg == nil {
+			continue
+		}
+		if _, ok := arg.kind.(*AstNodeKind_AstNField_); !ok {
+			continue
+		}
+		key := arg.text
+		switch key {
+		case "input":
+			sawInput = true
+			inputCount = exampleInputArity(arena, arg.left)
+		case "output":
+			// Output runtime check is follow-up; ensure presence only.
+		case "uses":
+			name := annotationStringLiteralValue(arena, arg.left)
+			if name != "" {
+				usesFixture = name
+			}
+		default:
+			cx.env.local.diagnostics = append(cx.env.local.diagnostics, diagExampleUnknownKey(fnNode.text, key, arg.start, arg.end))
+		}
+	}
+	if sawInput && fnParamCount >= 0 && inputCount != fnParamCount {
+		cx.env.local.diagnostics = append(cx.env.local.diagnostics, diagExampleArityMismatch(fnNode.text, fnParamCount, inputCount, annot.start, annot.end))
+	}
+	if usesFixture != "" && !structuredIntentListContains(fixtureNames, usesFixture) {
+		cx.env.local.diagnostics = append(cx.env.local.diagnostics, diagExampleUnknownFixture(fnNode.text, usesFixture, annot.start, annot.end))
+	}
+}
+
+func exampleInputArity(arena *AstArena, valueIdx int) int {
+	if valueIdx < 0 {
+		return 0
+	}
+	v := astArenaNodeAt(arena, valueIdx)
+	if v == nil {
+		return 0
+	}
+	if _, ok := v.kind.(*AstNodeKind_AstNList); ok {
+		return len(v.children)
+	}
+	return 1
+}
+
+func annotationStringLiteralValue(arena *AstArena, valueIdx int) string {
+	if valueIdx < 0 {
+		return ""
+	}
+	v := astArenaNodeAt(arena, valueIdx)
+	if v == nil {
+		return ""
+	}
+	if _, ok := v.kind.(*AstNodeKind_AstNStringLit); !ok {
+		return ""
+	}
+	if len(v.children) > 0 {
+		return ""
+	}
+	raw := v.text
+	if strings.HasPrefix(raw, "r\"") {
+		return ""
+	}
+	if strings.HasPrefix(raw, "\"\"\"") {
+		return ""
+	}
+	n := len(raw)
+	if n < 2 {
+		return raw
+	}
+	if strings.HasPrefix(raw, "\"") && strings.HasSuffix(raw, "\"") {
+		return raw[1 : n-1]
+	}
+	return raw
+}
+
+func collectFixtureNames(arena *AstArena) []string {
+	var out []string
+	for _, declIdx := range arena.decls {
+		node := astArenaNodeAt(arena, declIdx)
+		if node == nil || node.extra < 0 {
+			continue
+		}
+		if _, ok := node.kind.(*AstNodeKind_AstNFnDecl); !ok {
+			continue
+		}
+		fixtureAnnots := structuredIntentCollectAnnotations(arena, node.extra, "fixture")
+		for _, annot := range fixtureAnnots {
+			name := fixtureAnnotName(arena, annot)
+			if name != "" {
+				out = append(out, name)
+			} else {
+				out = append(out, node.text)
+			}
+		}
+	}
+	return out
+}
+
+func fixtureAnnotName(arena *AstArena, annot *AstNode) string {
+	if annot == nil {
+		return ""
+	}
+	for _, argIdx := range annot.children {
+		arg := astArenaNodeAt(arena, argIdx)
+		if arg == nil {
+			continue
+		}
+		if _, ok := arg.kind.(*AstNodeKind_AstNField_); !ok {
+			continue
+		}
+		if arg.text == "name" {
+			return annotationStringLiteralValue(arena, arg.left)
+		}
+	}
+	return ""
+}
+
+func structuredIntentCollectAnnotations(arena *AstArena, idx int, name string) []*AstNode {
+	var out []*AstNode
+	if idx < 0 {
+		return out
+	}
+	structuredIntentCollectAnnotationsWalk(arena, idx, name, &out)
+	return out
+}
+
+func structuredIntentCollectAnnotationsWalk(arena *AstArena, idx int, name string, out *[]*AstNode) {
+	if idx < 0 {
+		return
+	}
+	node := astArenaNodeAt(arena, idx)
+	if node == nil {
+		return
+	}
+	if _, ok := node.kind.(*AstNodeKind_AstNAnnotation); !ok {
+		return
+	}
+	if node.text == name {
+		*out = append(*out, node)
+		return
+	}
+	if node.text == "__group" {
+		for _, childIdx := range node.children {
+			structuredIntentCollectAnnotationsWalk(arena, childIdx, name, out)
+		}
+	}
+}
+
+func fnParamCountExcludingSelf(arena *AstArena, fnNode *AstNode) int {
+	if fnNode == nil {
+		return 0
+	}
+	count := 0
+	for _, paramIdx := range fnNode.children {
+		param := astArenaNodeAt(arena, paramIdx)
+		if param == nil {
+			continue
+		}
+		if _, ok := param.kind.(*AstNodeKind_AstNParam); !ok {
+			continue
+		}
+		if param.text == "self" {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func structuredIntentListContains(xs []string, x string) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/selfhost/structured_intent_gate_test.go
+++ b/internal/selfhost/structured_intent_gate_test.go
@@ -1,0 +1,116 @@
+package selfhost
+
+import "testing"
+
+// TestStructuredIntentGateAcceptsValidForms exercises the v0.6 G42
+// `#[purpose]` / `#[example]` / `#[fixture]` annotations in their
+// canonical shapes and asserts the gate stays silent.
+func TestStructuredIntentGateAcceptsValidForms(t *testing.T) {
+	src := []byte(`#[fixture(name = "alice")]
+fn aliceFixture() -> Int { 42 }
+
+#[purpose("compute the rounded score")]
+#[example(input = ["alice"], output = "Ok(42)", uses = "alice")]
+fn computeScore(name: String) -> Int { 0 }
+`)
+	checked := CheckSourceStructured(src)
+	for _, d := range checked.Diagnostics {
+		switch d.Code {
+		case "E0431", "E0432", "E0433", "E0434", "E0435", "E0436":
+			t.Fatalf("valid intent surface emitted %s: %#v", d.Code, checked.Diagnostics)
+		}
+	}
+}
+
+// TestStructuredIntentGateRejectsInterpolatedPurpose locks in the
+// E0434 contract: `#[purpose]` arguments must be plain string literals.
+func TestStructuredIntentGateRejectsInterpolatedPurpose(t *testing.T) {
+	src := []byte(`let name = "world"
+
+#[purpose("hello {name}")]
+fn greet() -> Int { 0 }
+`)
+	checked := CheckSourceStructured(src)
+	if got := countCode(checked, "E0434"); got != 1 {
+		t.Fatalf("E0434 count = %d, want 1; diagnostics=%#v", got, checked.Diagnostics)
+	}
+}
+
+// TestStructuredIntentGateRejectsNonLiteralPurpose covers the
+// `key = value` and identifier purpose forms.
+func TestStructuredIntentGateRejectsNonLiteralPurpose(t *testing.T) {
+	src := []byte(`#[purpose(text = "intent")]
+fn declarative() -> Int { 0 }
+
+#[purpose(intent)]
+fn bareIdent() -> Int { 0 }
+`)
+	checked := CheckSourceStructured(src)
+	if got := countCode(checked, "E0434"); got != 2 {
+		t.Fatalf("E0434 count = %d, want 2; diagnostics=%#v", got, checked.Diagnostics)
+	}
+}
+
+// TestStructuredIntentGateRejectsUnknownExampleKey locks in E0435.
+func TestStructuredIntentGateRejectsUnknownExampleKey(t *testing.T) {
+	src := []byte(`#[example(input = [1], output = "1", tags = "smoke")]
+fn identity(x: Int) -> Int { x }
+`)
+	checked := CheckSourceStructured(src)
+	if got := countCode(checked, "E0435"); got != 1 {
+		t.Fatalf("E0435 count = %d, want 1; diagnostics=%#v", got, checked.Diagnostics)
+	}
+}
+
+// TestStructuredIntentGateRejectsFixtureOnStruct locks in E0436.
+func TestStructuredIntentGateRejectsFixtureOnStruct(t *testing.T) {
+	src := []byte(`#[fixture(name = "basic")]
+pub struct SpecFixture {
+    pub value: Int,
+}
+
+#[fixture(name = "shape")]
+pub enum Shape {
+    Circle,
+    Square,
+}
+`)
+	checked := CheckSourceStructured(src)
+	if got := countCode(checked, "E0436"); got != 2 {
+		t.Fatalf("E0436 count = %d, want 2; diagnostics=%#v", got, checked.Diagnostics)
+	}
+}
+
+// TestStructuredIntentGatePreservesExistingDiagnostics ensures the
+// new path doesn't regress E0431/E0432/E0433.
+func TestStructuredIntentGatePreservesExistingDiagnostics(t *testing.T) {
+	src := []byte(`#[fixture(name = "withArg")]
+fn withArg(x: Int) -> Int { x }
+
+#[example(input = [1, 2], output = "3")]
+fn singleArg(x: Int) -> Int { x }
+
+#[example(input = [1], output = "1", uses = "missing")]
+fn unknownFixture(x: Int) -> Int { x }
+`)
+	checked := CheckSourceStructured(src)
+	if got := countCode(checked, "E0432"); got != 1 {
+		t.Fatalf("E0432 count = %d, want 1; diagnostics=%#v", got, checked.Diagnostics)
+	}
+	if got := countCode(checked, "E0431"); got != 1 {
+		t.Fatalf("E0431 count = %d, want 1; diagnostics=%#v", got, checked.Diagnostics)
+	}
+	if got := countCode(checked, "E0433"); got != 1 {
+		t.Fatalf("E0433 count = %d, want 1; diagnostics=%#v", got, checked.Diagnostics)
+	}
+}
+
+func countCode(checked CheckResult, code string) int {
+	count := 0
+	for _, d := range checked.Diagnostics {
+		if d.Code == code {
+			count++
+		}
+	}
+	return count
+}

--- a/testdata/spec/negative/reject.osty
+++ b/testdata/spec/negative/reject.osty
@@ -403,6 +403,29 @@ fn badSinceTwoArgs() {}
 fn badSinceKwarg() {}
 // === END
 
+// === CASE: E0434 === purpose argument is interpolated string
+let target = "world"
+
+#[purpose("hello {target}")]
+fn greet() -> Int {
+    0
+}
+// === END
+
+// === CASE: E0435 === example uses key outside the input/output/uses catalog
+#[example(input = [1], output = "1", tags = "smoke")]
+fn echoExample(x: Int) -> Int {
+    x
+}
+// === END
+
+// === CASE: E0436 === fixture annotation on a non-function declaration
+#[fixture(name = "shape")]
+pub struct ShapeFixture {
+    pub value: Int,
+}
+// === END
+
 // === CASE: E0004 === unterminated block comment (MUST remain last — the
 // unclosed /* is intentional and swallows every byte to EOF).
 /* never closes

--- a/testdata/spec/positive/16-v06-spec-intent.osty
+++ b/testdata/spec/positive/16-v06-spec-intent.osty
@@ -1,14 +1,28 @@
 // v0.6 Phase 2 metadata surface — declaration-level spec/intent
 // annotations parse cleanly, and #[spec] points at a real spec section.
+//
+// G42 (§3.12) entry — `#[purpose]` accepts a single plain string
+// literal; `#[example]` accepts the `input` / `output` / `uses` catalog
+// keys; `#[fixture]` is restricted to zero-arity functions.
 
 #[spec("§3.10")]
 #[purpose("link a declaration to the language spec")]
-#[example(input = "1", output = "1")]
+#[example(input = [], output = "1")]
 fn linkedSpecExample() -> Int {
     1
 }
 
 #[fixture(name = "basic")]
+fn basicFixture() -> Int {
+    7
+}
+
+#[purpose("compose a fixtures-driven example")]
+#[example(input = [42], output = "Ok(42)", uses = "basic")]
+fn echoLine(value: Int) -> Int {
+    value
+}
+
 pub struct SpecFixture {
     pub value: Int,
 }

--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -95,6 +95,9 @@ pub fn checkCodeExampleMismatch() -> String { "E0430" }
 pub fn checkCodeExampleArityMismatch() -> String { "E0431" }
 pub fn checkCodeFixtureNonZeroArity() -> String { "E0432" }
 pub fn checkCodeExampleUnknownFixture() -> String { "E0433" }
+pub fn checkCodePurposeNotStringLiteral() -> String { "E0434" }
+pub fn checkCodeExampleUnknownKey() -> String { "E0435" }
+pub fn checkCodeFixtureNonFunction() -> String { "E0436" }
 
 // v0.6 G43 — Executable spec block (LANG_SPEC_v0.6 §3.13).
 pub fn checkCodeSpecBlockMisplaced() -> String { "E0440" }
@@ -1275,6 +1278,53 @@ pub fn diagExampleUnknownFixture(fnName: String, fixtureName: String, start: Int
         [
             "LANG_SPEC §3.12.3: fixture names must resolve to a `#[fixture]` declaration",
             "hint: declare the fixture, or correct the name",
+        ],
+    )
+}
+
+/// diagPurposeNotStringLiteral reports a `#[purpose(...)]` whose argument
+/// is not a single plain string literal. Tooling extracts the purpose
+/// verbatim, so interpolated/raw/triple-quoted/expression forms are
+/// rejected.
+pub fn diagPurposeNotStringLiteral(detail: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiagWithNotes(
+        checkCodePurposeNotStringLiteral(),
+        "`#[purpose]` argument must be a plain string literal ({detail})",
+        start,
+        end,
+        [
+            "LANG_SPEC §3.12.1: `#[purpose]` accepts exactly one plain `\"...\"` literal",
+            "hint: replace the argument with a single non-interpolated string literal",
+        ],
+    )
+}
+
+/// diagExampleUnknownKey reports an `#[example(...)]` keyword argument
+/// whose name is not in the {`input`, `output`, `uses`} catalog.
+pub fn diagExampleUnknownKey(fnName: String, key: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiagWithNotes(
+        checkCodeExampleUnknownKey(),
+        "`#[example]` on `{fnName}` uses unknown key `{key}`",
+        start,
+        end,
+        [
+            "LANG_SPEC §3.12.2: `#[example]` keys are `input`, `output`, `uses`",
+            "hint: rename the key to one of the catalog entries, or drop it",
+        ],
+    )
+}
+
+/// diagFixtureNonFunction reports a `#[fixture]` annotation applied to a
+/// declaration that is not a function (struct, enum, interface, etc.).
+pub fn diagFixtureNonFunction(declName: String, kind: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiagWithNotes(
+        checkCodeFixtureNonFunction(),
+        "`#[fixture]` cannot be applied to {kind} `{declName}`; only functions are eligible",
+        start,
+        end,
+        [
+            "LANG_SPEC §3.12.3: `#[fixture]` registers a zero-arity factory function",
+            "hint: move `#[fixture]` to a `fn` that returns the value",
         ],
     )
 }

--- a/toolchain/check_diag_test.osty
+++ b/toolchain/check_diag_test.osty
@@ -407,6 +407,27 @@ fn testDiagExampleUnknownFixtureStampsE0433() {
     testing.assert(stringsContains(d.message, "missingFixture"))
 }
 
+fn testDiagPurposeNotStringLiteralStampsE0434() {
+    let d = diagPurposeNotStringLiteral("interpolated string", 0, 10)
+    testing.assertEq(d.code, "E0434")
+    testing.assert(stringsContains(d.message, "interpolated"))
+    testing.assert(stringsContains(d.message, "string literal"))
+}
+
+fn testDiagExampleUnknownKeyStampsE0435() {
+    let d = diagExampleUnknownKey("f", "tags", 0, 10)
+    testing.assertEq(d.code, "E0435")
+    testing.assert(stringsContains(d.message, "f"))
+    testing.assert(stringsContains(d.message, "tags"))
+}
+
+fn testDiagFixtureNonFunctionStampsE0436() {
+    let d = diagFixtureNonFunction("MyStruct", "struct", 0, 10)
+    testing.assertEq(d.code, "E0436")
+    testing.assert(stringsContains(d.message, "MyStruct"))
+    testing.assert(stringsContains(d.message, "struct"))
+}
+
 // ---------------------------------------------------------------------
 // v0.6 G43 — Spec block diagnostics.
 // ---------------------------------------------------------------------

--- a/toolchain/check_gates.osty
+++ b/toolchain/check_gates.osty
@@ -2844,13 +2844,21 @@ fn errorContractCheckErased(cx: ElabCx, arena: AstArena, contracts: List<ErrorCo
 }
 
 // ---------------------------------------------------------------------
-// E0430–E0433 — structured intent gate (G42, v0.6 §3.12).
+// E0430–E0436 — structured intent gate (G42, v0.6 §3.12).
 //
-// Validates `#[example]` and `#[fixture]` annotations:
+// Validates `#[purpose]` / `#[example]` / `#[fixture]` annotations:
 //   E0430 — example output mismatch (requires runtime; placeholder)
 //   E0431 — example input arity mismatch
 //   E0432 — fixture with non-zero arity
 //   E0433 — example references unknown fixture
+//   E0434 — `#[purpose]` argument is not a plain string literal
+//   E0435 — `#[example]` uses an unknown key (must be input/output/uses)
+//   E0436 — `#[fixture]` applied to a non-function declaration
+//
+// `#[purpose]` is allowed on any declaration site (fn / method / struct /
+// enum / interface / interface method / pub field). Parameter / local
+// positions are already rejected by the parser, so the gate does not
+// re-check them.
 // ---------------------------------------------------------------------
 
 fn runStructuredIntentGate(cx: ElabCx) {
@@ -2860,9 +2868,29 @@ fn runStructuredIntentGate(cx: ElabCx) {
         let node = astArenaNodeAt(arena, declIdx)
         match node.kind {
             AstNFnDecl -> structuredIntentCheckFn(cx, arena, node, fixtureNames),
-            AstNStructDecl -> structuredIntentCheckMethods(cx, arena, node, fixtureNames),
-            AstNEnumDecl -> structuredIntentCheckMethods(cx, arena, node, fixtureNames),
-            AstNInterfaceDecl -> structuredIntentCheckMethods(cx, arena, node, fixtureNames),
+            AstNStructDecl -> {
+                structuredIntentCheckPurposeAt(cx, arena, node.text, "struct", node.extra, node.start, node.end)
+                structuredIntentCheckFixtureNonFn(cx, arena, node.text, "struct", node.extra, node.start, node.end)
+                structuredIntentCheckStructMembers(cx, arena, node, fixtureNames)
+            },
+            AstNEnumDecl -> {
+                structuredIntentCheckPurposeAt(cx, arena, node.text, "enum", node.extra, node.start, node.end)
+                structuredIntentCheckFixtureNonFn(cx, arena, node.text, "enum", node.extra, node.start, node.end)
+                structuredIntentCheckEnumMembers(cx, arena, node, fixtureNames)
+            },
+            AstNInterfaceDecl -> {
+                structuredIntentCheckPurposeAt(cx, arena, node.text, "interface", node.extra, node.start, node.end)
+                structuredIntentCheckFixtureNonFn(cx, arena, node.text, "interface", node.extra, node.start, node.end)
+                structuredIntentCheckMethods(cx, arena, node, fixtureNames)
+            },
+            AstNTypeAlias -> {
+                structuredIntentCheckPurposeAt(cx, arena, node.text, "type alias", node.extra, node.start, node.end)
+                structuredIntentCheckFixtureNonFn(cx, arena, node.text, "type alias", node.extra, node.start, node.end)
+            },
+            AstNLetDecl -> {
+                structuredIntentCheckPurposeAt(cx, arena, node.text, "let", node.extra, node.start, node.end)
+                structuredIntentCheckFixtureNonFn(cx, arena, node.text, "let", node.extra, node.start, node.end)
+            },
             _ -> {},
         }
     }
@@ -2873,6 +2901,31 @@ fn structuredIntentCheckMethods(cx: ElabCx, arena: AstArena, parent: AstNode, fi
         let member = astArenaNodeAt(arena, memberIdx)
         if member.kind == AstNFnDecl {
             structuredIntentCheckFn(cx, arena, member, fixtureNames)
+        }
+    }
+}
+
+fn structuredIntentCheckStructMembers(cx: ElabCx, arena: AstArena, parent: AstNode, fixtureNames: List<String>) {
+    for memberIdx in parent.children {
+        let member = astArenaNodeAt(arena, memberIdx)
+        if member.kind == AstNFnDecl {
+            structuredIntentCheckFn(cx, arena, member, fixtureNames)
+        } else if member.kind == AstNField_ {
+            // `#[purpose]` is permitted on struct fields. `#[fixture]` is not.
+            structuredIntentCheckPurposeAt(cx, arena, member.text, "field", member.extra, member.start, member.end)
+            structuredIntentCheckFixtureNonFn(cx, arena, member.text, "field", member.extra, member.start, member.end)
+        }
+    }
+}
+
+fn structuredIntentCheckEnumMembers(cx: ElabCx, arena: AstArena, parent: AstNode, fixtureNames: List<String>) {
+    for memberIdx in parent.children {
+        let member = astArenaNodeAt(arena, memberIdx)
+        if member.kind == AstNFnDecl {
+            structuredIntentCheckFn(cx, arena, member, fixtureNames)
+        } else if member.kind == AstNVariant {
+            structuredIntentCheckPurposeAt(cx, arena, member.text, "enum variant", member.extra, member.start, member.end)
+            structuredIntentCheckFixtureNonFn(cx, arena, member.text, "enum variant", member.extra, member.start, member.end)
         }
     }
 }
@@ -2889,13 +2942,6 @@ fn collectFixtureNames(arena: AstArena) -> List<String> {
         }
         let fixtureAnnots = collectAnnotationByName(arena, node.extra, "fixture")
         for annot in fixtureAnnots {
-            // E0432: fixture functions must be zero-arity.
-            let paramCount = fnParamCountExcludingSelf(arena, node)
-            if paramCount > 0 {
-                // Note: this is emitted during collection so it fires
-                // regardless of whether the fixture is referenced.
-                // We skip emitting here and do it in structuredIntentCheckFn.
-            }
             // Extract fixture name from annotation args.
             let name = fixtureAnnotName(arena, annot)
             if name != "" {
@@ -2912,23 +2958,8 @@ fn collectFixtureNames(arena: AstArena) -> List<String> {
 fn fixtureAnnotName(arena: AstArena, annot: AstNode) -> String {
     for argIdx in annot.children {
         let arg = astArenaNodeAt(arena, argIdx)
-        let text = arg.text
-        // Look for `name = "..."` pattern.
-        if strings.hasPrefix(text, "name") {
-            let parts = strings.split(text, "=")
-            if parts.len() >= 2 {
-                let v: String = strings.trimSpace(parts[parts.len() - 1])
-                if v != "" {
-                    return v
-                }
-            }
-            // Check children for the value.
-            for valIdx in arg.children {
-                let val = astArenaNodeAt(arena, valIdx)
-                if val.text != "" {
-                    return val.text
-                }
-            }
+        if arg.kind == AstNField_ && arg.text == "name" {
+            return annotationStringLiteralValue(arena, arg.left)
         }
     }
     ""
@@ -2938,6 +2969,8 @@ fn structuredIntentCheckFn(cx: ElabCx, arena: AstArena, fnNode: AstNode, fixture
     if fnNode.extra < 0 {
         return
     }
+    // E0434: `#[purpose]` argument must be a plain string literal.
+    structuredIntentCheckPurposeAt(cx, arena, fnNode.text, "function", fnNode.extra, fnNode.start, fnNode.end)
     // E0432: check fixture arity.
     let fixtureAnnots = collectAnnotationByName(arena, fnNode.extra, "fixture")
     for _ in fixtureAnnots {
@@ -2948,44 +2981,118 @@ fn structuredIntentCheckFn(cx: ElabCx, arena: AstArena, fnNode: AstNode, fixture
             )
         }
     }
-    // E0431: check example arity.
-    // E0433: check example fixture references.
+    // E0431/E0433/E0435: check example arity, fixture references, unknown keys.
     let exampleAnnots = collectAnnotationByName(arena, fnNode.extra, "example")
     for annot in exampleAnnots {
         structuredIntentCheckExample(cx, arena, annot, fnNode, fixtureNames)
     }
 }
 
+fn structuredIntentCheckPurposeAt(cx: ElabCx, arena: AstArena, declName: String, _kind: String, annotIdx: Int, _start: Int, _end: Int) {
+    if annotIdx < 0 {
+        return
+    }
+    let purposeAnnots = collectAnnotationByName(arena, annotIdx, "purpose")
+    for annot in purposeAnnots {
+        structuredIntentValidatePurposeArgs(cx, arena, annot)
+    }
+}
+
+fn structuredIntentValidatePurposeArgs(cx: ElabCx, arena: AstArena, annot: AstNode) {
+    let argCount = annot.children.len()
+    if argCount == 0 {
+        cx.env.local.diagnostics.push(
+            diagPurposeNotStringLiteral("missing argument", annot.start, annot.end),
+        )
+        return
+    }
+    if argCount > 1 {
+        cx.env.local.diagnostics.push(
+            diagPurposeNotStringLiteral("expected exactly one argument, got {argCount}", annot.start, annot.end),
+        )
+        // Continue to validate the first argument too so users see both
+        // shape complaints if applicable.
+    }
+    let firstIdx = annot.children[0]
+    let arg = astArenaNodeAt(arena, firstIdx)
+    let issue = classifyPurposeArg(arg)
+    if issue != "" {
+        cx.env.local.diagnostics.push(
+            diagPurposeNotStringLiteral(issue, arg.start, arg.end),
+        )
+    }
+}
+
+/// classifyPurposeArg returns "" when `arg` is a plain non-interpolated
+/// string literal, or a short detail string describing why it is not.
+fn classifyPurposeArg(arg: AstNode) -> String {
+    if arg.kind == AstNField_ {
+        return "argument has `key = value` form; use a plain string literal"
+    }
+    if arg.kind != AstNStringLit {
+        return "argument is not a string literal"
+    }
+    // Parser preserves the surface verbatim — distinguish raw / triple-quoted /
+    // interpolated forms and reject them.
+    if strings.hasPrefix(arg.text, "r\"") {
+        return "raw string literals are not accepted"
+    }
+    if strings.hasPrefix(arg.text, "\"\"\"") {
+        return "triple-quoted strings are not accepted"
+    }
+    if arg.children.len() > 0 {
+        return "interpolated strings are not accepted"
+    }
+    if containsInterpolation(arg.text) {
+        return "interpolated strings are not accepted"
+    }
+    ""
+}
+
+fn structuredIntentCheckFixtureNonFn(cx: ElabCx, arena: AstArena, declName: String, kind: String, annotIdx: Int, start: Int, end: Int) {
+    if annotIdx < 0 {
+        return
+    }
+    let fixtureAnnots = collectAnnotationByName(arena, annotIdx, "fixture")
+    for annot in fixtureAnnots {
+        cx.env.local.diagnostics.push(
+            diagFixtureNonFunction(declName, kind, annot.start, annot.end),
+        )
+    }
+}
+
 fn structuredIntentCheckExample(cx: ElabCx, arena: AstArena, annot: AstNode, fnNode: AstNode, fixtureNames: List<String>) {
     let fnParamCount = fnParamCountExcludingSelf(arena, fnNode)
     let mut inputCount = 0
+    let mut sawInput = false
     let mut usesFixture = ""
     for argIdx in annot.children {
         let arg = astArenaNodeAt(arena, argIdx)
-        let text = arg.text
-        if strings.hasPrefix(text, "input") {
-            // Count input values. The parser stores list items as children.
-            inputCount = arg.children.len()
-            if inputCount == 0 {
-                // Single value case.
-                inputCount = 1
-            }
+        if arg.kind != AstNField_ {
+            // Bare ident or expression — skip; not part of the keyword
+            // catalog. Future revisions may reject these positionally.
+            continue
         }
-        if strings.hasPrefix(text, "uses") {
-            let parts = strings.split(text, "=")
-            if parts.len() >= 2 {
-                usesFixture = strings.trimSpace(parts[parts.len() - 1])
+        let key = arg.text
+        if key == "input" {
+            sawInput = true
+            inputCount = exampleInputArity(arena, arg.left)
+        } else if key == "output" {
+            // No structural validation here yet — runtime example execution
+            // is follow-up. Presence of the key is enough.
+        } else if key == "uses" {
+            let name = annotationStringLiteralValue(arena, arg.left)
+            if name != "" {
+                usesFixture = name
             }
-            for valIdx in arg.children {
-                let val = astArenaNodeAt(arena, valIdx)
-                if val.text != "" {
-                    usesFixture = val.text
-                }
-            }
+        } else {
+            cx.env.local.diagnostics.push(
+                diagExampleUnknownKey(fnNode.text, key, arg.start, arg.end),
+            )
         }
     }
-    // E0431: arity mismatch.
-    if inputCount > 0 && fnParamCount > 0 && inputCount != fnParamCount {
+    // E0431: arity mismatch (only fires when an `input` key was provided).
+    if sawInput && fnParamCount >= 0 && inputCount != fnParamCount {
         cx.env.local.diagnostics.push(
             diagExampleArityMismatch(fnNode.text, fnParamCount, inputCount, annot.start, annot.end),
         )
@@ -2996,6 +3103,52 @@ fn structuredIntentCheckExample(cx: ElabCx, arena: AstArena, annot: AstNode, fnN
             diagExampleUnknownFixture(fnNode.text, usesFixture, annot.start, annot.end),
         )
     }
+}
+
+/// exampleInputArity counts the positional arguments in an `#[example]`
+/// `input` value. A list literal contributes its element count; any other
+/// expression (single value short-form) contributes one.
+fn exampleInputArity(arena: AstArena, valueIdx: Int) -> Int {
+    if valueIdx < 0 {
+        return 0
+    }
+    let v = astArenaNodeAt(arena, valueIdx)
+    if v.kind == AstNList {
+        return v.children.len()
+    }
+    1
+}
+
+/// annotationStringLiteralValue returns the unquoted string for a plain
+/// string literal expression, or "" when the expression is not a plain
+/// string. Interpolated / raw / triple-quoted forms return "" so callers
+/// can fall back to error reporting.
+fn annotationStringLiteralValue(arena: AstArena, valueIdx: Int) -> String {
+    if valueIdx < 0 {
+        return ""
+    }
+    let v = astArenaNodeAt(arena, valueIdx)
+    if v.kind != AstNStringLit {
+        return ""
+    }
+    if v.children.len() > 0 {
+        return ""
+    }
+    let raw = v.text
+    if strings.hasPrefix(raw, "r\"") {
+        return ""
+    }
+    if strings.hasPrefix(raw, "\"\"\"") {
+        return ""
+    }
+    let n = raw.len()
+    if n < 2 {
+        return raw
+    }
+    if strings.hasPrefix(raw, "\"") && strings.hasSuffix(raw, "\"") {
+        return strings.slice(raw, 1, n - 1)
+    }
+    raw
 }
 
 fn fnParamCountExcludingSelf(arena: AstArena, fnNode: AstNode) -> Int {

--- a/toolchain/diag_manifest.osty
+++ b/toolchain/diag_manifest.osty
@@ -183,6 +183,9 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
     if code == "E0431" { return FamilyAnnotation }
     if code == "E0432" { return FamilyAnnotation }
     if code == "E0433" { return FamilyAnnotation }
+    if code == "E0434" { return FamilyAnnotation }
+    if code == "E0435" { return FamilyAnnotation }
+    if code == "E0436" { return FamilyAnnotation }
     // G45 — Golden tests (§11.5)
     if code == "E0444" { return FamilyAnnotation }
     if code == "E0445" { return FamilyAnnotation }


### PR DESCRIPTION
## Summary

Phase 2 (G42, LANG_SPEC_v0.6 §3.12) entry — three new structured-intent semantic gates land in the front-end:

- **E0434** `CodePurposeNotStringLiteral` — `#[purpose]` accepts exactly one plain string literal. Interpolated, raw, triple-quoted, expression, and `key = value` arguments are rejected with a structured detail.
- **E0435** `CodeExampleUnknownKey` — `#[example]` keys are restricted to `{input, output, uses}`. Unknown keys (e.g. `tags`) fire per-arg.
- **E0436** `CodeFixtureNonFunction` — `#[fixture]` only on function declarations. Struct / enum / interface / variant / field / type alias / let positions are rejected at the annotation span.

The existing `E0431` (input arity), `E0432` (zero-arity fixture), and `E0433` (unknown fixture) gates were inert (helper bugs + counted `AstNField_.children`). They are rewired so they actually fire on real input and now run on struct fields, enum variants, type aliases, and top-level lets in addition to fn / method targets.

## Implementation

- **Authoritative**: `toolchain/check_gates.osty::runStructuredIntentGate` (Osty-first per CLAUDE.md). New helpers: `classifyPurposeArg`, `exampleInputArity`, `annotationStringLiteralValue`, `structuredIntentCheckPurposeAt`, `structuredIntentCheckFixtureNonFn`.
- **Go mirror**: `internal/selfhost/generated.go` gains the corresponding Go body and is wired into `runCheckGates` so the bootstrapped Go-side checker emits the same diagnostics until the next LLVM seed regen (mirrors the precedent set by `feat(check): activate v0.6 ambient gate` 5d91dd1).
- **Diag helpers**: `diagPurposeNotStringLiteral` / `diagExampleUnknownKey` / `diagFixtureNonFunction` in `toolchain/check_diag.osty` + Go-side mirrors. Codes registered in `internal/diag/codes.go`; `ERROR_CODES.md` and `toolchain/diag_manifest.osty` regenerated via `go generate`.

## Spec / corpus

- `LANG_SPEC_v0.6/03-declarations.md` §3.12.1 / §3.12.2 / §3.12.3 reference the new codes (E0434 replaces the previously-listed E0431 for `#[purpose]` non-literal — the existing E0431 reservation in `codes.go` is for input arity).
- `LANG_SPEC_v0.6/00-revision.md` §3.12.5 + Error Code Allocations table extended with E0434–E0436.
- `testdata/spec/positive/16-v06-spec-intent.osty` rewritten to use the v0.6 surface (zero-arity fixture function plus example referencing it).
- `testdata/spec/negative/reject.osty` gains E0434 / E0435 / E0436 CASE blocks; all three pass via `pipeline.Run`.
- `internal/selfhost/structured_intent_gate_test.go` covers six axes (valid forms, interpolated purpose, non-literal purpose, unknown example key, fixture-on-struct/enum, preservation of existing E0431/E0432/E0433).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/diag ./internal/check ./internal/lexer ./internal/parser ./internal/resolve ./internal/format ./internal/lint ./internal/pipeline ./internal/speccorpus`
- [x] `go test ./internal/selfhost -run "TestStructuredIntent|TestAmbient|TestReproducibleCapability|TestCheckSourceStructured"`
- [x] Pre-existing failures `TestParseMatchArmAllowsBareAssignmentBody` and `TestParseSnapshot/word_freq` confirmed unrelated to this PR (verified by stashing changes and observing identical baseline failures).

## Phase 2 follow-ups (out of scope)

- Runtime `osty test --example` execution and `E0430` (output mismatch).
- `osty context <fn>` JSON output (G47).
- Resolver allow-list expansion so `#[purpose]` can target struct fields / enum variants (currently rejected by E0607).

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_