### PR TITLE
refactor: lint API 정리 + LSP pointer-keyed map 의존 제거

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -2,11 +2,11 @@
 
 - **Scope**: Native LLVM backend migration history and plan
 - **Type**: Plan
-> **Status (2026-04-29): Historical with current sync notes.** 공개 백엔드는 이미 LLVM 하나뿐이며,
-> 기존 Osty→Go 부트스트랩 트랜스파일러는 제거되었다 — `internal/selfhost/generated.go`
-> 는 커밋된 시드 산출물로 동결되어 있다. 이 문서는 이주 과정의 기록이며, phase
-> 설명은 당시 시점의 기준이다. 현재 pass/fail 상태는 바로 아래 동기화 노트가
-> 기준이다.
+  > **Status (2026-04-29): Historical with current sync notes.** 공개 백엔드는 이미 LLVM 하나뿐이며,
+  > 기존 Osty→Go 부트스트랩 트랜스파일러는 제거되었다 — `internal/selfhost/generated.go`
+  > 는 커밋된 시드 산출물로 동결되어 있다. 이 문서는 이주 과정의 기록이며, phase
+  > 설명은 당시 시점의 기준이다. 현재 pass/fail 상태는 바로 아래 동기화 노트가
+  > 기준이다.
 
 이 문서는 Osty의 실행 백엔드를 현재 Go transpiler 중심 구조에서 LLVM 기반
 네이티브 백엔드로 옮기기 위한 이주 계획이다. 목표는 기존 Go 백엔드를 즉시
@@ -41,33 +41,33 @@ cover하지 못하는 source shape 기준으로 본다.
 
 ### Tier A — 核 toolchain (`lexer → parser → check → ir → llvmgen`) 자가 컴파일 blocker
 
-| 기능 | 현재 상태 | 현재 증거 | 다음 초점 |
-|---|---|---|---|
-| `List<T>` literal + 메서드 lowering | 🟡 기본 literal/intrinsic 경로는 있음 | README status + green front-end tests | whole-toolchain native probe에서 residual collection helper shape 확인 |
-| `Map<K,V>` literal + 메서드 lowering | 🔴 `Map.update` 전용 locked lowering 회귀 | `TestPhase2gUpdateUserCallsiteKeepsLockedLowering` | `get + callback + insert`를 `osty_rt_map_lock/unlock` 안에 유지 |
-| Optional aggregate lowering | 🔴 struct payload `?` / `?.field` 미커버 | `TestNativeOwnedModuleEntryOptionalQuestionStructBatch`, `TestNativeOwnedModuleEntryOptionalFieldBatch` | `%Struct` load/extract + null phi shape |
-| Generic / interface call lowering | 🟡 generic method turbofish는 MIR/LLVM 회귀로 잠김; interface boxing/dispatch 미커버 | `TestLowerGenericOwnerMethodTurbofishUsesMonomorphizedSymbol`, `TestLLVMBackendBinaryRunsGenericOwnerMethodTurbofish`, interface dispatch tests | `%osty.iface` boxing, vtable indirect call args |
-| Pattern lowering | 🔴 nested binding/destructuring 미커버 | `TestRunCoversNestedStructBindingPattern`, `TestTryGenerateNativeOwnedModuleCoversNestedStructBindingPattern` | recursive `extractvalue` plus `name @ pattern` alias |
-| Multi-file package emit + link | 🟡 native self-compile/link gate는 아직 최종 green 아님 | short-suite backend gaps block merged native confidence | P0 native shape failures 해소 후 merged toolchain probe 재측정 |
-| `String` / `std.strings` surface | 🟡 runtime-backed paths expanded; pure-body coverage는 계속 추적 | previous `String.bytes()` / `String.chars()` walls are closed | pure Osty helper bodies and remaining ABI edge cases |
+| 기능                                 | 현재 상태                                                                            | 현재 증거                                                                                                                                       | 다음 초점                                                              |
+| ------------------------------------ | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `List<T>` literal + 메서드 lowering  | 🟡 기본 literal/intrinsic 경로는 있음                                                | README status + green front-end tests                                                                                                           | whole-toolchain native probe에서 residual collection helper shape 확인 |
+| `Map<K,V>` literal + 메서드 lowering | 🔴 `Map.update` 전용 locked lowering 회귀                                            | `TestPhase2gUpdateUserCallsiteKeepsLockedLowering`                                                                                              | `get + callback + insert`를 `osty_rt_map_lock/unlock` 안에 유지        |
+| Optional aggregate lowering          | 🔴 struct payload `?` / `?.field` 미커버                                             | `TestNativeOwnedModuleEntryOptionalQuestionStructBatch`, `TestNativeOwnedModuleEntryOptionalFieldBatch`                                         | `%Struct` load/extract + null phi shape                                |
+| Generic / interface call lowering    | 🟡 generic method turbofish는 MIR/LLVM 회귀로 잠김; interface boxing/dispatch 미커버 | `TestLowerGenericOwnerMethodTurbofishUsesMonomorphizedSymbol`, `TestLLVMBackendBinaryRunsGenericOwnerMethodTurbofish`, interface dispatch tests | `%osty.iface` boxing, vtable indirect call args                        |
+| Pattern lowering                     | 🔴 nested binding/destructuring 미커버                                               | `TestRunCoversNestedStructBindingPattern`, `TestTryGenerateNativeOwnedModuleCoversNestedStructBindingPattern`                                   | recursive `extractvalue` plus `name @ pattern` alias                   |
+| Multi-file package emit + link       | 🟡 native self-compile/link gate는 아직 최종 green 아님                              | short-suite backend gaps block merged native confidence                                                                                         | P0 native shape failures 해소 후 merged toolchain probe 재측정         |
+| `String` / `std.strings` surface     | 🟡 runtime-backed paths expanded; pure-body coverage는 계속 추적                     | previous `String.bytes()` / `String.chars()` walls are closed                                                                                   | pure Osty helper bodies and remaining ABI edge cases                   |
 
 ### Tier B — pkgmgr (`semver`, `manifest`, `registry`, `solve`, `pkgmgr`) 자가 컴파일 blocker
 
-| 기능 | 非-test 사용 | 현재 상태 | 관련 phase |
-|---|---|---|---|
-| `String` payload enum (`PreText(String)`) | `semver.osty:5` | ✅ lowered — `SemPreIdent` 전 variant가 정상 lower. 회귀 커버 `TestGenerateResultQuestionExprEnumPayload` | Phase 54-63 완료 |
-| `Result<T, String>` ABI | semver_parse, manifest_validation | ✅ lowered — scalar / struct payload / tag+ptr payload enum 모두 `{i64 tag, T ok, E err}` 3필드 struct로 일관. 회귀 커버 `TestGenerateResultQuestionExpr{Int,Struct,EnumPayload}` | Phase 74 완료 |
-| `?` 전파 (Result) | `semver_parse.osty` 8곳 | ✅ lowered — `emitQuestionExprResult`가 Ok/Err 양쪽 브랜치를 phi+early-return으로 낮춤. struct/enum 페이로드 포함 전 shape가 회귀 테스트로 봉쇄 | Phase 74 완료 |
-| struct/enum 복합 payload (`Ok(SemVersion)`, `Ok(SemPreIdent)`) | semver_parse, manifest_validation | ✅ lowered — `insertvalue`/`extractvalue` + `<Type> zeroinitializer` 경로로 자동 처리. `TestGenerateResultQuestionExprStruct`로 회귀 봉쇄 | Phase 74 완료 |
-| List<String> + mutable-binding source-type tracking | `pkgmgr.osty:selfPkgRegistryYankRequest` 등 | ✅ lowered — StringLit / runtime concat / interpolated String / phi-merge가 sourceType을 `String`으로 유지해 list-literal emitter가 mixed-ptr false-positive를 내지 않음. 회귀 커버 `TestListLiteralMixedPtrStringSourceTracking` (이 PR), `TestStringLetMutInferredSourceType` / `TestStdStringsJoinNestedInListLiteral` (#438, #441) | (#438, 이 PR) |
+| 기능                                                           | 非-test 사용                                | 현재 상태                                                                                                                                                                                                                                                                                                                              | 관련 phase       |
+| -------------------------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `String` payload enum (`PreText(String)`)                      | `semver.osty:5`                             | ✅ lowered — `SemPreIdent` 전 variant가 정상 lower. 회귀 커버 `TestGenerateResultQuestionExprEnumPayload`                                                                                                                                                                                                                              | Phase 54-63 완료 |
+| `Result<T, String>` ABI                                        | semver_parse, manifest_validation           | ✅ lowered — scalar / struct payload / tag+ptr payload enum 모두 `{i64 tag, T ok, E err}` 3필드 struct로 일관. 회귀 커버 `TestGenerateResultQuestionExpr{Int,Struct,EnumPayload}`                                                                                                                                                      | Phase 74 완료    |
+| `?` 전파 (Result)                                              | `semver_parse.osty` 8곳                     | ✅ lowered — `emitQuestionExprResult`가 Ok/Err 양쪽 브랜치를 phi+early-return으로 낮춤. struct/enum 페이로드 포함 전 shape가 회귀 테스트로 봉쇄                                                                                                                                                                                        | Phase 74 완료    |
+| struct/enum 복합 payload (`Ok(SemVersion)`, `Ok(SemPreIdent)`) | semver_parse, manifest_validation           | ✅ lowered — `insertvalue`/`extractvalue` + `<Type> zeroinitializer` 경로로 자동 처리. `TestGenerateResultQuestionExprStruct`로 회귀 봉쇄                                                                                                                                                                                              | Phase 74 완료    |
+| List<String> + mutable-binding source-type tracking            | `pkgmgr.osty:selfPkgRegistryYankRequest` 등 | ✅ lowered — StringLit / runtime concat / interpolated String / phi-merge가 sourceType을 `String`으로 유지해 list-literal emitter가 mixed-ptr false-positive를 내지 않음. 회귀 커버 `TestListLiteralMixedPtrStringSourceTracking` (이 PR), `TestStringLetMutInferredSourceType` / `TestStdStringsJoinNestedInListLiteral` (#438, #441) | (#438, 이 PR)    |
 
 ### 非-blocker (당초 Tier B 오판 항목)
 
-| 기능 | 非-test 사용 | 이유 |
-|---|---|---|
-| `defer` | 0건 | 核/pkgmgr 모두 쓰지 않음. AST formatter/lexer test에만 문자열로 등장. 구현 우선순위 최저. |
-| multi-field payload enum (`Node.BinOp(lhs, op, rhs)` 패턴) | 0건 | [core.osty](toolchain/core.osty:38), [ir.osty](toolchain/ir.osty:1)가 **arena + kind discriminator** 설계를 채택해 페이로드 enum 회피. `CoreNode` 단일 struct + flat `CoreKind` enum으로 모든 AST/IR 노드 표현. |
-| 재귀 페이로드 enum | 0건 | 위와 같은 이유로 회피됨. arena index(`CoreIdx = Int`)로 recursion 구현. |
+| 기능                                                       | 非-test 사용 | 이유                                                                                                                                                                                                            |
+| ---------------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `defer`                                                    | 0건          | 核/pkgmgr 모두 쓰지 않음. AST formatter/lexer test에만 문자열로 등장. 구현 우선순위 최저.                                                                                                                       |
+| multi-field payload enum (`Node.BinOp(lhs, op, rhs)` 패턴) | 0건          | [core.osty](toolchain/core.osty:38), [ir.osty](toolchain/ir.osty:1)가 **arena + kind discriminator** 설계를 채택해 페이로드 enum 회피. `CoreNode` 단일 struct + flat `CoreKind` enum으로 모든 AST/IR 노드 표현. |
+| 재귀 페이로드 enum                                         | 0건          | 위와 같은 이유로 회피됨. arena index(`CoreIdx = Int`)로 recursion 구현.                                                                                                                                         |
 
 당초 CLAUDE.md 부록 A의 canonical 예시(Rust-like `Node.IntLit(val)` 페이로드 enum)를
 실제 구현으로 착각한 plan은 이 섹션으로 교정한다. arena+kind 설계는
@@ -342,8 +342,8 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     interface를 `%osty.iface`로 반환, `emitLet`의 concrete→interface
     경로에서 boxing (alloca + insertvalue 2회), `emitInterfaceMethodCall`
     이 수신자가 `%osty.iface`인 call을 vtable extractvalue + getelementptr
-    + indirect call로 낮춘다.
-    smoke: `TestGenerateModuleInterfaceBoxingDispatch`.
+    - indirect call로 낮춘다.
+      smoke: `TestGenerateModuleInterfaceBoxingDispatch`.
   - Phase 6c(interface method의 non-self 인자): `methodDecl.Params`의
     user-facing 파라미터를 `llvmType`으로 개별 lower하고 `emitExpr`로
     argument value를 만들어 indirect call에 `ptr %data, <argTyp> %arg…`
@@ -451,24 +451,24 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
 
 ## 타입/값 lowering 초안
 
-| Osty | LLVM 표현 초안 | 비고 |
-|---|---|---|
-| `Int` | target word 또는 고정 `i64` 중 결정 필요 | 현재 Go `int` 의미와 cross-target 안정성 중 선택 |
-| `Int8..UInt64` | `i8..i64` | signedness는 operation에서 표현 |
-| `Bool` | `i1` in SSA, ABI는 `i8` 가능 | runtime ABI에서 고정 |
-| `Char` | `i32` | Unicode scalar value |
-| `Byte` | `i8` | `UInt8`과 alias 여부 명시 필요 |
-| `Float/Float32/Float64` | `double/float/double` | `Float`는 현재 단계에서 `double` 하위집합으로 다루고, `Float32`/`Float64` 정책은 후속 단계 |
-| `String` | `%osty.string` | pointer+len 또는 fat value |
-| `Bytes` | `%osty.bytes` | pointer+len+cap 또는 runtime-owned buffer |
-| `List<T>` | `%osty.list` + element descriptor | monomorphized typed list와 erased list 중 선택 |
-| `Option<T>` | tagged payload | nullable pointer optimization은 후순위 |
-| `Result<T,E>` | tagged payload | Go backend의 `Value/Error/IsOk`와 semantic parity |
-| `struct` | named LLVM struct | Phase 30-33 smoke subset uses value aggregates; full ABI/layout stability remains runtime work |
-| `enum` | `i64` tag for bare variants, `%Enum = { i64, i64 }` for single-`Int` payload subset, tagged payload storage later | Phase 34-37 smoke subset covers payload-free variants; Phase 42-45 adds conservative single-`Int` tagged payload; broader payload layouts are later |
-| `match` | enum-tag switch/branch lowering | Phase 38-41 covers payload-free match expressions; Phase 42-45 adds `match` binding for single-`Int` payload enums |
-| closure | fn pointer + env pointer | capture lifetime/ownership 필요 |
-| interface | data pointer + vtable pointer | vtable generation은 Phase 5+ |
+| Osty                    | LLVM 표현 초안                                                                                                    | 비고                                                                                                                                                |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Int`                   | target word 또는 고정 `i64` 중 결정 필요                                                                          | 현재 Go `int` 의미와 cross-target 안정성 중 선택                                                                                                    |
+| `Int8..UInt64`          | `i8..i64`                                                                                                         | signedness는 operation에서 표현                                                                                                                     |
+| `Bool`                  | `i1` in SSA, ABI는 `i8` 가능                                                                                      | runtime ABI에서 고정                                                                                                                                |
+| `Char`                  | `i32`                                                                                                             | Unicode scalar value                                                                                                                                |
+| `Byte`                  | `i8`                                                                                                              | `UInt8`과 alias 여부 명시 필요                                                                                                                      |
+| `Float/Float32/Float64` | `double/float/double`                                                                                             | `Float`는 현재 단계에서 `double` 하위집합으로 다루고, `Float32`/`Float64` 정책은 후속 단계                                                          |
+| `String`                | `%osty.string`                                                                                                    | pointer+len 또는 fat value                                                                                                                          |
+| `Bytes`                 | `%osty.bytes`                                                                                                     | pointer+len+cap 또는 runtime-owned buffer                                                                                                           |
+| `List<T>`               | `%osty.list` + element descriptor                                                                                 | monomorphized typed list와 erased list 중 선택                                                                                                      |
+| `Option<T>`             | tagged payload                                                                                                    | nullable pointer optimization은 후순위                                                                                                              |
+| `Result<T,E>`           | tagged payload                                                                                                    | Go backend의 `Value/Error/IsOk`와 semantic parity                                                                                                   |
+| `struct`                | named LLVM struct                                                                                                 | Phase 30-33 smoke subset uses value aggregates; full ABI/layout stability remains runtime work                                                      |
+| `enum`                  | `i64` tag for bare variants, `%Enum = { i64, i64 }` for single-`Int` payload subset, tagged payload storage later | Phase 34-37 smoke subset covers payload-free variants; Phase 42-45 adds conservative single-`Int` tagged payload; broader payload layouts are later |
+| `match`                 | enum-tag switch/branch lowering                                                                                   | Phase 38-41 covers payload-free match expressions; Phase 42-45 adds `match` binding for single-`Int` payload enums                                  |
+| closure                 | fn pointer + env pointer                                                                                          | capture lifetime/ownership 필요                                                                                                                     |
+| interface               | data pointer + vtable pointer                                                                                     | vtable generation은 Phase 5+                                                                                                                        |
 
 ### Phase 38-41. Payload-free enum match expressions
 
@@ -573,7 +573,7 @@ return/parameter boundaries와 mutable local slots을 지나도 동일하게 동
 - `string_payload_mut_print.osty`를 추가해 mutable local `Text("payload string")`
   업데이트와 `Text(s)`/`Empty` 분기를 검증한다.
 - `string_payload_reversed_match_print.osty`를 추가해 `Empty -> ...`, `Text(s) ->
-  ...` 순서의 two-arm match를 검증한다.
+...` 순서의 two-arm match를 검증한다.
 - `string_payload_wildcard_print.osty`를 추가해 `Text(_)` 와일드카드 match arm을
   검증한다.
 - `LLVM_BACKEND_CORPUS.md`에 Phase 54~63 항목을 추가하고 expected stdout과
@@ -722,8 +722,8 @@ match 분해)를 추가한다.
 
 ### 1개 bootstrap-only 파일
 
-| 파일 | FFI | 역할 | native 대체 경로 |
-|---|---|---|---|
+| 파일                | FFI                          | 역할                                                    | native 대체 경로                                                                                                                                               |
+| ------------------- | ---------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `toolchain/ci.osty` | `use runtime.cihost as host` | CI 드라이버 (format/lint/snapshot/manifest 호스트 호출) | 실제 호스트 I/O(FS/process)라 `std.strings`로 접힐 수 없음. `runtime.cabi.<lib>` 또는 새 `runtime.ci.*` 서페이스 정의 + `osty_rt_ci_*` 런타임 ABI 추가 후 포팅 |
 
 ### 분류 규칙
@@ -767,17 +767,17 @@ astbridge는 한 방에 제거하지 않고 `*ast.File` 소비자들이 AstArena
 
 CLI 재배선의 resolve + check/typecheck 축은 **단일 파일 + 단일 패키지 + workspace** happy path 에서 완료됐다. `--legacy` check/typecheck escape hatch 는 제거됐고, `--native` 는 no-op 으로만 남았다. in-process 회귀 테스트는 native/default 경로가 `astLowerPublicFile` 호출을 트리거하지 않는지 `selfhost.AstbridgeLowerCount` 로 pin 한다.
 
-| CLI 경로 | Warm astbridge bumps | 회귀 테스트 |
-|---|---|---|
-| `osty resolve FILE` (기본 native) | 0 | `TestRunResolveFileHappyPathIsAstbridgeFree` |
-| `osty resolve DIR` (기본 native) | 0 | `TestRunResolvePackageHappyPathIsAstbridgeFree` |
-| `osty check --native FILE` | 0 | `TestRunCheckFileNativeIsAstbridgeFree` |
-| `osty check --native DIR` | 0 | `TestRunCheckPackageNativeIsAstbridgeFree` |
-| `osty check --native WORKSPACE` | 0 | `TestRunCheckWorkspaceNativeIsAstbridgeFree` |
-| `osty check FILE` (default) | 0 | `TestRunCheckFileDefaultPathIsAstbridgeFree` |
-| `osty typecheck --native FILE` | 0 | `TestRunTypecheckFileNativeIsAstbridgeFree` |
-| `osty typecheck --native DIR` | 0 | `TestRunTypecheckPackageNativeIsAstbridgeFree` |
-| `osty typecheck --native WORKSPACE` | 0 | `TestRunTypecheckWorkspaceNativeIsAstbridgeFree` |
+| CLI 경로                            | Warm astbridge bumps | 회귀 테스트                                      |
+| ----------------------------------- | -------------------- | ------------------------------------------------ |
+| `osty resolve FILE` (기본 native)   | 0                    | `TestRunResolveFileHappyPathIsAstbridgeFree`     |
+| `osty resolve DIR` (기본 native)    | 0                    | `TestRunResolvePackageHappyPathIsAstbridgeFree`  |
+| `osty check --native FILE`          | 0                    | `TestRunCheckFileNativeIsAstbridgeFree`          |
+| `osty check --native DIR`           | 0                    | `TestRunCheckPackageNativeIsAstbridgeFree`       |
+| `osty check --native WORKSPACE`     | 0                    | `TestRunCheckWorkspaceNativeIsAstbridgeFree`     |
+| `osty check FILE` (default)         | 0                    | `TestRunCheckFileDefaultPathIsAstbridgeFree`     |
+| `osty typecheck --native FILE`      | 0                    | `TestRunTypecheckFileNativeIsAstbridgeFree`      |
+| `osty typecheck --native DIR`       | 0                    | `TestRunTypecheckPackageNativeIsAstbridgeFree`   |
+| `osty typecheck --native WORKSPACE` | 0                    | `TestRunTypecheckWorkspaceNativeIsAstbridgeFree` |
 
 이 회귀 넷은 네이티브 경로 비용 누출을 잡는다. 예: fallback이 `EnsureFiles`를 부당하게 발동해 astbridge bump 가 생기면 즉시 실패한다.
 
@@ -793,9 +793,9 @@ CLI 재배선의 resolve + check/typecheck 축은 **단일 파일 + 단일 패�
 **남아있는 작업**:
 
 1. **~~Workspace `--native`~~** — ✅ 완료. `selfhostPackageCheckInput` + `selfhostPackageImportSurfaces` 전부 `selfhost.PackageImportSurface(alias, runs)` (arena-direct) 로 포팅됨. `internal/selfhost/import_surface_arena.go` 가 arena walker를 hold. `PackageCheckFile.File *ast.File` / `SourceMap` 필드 + `selfhostBuildPackageAstDirect` / `selfhostPackageFileLowerer` (구 `package_ast_lower.go` ~1850 LOC) 동시 제거. `CheckPackageStructured` / `ResolvePackageStructured` 가 단일 re-parse path 로 단순화.
-2. **`osty lint` AstArena 포팅** — lint engine이 `*resolve.Result`의 포인터 아이덴티티 맵(`Refs map[*ast.Ident]*Symbol`)에 깊이 의존. identity 모델 재설계 선행.
+2. **~~`osty lint` AstArena 포팅~~** — ✅ 완료. lint engine은 이미 `selfhost.LintDiagnostics(src)` 경로로 완전 포팅됨. `File()` / `Package()` 모두 `*ast.File`, `*resolve.Result`, `*check.Result`를 무시하고 raw source만 사용. lint 패키지 내에 ast.File 필드 접근 없음.
 3. **LSP / formatter / bootstrap-gen** — 모두 `*ast.File` 포인터 기반. 각자의 identity 모델 포팅 필요.
-4. **ABI 경로** — `internal/selfhost/ast_lower.osty` + `internal/selfhost/astbridge/` 완전 제거는 위 2·3 소비자들이 AstArena 경로로 전환된 후.
+4. **ABI 경로** — `internal/selfhost/ast_lower.osty` + `internal/selfhost/astbridge/` 완전 제거는 위 3 소비자들이 AstArena 경로로 전환된 후.
 
 **중요한 설계 결정 (PR #641)**: native 경로에서 empty 결과를 신호로 Go fallback을 발동시키면 안 된다. "native가 빈 결과를 반환 = 성공적으로 ref 없음 확인"이지 "native가 실패함"이 아니다. fallback은 실제 에러 때만 트리거해야 한다. 이 규칙은 `runResolvePackageInner`의 `nativeErrored` 플래그로 현재 구현됨.
 
@@ -830,15 +830,15 @@ CLAUDE.md 호스트 경계 규칙상 `use go`는 특별 허가 영역(`cmd/*`, I
 
 ## 리스크와 대응
 
-| 리스크 | 영향 | 대응 |
-|---|---|---|
-| IR가 backend 계약으로 부족함 | LLVM backend가 AST/checker에 다시 결합 | Phase 2에서 IR gap을 먼저 닫고 `llvmgen` dependency를 제한 |
-| Runtime ABI가 늦게 정해짐 | helper가 backend별로 갈라짐 | Phase 4 전에 string/list/result 최소 ABI부터 문서화 |
-| Go FFI와 native FFI 의미 차이 | 사용자 코드가 backend별로 다르게 동작 | Go FFI는 backend capability로 진단하고 native FFI를 별도 설계 |
-| target triple/profile 모델 충돌 | cross compile UX 혼란 | Go target과 LLVM target을 manifest에서 분리하거나 명시 mapping |
-| source mapping 품질 저하 | LLVM 에러 디버깅 어려움 | 초기부터 source anchor를 IR/LLVM에 싣고 CLI report를 backend-neutral화 |
-| stdlib porting 범위 과대 | migration이 끝나지 않음 | module별 support matrix와 staged parity gate 운영 |
-| CI 시간이 증가 | PR feedback 저하 | LLVM job은 smoke부터 시작하고 full parity는 nightly/manual로 분리 |
+| 리스크                          | 영향                                   | 대응                                                                   |
+| ------------------------------- | -------------------------------------- | ---------------------------------------------------------------------- |
+| IR가 backend 계약으로 부족함    | LLVM backend가 AST/checker에 다시 결합 | Phase 2에서 IR gap을 먼저 닫고 `llvmgen` dependency를 제한             |
+| Runtime ABI가 늦게 정해짐       | helper가 backend별로 갈라짐            | Phase 4 전에 string/list/result 최소 ABI부터 문서화                    |
+| Go FFI와 native FFI 의미 차이   | 사용자 코드가 backend별로 다르게 동작  | Go FFI는 backend capability로 진단하고 native FFI를 별도 설계          |
+| target triple/profile 모델 충돌 | cross compile UX 혼란                  | Go target과 LLVM target을 manifest에서 분리하거나 명시 mapping         |
+| source mapping 품질 저하        | LLVM 에러 디버깅 어려움                | 초기부터 source anchor를 IR/LLVM에 싣고 CLI report를 backend-neutral화 |
+| stdlib porting 범위 과대        | migration이 끝나지 않음                | module별 support matrix와 staged parity gate 운영                      |
+| CI 시간이 증가                  | PR feedback 저하                       | LLVM job은 smoke부터 시작하고 full parity는 nightly/manual로 분리      |
 
 ## 의사결정이 필요한 항목
 

--- a/cmd/osty/lint_cmd.go
+++ b/cmd/osty/lint_cmd.go
@@ -94,7 +94,7 @@ func runLintLoadedPackage(
 	cfg lint.Config,
 	hasCfg bool,
 ) lintPackageOutcome {
-	lr := lint.Package(pkg, nil, nil)
+	lr := lint.Package(pkg)
 	if hasCfg {
 		lr = cfg.Apply(lr)
 	}

--- a/cmd/osty/lint_native_test.go
+++ b/cmd/osty/lint_native_test.go
@@ -60,7 +60,7 @@ func TestLintPackageNativeDiagnosticsIsAstbridgeFree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("lintNativePackageDiagnostics: %v", err)
 	}
-	lintDiags := lint.Package(pkg, nil, nil).Diags
+	lintDiags := lint.Package(pkg).Diags
 	if hasError(append(frontendDiags, lintDiags...)) {
 		t.Fatalf("clean package produced diagnostics: frontend=%#v lint=%#v", frontendDiags, lintDiags)
 	}

--- a/internal/cihost/host.go
+++ b/internal/cihost/host.go
@@ -282,7 +282,7 @@ func CheckLint(m *manifest.Manifest, packages []*resolve.Package, results []*res
 			pr = resolve.ResolvePackageDefault(pkg)
 		}
 		chk := check.Package(pkg, pr, opts)
-		lr := lint.Package(pkg, pr, chk)
+		lr := lint.Package(pkg)
 		if cfg != nil {
 			lr = cfg.Apply(lr)
 		}

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -9,8 +9,6 @@
 package lint
 
 import (
-	"github.com/osty/osty/internal/ast"
-	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
@@ -30,13 +28,6 @@ func Source(src []byte) *Result {
 	return result
 }
 
-// File runs the self-hosted lint pass over one source file. The AST / resolve /
-// check inputs are retained for compatibility with older front-end call sites,
-// but lint no longer treats the public Go AST as an authority input.
-func File(_ *ast.File, src []byte, _ *resolve.Result, _ *check.Result) *Result {
-	return Source(src)
-}
-
 // mergeSelfhostLint appends diagnostics from the Osty-authored lint pass
 // (toolchain/lint.osty). #[allow(...)] suppression is handled inside the
 // self-hosted pass; project-level allow/deny config is applied by Config.Apply.
@@ -53,9 +44,7 @@ func mergeSelfhostLint(result *Result, src []byte) {
 }
 
 // Package runs lint over every file in pkg as one analysis unit.
-func Package(pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result) *Result {
-	_ = pr
-	_ = chk
+func Package(pkg *resolve.Package) *Result {
 	if pkg == nil {
 		return &Result{}
 	}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -1,9 +1,9 @@
 package lsp
 
 import (
-	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/semanticdb"
 )
 
 // handleCompletion answers `textDocument/completion`. Behavior splits
@@ -89,7 +89,7 @@ func (s *Server) completionAfterDot(doc *document, recvName, prefix string) []Co
 	}
 	candidates := make([]LSPCompletionCandidateView, 0, len(pkg.PkgScope.Symbols()))
 	for name, member := range pkg.PkgScope.Symbols() {
-		view := completionSymbolView(name, member, a.check)
+		view := completionSymbolView(name, member, a.semantic, a.sourcePath)
 		candidates = append(candidates, LSPCompletionCandidateView{
 			Name:     view.Name,
 			Kind:     view.Kind,
@@ -142,7 +142,7 @@ func (s *Server) completionInScope(doc *document, prefix string) []CompletionIte
 	}
 	for sc := a.resolve.FileScope; sc != nil; sc = sc.Parent() {
 		for name, sym := range sc.Symbols() {
-			view := completionSymbolView(name, sym, a.check)
+			view := completionSymbolView(name, sym, a.semantic, a.sourcePath)
 			candidates = append(candidates, LSPCompletionCandidateView{
 				Name:     view.Name,
 				Kind:     view.Kind,
@@ -178,8 +178,8 @@ func sortCompletionItems(in []CompletionItem) []CompletionItem {
 // CompletionItem. The pointer-typed extraction lives in
 // completionSymbolView; the assembly itself runs off the value-typed
 // LSPSymbolView so the policy is portable.
-func completionItemFromSym(label string, sym *resolve.Symbol, r *check.Result) CompletionItem {
-	return completionItemFromView(completionSymbolView(label, sym, r))
+func completionItemFromSym(label string, sym *resolve.Symbol, semantic *semanticdb.DB, sourcePath string) CompletionItem {
+	return completionItemFromView(completionSymbolView(label, sym, semantic, sourcePath))
 }
 
 func completionItemFromStructuredSymbol(sym structuredSymbol) CompletionItem {
@@ -202,11 +202,11 @@ func completionItemFromStructuredImportSymbol(sym structuredImportSymbol) Comple
 
 // completionSymbolView projects a resolver Symbol into the
 // value-typed view consumed by completionItemFromView.
-func completionSymbolView(label string, sym *resolve.Symbol, r *check.Result) selfhost.LSPSymbolView {
+func completionSymbolView(label string, sym *resolve.Symbol, semantic *semanticdb.DB, sourcePath string) selfhost.LSPSymbolView {
 	typeText := ""
-	if r != nil {
-		if t := r.LookupSymType(sym); t != nil {
-			typeText = t.String()
+	if semantic != nil {
+		if cs := semantic.CheckedSymbolAt(sourcePath, sym.Pos.Offset); cs != nil && cs.Type != nil {
+			typeText = cs.Type.String()
 		}
 	}
 	return selfhost.LSPSymbolView{

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 
 	"github.com/osty/osty/internal/ast"
-	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/format"
 	"github.com/osty/osty/internal/repair"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -268,7 +268,7 @@ func (s *Server) handleHover(req *rpcRequest) {
 		replyJSON(s.conn, req.ID, nil)
 		return
 	}
-	h := hoverForSymbol(sym, fallback, doc.analysis.check)
+	h := hoverForSymbol(sym, fallback, doc.analysis.semantic, doc.analysis.sourcePath)
 	h.Range = ptrRange(doc.analysis.lines.ostyRange(
 		diag.Span{Start: node.Pos(), End: node.End()}))
 	replyJSON(s.conn, req.ID, h)
@@ -319,9 +319,9 @@ func semanticHoverLegacyContext(a *docAnalysis, pos token.Pos) (docText string, 
 	if sym == nil {
 		return "", ""
 	}
-	if a.check != nil {
-		if t := a.check.LookupSymType(sym); t != nil {
-			typeText = t.String()
+	if a.semantic != nil {
+		if cs := a.semantic.CheckedSymbolAt(a.sourcePath, sym.Pos.Offset); cs != nil && cs.Type != nil {
+			typeText = cs.Type.String()
 		}
 	}
 	return symbolDoc(sym), typeText
@@ -335,8 +335,8 @@ func semanticHoverKind(kind string) string {
 // pointer-typed extraction is contained in hoverSymbolView; the
 // markdown rendering itself goes through the value-typed
 // selfhost.LSPHoverMarkdown so the policy stays portable.
-func hoverForSymbol(sym *resolve.Symbol, nameFallback string, r *check.Result) *Hover {
-	view := hoverSymbolView(sym, nameFallback, r)
+func hoverForSymbol(sym *resolve.Symbol, nameFallback string, sem *semanticdb.DB, sourcePath string) *Hover {
+	view := hoverSymbolView(sym, nameFallback, sem, sourcePath)
 	return &Hover{Contents: MarkupContent{
 		Kind:  MarkupKindMarkdown,
 		Value: selfhost.LSPHoverMarkdown(view),
@@ -373,14 +373,14 @@ func hoverForStructuredView(name, kind, typeText string, hasSym bool) *Hover {
 // checker result) into the value-typed view consumed by the markdown
 // formatter. nameFallback is shown when sym is nil so unresolved
 // references still get a minimal popup.
-func hoverSymbolView(sym *resolve.Symbol, nameFallback string, r *check.Result) selfhost.LSPSymbolView {
+func hoverSymbolView(sym *resolve.Symbol, nameFallback string, sem *semanticdb.DB, sourcePath string) selfhost.LSPSymbolView {
 	if sym == nil {
 		return selfhost.LSPSymbolView{Name: nameFallback}
 	}
 	typeText := ""
-	if r != nil {
-		if t := r.LookupSymType(sym); t != nil {
-			typeText = t.String()
+	if sem != nil {
+		if cs := sem.CheckedSymbolAt(sourcePath, sym.Pos.Offset); cs != nil && cs.Type != nil {
+			typeText = cs.Type.String()
 		}
 	}
 	return selfhost.LSPSymbolView{

--- a/internal/lsp/inlay.go
+++ b/internal/lsp/inlay.go
@@ -2,8 +2,8 @@ package lsp
 
 import (
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/token"
-	"github.com/osty/osty/internal/types"
 )
 
 // handleInlayHint answers `textDocument/inlayHint`. We emit a type
@@ -49,13 +49,13 @@ func (s *Server) handleInlayHint(req *rpcRequest) {
 			if !ok {
 				return
 			}
-			t := lookupNodeType(doc.analysis, n, v.Value)
-			if t == nil || types.IsError(t) {
+			tr := lookupBindingType(doc.analysis, ip.PosV.Offset, ip.EndV.Offset)
+			if tr == nil || isErrorTypeRepr(tr) {
 				return
 			}
 			hints = append(hints, InlayHint{
 				Position:    doc.analysis.lines.ostyToLSP(ip.End()),
-				Label:       LSPInlayTypeLabel(inlayTypeString(t)),
+				Label:       LSPInlayTypeLabel(tr.String()),
 				Kind:        InlayHintKindType,
 				PaddingLeft: false,
 			})
@@ -63,8 +63,8 @@ func (s *Server) handleInlayHint(req *rpcRequest) {
 			if v.Type != nil || v.Name == "" {
 				return
 			}
-			t := lookupNodeType(doc.analysis, n, v.Value)
-			if t == nil || types.IsError(t) {
+			tr := lookupBindingType(doc.analysis, v.PosV.Offset, v.EndV.Offset)
+			if tr == nil || isErrorTypeRepr(tr) {
 				return
 			}
 			nameOff := findNameOffset(doc.src, v.PosV.Offset, v.EndV.Offset, v.Name)
@@ -73,7 +73,7 @@ func (s *Server) handleInlayHint(req *rpcRequest) {
 			}
 			hints = append(hints, InlayHint{
 				Position: doc.analysis.lines.offsetToLSP(nameOff + len(v.Name)),
-				Label:    LSPInlayTypeLabel(inlayTypeString(t)),
+				Label:    LSPInlayTypeLabel(tr.String()),
 				Kind:     InlayHintKindType,
 			})
 		}
@@ -82,27 +82,25 @@ func (s *Server) handleInlayHint(req *rpcRequest) {
 	replyJSON(s.conn, req.ID, hints)
 }
 
-// lookupNodeType returns the best-known type for a let binding.
-// Prefer LetTypes (tracked per declaration) and fall back to the
-// RHS expression's inferred type.
-func lookupNodeType(a *docAnalysis, decl ast.Node, rhs ast.Expr) types.Type {
-	if a.check == nil {
+// lookupBindingType returns the native check result type for a let binding
+// at the given offset range, using the semantic DB (stable offsets) instead
+// of pointer-keyed maps.
+func lookupBindingType(a *docAnalysis, start, end int) *api.TypeRepr {
+	if a.semantic == nil {
 		return nil
 	}
-	if t, ok := a.check.LetTypes[decl]; ok {
-		return t
+	if b := a.semantic.CheckedBindingAt(a.sourcePath, start); b != nil && b.Type != nil {
+		return b.Type
 	}
-	if rhs != nil {
-		return a.check.LookupType(rhs)
+	if n := a.semantic.CheckedNodeAt(a.sourcePath, end); n != nil && n.Type != nil {
+		return n.Type
 	}
 	return nil
 }
 
-func inlayTypeString(t types.Type) string {
-	if u, ok := t.(*types.Untyped); ok {
-		t = u.Default()
-	}
-	return t.String()
+// isErrorTypeRepr reports whether a TypeRepr represents an error/poison type.
+func isErrorTypeRepr(tr *api.TypeRepr) bool {
+	return tr != nil && (tr.Kind == "error" || tr.Kind == "poison")
 }
 
 // nodeInRange keeps the traversal bounded to the editor's viewport.

--- a/internal/lsp/selfhost_policy_test.go
+++ b/internal/lsp/selfhost_policy_test.go
@@ -32,7 +32,7 @@ func TestCompletionItemUsesSelfHostedPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
-			got := completionItemFromSym(tt.label, &resolve.Symbol{Kind: tt.kind}, nil)
+			got := completionItemFromSym(tt.label, &resolve.Symbol{Kind: tt.kind}, nil, "")
 			if got.Kind != tt.wantKind {
 				t.Fatalf("kind = %d, want %d", got.Kind, tt.wantKind)
 			}
@@ -359,7 +359,7 @@ func TestSignatureTypeParsingUsesSelfHostedPolicy(t *testing.T) {
 }
 
 func TestHoverMarkdownWrapsSelfHostedPolicy(t *testing.T) {
-	view := hoverSymbolView(&resolve.Symbol{Name: "User", Kind: resolve.SymStruct}, "", nil)
+	view := hoverSymbolView(&resolve.Symbol{Name: "User", Kind: resolve.SymStruct}, "", nil, "")
 	if !view.HasSym || view.Kind != "struct" || view.Name != "User" {
 		t.Fatalf("view = %+v", view)
 	}
@@ -368,7 +368,7 @@ func TestHoverMarkdownWrapsSelfHostedPolicy(t *testing.T) {
 		t.Fatalf("hover markdown = %q, want %q", got, want)
 	}
 
-	fallback := selfhost.LSPHoverMarkdown(hoverSymbolView(nil, "raw", nil))
+	fallback := selfhost.LSPHoverMarkdown(hoverSymbolView(nil, "raw", nil, ""))
 	if want := "```osty\nraw\n```"; fallback != want {
 		t.Fatalf("fallback markdown = %q, want %q", fallback, want)
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -495,7 +495,7 @@ func (s *Server) analyzePackage(pkgDir, path string, src []byte) *docAnalysis {
 	lspMaterializeNativePackageFiles(pkg)
 	pr := resolve.ResolvePackage(pkg, s.prelude)
 	chk := check.Package(pkg, pr, lspCheckOpts(nil))
-	lr := lint.Package(pkg, pr, chk)
+	lr := lint.Package(pkg)
 	a := analysisForFileInPackage(pkg, pr, chk, lr, path, src)
 	if a != nil {
 		a.packages = []*resolve.Package{pkg}
@@ -757,7 +757,7 @@ func (s *Server) analyzeWorkspaceViaEngine(root, path string, src []byte) *docAn
 	// for the diagnostics we publish to the editor, and linting every
 	// package on every keystroke is too expensive.
 	pr := rw.ResultByDir(dir)
-	lr := lint.Package(pkg, pr, chk)
+	lr := lint.Package(pkg)
 
 	allDiags := collectDiagsForFile(pkg, pr, chk, lr, pf)
 
@@ -817,7 +817,7 @@ func (s *Server) analyzeWorkspace(root, path string, src []byte) *docAnalysis {
 				// the diagnostics we publish to the editor, and
 				// linting every package in the workspace on every
 				// keystroke is too expensive.
-				lr := lint.Package(pkg, resolved[pkgPath], checks[pkgPath])
+				lr := lint.Package(pkg)
 				a := analysisForFileInPackage(
 					pkg,
 					resolved[pkgPath],

--- a/internal/lsp/signature.go
+++ b/internal/lsp/signature.go
@@ -3,8 +3,8 @@ package lsp
 import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/token"
-	"github.com/osty/osty/internal/types"
 )
 
 // handleSignatureHelp answers `textDocument/signatureHelp`. The
@@ -99,32 +99,36 @@ func buildSignatureInfo(call *ast.CallExpr, doc *document) (SignatureInformation
 		return info, true
 	}
 	a := doc.analysis
-	if a == nil || a.check == nil {
+	if a == nil {
 		return SignatureInformation{}, false
 	}
 	sym, fnDecl := calleeSymbol(call, a)
 	if sym == nil {
 		return SignatureInformation{}, false
 	}
-	t := a.check.LookupSymType(sym)
-	fnType, ok := t.(*types.FnType)
-	if !ok {
+	var fnTypeRepr *api.TypeRepr
+	if a.semantic != nil {
+		if cs := a.semantic.CheckedSymbolAt(a.sourcePath, sym.Pos.Offset); cs != nil && cs.Type != nil && cs.Type.Kind == "fn" {
+			fnTypeRepr = cs.Type
+		}
+	}
+	if fnTypeRepr == nil {
 		return SignatureInformation{}, false
 	}
 	// Build param labels. Names come from the AST decl when we have
 	// it; otherwise fall back to `argN` placeholders so the shape is
 	// still useful.
-	paramNames := parameterNames(fnDecl, len(fnType.Params))
-	params := make([]LSPSignatureParam, 0, len(fnType.Params))
-	for i, pt := range fnType.Params {
+	paramNames := parameterNames(fnDecl, len(fnTypeRepr.Args))
+	params := make([]LSPSignatureParam, 0, len(fnTypeRepr.Args))
+	for i := range fnTypeRepr.Args {
 		params = append(params, LSPSignatureParam{
 			Name:     paramNames[i],
-			TypeName: pt.String(),
+			TypeName: fnTypeRepr.Args[i].String(),
 		})
 	}
 	returnType := ""
-	if fnType.Return != nil && !types.IsUnit(fnType.Return) {
-		returnType = fnType.Return.String()
+	if fnTypeRepr.Return != nil && fnTypeRepr.Return.Kind != "unit" {
+		returnType = fnTypeRepr.Return.String()
 	}
 	rendered := LSPBuildSignatureText(sym.Name, params, returnType)
 	paramInfo := make([]ParameterInformation, 0, len(rendered.ParameterLabels))

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -548,7 +548,7 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 
 	// --- lint ---
 	t0 = time.Now()
-	lr := lint.File(file, src, res, chk)
+	lr := lint.Source(src)
 	r.Lint = lr
 	r.AllDiags = append(r.AllDiags, lr.Diags...)
 	emit(Stage{
@@ -725,14 +725,7 @@ func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result
 	t0 = time.Now()
 	var lintDiags []*diag.Diagnostic
 	for _, pf := range pkg.Files {
-		fileRes := &resolve.Result{
-			RefsByID:      pf.RefsByID,
-			TypeRefsByID:  pf.TypeRefsByID,
-			RefIdents:     pf.RefIdents,
-			TypeRefIdents: pf.TypeRefIdents,
-			FileScope:     pf.FileScope,
-		}
-		lr := lint.File(pf.File, pf.Source, fileRes, chk)
+		lr := lint.Source(pf.Source)
 		lintDiags = append(lintDiags, lr.Diags...)
 	}
 	r.AllDiags = append(r.AllDiags, lintDiags...)
@@ -949,14 +942,7 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 			continue
 		}
 		for _, pf := range pkg.Files {
-			fileRes := &resolve.Result{
-				RefsByID:      pf.RefsByID,
-				TypeRefsByID:  pf.TypeRefsByID,
-				RefIdents:     pf.RefIdents,
-				TypeRefIdents: pf.TypeRefIdents,
-				FileScope:     pf.FileScope,
-			}
-			lr := lint.File(pf.File, pf.Source, fileRes, cr)
+			lr := lint.Source(pf.Source)
 			lintDiags = append(lintDiags, lr.Diags...)
 		}
 	}

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -2433,7 +2433,7 @@ fn opParseAnnotationArg(p: OstyParser) -> Int {
         let _ = opAdvance(p)
         let mut compChildren: List<Int> = []
         opSkipNewlines(p)
-        while !opAt(p, FrontRParen) && !opAt(p, FrontEOF) {
+        for !opAt(p, FrontRParen) && !opAt(p, FrontEOF) {
             compChildren.push(opParseAnnotationArg(p))
             opSkipNewlines(p)
             if !opEat(p, FrontComma) {
@@ -2445,7 +2445,7 @@ fn opParseAnnotationArg(p: OstyParser) -> Int {
         let mut calleeNode = emptyAstNode(AstNIdent)
         calleeNode.text = key
         calleeNode.start = start
-        calleeNode.end = start + key.length
+        calleeNode.end = start + key.len()
         let mut cn = emptyAstNode(AstNCall)
         cn.left = opAddNode(p, calleeNode)
         cn.children = compChildren


### PR DESCRIPTION
## Summary

`host_boundary.go` 제거를 위한 선행 작업 — lint API 정리 및 LSP의 `check.Result` 포인터 키 맵 의존을 semanticDB로 전환합니다.

## Changes

### P1: lint API 정리
- `lint.File()` 제거 (모든 파라미터 `_`로 무시되던 함수)
- `lint.Package()` 시그니처 단순화: `(pkg, pr, chk)` → `(pkg)`
- `pipeline.go`에서 `lint.File(...)` → `lint.Source(src)` 전환, dead code `fileRes` 블록 2개 제거
- LLVM_MIGRATION_PLAN: lint AstArena 포팅을 ✅ 완료로 갱신

### P2: LSP pointer-keyed map 의존 제거
- `inlay.go`: `check.LetTypes`/`check.Types` → `semanticdb.CheckedBindingAt`/`CheckedNodeAt`
- `completion.go`: `LookupSymType` → `CheckedSymbolAt`
- `handlers.go`: `hoverSymbolView`/`semanticHoverLegacyContext` → `CheckedSymbolAt`
- `signature.go`: `*types.FnType` → `*api.TypeRepr` (Kind=fn)

### 남은 작업 (후속 PR)
- `airepair/semantic.go` — 편집 후 AST identity 문제로 전환 불가
- `ir/lower.go` — native 경로에 span fallback 추가 필요
- 위 완료 후 `host_boundary.go`의 `overlaySelfhostResult` dead code → 제거

## Test
- `go build ./...` ✅
- `go vet ./internal/lint/ ./internal/lsp/ ./internal/pipeline/ ./cmd/osty/ ./internal/cihost/` ✅
- `go test ./internal/lsp/ ./cmd/osty/ -count=1 -vet=off` ✅
