### PR TITLE
feat(mir): lower RangeLit in value position as struct aggregate

### DIFF
--- a/internal/backend/entry_test.go
+++ b/internal/backend/entry_test.go
@@ -1,18 +1,20 @@
 package backend
 
 import (
-	"errors"
-	"strings"
 	"testing"
 
 	"github.com/osty/osty/internal/ir"
 )
 
-func TestLowerEntryMIRRejectsMIRLoweringIssues(t *testing.T) {
+func TestLowerEntryMIRAcceptsRangeLitValuePosition(t *testing.T) {
+	// RangeLit in value position (not directly in for-in) used to emit
+	// ErrMIRCoverageIncomplete. After the MIR lowering improvement, it
+	// should succeed and produce a valid MIR module.
 	rangeLit := &ir.RangeLit{
-		Start: &ir.IntLit{Text: "0", T: ir.TInt},
-		End:   &ir.IntLit{Text: "1", T: ir.TInt},
-		T:     ir.TUnit,
+		Start:     &ir.IntLit{Text: "0", T: ir.TInt},
+		End:       &ir.IntLit{Text: "10", T: ir.TInt},
+		T:         &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TInt}, Builtin: true},
+		Inclusive: false,
 	}
 	mod := &ir.Module{
 		Package: "main",
@@ -21,7 +23,7 @@ func TestLowerEntryMIRRejectsMIRLoweringIssues(t *testing.T) {
 				Name:   "main",
 				Return: ir.TUnit,
 				Body: &ir.Block{Stmts: []ir.Stmt{
-					&ir.LetStmt{Name: "r", Type: ir.TUnit, Value: rangeLit},
+					&ir.LetStmt{Name: "r", Type: rangeLit.T, Value: rangeLit},
 				}},
 			},
 		},
@@ -32,16 +34,15 @@ func TestLowerEntryMIRRejectsMIRLoweringIssues(t *testing.T) {
 		t.Fatalf("finalizeEntryIR returned error before MIR lowering: %v", err)
 	}
 	entry, err = LowerEntryMIR(entry)
-	if err == nil {
-		t.Fatal("LowerEntryMIR returned nil error for MIR lowering issue")
+	if err != nil {
+		t.Fatalf("LowerEntryMIR returned error for RangeLit value position: %v", err)
 	}
-	if !errors.Is(err, ErrMIRCoverageIncomplete) {
-		t.Fatalf("error = %v, want ErrMIRCoverageIncomplete", err)
+	if len(entry.MIRIssues) > 0 {
+		for _, iss := range entry.MIRIssues {
+			t.Errorf("unexpected MIR issue: %s", iss.Error())
+		}
 	}
-	if len(entry.MIRIssues) == 0 {
-		t.Fatal("entry.MIRIssues empty, want recorded MIR coverage issue")
-	}
-	if got := entry.MIRIssues[0].Error(); !strings.Contains(got, "range literal in value position") {
-		t.Fatalf("first MIR issue = %q, want range literal coverage issue", got)
+	if entry.MIR == nil {
+		t.Fatal("entry.MIR is nil after lowering")
 	}
 }

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3692,19 +3692,7 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 	case *ir.VariantLit:
 		return bs.lowerVariantLit(x, hint)
 	case *ir.RangeLit:
-		// Range values — unsupported in value position for MIR stage 1.
-		// Surface the source span + enclosing function so toolchain
-		// authors can find the blocking site quickly; see
-		// docs/osty_self_b2_1_audit.md for the in-progress range-value
-		// lowering plan.
-		span := x.At()
-		fnName := ""
-		if bs.fn != nil {
-			fnName = bs.fn.Name
-		}
-		bs.l.noteIssue("range literal in value position not lowered to MIR (fn %q, span line %d:%d-%d:%d, offset %d-%d)",
-			fnName, span.Start.Line, span.Start.Column, span.End.Line, span.End.Column, span.Start.Offset, span.End.Offset)
-		return &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}}
+		return bs.lowerRangeLit(x, hint)
 	case *ir.Closure:
 		return bs.lowerClosure(x, hint)
 	case *ir.ErrorExpr:
@@ -5905,6 +5893,59 @@ func (bs *bodyState) lowerVariantLit(v *ir.VariantLit, hint Type) RValue {
 		T:          t,
 		VariantIdx: idx,
 		VariantTag: v.Variant,
+	}
+}
+
+// lowerRangeLit lowers a RangeLit (e.g. `0..10` or `0..=9`) that appears
+// in value position -- `let r = 0..10`, `return 0..n`, function arguments,
+// etc. The range is represented as a two-field struct aggregate: [start, end].
+// Both fields are Int (Char ranges are already converted to Int codepoints
+// by the checker). The Inclusive flag is a compile-time constant that the
+// for-in desugaring reads back from rangeBindings; it is not stored in the
+// aggregate itself.
+//
+// For the common `let r = 0..n` pattern, the pseudo-binding fast path in
+// lowerLet is preferred because it avoids materialising the aggregate and
+// lets the for-in lowerer read the bounds directly. This path handles
+// everything else: return values, call arguments, nested expressions.
+func (bs *bodyState) lowerRangeLit(x *ir.RangeLit, hint Type) RValue {
+	t := x.T
+	if t == nil || t == ir.ErrTypeVal {
+		t = hint
+	}
+	if t == nil || t == ir.ErrTypeVal {
+		t = &ir.NamedType{Name: "Range", Args: []ir.Type{TInt}, Builtin: true}
+	}
+
+	// Determine element type from Range<T>.
+	elemT := TInt
+	if nt, ok := t.(*ir.NamedType); ok && len(nt.Args) == 1 {
+		if pt, ok := nt.Args[0].(*ir.PrimType); ok && pt.Kind == ir.PrimChar {
+			elemT = TChar
+		}
+	}
+
+	// Start field. Unbounded start (..end) defaults to 0.
+	var startOp Operand
+	if x.Start != nil {
+		startOp = bs.lowerExprAsOperandHint(x.Start, elemT)
+	} else {
+		startOp = &ConstOp{Const: &IntConst{Value: 0, T: elemT}, T: elemT}
+	}
+
+	// End field. Unbounded end (start..) is not fully supported yet.
+	var endOp Operand
+	if x.End != nil {
+		endOp = bs.lowerExprAsOperandHint(x.End, elemT)
+	} else {
+		endOp = &ConstOp{Const: &IntConst{Value: 0, T: elemT}, T: elemT}
+		bs.l.noteIssue("range literal with unbounded end not fully lowered to MIR (fn %q)", bs.fn.Name)
+	}
+
+	return &AggregateRV{
+		Kind:   AggStruct,
+		Fields: []Operand{startOp, endOp},
+		T:      t,
 	}
 }
 


### PR DESCRIPTION
## Summary

RangeLit expressions in value positions (`return 0..10`, call arguments, let bindings with non-Range type, etc.) previously emitted `ErrMIRCoverageIncomplete`. This PR lowers them to a two-field `AggStruct [start, end]` using the existing `AggregateRV` infrastructure.

## Changes

- **`internal/mir/lower.go`** — Add `lowerRangeLit()` that:
  - Extracts start/end operands from the `RangeLit`
  - Creates an `AggregateRV{Kind: AggStruct, Fields: [startOp, endOp]}` with the `Range<T>` type
  - Handles `Range<Int>` and `Range<Char>` element types
  - Unbounded start (`..end`) defaults to 0; unbounded end (`start..`) still emits a `noteIssue` (future work)
  - Replaces the existing diagnostic stub in `lowerExprToRValue`

- **`internal/backend/entry_test.go`** — Update the test that expected `ErrMIRCoverageIncomplete` to now expect successful lowering with no MIR issues.

## Design notes

- The common `let r = 0..n` pseudo-binding fast path via `rangeBindings` is **unchanged** — this new path handles everything else that the pseudo-binding cannot (return values, call arguments, etc.).
- The `Inclusive` flag is a compile-time constant stored in `rangeBindings` for the for-in desugaring. It is not stored in the aggregate value itself — a future iteration may add it if range values need to be passed across function boundaries where inclusive semantics matter.

## Test results

- `internal/mir/` — all pass
- `internal/backend/` — all pass
- `internal/ir/` — all pass
- `go vet` — clean