### PR TITLE
fix(stage0): capture discarded value-call into named SSA register

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -1314,7 +1314,7 @@ func classifyDiscardedValueIntrinsicLine(fn *mir.Function, ii *mir.IntrinsicInst
 		return "", false
 	}
 	declareRuntimePrototype(mctx, spec.symbol, spec.ret, args)
-	return prelude + renderDiscardValueCallLine(spec.symbol, spec.ret, args), true
+	return prelude + renderDiscardValueCallLine(mctx, spec.symbol, spec.ret, args), true
 }
 
 func classifyPrintIntrinsicLine(fn *mir.Function, ii *mir.IntrinsicInstr, bindings map[mir.LocalID]localBinding, mctx *moduleCtx) (string, bool) {
@@ -2004,7 +2004,7 @@ func classifyVoidCallLine(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.
 			if !mctx.knownSymbols[ref.Symbol] {
 				declareFunctionPrototype(mctx, ref.Symbol, retType, args)
 			}
-			return resolved.prelude + renderDiscardValueCallLine(ref.Symbol, retType, args), true
+			return resolved.prelude + renderDiscardValueCallLine(mctx, ref.Symbol, retType, args), true
 		}
 		if !mctx.knownSymbols[ref.Symbol] {
 			declareVoidFunctionPrototype(mctx, ref.Symbol, args)
@@ -2119,9 +2119,23 @@ func renderVoidCallLine(symbol string, args []callArg) string {
 	return b.String()
 }
 
-func renderDiscardValueCallLine(symbol string, retType scalarType, args []callArg) string {
+func renderDiscardValueCallLine(mctx *moduleCtx, symbol string, retType scalarType, args []callArg) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "  call %s @%s(", retType.llvm(), symbol)
+	// Capture the result into a uniquely-named SSA register even though
+	// the caller will not consume it. LLVM auto-allocates an anonymous
+	// number for any value-producing instruction that lacks a `%X = `
+	// prefix; without an explicit (named) capture, the next anonymous
+	// `%N = ...` instruction in the same basic block collides with the
+	// reserved slot, e.g.:
+	//
+	//   call i1 @checkIsAssignableDepth(...)   ; LLVM auto-allocates %308
+	//   %308 = load ptr, ptr %sa.slot           ; collides → "expected '%309'"
+	//
+	// Naming the capture (via `mctx.freshDiscardName`) keeps it out of
+	// the anonymous numbering pool so subsequent positional `%N`
+	// instructions stay in sequence. The named register is otherwise
+	// inert — no later instruction references it.
+	fmt.Fprintf(&b, "  %s = call %s @%s(", mctx.freshDiscardName(symbol), retType.llvm(), symbol)
 	for i, a := range args {
 		if i > 0 {
 			b.WriteString(", ")
@@ -2130,6 +2144,19 @@ func renderDiscardValueCallLine(symbol string, retType scalarType, args []callAr
 	}
 	b.WriteString(")\n")
 	return b.String()
+}
+
+// freshDiscardName allocates a uniquely-named SSA register for a
+// value-returning call whose result is discarded by the source.
+// `symbol` is the called function's LLVM symbol — it is sanitized into
+// the register name so the generated IR is self-explanatory in dumps.
+func (m *moduleCtx) freshDiscardName(symbol string) string {
+	if m == nil {
+		return "%stage0.discard"
+	}
+	name := fmt.Sprintf("%%stage0.discard.%s.%d", sanitizeLLVMName(symbol, "fn"), m.nextTempID)
+	m.nextTempID++
+	return name
 }
 
 type intrinsicRuntimeSpec struct {
@@ -7833,7 +7860,7 @@ func emitWhileDiscardedValueIntrinsic(ctx *whileLoopEmitCtx, out *strings.Builde
 		return false
 	}
 	declareRuntimePrototype(ctx.mctx, spec.symbol, spec.ret, args)
-	out.WriteString(renderDiscardValueCallLine(spec.symbol, spec.ret, args))
+	out.WriteString(renderDiscardValueCallLine(ctx.mctx, spec.symbol, spec.ret, args))
 	return true
 }
 
@@ -9655,7 +9682,7 @@ func emitWhileVoidCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.Call
 			if !ctx.mctx.knownSymbols[ref.Symbol] {
 				declareFunctionPrototype(ctx.mctx, ref.Symbol, retType, args)
 			}
-			out.WriteString(renderDiscardValueCallLine(ref.Symbol, retType, args))
+			out.WriteString(renderDiscardValueCallLine(ctx.mctx, ref.Symbol, retType, args))
 			return true
 		}
 	} else {
@@ -9674,7 +9701,7 @@ func emitWhileVoidCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.Call
 			if !ctx.mctx.knownSymbols[ref.Symbol] {
 				declareFunctionPrototype(ctx.mctx, ref.Symbol, retType, args)
 			}
-			out.WriteString(renderDiscardValueCallLine(ref.Symbol, retType, args))
+			out.WriteString(renderDiscardValueCallLine(ctx.mctx, ref.Symbol, retType, args))
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

\`renderDiscardValueCallLine\` emitted a call without \`%X = \` prefix:

\`\`\`
call i1 @checkIsAssignableDepth(...)
%308 = load ptr, ptr %sa.slot   ; <- collides with auto-allocated slot
\`\`\`

LLVM auto-allocates the next anonymous number for any value-producing instruction lacking an explicit capture, so the discarded \`i1 @check…\` claims \`%308\`, then the next intended \`%308 = load …\` collides:

\`\`\`
error: instruction expected to be numbered '%309' or greater
\`\`\`

Surfaced in \`@checkIsAssignableDepth\` (recursive \`||\` chain in \`check_env.osty:1156\`) where stage0 emits the recursive call as discarded — the source uses the boolean in \`!(...) || !(...)\`, but stage0's CallInstr-with-no-Dest path lowers it through this helper.

## Fix

Capture the discarded result into a named SSA register (\`%stage0.discard.<sym>.<N>\`). Named registers are scoped separately from the anonymous numbering pool, so subsequent \`%N = ...\` instructions stay in sequence. The register is otherwise inert — no later instruction references it — but its presence consumes the implicit allocation LLVM would otherwise grab.

### Plumbing

- Add \`freshDiscardName(symbol)\` to \`moduleCtx\`, mirroring the existing \`nextTempID\`-based fresh-name pattern (emit.go:386).
- Thread \`mctx\` through five \`renderDiscardValueCallLine\` call sites (\`classifyVoidCallLine\` plus four while-loop variants).

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0\` passes (all 160 existing tests). None asserted on the exact discard format, so the new \`%stage0.discard.*\` capture doesn't break expectations.
- New regression test not added — the bug surfaces only when the produced IR reaches clang.

## Known remaining

\`osty install-self\` advances further still, hits a fourth distinct stage0 emit bug: \`corePrintList\`'s \`\"[{strings.join(parts, sep)}]\"\` interpolation wraps the join result in brackets, but the wrap-concat instructions are dropped from the exit block emit, leaving \`ret ptr %11\` referencing an undefined \`%11\`. Appears to be a \`forInListExit\` / synthetic string-join interaction where one helper consumes the SSA slot the other relies on. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)