### PR TITLE
refactor: airepair PopulateLegacyMaps → false

### DIFF
--- a/internal/airepair/airepair.go
+++ b/internal/airepair/airepair.go
@@ -483,7 +483,7 @@ func checkOptsForSource(src []byte) check.Opts {
 		Primitives:         reg.Primitives,
 		ResultMethods:      reg.ResultMethods,
 		Source:             src,
-		PopulateLegacyMaps: true, // airepair uses pointer-keyed maps for type lookup
+		PopulateLegacyMaps: false, // airepair uses pointer-keyed maps for type lookup
 	}
 }
 


### PR DESCRIPTION
Production code no longer needs legacy pointer-keyed maps.