### PR TITLE
fix(ir): recover closure inferred FnType via SemanticDB byte-range fallback

### DIFF
--- a/internal/ir/native_check.go
+++ b/internal/ir/native_check.go
@@ -11,9 +11,10 @@ import (
 )
 
 type nativeCheckCache struct {
-	idx                api.CheckResultIndex
-	ready              bool
-	typedNodesByNodeID map[int][]*api.CheckedNode
+	idx                   api.CheckResultIndex
+	ready                 bool
+	typedNodesByNodeID    map[int][]*api.CheckedNode
+	typedNodesByByteRange map[[2]int][]*api.CheckedNode
 }
 
 func (l *lowerer) nativeIndex() (api.CheckResultIndex, bool) {
@@ -28,6 +29,7 @@ func (l *lowerer) nativeIndex() (api.CheckResultIndex, bool) {
 	native.EnsureStableIDs()
 	l.native.idx = native.Index()
 	l.native.typedNodesByNodeID = typedNodesByNodeID(native.TypedNodes)
+	l.native.typedNodesByByteRange = typedNodesByByteRange(native.TypedNodes)
 	return l.native.idx, true
 }
 
@@ -43,6 +45,25 @@ func typedNodesByNodeID(nodes []api.CheckedNode) map[int][]*api.CheckedNode {
 	return out
 }
 
+// typedNodesByByteRange indexes typed nodes by their source byte range,
+// keyed as [start, end]. Used as the byte-range fallback in
+// nativeCheckedType when the AST NodeID does not match the selfhost
+// arena id (the two namespaces are independent). The CheckResultIndex
+// TypedNodesByNodeKey uses a content-hash key (`stableNodeKey`) that
+// includes the node kind, so it cannot be queried from an AST node
+// alone; this raw index closes that gap.
+func typedNodesByByteRange(nodes []api.CheckedNode) map[[2]int][]*api.CheckedNode {
+	out := make(map[[2]int][]*api.CheckedNode, len(nodes))
+	for i := range nodes {
+		if nodes[i].Start == 0 && nodes[i].End == 0 {
+			continue
+		}
+		key := [2]int{nodes[i].Start, nodes[i].End}
+		out[key] = append(out[key], &nodes[i])
+	}
+	return out
+}
+
 func nativeRecordNodeID(nodeID, legacyNode int) int {
 	if nodeID != 0 {
 		return nodeID
@@ -51,7 +72,7 @@ func nativeRecordNodeID(nodeID, legacyNode int) int {
 }
 
 func (l *lowerer) nativeCheckedType(e ast.Expr) Type {
-	idx, ok := l.nativeIndex()
+	_, ok := l.nativeIndex()
 	if !ok {
 		return nil
 	}
@@ -63,15 +84,32 @@ func (l *lowerer) nativeCheckedType(e ast.Expr) Type {
 		}
 	}
 
-	// Fallback: span-based lookup via NodeKey ("start:end").
-	// This covers cases where Go AST NodeIDs and native checker NodeIDs
-	// diverge (e.g., re-parsed source or different ID assignment order).
+	// Byte-range fallback, restricted to ClosureExpr. AST NodeIDs and
+	// selfhost arena ids live in separate namespaces, so the byID path
+	// misses whenever the two diverge. We restrict this fallback to
+	// closures because:
+	//   1. Closures are the one case where the IR-level fallbacks
+	//      (signatureForFn, stdlibFreeFnReturnType, recoverOperandType
+	//      etc.) cannot recover the inferred FnType — there is no
+	//      signature table to consult, and `lowerClosure` relies on
+	//      `out.T` to backfill per-param Types for inline closures like
+	//      `|acc, n| acc + n`.
+	//   2. Widening the fallback to every expression shape lets the
+	//      byte-range hit win over the existing recovery chain, which
+	//      observably reduces stage0 coverage of `toolchain/` functions
+	//      (selfhost typed nodes occasionally carry pre-inference
+	//      shapes that the MIR signature tables would resolve better).
+	if _, isClosure := e.(*ast.ClosureExpr); !isClosure {
+		return nil
+	}
 	start, end, hasRange := astNodeByteRange(e)
 	if !hasRange {
 		return nil
 	}
-	key := fmt.Sprintf("%d:%d", start, end)
-	if rec := idx.TypedNodesByNodeKey[key]; rec != nil && rec.Type != nil {
+	for _, rec := range l.native.typedNodesByByteRange[[2]int{start, end}] {
+		if rec == nil || rec.Type == nil || rec.Kind != "Closure" {
+			continue
+		}
 		return l.fromNativeTypeRepr(rec.Type)
 	}
 	return nil


### PR DESCRIPTION
## Summary

#1645 가 `PopulateLegacyMaps` 와 `overlaySelfhostResult` production 호출을 제거하면서 `Result.Types` 가 더 이상 채워지지 않게 됐고, `lowerClosure` 의 inline-closure 파라미터 Type backfill 이 회귀로 깨졌습니다. 이번 PR 은 `nativeCheckedType` 의 lookup 을 보강해 회귀를 복구합니다.

## 원인

`lowerClosure` 는 `out.T = l.exprType(c)` 가 반환하는 inferred `FnType` 으로 inline closure (`|acc, n| acc + n`) 의 nil 파라미터 Type 들을 backfill 합니다. #1645 이후 `chk.Types` 가 비어 있어 `exprType` 는 `nativeCheckedType` 로 빠지지만, 두 lookup 모두 closure 에 대해 미스합니다:

- **byID 경로:** AST node ID 와 selfhost arena ID 가 독립 네임스페이스라서 같은 closure 인데 AST 는 `ID=19`, SemanticDB record 는 `ID=17` — 미스.
- **byKey 경로:** `TypedNodesByNodeKey` 키는 `stableID("node", kind, start, end)` 콘텐츠 해시 (`node:1846256d...`) 인데 lookup 은 raw `"start:end"` 포맷 (`"70:86"`) — 미스.

결과: `out.T = ErrTypeVal` → `*FnType` cast 실패 → param Type 이 nil 채 남음 → `Validate` 가 `Closure: param[i] nil Type` 로 거부.

## 변경

`typedNodesByByteRange` 인덱스 (`[start, end] → []*CheckedNode`) 를 `nativeCheckCache` 에 추가하고, `nativeCheckedType` 의 마지막 fallback 으로 사용. **ClosureExpr 에 한정** — 다른 expression shape 는 MIR 의 `signatureForFn` / `stdlibFreeFnReturnType` / `recoverOperandType` 가 더 정확한 type 을 복원하므로 그쪽을 우선시.

광역 byte-range fallback 도 실험했으나 stage0 `toolchain/` coverage 가 6112 → 6089 (−23) 로 떨어졌습니다 — selfhost 의 typed node 가 가끔 pre-inference 모양을 carry 해서 MIR 의 signature-driven recovery 보다 부정확. closure 한정 fallback 으로 coverage 를 6112 로 유지.

## 검증

- `TestLowerClosureBackfillsNilParamTypesFromInferredFnType` — #1645 이전: PASS, 이후: FAIL, 이번 PR: PASS
- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit` — 6112 / 6489 (94.2%) — 변동 없음
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit` — 0 errors
- `internal/{ir,check,airepair,mir,lsp,format,resolve,stdlib,query}` + `cmd/{osty,osty-native-llvmgen}` — 전부 green

## 부수 발견

PR #1639 (`56d918f`) 의 PR body 는 "`queries.go`, `cmd/osty/main.go` 두 경로에 `PopulateLegacyMaps: true` 를 추가해 for-in iterable type recovery 를 살린다" 고 주장하지만 실제 commit diff 는 `check.test` (12MB 바이너리 실수 커밋) + `random_test.go` 의 `"next"`/`"nextBytes"` 제거 — **PR body 와 실제 diff 가 완전 불일치**. `git log -S "PopulateLegacyMaps"` 도 commit 2개만 잡힘 (#1600 도입, #1645 삭제). 따라서 사용자가 의심한 "#1639 ↔ #1645 의도적 불일치" 는 전제 자체가 거짓 — #1639 는 그 변경을 시도조차 하지 않았음. 이 PR 의 closure backfill 회귀가 그 미스매치로 가려졌던 진짜 회귀였습니다.

## Test plan

- [x] `go test ./internal/ir/...` — green
- [x] `go test ./internal/check/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 94.2% coverage
- [x] `OSTY_CHECK_PARITY_AUDIT=1 go test -run TestCheckPackageParityAudit ./internal/check/` — 0 errors
- [x] `go test ./cmd/osty/...` — green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_