### PR TITLE
fix(stage0): synthetic prelude block when entry has predecessors (cluster 2/5)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -14947,12 +14947,36 @@ func emitGenericScalarCFG(out *strings.Builder, fn *mir.Function, pat genericCFG
 		}
 		out.WriteString(") {\n")
 	}
+	// LLVM rule: the FIRST basic block in a function may not have
+	// predecessors. When the source MIR's entry block is the target
+	// of a backedge (loop continue, while-style structure), emitting
+	// it as the LLVM `entry:` block violates the rule.
+	//
+	// Fix: emit a synthetic prelude block (`stage0.prelude:`) FIRST.
+	// It holds the allocas and unconditionally branches to the
+	// original entry. The block named `entry` is no longer the
+	// function's first block — LLVM treats whatever appears first
+	// as the entry, so `stage0.prelude` becomes the actual entry
+	// and the user's `entry` block becomes a regular block that's
+	// allowed to have predecessors.
+	//
+	// Pre-rendered `pat.blockBodies` strings reference `%entry` for
+	// branches to the user's first block; we keep those intact by
+	// not renaming it.
+	splitEntry := genericEntryHasPredecessors(fn)
+	if splitEntry {
+		out.WriteString("stage0.prelude:\n")
+		for _, sd := range pat.stackDecls {
+			fmt.Fprintf(out, "  %%%s = alloca %s\n", sd.name, sd.ty.llvm())
+		}
+		fmt.Fprintf(out, "  br label %%%s\n\n", genericBlockLabel(fn, fn.Entry))
+	}
 	for i, id := range pat.blockOrder {
 		if i > 0 {
 			out.WriteString("\n")
 		}
 		fmt.Fprintf(out, "%s:\n", genericBlockLabel(fn, id))
-		if id == fn.Entry {
+		if id == fn.Entry && !splitEntry {
 			for _, sd := range pat.stackDecls {
 				fmt.Fprintf(out, "  %%%s = alloca %s\n", sd.name, sd.ty.llvm())
 			}
@@ -14961,6 +14985,33 @@ func emitGenericScalarCFG(out *strings.Builder, fn *mir.Function, pat genericCFG
 	}
 	out.WriteString("}\n\n")
 	return nil
+}
+
+// genericEntryHasPredecessors reports whether any block in fn
+// branches (Goto, Branch then/else) to the function's entry block.
+// LLVM's IR validator rejects functions whose first basic block has
+// predecessors; emitGenericScalarCFG inserts a synthetic prelude
+// block before the entry when this returns true.
+func genericEntryHasPredecessors(fn *mir.Function) bool {
+	if fn == nil {
+		return false
+	}
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		switch term := bb.Term.(type) {
+		case *mir.GotoTerm:
+			if term.Target == fn.Entry {
+				return true
+			}
+		case *mir.BranchTerm:
+			if term.Then == fn.Entry || term.Else == fn.Entry {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func genericBlockLabel(fn *mir.Function, id mir.BlockID) string {


### PR DESCRIPTION
## Summary

LLVM rejects functions whose first basic block has predecessors:
\`error: invalid LLVM IR input: Entry block to function must not have predecessors!\`. Stage0's \`emitGenericScalarCFG\` named the source MIR's first block \`entry:\`, then emitted backedge \`br label %entry\` for while-loop bodies that wrapped back.

Audit-time L1 reported 6 functions with this exact shape — all \`while cond { ... }\` source patterns whose MIR has the loop condition computed in the entry block and the loop body branching back to it: \`opSkipNewlines\`, \`opSyncDecl\`, \`opSyncStmt\`, \`opTruncateErrors\`, \`skipHorizontalWhitespace\`, \`skipWhitespaceAndComments\`.

## Fix

When the source's entry block has any predecessor (Goto or Branch from another block), emit a synthetic \`stage0.prelude:\` block FIRST that contains the function's allocas and unconditionally branches to \`entry\`. LLVM treats whatever appears first as the entry block; the user's \`entry:\` label becomes a regular block that's allowed to have predecessors. Pre-rendered \`pat.blockBodies\` strings keep their \`br label %entry\` references intact (no renaming required).

### Detection

\`genericEntryHasPredecessors(fn)\` walks all blocks once, checks \`GotoTerm.Target\` / \`BranchTerm.{Then,Else}\` against \`fn.Entry\`. Runs once per function during emit; negligible cost.

## Audit progression

| Bucket | Before | After |
|---|---|---|
| \`Entry block must not have predecessors\` | 6 | **0** ✅ |
| \`expected type\` | 4 | 4 |
| \`integer constant must have integer type\` | 3 | 3 |
| \`defined with type A but expected B\` | 2 | 2 |
| \`unable to create block named 'entry'\` | 2 | 2 |
| **Total emit-broken** | **18** | **12** |

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0\` passes (160 emit_test cases — none asserted on the entry block's exact label structure for the generic-CFG path)
- [x] \`OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_CLANG_VERIFY=1 go test -timeout 30m -run TestStage0ToolchainAudit -v ./internal/backend/\` shows 12 emit-broken across 4 shapes (down from 18 across 5)

## Trail

Cluster 1 (SSA collision): #1592 — 6 → 0.
**Cluster 2 (Entry block predecessors): this PR — 6 → 0.**
Cluster 3 (expected type): pending — 4 cases of intrinsic-call without retType in non-\`classifyIntrinsicValueStep\` paths.
Cluster 4 (integer constant): pending — \`fcmp oeq double X, 0e+00\` rejected; LLVM wants \`0.000000e+00\` or \`0.0\` for f64.
Cluster 5 (type mismatch): pending — \`call ptr @sym(i64 %idx.slot, ...)\` — passing alloca slot pointer where i64 expected.
Cluster 6 (duplicate entry label): pending — different bug, function emits 2× \`entry:\` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)