### PR TITLE
fix(stage0): match string_char_at runtime call return type to scalarChar (cluster 5)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -9911,9 +9911,17 @@ func resolveWhileIndexedOperand(ctx *whileLoopEmitCtx, out *strings.Builder, pla
 		if !ok || indexTy != scalarInt {
 			return "", scalarUnknown, false
 		}
+		// Char element (i32) — match the runtime prototype's return
+		// type. The previous `call i64` form left `%value` as i64
+		// while every consumer (`store i32 %value, ptr %char.slot`,
+		// `icmp eq i32 %value, …`) treated it as i32, producing
+		// clang `'<id>' defined with type 'i64' but expected 'i32'`.
+		// Other byte-/codepoint-returning runtime helpers in this
+		// file (e.g. `osty_rt_bytes_get` → i8 at line ~9929) follow
+		// the same scalar-matches-prototype convention.
 		declareRuntimePrototype(ctx.mctx, "osty_rt_stage0_string_char_at", scalarChar, []callArg{{ty: "ptr"}, {ty: "i64"}})
 		value := freshReg(ctx)
-		fmt.Fprintf(out, "  %s = call i64 @osty_rt_stage0_string_char_at(ptr %s, i64 %s)\n", value, listExpr, indexExpr)
+		fmt.Fprintf(out, "  %s = call i32 @osty_rt_stage0_string_char_at(ptr %s, i64 %s)\n", value, listExpr, indexExpr)
 		return value, scalarChar, true
 	}
 	if listScalarTy != scalarOpaquePtr {


### PR DESCRIPTION
## Summary

Stage0's String→Char subscript path declared the runtime helper \`osty_rt_stage0_string_char_at\` with \`scalarChar\` (i32) return type but emitted the call as \`call i64 @…\`. The returned register was then handed back to callers tagged as \`scalarChar\`, so consumers treating it as i32 (e.g. \`store i32 %X, ptr %char.slot\`, \`icmp eq i32 %X, 95\`) hit clang \`'<id>' defined with type 'i64' but expected 'i32'\`.

## Surfaced in

\`mirLLVMBuiltinAggregatePart\` (toolchain/mir_generator.osty) — body indexes into a String to inspect codepoints.

## Fix

Change emitted call from \`call i64\` to \`call i32\` so the IR-level call signature matches the prototype declaration. Other small-int runtime helpers (\`osty_rt_bytes_get\` → i8) follow the same scalar-matches-prototype convention.

## Audit progression

| Cluster | After #1611 | After this PR |
|---|---|---|
| **defined with type A but expected B** | **2** | **0** ✅ |
| Total emit-broken | 3 | 2 (only `main` duplicate issue remains) |

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0\` passes (160 cases)
- [x] Targeted audit: \`OSTY_STAGE0_AUDIT_FN=mirLLVMBuiltinAggregatePart\` → 1/1 covered, 0 emit-broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)