### PR TITLE
test(parser): add follow-on parity coverage for A2

### DIFF
--- a/internal/parser/frontend_followon_parity_a2_test.go
+++ b/internal/parser/frontend_followon_parity_a2_test.go
@@ -1,0 +1,20 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+func TestParseFollowOnRecoveryA2ElseNewlineTopLevelDecl(t *testing.T) {
+	src := fixtureFollowOnAElseNewline("rfA2ElseNewlineTopLevelDecl", "rfA2Cond")
+
+	result := ParseDetailed(src)
+	fn, _ := requireFollowOnFnWithHelper(t, result, 0, 1, 1, 1, "rfA2Cond", "E0105", "E0204", "E0100")
+	requireParseDiagnosticCodePresent(t, result, "E0100")
+	stmt := requireExprStmtAt(t, fn.Body.Stmts, 0, "expression statement")
+	ifExpr, ok := stmt.X.(*ast.IfExpr)
+	if !ok || ifExpr.Else != nil {
+		t.Fatalf("stmt[0].X = %#v, want if expr with nil else after follow-on recovery", stmt.X)
+	}
+}


### PR DESCRIPTION
## Summary

Widen follow-on parity coverage by adding a focused parser regression for the remaining Axis-A follow-on matrix case.

## What changed

Added a new parser test:

- `TestParseFollowOnRecoveryA2ElseNewlineTopLevelDecl`

in a small companion file:

- `internal/parser/frontend_followon_parity_a2_test.go`

## Coverage added

This mirrors the corpus case:

- `A2 top-level } follow-on after } else newline recovery`

and locks that the parser currently:

- emits the expected follow-on code set including `E0100`
- preserves the helper declaration `rfA2Cond`
- leaves the recovered `if` expression with no `else` branch in the lowered AST

## Why

Before this change, the follow-on parity tests covered:

- `A1` (newline-else primary)
- `B1` (declaration-layer fallout after broken match-arm assignment)

Adding `A2` widens the follow-on parity coverage across the A/B axes without needing a broader corpus reshuffle.

## Scope

Test-only addition:

- no parser logic changed
- no corpus changes
- no snapshots changed
