### PR TITLE
fix(stage0): route for-in-list IntrinsicStringConcat through while-loop emitter (cluster 3b)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -11116,6 +11116,30 @@ func forInListCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInst
 // intrinsics (string_byte_len, list_len, etc.) by delegating to
 // classifyIntrinsicValueStep for the latter.
 func forInListIntrinsic(ctx *whileLoopEmitCtx, out *strings.Builder, ii *mir.IntrinsicInstr) bool {
+	// IntrinsicStringConcat: delegate to the while-loop emitter so
+	// stack-backed string accumulators (e.g. `let mut out = ""; for ...
+	// { out = "{out}{f(x)}" }`) get a `load` for `out` rather than
+	// having the `osty_rt_strings_Concat` runtime call see the slot
+	// pointer raw. The shared sequential classifier
+	// (`classifyStringConcatIntrinsic`) routes through
+	// `resolveOperandWithPrelude` → `resolveOperand`, which does not
+	// load from `isStack` bindings, so it would emit
+	// `call  @osty_rt_strings_Concat(ptr %out.slot, ptr %lower)` —
+	// missing return type AND passing the slot pointer. The
+	// while-loop variant (`emitWhileStringConcatIntrinsic`) uses
+	// `stringConcatWhileArg` → `resolveOperandWithLoad` and emits
+	// the call line directly with a literal `ptr` return type.
+	if ii.Dest != nil && !ii.Dest.HasProjections() && ii.Kind == mir.IntrinsicStringConcat {
+		destLocal := lookupLocal(ctx.fn, ii.Dest.Local)
+		if destLocal == nil {
+			return false
+		}
+		destType := ctx.mctx.scalarFromType(destLocal.Type, true)
+		if destType == scalarUnknown {
+			return false
+		}
+		return emitWhileStringConcatIntrinsic(ctx, out, ii, ii.Dest.Local, destType)
+	}
 	// Value-returning intrinsic: delegate to the shared sequential classifier,
 	// then bind the result in the while-loop context.
 	if ii.Dest != nil {


### PR DESCRIPTION
## Summary

PR #1600 fixed the sequential \`classifyAssignSrc\` String + Add path. Audit-time L1 still showed 4 emit-broken in the \`expected type\` bucket — the for-in-list / while-loop body path goes through a different emitter.

## Surfaced in

\`lspAsciiLowerText\` and similar functions whose body is \`let mut out = \"{prefix}\"; for x in items { out = \"{out}{f(x)}\" }\`:

\`\`\`llvm
body.2:
  %5 = call ptr @osty_rt_list_get_string(ptr %0, i64 %4)
  %6 = call ptr @lspAsciiLowerUnit(ptr %5)
  %7 = call  @osty_rt_strings_Concat(ptr %out.slot, ptr %6)  ; <- broken
  store ptr %7, ptr %out.slot
\`\`\`

Two issues:
1. \`call  @sym(…)\` (two spaces) — return type missing
2. \`ptr %out.slot\` — alloca slot pointer raw, not loaded

## Root cause

\`forInListIntrinsic\` for value-returning intrinsics delegated to the shared sequential classifier \`classifyIntrinsicValueStep\`, which routes \`IntrinsicStringConcat\` through \`classifyStringConcatIntrinsic\`. That path resolves operands via \`resolveOperandWithPrelude\` → \`resolveOperand\`, which does NOT load from \`isStack\` bindings — returns the slot ptr directly. Then \`emitPendingInstr\` for \`instrCall\` renders \`%X = call <retType> @<sym>(...)\`; the pendingInstr's resultType was never set for the call form (see #1587 / #1600 family).

## Fix

In \`forInListIntrinsic\`, special-case \`IntrinsicStringConcat\` with \`Dest != nil\` BEFORE the generic value-returning delegation, and route directly to \`emitWhileStringConcatIntrinsic\`. That helper:
- uses \`stringConcatWhileArg\` → \`resolveOperandWithLoad\` (loads stack-backed locals)
- emits the call line with a literal \`ptr\` return type (bypasses pendingInstr/resultType plumbing)
- stores result back to stack slot via \`bindWhileResult\` (preserves accumulator semantics)

## Audit progression

| Cluster | After #1611 | After this PR |
|---|---|---|
| **expected type** | **4** | **TBD** (lspAsciiLowerText etc. should clear) |
| defined with type A vs B | 2 | 2 |
| **Total** | **10** | **TBD** |

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0\` passes (160 cases)
- [x] Targeted audit: \`OSTY_STAGE0_AUDIT_FN=lspAsciiLowerText\` → 1/1 covered, 0 emit-broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)