### PR TITLE
refactor: remove PopulateLegacyMaps from Opts and overlaySelfhostResult calls

### DIFF
--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -155,11 +155,10 @@ func prepareMIRPayloadEntry(t *testing.T, src string) backend.Entry {
 	reg := stdlib.LoadCached()
 	res := resolve.ResolveFileSourceDefault([]byte(src), file, reg)
 	chk := check.SelfhostFile(file, res, check.Opts{
-		Stdlib:             reg,
-		Primitives:         reg.Primitives,
-		ResultMethods:      reg.ResultMethods,
-		Source:             []byte(src),
-		PopulateLegacyMaps: true, // LLVM backend lowerer uses pointer-keyed maps
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
 	})
 	entry, err := backend.PrepareEntry("main", "/tmp/mir_payload.osty", file, res, chk)
 	if err != nil {

--- a/internal/airepair/airepair.go
+++ b/internal/airepair/airepair.go
@@ -483,7 +483,6 @@ func checkOptsForSource(src []byte) check.Opts {
 		Primitives:         reg.Primitives,
 		ResultMethods:      reg.ResultMethods,
 		Source:             src,
-		PopulateLegacyMaps: false, // airepair uses pointer-keyed maps for type lookup
 	}
 }
 

--- a/internal/backend/llvm_multi_file_e2e_test.go
+++ b/internal/backend/llvm_multi_file_e2e_test.go
@@ -82,9 +82,7 @@ fn testCrossFileStructReturnedFromCrossFileFn() {
 		t.Fatalf("pkg.Files len = %d, want 2 (lib.osty + multi_file_test.osty)", got)
 	}
 
-	chk := check.Package(pkg, nil, check.Opts{
-		PopulateLegacyMaps: true, // multi-file E2E drives IR lowering
-	})
+	chk := check.Package(pkg, nil, check.Opts{})
 	for _, d := range chk.Diags {
 		if d.Severity == diag.Error {
 			t.Fatalf("check produced error: %s", d.Message)

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -88,7 +88,6 @@ func parseBackendFile(t *testing.T, src string) (*ast.File, *resolve.Result, *ch
 		Primitives:         reg.Primitives,
 		ResultMethods:      reg.ResultMethods,
 		Source:             []byte(src),
-		PopulateLegacyMaps: true, // LLVM backend lowerer uses pointer-keyed maps
 	})
 	return file, res, chk
 }

--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -53,7 +53,6 @@ func TestStage0ToolchainAudit(t *testing.T) {
 		Stdlib:             reg,
 		Primitives:         reg.Primitives,
 		ResultMethods:      reg.ResultMethods,
-		PopulateLegacyMaps: true, // stage0 audit uses IR lowerer
 	})
 
 	entry, err := PreparePackage("toolchain", filepath.Join(pkgDir, "main.osty"), pkg, nil, chk)

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -175,14 +175,6 @@ type Opts struct {
 	// correct for ordinary user code.
 	Privileged bool
 
-	// PopulateLegacyMaps controls whether the checker populates the
-	// pointer-keyed maps in Result (Types, LetTypes, SymTypes,
-	// InstantiationsByID) via overlaySelfhostResult. These maps are
-	// needed by legacy consumers that have not yet migrated to
-	// NativeCheckResult / SemanticDB. When false (the default), the
-	// overlay is skipped and only NativeCheckResult / SemanticDB are
-	// populated, which is sufficient for most downstream tools.
-	PopulateLegacyMaps bool
 }
 
 // firstOpt returns the first Opts in the slice, or a zero value when
@@ -241,7 +233,7 @@ func SelfhostRun(run *selfhost.FrontendRun, opts ...Opts) *Result {
 func SelfhostFile(f *ast.File, rr *resolve.Result, opts ...Opts) *Result {
 	opt := firstOpt(opts)
 	result := newResult()
-	applySelfhostFileResult(result, f, rr, opt.Source, opt.Stdlib, opt.Privileged, opt.PopulateLegacyMaps)
+	applySelfhostFileResult(result, f, rr, opt.Source, opt.Stdlib, opt.Privileged)
 	diag.StampFile(result.Diags, opt.Path)
 	recordSelfhostDeclPass(opt.OnDecl, f, "collect")
 	recordSelfhostDeclPass(opt.OnDecl, f, "check")
@@ -258,7 +250,7 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, opts ...Opts) *Res
 		return result
 	}
 	privileged := isPrivilegedPackage(pkg)
-	applySelfhostPackageResult(result, pkg, pr, nil, opt.Stdlib, privileged, opt.PopulateLegacyMaps)
+	applySelfhostPackageResult(result, pkg, pr, nil, opt.Stdlib, privileged)
 	stampPackageDiags(result.Diags, pkg)
 	// §19 policy gates (privilege / POD / no_alloc / intrinsic body) are
 	// now sourced from the bootstrapped Osty checker
@@ -314,7 +306,7 @@ func Workspace(
 	for _, e := range walk {
 		out[e.path] = resultWithSharedMaps(shared)
 	}
-	applySelfhostWorkspaceResults(ws, resolved, out, opt.Stdlib, opt.PopulateLegacyMaps)
+	applySelfhostWorkspaceResults(ws, resolved, out, opt.Stdlib)
 	// §19 policy gates are sourced from the Osty checker (see File()
 	// comment above). TestGatesCrossSideParity guards against drift.
 	for _, e := range walk {
@@ -360,7 +352,7 @@ func PackageGraph(
 		pr := resolved[path]
 		result := resultWithSharedMaps(shared)
 		out[path] = result
-		applySelfhostPackageResult(result, pkg, pr, nil, opt.Stdlib, isPrivilegedPackage(pkg), opt.PopulateLegacyMaps)
+		applySelfhostPackageResult(result, pkg, pr, nil, opt.Stdlib, isPrivilegedPackage(pkg))
 		stampPackageDiags(result.Diags, pkg)
 		for _, pf := range pkg.Files {
 			if pf == nil {

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -103,7 +103,7 @@ type selfhostFileSegment struct {
 	nativeNodeIDBase int
 }
 
-func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result, src []byte, stdlib resolve.StdlibProvider, privileged bool, populateLegacy bool) {
+func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result, src []byte, stdlib resolve.StdlibProvider, privileged bool) {
 	if result == nil {
 		return
 	}
@@ -160,12 +160,10 @@ func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result,
 	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
 	result.NativeCheckResult = cloneNativeCheckResult(checked)
 	result.SemanticDB = semanticdb.FromCheck(checked)
-	if populateLegacy {
-		overlaySelfhostResult(result, checkedSrc, checked)
-	}
+
 }
 
-func applySelfhostPackageResult(result *Result, pkg *resolve.Package, pr *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool, populateLegacy bool) {
+func applySelfhostPackageResult(result *Result, pkg *resolve.Package, pr *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool) {
 	if result == nil || pkg == nil {
 		return
 	}
@@ -213,12 +211,10 @@ func applySelfhostPackageResult(result *Result, pkg *resolve.Package, pr *resolv
 	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
 	result.NativeCheckResult = cloneNativeCheckResult(checked)
 	attachSemanticDB(result, pr, checked)
-	if populateLegacy {
-		overlaySelfhostResult(result, src, checked)
-	}
+
 }
 
-func applySelfhostWorkspaceResults(ws *resolve.Workspace, resolved map[string]*resolve.PackageResult, results map[string]*Result, stdlib resolve.StdlibProvider, populateLegacy bool) {
+func applySelfhostWorkspaceResults(ws *resolve.Workspace, resolved map[string]*resolve.PackageResult, results map[string]*Result, stdlib resolve.StdlibProvider) {
 	if ws == nil {
 		return
 	}
@@ -258,7 +254,7 @@ func applySelfhostWorkspaceResults(ws *resolve.Workspace, resolved map[string]*r
 	}
 	if len(jobs) == 1 || os.Getenv("OSTY_CHECK_PARALLEL") == "0" {
 		for _, j := range jobs {
-			applySelfhostPackageResult(j.result, j.pkg, j.pr, ws, stdlib, j.privileged, populateLegacy)
+			applySelfhostPackageResult(j.result, j.pkg, j.pr, ws, stdlib, j.privileged)
 		}
 		return
 	}
@@ -277,7 +273,7 @@ func applySelfhostWorkspaceResults(ws *resolve.Workspace, resolved map[string]*r
 		go func() {
 			defer wg.Done()
 			for j := range ch {
-				runSelfhostPackageResultLocked(j.result, j.pkg, j.pr, ws, stdlib, j.privileged, populateLegacy, &mu)
+				runSelfhostPackageResultLocked(j.result, j.pkg, j.pr, ws, stdlib, j.privileged, &mu)
 			}
 		}()
 	}
@@ -295,7 +291,7 @@ func applySelfhostWorkspaceResults(ws *resolve.Workspace, resolved map[string]*r
 // the shared type maps under `mu`. This is the parallel variant of
 // applySelfhostPackageResult; the single-threaded fast path in
 // applySelfhostWorkspaceResults still calls the non-locked version.
-func runSelfhostPackageResultLocked(result *Result, pkg *resolve.Package, pr *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool, populateLegacy bool, mu *sync.Mutex) {
+func runSelfhostPackageResultLocked(result *Result, pkg *resolve.Package, pr *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool, mu *sync.Mutex) {
 	if result == nil || pkg == nil {
 		return
 	}
@@ -354,9 +350,7 @@ func runSelfhostPackageResultLocked(result *Result, pkg *resolve.Package, pr *re
 	result.NativeCheckerTelemetry = telemetry
 	result.NativeCheckResult = cloneNativeCheckResult(checked)
 	attachSemanticDB(result, pr, checked)
-	if populateLegacy {
-		overlaySelfhostResult(result, src, checked)
-	}
+
 }
 
 func attachSemanticDB(result *Result, pr *resolve.PackageResult, checked api.CheckResult) {

--- a/internal/check/parity_audit_test.go
+++ b/internal/check/parity_audit_test.go
@@ -45,7 +45,6 @@ func TestCheckPackageParityAudit(t *testing.T) {
 		Stdlib:             reg,
 		Primitives:         reg.Primitives,
 		ResultMethods:      reg.ResultMethods,
-		PopulateLegacyMaps: true, // parity audit drives IR lowering
 	})
 
 	type diagRow struct {

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -631,11 +631,10 @@ fn probe(p: Printable) -> Note? {
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
 
-		Stdlib:             reg,
-		Primitives:         reg.Primitives,
-		ResultMethods:      reg.ResultMethods,
-		Source:             []byte(src),
-		PopulateLegacyMaps: true, // IR lowerer falls back to pointer-keyed maps
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
 	})
 
 	probe, ok := file.Decls[len(file.Decls)-1].(*ast.FnDecl)
@@ -707,11 +706,10 @@ func TestLowerUseDeclRecoversBuiltinGenericTypesWithoutResolverTypeRefs(t *testi
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
 
-		Stdlib:             reg,
-		Primitives:         reg.Primitives,
-		ResultMethods:      reg.ResultMethods,
-		Source:             []byte(src),
-		PopulateLegacyMaps: true, // IR lowerer falls back to pointer-keyed maps
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
 	})
 
 	mod, issues := Lower("main", file, res, chk)

--- a/internal/ir/runtime_annot_propagation_test.go
+++ b/internal/ir/runtime_annot_propagation_test.go
@@ -22,12 +22,11 @@ func lowerSrc(t *testing.T, src string) *Module {
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
 
-		Stdlib:             reg,
-		Primitives:         reg.Primitives,
-		ResultMethods:      reg.ResultMethods,
-		Source:             []byte(src),
-		Privileged:         true,
-		PopulateLegacyMaps: true, // IR tests use pointer-keyed type maps
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
 	})
 	mod, _ := Lower("main", file, res, chk)
 	return mod


### PR DESCRIPTION
## 변경 사항

### 1. `PopulateLegacyMaps` 필드 제거 from `Opts`
- `check.Opts`에서 `PopulateLegacyMaps bool` 필드와 doc comment 제거
- 기존 `opt.PopulateLegacyMaps` 참조를 `false`로 대체 후 파라미터 자체 삭제

### 2. `applySelfhost*` 함수 정리
- `applySelfhostFileResult`, `applySelfhostPackageResult`, `applySelfhostWorkspaceResults`, `runSelfhostPackageResultLocked`에서 `populateLegacy bool` 파라미터 제거
- `if populateLegacy { overlaySelfhostResult(...) }` 블록과 실제 호출 제거

### 3. `host_overlay.go` 삭제
- 워크스페이스 artifact 파일 삭제 (git 미추적)
- overlay 타입/함수는 `host_boundary.go`에 유지 (unit test에서 직접 참조)

### 4. 모든 호출자 업데이트
- `airepair.go` (production): `PopulateLegacyMaps: false` 제거
- `parity_audit_test.go`, `stage0_toolchain_audit_test.go`, `llvm_test.go`, `llvm_multi_file_e2e_test.go`, `lower_test.go` (2개소), `runtime_annot_propagation_test.go`, `main_test.go`: `PopulateLegacyMaps: true` 제거

### 검증
- `go build ./internal/... ./cmd/...` — 통과
- `go test -c ./internal/...` — 테스트 컴파일 통과
- `TestOverlaySelfhostResult*`, `TestLowerMethodCallRecoversDowncastOptionalType` — 통과