### PR TITLE
fix(stage0/audit): skip synthetic main injection when auditing real main

### DIFF
--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -116,7 +116,17 @@ func TestStage0ToolchainAudit(t *testing.T) {
 		}
 		totalFns++
 		oneFn := *entry.MIR
-		oneFn.Functions = []*mir.Function{fn, syntheticEmptyMain()}
+		// When auditing the toolchain's own `main` function, don't
+		// inject a synthetic `main` alongside — LLVM rejects two
+		// `define i32 @main()` blocks with `invalid redefinition of
+		// function 'main'`. The real `main` already satisfies stage0's
+		// `module has no main` guard. For every other function, inject
+		// the synthetic main so stage0 doesn't decline the module.
+		if fn.Name == "main" {
+			oneFn.Functions = []*mir.Function{fn}
+		} else {
+			oneFn.Functions = []*mir.Function{fn, syntheticEmptyMain()}
+		}
 		irBytes, err := stage0.EmitMIR(&oneFn, llvmabi.Options{PackageName: "audit"})
 		if err == nil {
 			if clangVerify {
@@ -266,7 +276,14 @@ func TestStage0ToolchainAudit(t *testing.T) {
 				continue
 			}
 			oneFn := *entry.MIR
-			oneFn.Functions = []*mir.Function{fn, syntheticEmptyMain()}
+			// Same redefinition guard as the main loop above —
+			// auditing `main` itself must not inject a second
+			// synthetic `main` into the module.
+			if fn.Name == "main" {
+				oneFn.Functions = []*mir.Function{fn}
+			} else {
+				oneFn.Functions = []*mir.Function{fn, syntheticEmptyMain()}
+			}
 			_, err := stage0.EmitMIR(&oneFn, llvmabi.Options{PackageName: "audit"})
 			if err == nil {
 				continue


### PR DESCRIPTION
## Summary

The audit harness wraps each function under test in a tiny module alongside \`syntheticEmptyMain()\` so stage0 doesn't decline the module on \`module has no main\`. But when the function under test IS already named \`main\` (the toolchain's entry point), this injects a SECOND \`define i32 @main()\` and clang rejects with \`error: invalid redefinition of function 'main'\`.

## Surfaced after #1624

Audit output went from 3 → 2 emit-broken, and the remaining 2 cases both listed \`main\` as the function name. The bug was in the audit harness, not stage0's emitter.

## Fix

When \`fn.Name == \"main\"\`, skip the synthetic-main injection. The real \`main\` already satisfies stage0's \`emittedMain\` guard. Apply the same check in both audit emit paths (the L1 main loop and the declined-functions sample loop).

## Audit progression — milestone

| Cluster | Session start | After this PR |
|---|---|---|
| instruction expected to be numbered | 6 | 0 |
| Entry block must not have predecessors | 6 | 0 |
| expected type | 4 | 0 |
| integer constant must be integer | 3 | 0 |
| defined with type A vs B | 2 | 0 |
| unable to create block 'entry' | 2 | 0 |
| invalid redefinition of function | (new) | **0** ✅ |
| **Total** | **23** | **0** 🎉 |

This closes the original 23-bug emit-broken backlog from session start. Remaining 8 not-covered are audit-declined (matchers reject the MIR shape) — a different category from emit-broken; fixing those is the next phase of stage0 expansion work.

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0\` passes
- [x] Targeted audit: \`OSTY_STAGE0_AUDIT_FN=main\` → 2/2 covered, 0 emit-broken
- [x] Full audit: \`OSTY_STAGE0_AUDIT_CLANG_VERIFY=1\` reports **0 emit-broken** across the entire toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)