### PR TITLE
fix(stage0/audit): include platform link flags in exec/fp verify

### DIFF
--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -920,7 +921,15 @@ func runStage0AuditExecVerify(t *testing.T, module *mir.Module, clangPath string
 		return
 	}
 	binPath := filepath.Join(tmp, "audit-exec")
-	linkArgs := []string{"-O0", "-o", binPath, llPath, runtimeC}
+	// Link flags mirror the production `clangPlatformRuntimeLinkArgs`
+	// + `clangLinkLibraryArgs` (`internal/backend/llvm.go:425` and
+	// `internal/llvmabi/api.go:164`). Without these, the runtime
+	// fails to resolve macOS Keychain (`-framework Security
+	// CoreFoundation`), zlib (`-lz`), and libm (`-lm`) symbols at
+	// link time, swamping audit output with 70+ undefined-symbol
+	// errors that aren't actually stage0 emit bugs.
+	linkArgs := append([]string{"-O0", "-o", binPath, llPath, runtimeC},
+		stage0AuditPlatformLinkArgs()...)
 	cmd := exec.Command(clangPath, linkArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -934,7 +943,7 @@ func runStage0AuditExecVerify(t *testing.T, module *mir.Module, clangPath string
 		var errLines []string
 		for _, line := range strings.Split(combined, "\n") {
 			line = strings.TrimSpace(line)
-			if strings.Contains(line, "error:") || strings.Contains(line, "Undefined symbols") || strings.Contains(line, "ld: ") {
+			if strings.Contains(line, "error:") || strings.Contains(line, "Undefined symbols") || strings.Contains(line, "ld: ") || strings.Contains(line, "_osty_") || strings.Contains(line, "referenced from") || strings.HasPrefix(line, "\"_") {
 				errLines = append(errLines, line)
 			}
 		}
@@ -1074,7 +1083,8 @@ func runStage0AuditFixedPointVerify(t *testing.T, module *mir.Module, clangPath 
 		return
 	}
 	binPath := filepath.Join(tmp, "audit-fp-osty")
-	linkArgs := []string{"-O0", "-o", binPath, llPath, runtimeC}
+	linkArgs := append([]string{"-O0", "-o", binPath, llPath, runtimeC},
+		stage0AuditPlatformLinkArgs()...)
 	cmd := exec.Command(clangPath, linkArgs...)
 	out, linkErr := cmd.CombinedOutput()
 	if linkErr != nil {
@@ -1082,7 +1092,7 @@ func runStage0AuditFixedPointVerify(t *testing.T, module *mir.Module, clangPath 
 		var errLines []string
 		for _, line := range strings.Split(combined, "\n") {
 			line = strings.TrimSpace(line)
-			if strings.Contains(line, "error:") || strings.Contains(line, "Undefined symbols") || strings.Contains(line, "ld: ") {
+			if strings.Contains(line, "error:") || strings.Contains(line, "Undefined symbols") || strings.Contains(line, "ld: ") || strings.Contains(line, "_osty_") || strings.Contains(line, "referenced from") || strings.HasPrefix(line, "\"_") {
 				errLines = append(errLines, line)
 			}
 		}
@@ -1165,4 +1175,23 @@ func runStage0AuditFixedPointVerify(t *testing.T, module *mir.Module, clangPath 
 		}
 		t.Logf("fp-verify (full): produced binary completed install-self ✓ (%d bytes output)", len(runOut))
 	}
+}
+
+// stage0AuditPlatformLinkArgs returns the platform-specific link
+// flags the audit harness needs when invoking clang to link a stage0
+// IR module + the runtime C source. Mirrors the production
+// `clangPlatformRuntimeLinkArgs` + `clangLinkLibraryArgs` chain so
+// the audit doesn't burn iterations on link errors that aren't
+// actually stage0 bugs (Keychain frameworks, zlib, libm).
+func stage0AuditPlatformLinkArgs() []string {
+	args := []string{"-pthread", "-lz"}
+	switch runtime.GOOS {
+	case "windows":
+		args = append(args, "-ladvapi32")
+	case "darwin":
+		args = append(args, "-lm", "-framework", "Security", "-framework", "CoreFoundation")
+	default:
+		args = append(args, "-lm")
+	}
+	return args
 }


### PR DESCRIPTION
## Summary

Audit's exec-verify and fp-verify invoked clang to link the stage0 IR with the runtime C source but passed only \`-O0\`. The runtime references macOS Keychain framework symbols (\`SecKeychain*\`, \`CFRelease\`), zlib (\`deflate\`/\`inflate\`), and libm — none of which ld can find without explicit \`-framework\`/\`-l\` flags. Result: ~70 undefined-symbol errors per L3 audit run, all link-environment noise rather than stage0 bugs.

## Fix

- Add \`stage0AuditPlatformLinkArgs\` mirroring production \`clangPlatformRuntimeLinkArgs\` + \`clangLinkLibraryArgs\` (\`-pthread\`, \`-lz\`, \`-lm\`, \`-framework Security CoreFoundation\` on Darwin, \`-ladvapi32\` on Windows). Append to both audit link invocations.
- Extend link-error filter: keep \`_osty_\`, \`referenced from\`, leading \`\"_\` so the filter surfaces the actual symbol list (was dropping the \`\"_symbol\", referenced from:\` lines that name what's missing).

## Audit progression

| | Before | After |
|---|---|---|
| L3 link errors | **70** | **36** |
| Link-environment noise | many | 0 |
| Real stage0/runtime gap | hidden | surfaced |

The 36 remaining errors are the actual L3 work — runtime stub gap (stage0 declares prototypes the runtime doesn't export, e.g. \`osty_rt_list_contains_str\`, \`osty_rt_strings_to_int\`, \`osty_rt_stage0_string_char_at\`) plus host-only bridges that user code references (\`runtime.cihost.*\`, \`std.fs.readToString\`). Tracked separately.

## Test

- [x] \`go test -count=1 -vet=off ./internal/backend/stage0\` passes
- [x] L3 audit: link errors drop from 70 → 36; remaining set is all Osty-side gaps, not link-environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)