### PR TITLE
fix(stage0): rename params colliding with bare 'entry' block label (cluster 6)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -4394,6 +4394,17 @@ func paramFallbackName(i int) string {
 }
 
 func disambiguateParamNames(names []string) {
+	// LLVM IR puts parameter names and basic-block labels in the same
+	// per-function value namespace. Stage0 reserves a small set of bare
+	// block label names that can collide with user-source parameter
+	// names. Rename any parameter that hits a reserved label so the
+	// emitted IR doesn't produce e.g. `%entry` (parameter) and `entry:`
+	// (block label) in the same function.
+	for i := range names {
+		if isReservedStage0Label(names[i]) {
+			names[i] = fmt.Sprintf("%s.%d", names[i], i)
+		}
+	}
 	for i := 1; i < len(names); i++ {
 		for j := 0; j < i; j++ {
 			if names[i] == names[j] {
@@ -4402,6 +4413,20 @@ func disambiguateParamNames(names []string) {
 			}
 		}
 	}
+}
+
+// isReservedStage0Label reports whether `name` collides with a bare
+// (non-numbered) block label that stage0's emitter unconditionally
+// produces. All other stage0 labels go through blockLabelName, which
+// formats as "<prefix>.<id>" — those can't collide with valid Osty
+// identifier-style parameter names because Osty source identifiers
+// have no '.'.
+func isReservedStage0Label(name string) bool {
+	switch name {
+	case "entry":
+		return true
+	}
+	return false
 }
 
 // ---- P3c: if-else with phi-merged return ----

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -310,6 +310,33 @@ func TestStage0SanitizesEmptyParamName(t *testing.T) {
 	}
 }
 
+// TestStage0RenamesParamCollidingWithEntryLabel guards against a
+// regression where a user-source parameter named `entry` collides
+// with the LLVM `entry:` block label (LLVM puts param names and
+// block labels in the same per-function value namespace, so the
+// duplicate name produces "unable to create block named 'entry'").
+// The fix renames such a parameter via the disambiguation pass.
+func TestStage0RenamesParamCollidingWithEntryLabel(t *testing.T) {
+	t.Parallel()
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "passthroughEntry",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "entry", ty: ir.TInt}},
+			src:    useRV(paramCopy(1, ir.TInt)),
+		}),
+	)
+	if strings.Contains(got, "(i64 %entry)") {
+		t.Fatalf("expected param `entry` to be renamed to avoid label collision:\n%s", got)
+	}
+	if !strings.Contains(got, "define i64 @passthroughEntry(i64 %entry.0)") {
+		t.Fatalf("expected param to be renamed to `%%entry.0`:\n%s", got)
+	}
+	if !strings.Contains(got, "ret i64 %entry.0") {
+		t.Fatalf("expected return to reference renamed param:\n%s", got)
+	}
+}
+
 // ---- single-instruction return: arithmetic ops ----
 
 func TestStage0EmitsIntArithOps(t *testing.T) {


### PR DESCRIPTION
## Summary

LLVM puts parameter names and basic-block labels in the same per-function value namespace. Stage0 emits an \`entry:\` block label unconditionally, but \`disambiguateParamNames\` only deduplicated parameters against each other — not against reserved block labels. A user-source parameter named \`entry\` collided, producing clang \`error: unable to create block named 'entry'\` on the second declaration of \`entry\` in the function value namespace.

## Surfaced in

- \`selfLintAstReadsBindingInExpr(entry: SelfLintEntry, ...)\`
- \`selfLintAstReadsBindingInWriteTarget(entry: SelfLintEntry, ...)\`

Both pass an \`entry\` named parameter through their public surface.

## Fix

Extend \`disambiguateParamNames\` with a reserved-label rename pass: rename any parameter matching \`isReservedStage0Label\` (currently just \`\"entry\"\`) by appending \`.<index>\` — same suffix shape the existing dedup pass uses, so subsequent dedup passes see a stable form.

The reserved-label set is intentionally narrow. Every other stage0 label goes through \`blockLabelName\` which formats as \`<prefix>.<id>\` — those can't collide with Osty identifier-style parameter names because Osty source identifiers have no \`.\`.

## Test

- \`TestStage0RenamesParamCollidingWithEntryLabel\` — asserts a \`passthroughEntry\` fixture with param \`entry\` emits \`define i64 @passthroughEntry(i64 %entry.0)\` and returns \`ret i64 %entry.0\` (rename propagates through body).
- \`go test -count=1 -vet=off ./internal/backend/stage0\` passes (160 + 1 new test).
- Targeted audit: \`OSTY_STAGE0_AUDIT_FN=selfLintAstReadsBindingInExpr\` → 1/1 covered, 0 emit-broken.

## Audit progression

| Cluster | Before #1592 | After #1592 | After #1594 | After #1600 | After this PR |
|---|---|---|---|---|---|
| instruction expected to be numbered | 6 | **0** ✅ | 0 | 0 | 0 |
| Entry block must not have predecessors | 6 | 6 | **0** ✅ | 0 | 0 |
| expected type | 4 | 4 | 4 | (partial) | 4 |
| integer constant must be integer | 3 | 3 | 3 | 3 | 3 |
| defined with type A vs B | 2 | 2 | 2 | 2 | 2 |
| **unable to create block 'entry'** | 2 | 2 | 2 | 2 | **0** ✅ |
| **Total** | **23** | **18** | **12** | **13** | **11** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)