### PR TITLE
feat(backend): add emit functions for Option payload return

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -13615,6 +13615,109 @@ func genericStorageOnlyUnreachableExit(fn *mir.Function) (*mir.BasicBlock, bool)
 	return exit, exit != nil
 }
 
+type PayloadType struct {
+	LocalID    mir.LocalID
+	CallInstr  *mir.CallInstr
+	Instr      *mir.IntrinsicInstr
+	Kind       payloadKind
+}
+
+type payloadKind int
+
+const (
+	payloadNone payloadKind = iota
+	payloadLocal
+	payloadCall
+	payloadIntrinsic
+)
+
+func isRecoverableReturnShape(fn *mir.Function) bool {
+	if fn == nil {
+		return false
+	}
+	if fn.ReturnType == nil {
+		return false
+	}
+	switch fn.ReturnType.(type) {
+	case *ir.NamedType:
+		return true
+	default:
+		return false
+	}
+}
+
+func genericInferXSyntheticReturn(fn *mir.Function, mctx *moduleCtx, retType scalarType) (mir.BlockID, PayloadType, bool) {
+	if fn == nil || mctx == nil {
+		return 0, PayloadType{}, false
+	}
+	if !isRecoverableReturnShape(fn) {
+		return 0, PayloadType{}, false
+	}
+	exit, ok := genericStorageOnlyUnreachableExit(fn)
+	if !ok {
+		return 0, PayloadType{}, false
+	}
+	candidates := map[mir.LocalID]bool{}
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		if _, unreachable := bb.Term.(*mir.UnreachableTerm); unreachable {
+			continue
+		}
+		for _, instr := range bb.Instrs {
+			ai, ok := instr.(*mir.AssignInstr)
+			if !ok || ai.Dest.HasProjections() {
+				continue
+			}
+			loc := lookupLocal(fn, ai.Dest.Local)
+			if loc == nil || !sameTypeString(loc.Type, fn.ReturnType) {
+				continue
+			}
+			if ai.Src != nil {
+				candidates[ai.Dest.Local] = true
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return 0, PayloadType{}, false
+	}
+	var selected mir.LocalID
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		if _, unreachable := bb.Term.(*mir.UnreachableTerm); unreachable {
+			continue
+		}
+		for _, instr := range bb.Instrs {
+			switch step := instr.(type) {
+			case *mir.AssignInstr:
+				if step.Dest.HasProjections() {
+					continue
+				}
+				if candidates[step.Dest.Local] {
+					if selected != 0 && selected != step.Dest.Local {
+						return 0, PayloadType{}, false
+					}
+					selected = step.Dest.Local
+				}
+			case *mir.CallInstr:
+				if step.Dest != nil && !step.Dest.HasProjections() && candidates[step.Dest.Local] {
+					if selected != 0 && selected != step.Dest.Local {
+						return 0, PayloadType{}, false
+					}
+					selected = step.Dest.Local
+				}
+			}
+		}
+	}
+	if selected == 0 {
+		return 0, PayloadType{}, false
+	}
+	return exit.ID, PayloadType{LocalID: selected, Kind: payloadLocal}, true
+}
+
 func isNamedListType(t mir.Type) bool {
 	named, ok := t.(*ir.NamedType)
 	return ok && named != nil && named.Name == "List"

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -13191,6 +13191,86 @@ func emitSyntheticStringCoalesceReturn(ctx *whileLoopEmitCtx, out *strings.Build
 	return true
 }
 
+func emitSyntheticXReturn(
+	ctx *whileLoopEmitCtx, out *strings.Builder, payload mir.LocalID, retType scalarType,
+) bool {
+	if ctx == nil || out == nil || ctx.fn == nil || ctx.mctx == nil {
+		return false
+	}
+	if retType == scalarUnknown {
+		return false
+	}
+	loc := lookupLocal(ctx.fn, payload)
+	if loc == nil {
+		return false
+	}
+	payloadTy, ok := optionPayloadScalar(loc.Type, ctx.mctx)
+	if !ok || payloadTy != retType {
+		return false
+	}
+	typeName, ok := ctx.mctx.emitOptionBoxDef(payloadTy)
+	if !ok {
+		return false
+	}
+	binding, ok := ctx.bindings[payload]
+	if !ok || !binding.defined || binding.ty != scalarOpaquePtr {
+		return false
+	}
+	optExpr := binding.expr
+	if binding.isStack {
+		loaded, ty, ok := loadFromStack(ctx, out, payload)
+		if !ok || ty != scalarOpaquePtr {
+			return false
+		}
+		optExpr = loaded
+	}
+	payloadSlot := freshReg(ctx)
+	payloadReg := freshReg(ctx)
+	fmt.Fprintf(out, "  %s = getelementptr inbounds %%%s, ptr %s, i32 0, i32 1\n", payloadSlot, typeName, optExpr)
+	fmt.Fprintf(out, "  %s = load %s, ptr %s\n", payloadReg, payloadTy.llvm(), payloadSlot)
+	fmt.Fprintf(out, "  ret %s %s\n", payloadTy.llvm(), payloadReg)
+	return true
+}
+
+func emitXAsReturn(ctx *whileLoopEmitCtx, out *strings.Builder, payload mir.LocalID, retType scalarType) bool {
+	if ctx == nil || out == nil {
+		return false
+	}
+	if retType == scalarUnknown {
+		return false
+	}
+	loc := lookupLocal(ctx.fn, payload)
+	if loc == nil {
+		return false
+	}
+	payloadTy, ok := optionPayloadScalar(loc.Type, ctx.mctx)
+	if !ok || payloadTy != retType {
+		return false
+	}
+	typeName, ok := ctx.mctx.emitOptionBoxDef(payloadTy)
+	if !ok {
+		return false
+	}
+	binding, ok := ctx.bindings[payload]
+	if !ok || !binding.defined || binding.ty != scalarOpaquePtr {
+		return false
+	}
+	optExpr := binding.expr
+	if binding.isStack {
+		loaded, ty, ok := loadFromStack(ctx, out, payload)
+		if !ok || ty != scalarOpaquePtr {
+			return false
+		}
+		optExpr = loaded
+	}
+	payloadSlot := freshReg(ctx)
+	payloadReg := freshReg(ctx)
+	fmt.Fprintf(out, "  %s = getelementptr inbounds %%%s, ptr %s, i32 0, i32 1\n", payloadSlot, typeName, optExpr)
+	fmt.Fprintf(out, "  %s = load %s, ptr %s\n", payloadReg, payloadTy.llvm(), payloadSlot)
+	fmt.Fprintf(out, "  ret %s %s\n", payloadTy.llvm(), payloadReg)
+	return true
+}
+
 func isStorageInstr(instr mir.Instr) bool {
 	switch instr.(type) {
 	case *mir.StorageLiveInstr, *mir.StorageDeadInstr:


### PR DESCRIPTION
## Summary

Option 타입 payload 반환을 위한 LLVM IR 방출 헬퍼 함수 추가.

## Changes

- `emitSyntheticXReturn` 함수 추가: Option payload를 추출하여 반환하는 LLVM IR 명령어 생성
- `emitXAsReturn` 함수 추가: x-return 시나리오를 위한 동일한 기능의_variant

두 함수 모두 Option 타입 바인딩을 검증하고, payload 스칼라 타입을 추출한 후 getelementptr/load/ret 명령어를 생성합니다.

## Test

```bash
go build ./internal/backend/stage0/... && go test ./internal/backend/stage0/... -count=1 -short
```