### PR TITLE
fix(stage0): populate pendingInstr.resultType in 3 more call builders (cluster 3 partial)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -1827,6 +1827,7 @@ func classifyCallStep(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.Loca
 			prelude:    resolved.prelude,
 			callSymbol: ref.Symbol,
 			callArgs:   resolved.args,
+			resultType: destType, // see #1587 / cluster 3 fix — emitPendingInstr needs this for the `<retType>` slot in `%reg = call <retType> @<sym>(…)`
 		}, destID, destType, true
 	}
 	if mctx.scalarFromType(fnTy.Return, allowOpaqueUserNamed) != destType {
@@ -1858,6 +1859,7 @@ func classifyCallStep(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.Loca
 		prelude:    prelude.String(),
 		callSymbol: ref.Symbol,
 		callArgs:   args,
+		resultType: destType, // see #1587 / cluster 3 fix
 	}, destID, destType, true
 }
 
@@ -2844,6 +2846,15 @@ func classifyAssignSrc(fn *mir.Function, src mir.RValue, destType scalarType, bi
 				prelude:    leftPrelude + rightPrelude,
 				callSymbol: symbol,
 				callArgs:   []callArg{leftArg, rightArg},
+				// `resultType` populates `<resultType.llvm()>` in the
+				// emitted `%reg = call <type> @<sym>(...)` line; missing
+				// it produced `call  @osty_rt_strings_Concat(…)` (two
+				// spaces, no return type) — clang `error: expected
+				// type`. Same fix family as #1587 bug 2 in the
+				// intrinsic-spec fallback path. Here we know the call
+				// returns String (the binary `+` on String is the only
+				// reason this branch fires).
+				resultType: scalarString,
 			}, "", true
 		}
 		// P16 — Special-case String ==/!= String: lowers to a runtime


### PR DESCRIPTION
## Summary

Audit-time L1 (\`OSTY_STAGE0_AUDIT_CLANG_VERIFY=1\`) reported 4 emit-broken functions with the \`expected type\` diagnostic — same shape as PR #1587's intrinsic-spec fix (\"\`call  @symbol(…)\` (two spaces, no return type)\") but in three additional \`pendingInstr{ kind: instrCall }\` builders that never set \`resultType\`.

## Sites fixed

| Site | Returns | Was missing |
|---|---|---|
| \`classifyCallStep\` ErrType branch (~line 1825) | \`destType\` | \`resultType: destType\` |
| \`classifyCallStep\` FnType branch (~line 1856) | \`destType\` | \`resultType: destType\` |
| \`classifyAssignSrc\` String + Add (~line 2842) | always \`scalarString\` (branch condition) | \`resultType: scalarString\` |

\`emitPendingInstr\` renders the \`instrCall\` form with \`fmt.Fprintf(out, \"  %s = call %s @%s(\", pi.binDestReg, pi.resultType.llvm(), pi.callSymbol)\`. With \`resultType\` zero (\`scalarUnknown\`), \`.llvm() == \"\"\` and the emitted line collapses to \`call  @sym(…)\` — clang \`error: expected type\`.

## Coverage

Drops bare \`call  @sym(…)\` for call sites these branches reach. The for-in-list / while-loop string-concat-via-stack-accumulator case (\`lspAsciiLowerText\` etc.) routes through \`forInListAssign\` / \`emitWhileAssign\` and resolves operands raw without loading a stack-backed accumulator — that's a different bug, queued for follow-up.

## Audit progression

| Cluster | Before #1592 | After #1592 | After #1594 | After this PR |
|---|---|---|---|---|
| instruction expected to be numbered | 6 | **0** ✅ | 0 | 0 |
| Entry block must not have predecessors | 6 | 6 | **0** ✅ | 0 |
| expected type | 4 | 4 | 4 | (partial; for-in-list path still broken) |
| integer constant must be integer | 3 | 3 | 3 | 3 |
| defined with type A vs B | 2 | 2 | 2 | 2 |
| unable to create block 'entry' | 2 | 2 | 2 | 2 |

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0\` passes (160 emit_test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)