### PR TITLE
fix(toolchain): escape embedded source braces in string interp tests

### DIFF
--- a/toolchain/parser_string_interp_test.osty
+++ b/toolchain/parser_string_interp_test.osty
@@ -14,49 +14,44 @@
 // canonical Osty parser shape ahead of when LLVM self-host LLVMgen
 // catches up. They type-check today, and the behaviour they assert
 // already lives in the `toolchain/parser.osty` source.
-
 use std.testing
-
 fn findFirstStringLit(file: AstFile) -> AstNode {
     for n in file.arena.nodes {
-        if n.kind == AstNStringLit { return n }
+        if n.kind == AstNStringLit {
+            return n
+        }
     }
     emptyAstNode(AstNError)
 }
-
 fn testParserAttachesIdentChildToStringInterp() {
-    let file = astParse("fn main() { let x = 1; let s = \"{x}\" }")
+    let file = astParse("fn main() \{ let x = 1; let s = \"\{x\}\" \}")
     let lit = findFirstStringLit(file)
     testing.assert(lit.kind == AstNStringLit)
-    // Exactly one interpolation part → one child.
     testing.assertEq(lit.children.len(), 1)
     let child = file.arena.nodes[lit.children[0]]
     testing.assert(child.kind == AstNIdent)
     testing.assertEq(child.text, "x")
 }
-
+// Exactly one interpolation part → one child.
 fn testParserAttachesMultiInterpChildren() {
-    // `"{a}-{b}"` → two interp parts, two children, in source order.
-    let file = astParse("fn main() { let a = 1; let b = 2; let s = \"{a}-{b}\" }")
+    let file = astParse("fn main() \{ let a = 1; let b = 2; let s = \"\{a\}-\{b\}\" \}")
     let lit = findFirstStringLit(file)
     testing.assertEq(lit.children.len(), 2)
     testing.assertEq(file.arena.nodes[lit.children[0]].text, "a")
     testing.assertEq(file.arena.nodes[lit.children[1]].text, "b")
 }
-
+// `"\{a\}-\{b\}"` → two interp parts, two children, in source order.
 fn testParserAttachesCallExprInsideInterp() {
-    // `"{f(x)}"` — the interp expression is a CallExpr. Verifies the
-    // sub-parser doesn't stop at the bare ident: it descends through
-    // the full expression grammar.
-    let file = astParse("fn main() { let s = \"{f(1)}\" }")
+    let file = astParse("fn main() \{ let s = \"\{f(1)\}\" \}")
     let lit = findFirstStringLit(file)
     testing.assertEq(lit.children.len(), 1)
     testing.assertEq(file.arena.nodes[lit.children[0]].kind, AstNCall)
 }
-
+// `"{f(x)}"` — the interp expression is a CallExpr. Verifies the
+// sub-parser doesn't stop at the bare ident: it descends through
+// the full expression grammar.
 fn testParserNoChildrenForLiteralOnlyString() {
-    // No interpolation → no children.
-    let file = astParse("fn main() { let s = \"hello\" }")
+    let file = astParse("fn main() \{ let s = \"hello\" \}")
     let lit = findFirstStringLit(file)
     testing.assertEq(lit.children.len(), 0)
 }

--- a/toolchain/resolve_string_interp_test.osty
+++ b/toolchain/resolve_string_interp_test.osty
@@ -8,40 +8,29 @@
 // No new resolver case is needed — `AstNStringLit` has no early-return
 // in `srAstResolveExpr`, so the generic walker already iterates
 // `node.children`. These tests lock that contract in.
-
 use std.testing
-
 fn testResolverWalksInterpIdent() {
-    // Single ident inside interpolation — `x` reaches the resolver
-    // via the StringLit's children, gets recorded in refList.
-    let res = selfResolveSource("fn main() { let x = 1; let s = \"{x}\" }")
+    let res = selfResolveSource("fn main() \{ let x = 1; let s = \"\{x\}\" \}")
     testing.assert(selfResolveHasRef(res, "x"))
 }
-
+// Single ident inside interpolation — `x` reaches the resolver
+// via the StringLit's children, gets recorded in refList.
 fn testResolverWalksMultipleInterpIdents() {
-    // Both `a` and `b` should appear in refs.
-    let res = selfResolveSource("fn main() { let a = 1; let b = 2; let s = \"{a}-{b}\" }")
+    let res = selfResolveSource("fn main() \{ let a = 1; let b = 2; let s = \"\{a\}-\{b\}\" \}")
     testing.assert(selfResolveHasRef(res, "a"))
     testing.assert(selfResolveHasRef(res, "b"))
 }
-
+// Both `a` and `b` should appear in refs.
 fn testResolverWalksInterpCallCallee() {
-    // Call inside interpolation — the callee `f` should appear in
-    // refs (assuming `f` is in scope; here we use a let-binding so
-    // the resolver matches without complaining).
-    let res = selfResolveSource(
-        "fn helper() -> Int { 42 }\n" +
-        "fn main() { let f = helper; let s = \"{f()}\" }"
-    )
-    // The closure capture `f` shows up as a ref, exercising the
-    // walker's recursion into AstNCall.callee inside the StringLit.
+    let res = selfResolveSource("fn helper() -> Int \{ 42 \}\n" + "fn main() \{ let f = helper; let s = \"\{f()\}\" \}")
     testing.assert(selfResolveHasRef(res, "f"))
 }
-
+// Call inside interpolation — the callee `f` should appear in
+// refs (assuming `f` is in scope; here we use a let-binding so
+// the resolver matches without complaining).
+// The closure capture `f` shows up as a ref, exercising the
+// walker's recursion into AstNCall.callee inside the StringLit.
 fn testResolverIgnoresLiteralOnlyString() {
-    // No interpolation, no extra refs. Just confirm the call shape
-    // doesn't blow up.
-    let res = selfResolveSource("fn main() { let s = \"hello\" }")
-    // 'hello' is not an ident — selfResolveHasRef returns false.
+    let res = selfResolveSource("fn main() \{ let s = \"hello\" \}")
     testing.assert(!selfResolveHasRef(res, "hello"))
 }


### PR DESCRIPTION
## Summary

Escape embedded source braces in the self-host string interpolation toolchain tests so the outer Osty string literals are valid source.

## Problem

These two files embed Osty source inside Osty string literals:

- `toolchain/parser_string_interp_test.osty`
- `toolchain/resolve_string_interp_test.osty`

The embedded snippets used literal `{ ... }` function-body braces and `"{x}"` / `"{f()}"` forms directly inside the outer strings. In Osty strings, unescaped `{` / `}` start interpolation, so the files themselves were not formatter-parseable.

That forced the toolchain-wide formatter sweep to exclude them.

## Fix

Escape all literal braces in the embedded snippets:

- `fn main() { ... }` → `fn main() \{ ... \}`
- `"{x}"` → `"\{x\}"`
- same for multi-interp / call-interp cases

Then run canonical formatting on both files.

## Validation

- `.bin/osty fmt --check toolchain/parser_string_interp_test.osty`
- `.bin/osty fmt --check toolchain/resolve_string_interp_test.osty`
- `.bin/osty ci toolchain/` → `0 error(s)`