### PR TITLE
fix(stage0): emit float constants with mandatory decimal point (cluster 4)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -3,6 +3,7 @@ package stage0
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -2042,9 +2043,29 @@ func isErrType(t mir.Type) bool {
 	return ok
 }
 
+// formatFloatConst renders a Go float64 as an LLVM IR floating-point
+// constant for the `double` type. LLVM's IR parser requires a decimal
+// point in textual fp constants — e.g. `0e+00`, `1e+02`, and `5e-01`
+// are all rejected as `integer constant must have integer type` even
+// when the surrounding context is `fcmp oeq double …`. To stay
+// human-readable while remaining LLVM-valid, we use the canonical hex
+// form (0x + 16 hex digits) for non-finite values and force a decimal
+// point ahead of the exponent for finite ones.
 func formatFloatConst(v float64) string {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return fmt.Sprintf("0x%016X", math.Float64bits(v))
+	}
 	s := strconv.FormatFloat(v, 'e', -1, 64)
-	if !strings.ContainsAny(s, ".eE") {
+	// FormatFloat with precision -1 uses the shortest round-trip form;
+	// for whole-number mantissas it produces output without `.` such as
+	// `0e+00` or `1e-10`. LLVM requires a `.` to disambiguate float vs
+	// integer literals, so insert `.0` immediately before the exponent
+	// when the mantissa lacks a fractional part.
+	if i := strings.IndexAny(s, "eE"); i >= 0 {
+		if !strings.ContainsRune(s[:i], '.') {
+			s = s[:i] + ".0" + s[i:]
+		}
+	} else if !strings.ContainsRune(s, '.') {
 		s += ".0"
 	}
 	return s


### PR DESCRIPTION
## Summary

LLVM's IR parser requires a decimal point in textual floating-point constants — \`0e+00\`, \`1e+02\`, \`5e-01\` are all rejected as \`integer constant must have integer type\` even when the context is \`fcmp oeq double …\`. The parser disambiguates float vs integer literals on the lexical form, not the typing context.

Stage0's \`formatFloatConst\` used \`strconv.FormatFloat(v, 'e', -1, 64)\` which, for whole-number mantissas, produces output without \`.\` such as \`0e+00\`. The dispatcher fell back to appending \`.0\` only when the string had NO \`.eE\` at all — but \`0e+00\` has an \`e\`, so the fallback skipped it.

## Surfaced in

Audit L1 reported 3 emit-broken \`mir_generator.osty\` helpers: \`mirConstFloatDiv\`, \`mirConstFloatBinary\`, \`mirConstFloatBinaryStatus\` — all use \`fcmp oeq double X, 0e+00\`.

## Fix

\`formatFloatConst\`:
1. NaN / ±Inf → canonical hex form (\`0x\` + 16 hex digits)
2. Finite values: insert \`.0\` immediately before the exponent when the mantissa lacks \`.\` — producing \`0.0e+00\`, \`1.0e+02\`
3. No-exponent fallback: append \`.0\` if missing

## Audit progression

| Cluster | Before #1605 | After this PR |
|---|---|---|
| **integer constant must be integer** | **3** | **0** ✅ |
| expected type | 4 | 4 |
| defined with type A vs B | 2 | 2 |
| unable to create block 'entry' | 0 | 0 |
| Entry block predecessors | 0 | 0 |
| instruction expected to be numbered | 0 | 0 |
| **Total emit-broken** | **11** | **10** |

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0\` passes (160 cases)
- [x] Targeted audit: \`OSTY_STAGE0_AUDIT_FN=mirConstFloatDiv\` → 1/1 covered, 0 emit-broken (likewise for two siblings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)