### PR TITLE
fix(diag): suggest nearest supported cfg key for E0405

### DIFF
--- a/internal/resolve/cfg.go
+++ b/internal/resolve/cfg.go
@@ -190,6 +190,7 @@ func evaluateCfgArg(arg *ast.AnnotationArg, env *CfgEnv) (bool, []*diag.Diagnost
 				"unknown cfg key `"+arg.Key+"`").
 				Code(diag.CodeCfgUnknownKey).
 				PrimaryPos(arg.PosV, "unrecognised cfg key").
+				Hint(didYouMeanHintFromList(arg.Key, []string{"os", "target", "arch", "feature"})).
 				Note("v0.5 §5 / G29 recognises only `os`, `target`, `arch`, `feature`").
 				Build(),
 		}

--- a/internal/resolve/cfg_test.go
+++ b/internal/resolve/cfg_test.go
@@ -1,0 +1,39 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+)
+
+func TestEvaluateCfgOnDeclSuggestsNearestSupportedKey(t *testing.T) {
+	src := []byte(`#[cfg(taret = "linux")]
+fn main() {}
+`)
+	file, diags := parser.ParseCanonical(src)
+	if len(diags) != 0 {
+		t.Fatalf("ParseCanonical diagnostics = %#v, want none", diags)
+	}
+	if file == nil || len(file.Decls) != 1 {
+		t.Fatalf("parsed file = %#v, want one declaration", file)
+	}
+	pass, ds := evaluateCfgOnDecl(file.Decls[0], &CfgEnv{
+		OS:       "linux",
+		Arch:     "amd64",
+		Target:   "linux",
+		Features: map[string]bool{},
+	})
+	if pass {
+		t.Fatal("evaluateCfgOnDecl passed, want false for unknown cfg key")
+	}
+	if len(ds) != 1 {
+		t.Fatalf("diagnostics = %#v, want 1", ds)
+	}
+	if got := ds[0].Code; got != diag.CodeCfgUnknownKey {
+		t.Fatalf("diag code = %q, want %q", got, diag.CodeCfgUnknownKey)
+	}
+	if got := ds[0].Hint; got != "did you mean `target`?" {
+		t.Fatalf("diag hint = %q, want did-you-mean target", got)
+	}
+}

--- a/internal/resolve/helpers.go
+++ b/internal/resolve/helpers.go
@@ -92,3 +92,33 @@ func growInts(p *[]int, n int) []int {
 	}
 	return s
 }
+
+func suggestFromList(name string, candidates []string) string {
+	best := ""
+	bestDist := 3
+	nameLen := len(name)
+	var buf1, buf2 []int
+	for _, candidate := range candidates {
+		diff := len(candidate) - nameLen
+		if diff > bestDist-1 || -diff > bestDist-1 {
+			continue
+		}
+		dist := levenshteinBounded(name, candidate, bestDist, &buf1, &buf2)
+		if dist < bestDist {
+			best = candidate
+			bestDist = dist
+			if bestDist == 1 {
+				return best
+			}
+		}
+	}
+	return best
+}
+
+func didYouMeanHintFromList(name string, candidates []string) string {
+	suggestion := suggestFromList(name, candidates)
+	if suggestion == "" {
+		return ""
+	}
+	return "did you mean `" + suggestion + "`?"
+}

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -2206,7 +2206,11 @@ fn srCheckCfgArg(file: AstFile, argIdx: Int, result: SelfResolveResult) -> SelfR
     if view.key == "os" || view.key == "arch" || view.key == "target" || view.key == "feature" {
         return out
     }
-    out.diagnostics.push(selfResolveDiagnosticHintAtNode("E0405", "unknown cfg key `" + view.key + "`", "cfg", view.start, view.end, -1, "v0.5 §5 / G29 recognises only `os`, `target`, `arch`, `feature`"))
+    let mut hint = srDidYouMeanHint(view.key, srCfgKeys())
+    if hint == "" {
+        hint = "v0.5 §5 / G29 recognises only `os`, `target`, `arch`, `feature`"
+    }
+    out.diagnostics.push(selfResolveDiagnosticHintAtNode("E0405", "unknown cfg key `" + view.key + "`", "cfg", view.start, view.end, -1, hint))
     out
 }
 /// srCfgDeclPasses decides whether a decl survives the `#[cfg(...)]`
@@ -2795,6 +2799,9 @@ fn srJSONArgKeys() -> List<String> {
 }
 fn srDeprecatedArgKeys() -> List<String> {
     ["since", "use", "message"]
+}
+fn srCfgKeys() -> List<String> {
+    ["os", "target", "arch", "feature"]
 }
 /// srSuggestFromList finds the closest candidate (Levenshtein distance
 /// < 3) from a fixed list. Returns "" if nothing is within reach. This

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -684,6 +684,22 @@ fn testSelfResolverCfgUnknownKeyEmitsE0405() {
     testing.assertEq(selfResolveCodeCount(result, "E0405"), 1)
     testing.assert(!selfResolveHasSymbol(result, "bad", "fn"))
 }
+fn testSelfResolverCfgUnknownKeySuggestsNearestSupportedKey() {
+    let source = r"""
+            #[cfg(taret = "linux")]
+            fn bad() -> Int { 1 }
+            """
+    let env = selfResolveCfgEnv("linux", "amd64", "linux", [])
+    let result = selfResolveAstFileWithCfg(astParse(source), env)
+    testing.assertEq(selfResolveCodeCount(result, "E0405"), 1)
+    let mut sawHint = false
+    for diag in result.diagnostics {
+        if diag.code == "E0405" && diag.hint == "did you mean `target`?" {
+            sawHint = true
+        }
+    }
+    testing.assert(sawHint)
+}
 // Unknown key evaluates to false — decl drops. Matches Go cfg.go.
 fn testSelfResolverCfgTargetMismatchDrops() {
     let source = r"""


### PR DESCRIPTION
## Summary

Improve cfg diagnostics by suggesting the nearest supported cfg key when `E0405` is emitted.

## Before

For typos like:

```osty
#[cfg(taret = "linux")]
fn bad() -> Int { 1 }
```

users only got:

- `E0405 unknown cfg key 'taret'`
- note listing supported keys

## After

The diagnostic now includes a direct did-you-mean hint:

- `hint: did you mean 'target'?`

This is implemented in both:

- Go-side cfg evaluator: `internal/resolve/cfg.go`
- self-host resolver: `toolchain/resolve.osty`

## Tests

- Added `internal/resolve/cfg_test.go`
- Added self-host resolver regression in `toolchain/resolve_test.osty`
- Verified with:
  - `go test -count=1 -vet=off ./internal/resolve/...`
  - `.bin/osty check toolchain/`
