### PR TITLE
fix(stage0): prevent scalar matchers from stealing aggregate return functions

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -489,6 +489,8 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	if fn.Name == "main" {
 		return emitTrivialMain(out, fn, mctx)
 	}
+	// Match attempts
+
 	if pat, ok := matchStructFieldRead(fn, mctx); ok {
 		return emitStructFieldRead(out, fn, pat)
 	}
@@ -1365,6 +1367,13 @@ type sequentialPattern struct {
 // stage0 cannot declare).
 func matchSequentialReturn(fn *mir.Function, mctx *moduleCtx) (sequentialPattern, bool) {
 	pat := sequentialPattern{}
+
+	// Reject aggregate return types — these belong to P21/matchDirectAggregateCall
+	// or the if-else aggregate matchers.
+	if _, _, ok := classifyAggregateReturnType(fn.ReturnType, mctx); ok {
+		return pat, false
+	}
+
 	pat.retType = mctx.scalarFromType(fn.ReturnType, true)
 	if pat.retType == scalarUnknown {
 		return pat, false
@@ -4410,6 +4419,12 @@ type scalarReturnArm struct {
 
 func matchScalarReturnChain(fn *mir.Function, mctx *moduleCtx) (scalarReturnChainPattern, bool) {
 	pat := scalarReturnChainPattern{}
+
+	// Reject aggregate return types.
+	if _, _, ok := classifyAggregateReturnType(fn.ReturnType, mctx); ok {
+		return pat, false
+	}
+
 	pat.retType = mctx.scalarFromType(fn.ReturnType, true)
 	if pat.retType == scalarUnknown {
 		return pat, false


### PR DESCRIPTION
## Summary

Fix P21 struct-return tests that were failing since #1571.

**Root cause**: `matchSequentialReturn` and `matchScalarReturnChain` use `scalarFromType(fn.ReturnType, true)` which maps *all* `NamedType` values (including user structs like `R`) to `scalarOpaquePtr`. This caused aggregate-return functions (e.g. `fn wrap(a: String) -> R { innerFn(a) }`) to be incorrectly matched as scalar-return before `matchDirectAggregateCall` (P21) could see them.

**Fix**: Add `classifyAggregateReturnType` guard to both `matchSequentialReturn` and `matchScalarReturnChain` so they decline aggregate-return functions, letting P21 and other aggregate matchers handle them correctly.

**Before**: `define ptr @wrap(ptr %a)` (wrong — scalar ptr return)  
**After**: `define %R @wrap(ptr %a)` (correct — aggregate struct return)

## Test
- All 5 P21 tests now pass (was 1/5)
- No regressions in other stage0 tests
- Audit coverage unchanged at 99.4%