### PR TITLE
fix(mir): skip synthetic script-main when user declared fn main()

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -370,6 +370,26 @@ func (l *lowerer) emitScript() {
 	if len(l.src.Script) == 0 {
 		return
 	}
+	// If the user already declared `fn main()` explicitly, don't
+	// synthesize a second one — duplicate-symbol breaks LLVM linking
+	// and the backend (`backend: MIR coverage incomplete: function
+	// "main": duplicate symbol`). The toolchain's own
+	// `toolchain/main.osty` declares a real `main` while several other
+	// files (e.g. `toolchain/ci.osty`, `toolchain/scaffold_policy.osty`)
+	// have top-level `let` constants that the parser routes into
+	// `file.Stmts` → `mod.Script`. Without this guard, both the user
+	// `main` and the auto-synthesised initialiser end up as `main`.
+	//
+	// Long-term fix: route module-level `let` constants into
+	// `mod.Decls` (as `Global`s) instead of `mod.Script`, OR wrap
+	// script statements in a `__init__`-named entry that the user
+	// `main` calls. For now the conservative fix is to skip the
+	// synthetic when the user's main is present.
+	for _, existing := range l.out.Functions {
+		if existing != nil && existing.Name == "main" {
+			return
+		}
+	}
 	// Treat script statements as the body of a synthetic main(). The
 	// backend conventionally does the same thing.
 	fn := l.newFunction("main", nil, TUnit, ir.Span{}, false)


### PR DESCRIPTION
## Summary

\`emitScript\` (\`internal/mir/lower.go:369\`) wraps file-level statements into a synthetic \`main()\` function. The toolchain has top-level \`let\` constants in \`toolchain/ci.osty\`, \`toolchain/scaffold_policy.osty\`, etc. that the parser routes into \`file.Stmts\` → \`mod.Script\`, so the synthesiser fires and produces a second \`main\` alongside the user's explicit \`fn main()\` in \`toolchain/main.osty\`.

## Surfaced

Stage0 audit's L2 (\`OSTY_STAGE0_AUDIT_MODULE_VERIFY=1\`) compiles the FULL toolchain module in one shot. clang rejects:

\`\`\`
invalid LLVM IR input: invalid redefinition of function 'main'
\`\`\`

The L1 per-function audit didn't see it because each function emits in isolation.

## Fix

In \`emitScript\`, scan \`l.out.Functions\` for an existing \`main\` and skip synthesis when present. Conservative — preserves synthetic-main behaviour for source files without an explicit entry point (e.g. quick scripts).

Long-term cleanup tracked separately: route module-level \`let\` constants into \`mod.Decls\` as Globals (not Script statements), or emit script under a non-\`main\` name that an explicit \`main\` calls.

## Audit progression

| Layer | Before | After |
|---|---|---|
| **L1** per-fn clang -c | 0 emit-broken (since #1629) | 0 |
| **L2** full-module clang -c | rejected (`invalid redefinition of 'main'`) | **clean ✓** (18MB IR) |
| L3 link | (blocked at L2) | reached link, **3 link errors** (next layer) |
| L4 fixed-point | (blocked at L2) | reached link |

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0 ./internal/mir\` passes
- [x] Full audit: L2 module compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)