### PR TITLE
feat: add syntheticXReturns field to genericCFGPattern

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -12256,6 +12256,7 @@ type genericCFGPattern struct {
 	syntheticStringCoalesces  map[mir.BlockID]mir.LocalID
 	syntheticIntrinsicReturns map[mir.BlockID]*mir.IntrinsicInstr
 	syntheticCallReturns      map[mir.BlockID]*mir.CallInstr
+	syntheticXReturns        map[mir.BlockID]scalarType
 }
 
 func matchGenericScalarCFG(fn *mir.Function, mctx *moduleCtx) (genericCFGPattern, bool) {


### PR DESCRIPTION
블록 ID → 회복 payload 타입 매핑. 매처가 emit 단계에 정보 전달.