### PR TITLE
fix(diag): suggest nearest cfg composition name for E0739

### DIFF
--- a/internal/resolve/cfg.go
+++ b/internal/resolve/cfg.go
@@ -237,6 +237,7 @@ func evaluateCfgCompose(op string, children []*ast.AnnotationArg, pos token.Pos,
 				"unknown cfg composition `"+op+"`").
 				Code(diag.CodeAnnotationBadArg).
 				PrimaryPos(pos, "unknown cfg composition").
+				Hint(didYouMeanHintFromList(op, []string{"all", "any", "not"})).
 				Note("v0.5 §5 / G29: use `all`, `any`, or `not`").
 				Build(),
 		}

--- a/internal/resolve/cfg_test.go
+++ b/internal/resolve/cfg_test.go
@@ -3,27 +3,37 @@ package resolve
 import (
 	"testing"
 
+	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
 )
 
-func TestEvaluateCfgOnDeclSuggestsNearestSupportedKey(t *testing.T) {
-	src := []byte(`#[cfg(taret = "linux")]
-fn main() {}
-`)
-	file, diags := parser.ParseCanonical(src)
+func parseSingleDeclForCfgTest(t *testing.T, src string) ast.Decl {
+	t.Helper()
+	file, diags := parser.ParseCanonical([]byte(src))
 	if len(diags) != 0 {
 		t.Fatalf("ParseCanonical diagnostics = %#v, want none", diags)
 	}
 	if file == nil || len(file.Decls) != 1 {
 		t.Fatalf("parsed file = %#v, want one declaration", file)
 	}
-	pass, ds := evaluateCfgOnDecl(file.Decls[0], &CfgEnv{
+	return file.Decls[0]
+}
+
+func testCfgEnv() *CfgEnv {
+	return &CfgEnv{
 		OS:       "linux",
 		Arch:     "amd64",
 		Target:   "linux",
 		Features: map[string]bool{},
-	})
+	}
+}
+
+func TestEvaluateCfgOnDeclSuggestsNearestSupportedKey(t *testing.T) {
+	decl := parseSingleDeclForCfgTest(t, `#[cfg(taret = "linux")]
+fn main() {}
+`)
+	pass, ds := evaluateCfgOnDecl(decl, testCfgEnv())
 	if pass {
 		t.Fatal("evaluateCfgOnDecl passed, want false for unknown cfg key")
 	}
@@ -35,5 +45,31 @@ fn main() {}
 	}
 	if got := ds[0].Hint; got != "did you mean `target`?" {
 		t.Fatalf("diag hint = %q, want did-you-mean target", got)
+	}
+}
+
+func TestEvaluateCfgOnDeclSuggestsNearestSupportedComposition(t *testing.T) {
+	decl := &ast.FnDecl{Annotations: []*ast.Annotation{{
+		Name: "cfg",
+		Args: []*ast.AnnotationArg{{
+			Key: "al",
+			Compose: []*ast.AnnotationArg{{
+				Key:   "os",
+				Value: &ast.StringLit{Parts: []ast.StringPart{{IsLit: true, Lit: "linux"}}},
+			}},
+		}},
+	}}}
+	pass, ds := evaluateCfgOnDecl(decl, testCfgEnv())
+	if pass {
+		t.Fatal("evaluateCfgOnDecl passed, want false for unknown cfg composition")
+	}
+	if len(ds) != 1 {
+		t.Fatalf("diagnostics = %#v, want 1", ds)
+	}
+	if got := ds[0].Code; got != diag.CodeAnnotationBadArg {
+		t.Fatalf("diag code = %q, want %q", got, diag.CodeAnnotationBadArg)
+	}
+	if got := ds[0].Hint; got != "did you mean `all`?" {
+		t.Fatalf("diag hint = %q, want did-you-mean all", got)
 	}
 }

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -2185,15 +2185,23 @@ fn srCheckCfgArg(file: AstFile, argIdx: Int, result: SelfResolveResult) -> SelfR
     let arg = srAstNode(file, argIdx)
     if arg.kind == AstNCall && arg.left >= 0 {
         let callee = srAstNode(file, arg.left)
-        if callee.kind == AstNIdent && (callee.text == "all" || callee.text == "any" || callee.text == "not") {
+        if callee.kind == AstNIdent {
             let mut out = result
-            if callee.text == "not" && arg.children.len() != 1 {
-                out.diagnostics.push(selfResolveDiagnosticHintAtNode("E0739", "`not(...)` requires exactly one argument", "cfg", arg.start, arg.end, -1, "v0.5 §5 / G29: `not` takes exactly one cfg predicate"))
+            if callee.text == "all" || callee.text == "any" || callee.text == "not" {
+                if callee.text == "not" && arg.children.len() != 1 {
+                    out.diagnostics.push(selfResolveDiagnosticHintAtNode("E0739", "`not(...)` requires exactly one argument", "cfg", arg.start, arg.end, -1, "v0.5 §5 / G29: `not` takes exactly one cfg predicate"))
+                    return out
+                }
+                for childIdx in arg.children {
+                    out = srCheckCfgArg(file, childIdx, out)
+                }
                 return out
             }
-            for childIdx in arg.children {
-                out = srCheckCfgArg(file, childIdx, out)
+            let mut hint = srDidYouMeanHint(callee.text, srCfgComposeNames())
+            if hint == "" {
+                hint = "v0.5 §5 / G29: use `all`, `any`, or `not`"
             }
+            out.diagnostics.push(selfResolveDiagnosticHintAtNode("E0739", "unknown cfg composition `" + callee.text + "`", "cfg", arg.start, arg.end, -1, hint))
             return out
         }
     }
@@ -2802,6 +2810,9 @@ fn srDeprecatedArgKeys() -> List<String> {
 }
 fn srCfgKeys() -> List<String> {
     ["os", "target", "arch", "feature"]
+}
+fn srCfgComposeNames() -> List<String> {
+    ["all", "any", "not"]
 }
 /// srSuggestFromList finds the closest candidate (Levenshtein distance
 /// < 3) from a fixed list. Returns "" if nothing is within reach. This

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -700,6 +700,23 @@ fn testSelfResolverCfgUnknownKeySuggestsNearestSupportedKey() {
     }
     testing.assert(sawHint)
 }
+fn testSelfResolverCfgUnknownCompositionSuggestsNearestSupportedName() {
+    let source = r"""
+            #[cfg(al(os = "linux"))]
+            fn bad() -> Int { 1 }
+            """
+    let env = selfResolveCfgEnv("linux", "amd64", "linux", [])
+    let result = selfResolveAstFileWithCfg(astParse(source), env)
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+    let mut sawHint = false
+    for diag in result.diagnostics {
+        if diag.code == "E0739" && diag.hint == "did you mean `all`?" {
+            sawHint = true
+        }
+    }
+    testing.assert(sawHint)
+    testing.assert(!selfResolveHasSymbol(result, "bad", "fn"))
+}
 // Unknown key evaluates to false — decl drops. Matches Go cfg.go.
 fn testSelfResolverCfgTargetMismatchDrops() {
     let source = r"""


### PR DESCRIPTION
## Summary

Improve `#[cfg(...)]` diagnostics again by suggesting the nearest supported composition name when `E0739` is emitted for an unknown cfg composition.

## Before

For typos like:

```/dev/null/example.osty#L1-2
#[cfg(al(os = "linux"))]
fn main() {}
```

users got a generic error:

- `unknown cfg composition 'al'`
- hint/note only listing `all`, `any`, `not`

## After

The diagnostic now includes a direct did-you-mean hint:

- `hint: did you mean 'all'?`

## Implementation

- Go-side cfg evaluator: `internal/resolve/cfg.go`
- Self-host resolver: `toolchain/resolve.osty`

Also added a Go test helper for cfg parse/eval cases and a self-host resolver regression test.

## Validation

- `go test -count=1 -vet=off ./internal/resolve/...`
- `.bin/osty check toolchain/`
