### PR TITLE
fix(stage0): emit early-exit body + populate intrinsic call resultType

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -2218,6 +2218,15 @@ func classifyIntrinsicValueStep(fn *mir.Function, ii *mir.IntrinsicInstr, bindin
 		prelude:    prelude.String(),
 		callSymbol: spec.symbol,
 		callArgs:   args,
+		// `resultType` is required: emitPendingInstr renders the call as
+		// `%reg = call <resultType.llvm()> @<symbol>(...)`. Leaving it
+		// zero (`scalarUnknown`) emits `call  @symbol(…)` with two
+		// spaces and no return type, which clang rejects with
+		// `error: expected type`. The intrinsic-driven path here never
+		// set the field; the fallback through `intrinsicRuntimeCallSpec`
+		// already checked `spec.ret == destType`, so destType is
+		// authoritative.
+		resultType: destType,
 	}, destID, destType, true
 }
 
@@ -11225,6 +11234,7 @@ type forInListEarlyExitPattern struct {
 	falsePrepBody  string // optional work in false path
 	postBody       string
 	loopExitBody   string
+	earlyExitBody  string // body instrs preceding the early-exit ret (e.g. field reads, helper calls)
 	earlyRetExpr   string // what `ret retType` in the early-exit arm
 	loopRetExpr    string // what `ret retType` after the loop
 
@@ -11409,7 +11419,14 @@ func matchForInListEarlyExit(fn *mir.Function, mctx *moduleCtx) (forInListEarlyE
 	pat.bodyBody = bodyBuf.String()
 	pat.innerCondExpr = innerExpr
 
-	// Render early-exit block.
+	// Render early-exit block. The body instructions (e.g. field reads,
+	// helper calls that compute the return value) MUST be preserved —
+	// they're the source of `earlyRetExpr`'s SSA value. Without
+	// `earlyExitBody`, the emit path used to drop these instructions and
+	// emit just `<label>: ret <type> <undef>`, leaving downstream LLVM
+	// IR with `use of undefined value` errors at clang. Save the
+	// rendered text to `pat.earlyExitBody` so emitForInListEarlyExit can
+	// write it between the label and the `ret`.
 	earlyCtxBindings := copyBindings(ctx.bindings)
 	earlyCtx := &whileLoopEmitCtx{fn: fn, bindings: earlyCtxBindings, stack: stack, mctx: mctx, nextSSA: ctx.nextSSA}
 	var earlyBuf strings.Builder
@@ -11423,6 +11440,7 @@ func matchForInListEarlyExit(fn *mir.Function, mctx *moduleCtx) (forInListEarlyE
 		return pat, false
 	}
 	earlyRetExpr := earlyBinding.expr
+	pat.earlyExitBody = earlyBuf.String()
 	pat.earlyExitLabel = blockLabelName(earlyExit.ID, "early")
 
 	// Render false-prep block (connects body-false → post).
@@ -11491,6 +11509,7 @@ func emitForInListEarlyExit(out *strings.Builder, fn *mir.Function, pat forInLis
 
 	out.WriteString("\n")
 	fmt.Fprintf(out, "%s:\n", pat.earlyExitLabel)
+	out.WriteString(pat.earlyExitBody)
 	fmt.Fprintf(out, "  ret %s %s\n", retLLVM, pat.earlyRetExpr)
 
 	out.WriteString("\n")


### PR DESCRIPTION
## Summary

Two stage0 emission bugs surfaced when running \`osty install-self\` against PR #1586's \"0 declined\" stage0. With every function now reaching clang, latent malformed-IR bugs the audit-time matchers never caught are hitting compile errors.

## Bug 1 — \`matchForInListEarlyExit\` (P23) drops early-exit body

\`forInListEarlyExitPattern\` had body fields for entry/header/body/false-prep/post/loop-exit — but no \`earlyExitBody\`. The matcher rendered the early-exit instructions into a \`strings.Builder\` to populate \`ctx.bindings[ReturnLocal]\`, then discarded the buffer; only \`earlyRetExpr\` (the SSA name of the return value) was kept.

For functions where the early-exit is a single SSA copy of an existing binding this was harmless. But functions like \`selfCheckLetTypeNameAtOffset\` — which does \`frontTypeReprToString(b.typeRepr)\` then returns the result — had their GEP + helper-call dropped:

\`\`\`
early.5:
  ret ptr %10        ; <- %10 never defined; field read + helper call dropped
\`\`\`

clang: \`error: use of undefined value '%10'\`.

**Fix**: add \`earlyExitBody\` to the pattern struct, save \`earlyBuf.String()\` after the body walk, write it between label and ret in \`emitForInListEarlyExit\`. Mirrors existing \`bodyBody\` / \`loopExitBody\` plumbing.

## Bug 2 — \`classifyIntrinsicValueStep\` builds pendingInstr with no resultType

The runtime-spec fallback path in \`classifyIntrinsicValueStep\` (handling \`IntrinsicStringJoin\`, \`IntrinsicStringSplit\`, etc. through \`intrinsicRuntimeCallSpec\`) returned a \`pendingInstr\` with \`kind\` / \`prelude\` / \`callSymbol\` / \`callArgs\` — but left \`resultType\` zero (\`scalarUnknown\`).

\`emitPendingInstr\` renders \`instrCall\` as \`%reg = call <resultType.llvm()> @<symbol>(\`. With \`scalarUnknown.llvm() == \"\"\`, the emitted line collapsed to:

\`\`\`
%9 = call  @osty_rt_strings_Join(ptr %0, ptr @.str.351)
            ^^ two spaces, no return type
\`\`\`

clang: \`error: expected type\`.

Surfaced in \`@checkDiagRenderAll\` (List<String> accumulator + \`strings.join\`). Likely affects every value-returning intrinsic that flows through the spec fallback rather than a hand-written \`classify*Intrinsic\` helper.

**Fix**: set \`resultType: destType\` in the literal. The branch above already verified \`spec.ret == destType\`, so the field assignment is authoritative.

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0\` passes (160 existing tests)
- New regression tests not added — both bugs manifest only when the produced IR reaches clang, which the existing audit-time tests don't exercise. Adding fixture tests for these specific shape patterns is brittle; the bugs surface (and are now caught) at clang-compile time during install-self.

## Known remaining

After these two fixes, \`osty install-self\` advances further but hits a third stage0 emit bug: discarded \`i1\` calls in short-circuit \`||\` chains within for-in-list bodies fail to consume the auto-allocated SSA number, so the next-numbered instruction collides:

\`\`\`
error: instruction expected to be numbered '%309' or greater
   %308 = load ptr, ptr %sa.slot
\`\`\`

Surfaced in \`@checkIsAssignableDepth\` (recursive \`||\` evaluation). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)