### PR TITLE
fix(parser): backport opParseMatchArmBody to Go seed

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -21008,7 +21008,7 @@ func opParseMatchExpr(p *OstyParser) int {
 		// Osty: /tmp/selfhost_merged.osty:7772:9
 		_ = opExpect(p, FrontTokenKind(&FrontTokenKind_FrontArrow{}))
 		// Osty: /tmp/selfhost_merged.osty:7773:9
-		body := opParseExpr(p)
+		body := opParseMatchArmBody(p)
 		_ = body
 		// Osty: /tmp/selfhost_merged.osty:7774:9
 		armNode := emptyAstNode(AstNodeKind(&AstNodeKind_AstNMatchArm{}))
@@ -21049,6 +21049,42 @@ func opParseMatchExpr(p *OstyParser) int {
 	// Osty: /tmp/selfhost_merged.osty:7790:6
 	n.end = p.pos
 	return opAddNode(p, n)
+}
+
+// Backport of toolchain/parser.osty opParseMatchArmBody.
+// Handles assignment expressions as match arm bodies.
+func opParseMatchArmBody(p *OstyParser) int {
+	body := opParseExpr(p)
+	next := opPeek(p)
+	if !frontIsAssignOp(next.kind) {
+		return body
+	}
+	_ = opAdvance(p)
+	value := opParseExpr(p)
+	bodyNode := astArenaNodeAt(p.arena, body)
+	var stmtIdx int = -1
+	if _, ok := next.kind.(*FrontTokenKind_FrontAssign); ok {
+		lowered := opLowerAppendAssignmentStmt(p, body, value, bodyNode.start, p.pos)
+		if lowered >= 0 {
+			stmtIdx = lowered
+		}
+	}
+	if stmtIdx < 0 {
+		assign := emptyAstNode(AstNodeKind(&AstNodeKind_AstNAssign{}))
+		assign.left = body
+		assign.right = value
+		assign.op = next.kind
+		assign.start = bodyNode.start
+		assign.end = p.pos
+		stmtIdx = opAddNode(p, assign)
+	}
+	var stmts []int = make([]int, 0, 1)
+	stmts = opAppendCanonicalStmt(p, stmts, stmtIdx)
+	block := emptyAstNode(AstNodeKind(&AstNodeKind_AstNBlock{}))
+	block.children = stmts
+	block.start = bodyNode.start
+	block.end = p.pos
+	return opAddNode(p, block)
 }
 
 // Osty: /tmp/selfhost_merged.osty:7794:1


### PR DESCRIPTION
## Summary

Backport `opParseMatchArmBody` from `toolchain/parser.osty` into the Go seed (`internal/selfhost/generated.go`).

## Problem

The Osty-native parser has `opParseMatchArmBody` which handles assignment expressions as match arm bodies:

```osty
match value {
    Some(v) -> out.path = v,   // field assignment in arm body
    None -> {},
}
```

The Go seed was missing this function — it used plain `opParseExpr` instead, causing:

```
error[E0204]: expected }, got =
error[E0100]: expected declaration, got ,
```

## Fix

- Added `opParseMatchArmBody` to `generated.go` (faithful translation of the Osty source)
- Changed `opParseMatchExpr` to call `opParseMatchArmBody` instead of `opParseExpr`

## Test

- `TestParseMatchArmAllowsBareAssignmentBody`: FAIL → PASS
- Front-end suite (`just front` equivalent): 30/30 PASS, 0 failures