### PR TITLE
fix(test): align reject snapshot with v0.5 baseline (post-rollback)

### DIFF
--- a/internal/selfhost/testdata/parse_snapshots/testdata_spec_negative_reject.txt
+++ b/internal/selfhost/testdata/parse_snapshots/testdata_spec_negative_reject.txt
@@ -39,5 +39,5 @@ error E0600 "`break` outside of loop" ^[132:16-132:17] hint="move inside a `for`
 error E0601 "`continue` outside of loop" ^[136:19-136:20] hint="move inside a `for` loop"
 error E0607 "annotation on the wrong kind of declaration" ^[163:1-163:4] hint="annotations are not permitted on `use` statements"
 error E0608 "`defer` is not allowed at the top level of a script" ^[168:1-168:6] hint="move this `defer` inside a function body — it binds to the enclosing function's return"
-error E0202 "`as?` must be written without whitespace between `as` and `?`" ^[260:9-260:11] hint="write `as?` as a single token (no space)" note="OSTY_GRAMMAR_v0.6 §28"
+error E0202 "`as?` must be written without whitespace between `as` and `?`" ^[260:9-260:11] hint="write `as?` as a single token (no space)" note="OSTY_GRAMMAR_v0.5 §28"
 error E0004 "unterminated block comment" ^[375:1-376:1]


### PR DESCRIPTION
## Summary

PR #1572 rollback 후 stale snapshot 1줄 정렬.

`toolchain/parser.osty:1546` + `internal/selfhost/generated.go:21408` 둘 다 `OSTY_GRAMMAR_v0.5 §28` note 사용. `testdata_spec_negative_reject.txt:42` 만 `v0.6` 잔존 → `v0.5` 로 변경.

## Test plan

- [x] `go build ./...` clean
- [x] grep 으로 v0.6 reference 0 hits 확인
- [ ] CI

https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_