### PR TITLE
feat(stage0): OSTY_STAGE0_LIST_ALL_DECLINES env var for one-pass survey

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -3,6 +3,7 @@ package stage0
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/osty/osty/internal/ir"
@@ -15,6 +16,49 @@ import (
 // rather than a hard build failure — the dispatcher then surfaces the
 // usual unsupported skeleton diagnostic with route `stage0`.
 var ErrUnsupported = errors.New("stage0: MIR shape outside bootstrap subset")
+
+// ListAllDeclinesEnv opts EmitMIR into surveying all declined functions
+// in one pass instead of stopping at the first.
+//
+// Default behaviour: emit functions in order; on the first decline
+// return the (single) wrapped ErrUnsupported. Each `osty install-self`
+// iteration therefore reveals one blocking site at a time, costing a
+// fresh ~10–15 min toolchain build to learn the next.
+//
+// With `OSTY_STAGE0_LIST_ALL_DECLINES=1`: continue past declines,
+// collect every function name + reason, and return a single
+// ErrUnsupported-wrapping error that lists them all. The full picture
+// arrives in one build; consumers can plan multi-PR unblock waves
+// instead of serializing them.
+//
+// The env var is read once per EmitMIR call. No effect on production
+// builds (stage0 is only consulted under OSTY_STAGE0_FALLBACK=1 in the
+// first place — see internal/backend/bootstrap.go).
+const ListAllDeclinesEnv = "OSTY_STAGE0_LIST_ALL_DECLINES"
+
+func listAllDeclinesEnabled() bool {
+	switch strings.TrimSpace(os.Getenv(ListAllDeclinesEnv)) {
+	case "1", "true", "TRUE", "True", "on", "ON", "On", "yes", "YES", "Yes":
+		return true
+	}
+	return false
+}
+
+// declineReason renders the per-function decline explanation that
+// `emitFunction` produced, stripped of the common ErrUnsupported prefix
+// so the aggregated diagnostic stays readable. Inputs that are not
+// `ErrUnsupported`-shaped fall through to their plain Error() text.
+func declineReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	prefix := ErrUnsupported.Error() + ": "
+	if strings.HasPrefix(msg, prefix) {
+		return msg[len(prefix):]
+	}
+	return msg
+}
 
 // EmitMIR lowers `module` to textual LLVM IR for the small MVP subset
 // stage0 currently covers. It is invoked only when
@@ -89,18 +133,35 @@ func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 		mctx.extraDecls.WriteString("declare i32 @fprintf(ptr, ptr, ...)\n")
 	}
 
+	listAll := listAllDeclinesEnabled()
+
 	var fnBodies strings.Builder
 	emittedMain := false
+	var declines []string // function names that declined when listAll is on
 	for _, fn := range module.Functions {
 		if fn == nil {
 			continue
 		}
-		if err := emitFunction(&fnBodies, fn, mctx); err != nil {
-			return nil, err
+		// Trial-emit into a scratch buffer so a decline doesn't leave
+		// half-emitted IR in `fnBodies`.
+		var probe strings.Builder
+		err := emitFunction(&probe, fn, mctx)
+		if err != nil {
+			if !listAll {
+				return nil, err
+			}
+			declines = append(declines, fmt.Sprintf("%s: %s", fn.Name, declineReason(err)))
+			continue
 		}
+		fnBodies.WriteString(probe.String())
 		if fn.Name == "main" {
 			emittedMain = true
 		}
+	}
+	if listAll && len(declines) > 0 {
+		// Return a single aggregated error so the dispatcher's warning
+		// chain shows every blocking site in one build round-trip.
+		return nil, fmt.Errorf("%w: %d function(s) declined: %s", ErrUnsupported, len(declines), strings.Join(declines, "; "))
 	}
 	if !emittedMain {
 		return nil, fmt.Errorf("%w: module has no `main` function", ErrUnsupported)

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -5820,3 +5820,93 @@ func TestStage0RejectsWhileLoopExitNotReturning(t *testing.T) {
 	fn.Blocks[3].Term = &mir.GotoTerm{Target: 0}
 	mustReject(t, trivialMainFn(), fn)
 }
+
+// ---- OSTY_STAGE0_LIST_ALL_DECLINES env var ----
+//
+// Build a module with main + N declined functions. Default mode bails
+// on the first decline (so only one name appears in the error). With
+// the env var set, EmitMIR continues past each decline and the
+// returned error names every blocking function in one pass — letting
+// install-self iterations plan multi-PR unblock waves instead of one
+// fail-and-fix-and-rebuild cycle per function.
+
+// undecidableFn returns a function that no stage0 matcher will accept,
+// because its single block contains an instruction kind nothing
+// classifies. The Name is what the aggregated diagnostic should list.
+func undecidableFn(name string) *mir.Function {
+	return &mir.Function{
+		Name:        name,
+		ReturnType:  ir.TInt,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{{
+			ID: 0,
+			// Self-referential GotoTerm so the block neither returns
+			// nor terminates legally — every matcher's terminator
+			// shape check fails.
+			Instrs: []mir.Instr{},
+			Term:   &mir.GotoTerm{Target: 0},
+		}},
+	}
+}
+
+func TestStage0DefaultStopsAtFirstDecline(t *testing.T) {
+	// Cannot use t.Parallel — we touch the env var.
+	t.Setenv(ListAllDeclinesEnv, "")
+
+	module := moduleWith(trivialMainFn(), undecidableFn("first"), undecidableFn("second"))
+	_, err := EmitMIR(module, llvmabi.Options{PackageName: "main"})
+	if err == nil {
+		t.Fatal("expected error for declined functions")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+	// Default mode reports exactly one function — whichever was reached
+	// first. The aggregated multi-name diagnostic must NOT appear.
+	msg := err.Error()
+	if strings.Contains(msg, " function(s) declined:") {
+		t.Fatalf("default mode unexpectedly aggregated declines:\n%s", msg)
+	}
+}
+
+func TestStage0ListAllDeclinesAggregatesAcrossModule(t *testing.T) {
+	// Cannot use t.Parallel — we touch the env var.
+	t.Setenv(ListAllDeclinesEnv, "1")
+
+	module := moduleWith(trivialMainFn(), undecidableFn("alpha"), undecidableFn("beta"), undecidableFn("gamma"))
+	_, err := EmitMIR(module, llvmabi.Options{PackageName: "main"})
+	if err == nil {
+		t.Fatal("expected aggregated error")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"3 function(s) declined:",
+		"alpha:",
+		"beta:",
+		"gamma:",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("aggregated diagnostic missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestStage0ListAllDeclinesSkipsAggregationOnCleanModule(t *testing.T) {
+	// Cannot use t.Parallel — we touch the env var.
+	t.Setenv(ListAllDeclinesEnv, "1")
+
+	got, err := EmitMIR(moduleWith(trivialMainFn()), llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIR with no declines: %v", err)
+	}
+	if !strings.Contains(string(got), "define i32 @main()") {
+		t.Fatalf("expected normal main emission with env var on:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Default `stage0.EmitMIR` bails on the first declined function. Each `osty install-self` iteration therefore reveals one blocker at a time, costing a fresh ~10–15 min toolchain build per learn-the-next-name cycle. With #1561, #1563 we've established the pattern of \"unblock site → rebuild → see next\"; this PR collapses that into one round-trip.

`OSTY_STAGE0_LIST_ALL_DECLINES=1` switches `EmitMIR` to a survey mode: continue past each decline, accumulate `(fn name, reason)` pairs, return a single aggregated `ErrUnsupported`-wrapping error listing every blocked function in the module. Plan-side, one build populates the whole next-N-PRs backlog instead of a sequential chase.

## Changes

- `internal/backend/stage0/emit.go`
  - Add `ListAllDeclinesEnv` const + `listAllDeclinesEnabled()` reader.
  - `EmitMIR` trial-emits each function into a scratch buffer so a decline cannot leave half-baked IR in the module body. Default mode propagates the first error unchanged (no behaviour drift). Aggregated mode joins reasons with `; ` and prefixes a count.
  - `declineReason()` strips the common `stage0: MIR shape outside bootstrap subset:` prefix from per-function errors so the joined output stays readable.

- `internal/backend/stage0/emit_test.go`
  - `TestStage0DefaultStopsAtFirstDecline` — env unset; aggregated diagnostic must NOT appear.
  - `TestStage0ListAllDeclinesAggregatesAcrossModule` — three undecidable function bodies; final error must name all three plus `3 function(s) declined:` summary.
  - `TestStage0ListAllDeclinesSkipsAggregationOnCleanModule` — env set with no declines must still emit normal output.

## Compatibility

- No production-build effect. Stage0 only runs under `OSTY_STAGE0_FALLBACK=1` (`internal/backend/bootstrap.go`); this new env var is purely diagnostic and additive on top.
- Default behaviour preserved exactly — no test churn outside the three new ones.

## Test plan

- [x] `go test ./internal/backend/stage0` passes (1.4s)
- [x] Three new tests pass
- [x] No regressions in stage0 dispatch tests

## Follow-up

The aggregated output enables planning the master plan B2.4–B2.10+ unblock waves in one shot. Recommend running `OSTY_STAGE0_FALLBACK=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 osty build toolchain/` after this lands to populate the next-PR backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)