### PR TITLE
fix(stdlib): update random test to match post-v0.6-rollback module surface

### DIFF
--- a/internal/stdlib/random_test.go
+++ b/internal/stdlib/random_test.go
@@ -12,7 +12,10 @@ func TestRandomModuleDerivedHelpersAreBodied(t *testing.T) {
 		t.Fatal("stdlib random module missing")
 	}
 
-	for _, name := range []string{"next", "nextBytes", "choice", "shuffle"} {
+	// choice and shuffle are bodied derived helpers; the primitive
+	// methods (int, intInclusive, float, bool, bytes) are runtime-backed
+	// and carry no Osty body.
+	for _, name := range []string{"choice", "shuffle"} {
 		fn := reg.LookupMethodDecl("random", "Rng", name)
 		if fn == nil {
 			t.Fatalf("LookupMethodDecl(random, Rng, %s) = nil, want stdlib helper", name)


### PR DESCRIPTION
## Summary

`TestRandomModuleDerivedHelpersAreBodied` referenced `next` and `nextBytes` which only existed in the v0.6 capability baseline (removed in #1572). The surviving derived helpers with Osty bodies are `choice` and `shuffle`; all other methods (`int`, `intInclusive`, `float`, `bool`, `bytes`) are runtime-backed stubs without bodies.

## Test plan

- [x] `go test -count=1 -vet=off -run 'TestRandom' ./internal/stdlib/` — PASS