### PR TITLE
fix(stage0): extract discriminant from payloadful enums

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -8743,6 +8743,25 @@ func emitWhileDiscriminantRValue(ctx *whileLoopEmitCtx, out *strings.Builder, di
 	if placeTy == nil {
 		return "", scalarUnknown, false
 	}
+	if named, ok := placeTy.(*ir.NamedType); ok && named != nil {
+		if layout := ctx.mctx.module.Layouts.Enums[named.Name]; layout != nil && !enumLayoutIsPayloadless(layout) && len(layout.Variants) > 0 {
+			expr, ty, ok := resolveOperandWithLoad(ctx, out, &mir.CopyOp{Place: discr.Place, T: placeTy})
+			if !ok {
+				return "", scalarUnknown, false
+			}
+			if ty == scalarOpaquePtr {
+				tagSlot := freshReg(ctx)
+				tag := freshReg(ctx)
+				fmt.Fprintf(out, "  %s = getelementptr i64, ptr %s, i64 0\n", tagSlot, expr)
+				fmt.Fprintf(out, "  %s = load i64, ptr %s\n", tag, tagSlot)
+				return tag, scalarInt, true
+			}
+			if ty == scalarInt {
+				return expr, scalarInt, true
+			}
+			return "", scalarUnknown, false
+		}
+	}
 	if payloadTy, ok := optionPayloadScalar(placeTy, ctx.mctx); ok {
 		typeName, ok := ctx.mctx.emitOptionBoxDef(payloadTy)
 		if !ok {
@@ -8918,6 +8937,12 @@ func resultPayloadScalars(t mir.Type, mctx *moduleCtx) (scalarType, scalarType, 
 	}
 	okTy := mctx.scalarFromType(named.Args[0], true)
 	errTy := mctx.scalarFromType(named.Args[1], true)
+	if okTy == scalarUnknown && isUnitType(named.Args[0]) {
+		okTy = scalarInt
+	}
+	if errTy == scalarUnknown && isUnitType(named.Args[1]) {
+		errTy = scalarInt
+	}
 	if okTy == scalarUnknown || errTy == scalarUnknown {
 		return scalarUnknown, scalarUnknown, false
 	}
@@ -8978,7 +9003,7 @@ func emitWhileOptionAggregateRValue(ctx *whileLoopEmitCtx, out *strings.Builder,
 }
 
 func emitWhileResultAggregateRValue(ctx *whileLoopEmitCtx, out *strings.Builder, agg *mir.AggregateRV) (string, scalarType, bool) {
-	if ctx == nil || ctx.mctx == nil || agg == nil || agg.Kind != mir.AggEnumVariant {
+	if ctx == nil || ctx.mctx == nil || agg == nil {
 		return "", scalarUnknown, false
 	}
 	payloadTy, okTy, errTy, payloadIndex, ok := resultVariantPayloadScalar(agg.T, agg.VariantIdx, ctx.mctx)
@@ -8986,6 +9011,13 @@ func emitWhileResultAggregateRValue(ctx *whileLoopEmitCtx, out *strings.Builder,
 		return "", scalarUnknown, false
 	}
 	if len(agg.Fields) != 1 {
+		return "", scalarUnknown, false
+	}
+	isUnitPayload := len(agg.Fields) == 1 && isUnitOperand(agg.Fields[0])
+	if payloadTy == scalarUnknown && isUnitPayload {
+		payloadTy = scalarInt
+	}
+	if payloadTy == scalarUnknown {
 		return "", scalarUnknown, false
 	}
 	typeName, ok := ctx.mctx.emitResultBoxDef(okTy, errTy)
@@ -9002,12 +9034,20 @@ func emitWhileResultAggregateRValue(ctx *whileLoopEmitCtx, out *strings.Builder,
 	tagSlot := ctx.mctx.freshTempName("result.tag.slot")
 	fmt.Fprintf(out, "  %s = getelementptr inbounds %%%s, ptr %s, i32 0, i32 0\n", tagSlot, typeName, obj)
 	fmt.Fprintf(out, "  store i64 %d, ptr %s\n", agg.VariantIdx, tagSlot)
+	payloadSlot := ctx.mctx.freshTempName("result.payload.slot")
+	fmt.Fprintf(out, "  %s = getelementptr inbounds %%%s, ptr %s, i32 0, i32 %d\n", payloadSlot, typeName, obj, payloadIndex)
+	if isUnitPayload {
+		zero, ok := payloadTy.zeroValue()
+		if !ok {
+			return "", scalarUnknown, false
+		}
+		fmt.Fprintf(out, "  store %s %s, ptr %s\n", payloadTy.llvm(), zero, payloadSlot)
+		return obj, scalarOpaquePtr, true
+	}
 	expr, ty, ok := resolveOperandWithLoad(ctx, out, agg.Fields[0])
 	if !ok || ty != payloadTy {
 		return "", scalarUnknown, false
 	}
-	payloadSlot := ctx.mctx.freshTempName("result.payload.slot")
-	fmt.Fprintf(out, "  %s = getelementptr inbounds %%%s, ptr %s, i32 0, i32 %d\n", payloadSlot, typeName, obj, payloadIndex)
 	fmt.Fprintf(out, "  store %s %s, ptr %s\n", payloadTy.llvm(), expr, payloadSlot)
 	return obj, scalarOpaquePtr, true
 }

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -6420,6 +6420,61 @@ func TestStage0GenericCFGResultAggregateDiscriminantAndProjection(t *testing.T) 
 	}
 }
 
+func TestStage0DiscriminantPayloadfulEnumUsesTagSlot(t *testing.T) {
+	t.Parallel()
+	payloadfulKind := &ir.NamedType{Name: "PayloadfulKind"}
+	fn := &mir.Function{
+		Name:        "payloadfulDiscriminant",
+		ReturnType:  ir.TInt,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+			{ID: 1, Name: "kind", Type: payloadfulKind},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{{
+			ID: 0,
+			Instrs: []mir.Instr{
+				assign(1, &mir.AggregateRV{
+					Kind:       mir.AggEnumVariant,
+					VariantIdx: 1,
+					Fields:     []mir.Operand{stringConst("payload")},
+					T:          payloadfulKind,
+				}),
+				assign(0, &mir.DiscriminantRV{
+					Place: mir.Place{Local: 1},
+					T:     ir.TInt,
+				}),
+			},
+			Term: &mir.ReturnTerm{},
+		}},
+	}
+	module := moduleWith(trivialMainFn(), fn)
+	module.Layouts.Enums["PayloadfulKind"] = &mir.EnumLayout{
+		Name: "PayloadfulKind",
+		Variants: []mir.VariantLayout{
+			{Index: 0, Name: "Plain", Payload: []mir.FieldLayout{{Index: 0, Name: "v", Type: ir.TInt}}},
+			{Index: 1, Name: "Tagged", Payload: []mir.FieldLayout{{Index: 0, Name: "v", Type: ir.TString}}},
+		},
+	}
+	gotBytes, err := EmitMIR(module, llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIR: %v", err)
+	}
+	got := string(gotBytes)
+	for _, want := range []string{
+		"%stage0.Enum.PayloadfulKind.1 = type { i64, ptr }",
+		"store i64 1, ptr",
+		"getelementptr i64, ptr %",
+		"load i64, ptr",
+		"ret i64 %",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestStage0GenericCFGCallStoresIntoListIndex(t *testing.T) {
 	t.Parallel()
 	listString := &ir.NamedType{Name: "List", Builtin: true, Args: []ir.Type{ir.TString}}


### PR DESCRIPTION
## Why
- `discriminant` on payloadful named enums (e.g. `TomlKind`) was not supported in while-loop lowering.
- This blocked a small remaining subset in the stage0 audit.

## What changed
- Added a payloadful enum discriminant path in `emitWhileDiscriminantRValue` that loads the tag from the first i64 field.
- Kept existing `Option`/`Result`/payloadless enum behavior intact.
- Added a focused regression test: `TestStage0DiscriminantPayloadfulEnumUsesTagSlot`.

## Validation
- `go test -count=1 -vet=off ./internal/backend/stage0`
- `OSTY_STAGE0_AUDIT=1 go test -count=1 -vet=off ./internal/backend -run TestStage0ToolchainAudit -v`
- Audit result: 7544 / 7582 (99.5%)
