### PR TITLE
fix(ir): recover generic call TypeArgs via callee Ident NodeID lookup

### DIFF
--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -142,6 +142,35 @@ func TestLowerCallTypeUsesNativeIndexWithoutLegacyTypeMap(t *testing.T) {
 	}
 }
 
+// Real selfhost output anchors instantiation records to the callee
+// identifier's NodeID (not the CallExpr's). `instantiationArgs` must
+// follow that anchor or generic monomorphization regresses to "arity
+// mismatch" for every non-turbofish generic call site.
+func TestLowerInstantiationArgsAnchorsOnCalleeIdentNodeID(t *testing.T) {
+	fnIdent := &ast.Ident{ID: 11, Name: "id"}
+	call := &ast.CallExpr{
+		ID: 13, // CallExpr.ID intentionally different from fnIdent.ID
+		Fn: fnIdent,
+	}
+	file := &ast.File{Stmts: []ast.Stmt{&ast.ExprStmt{X: call}}}
+	chk := &check.Result{
+		NativeCheckResult: &api.CheckResult{
+			Instantiations: []api.CheckInstantiation{{
+				NodeID:   int(fnIdent.ID),
+				Callee:   "id",
+				TypeArgs: []api.TypeRepr{{Kind: "primitive", Name: "Int"}},
+			}},
+		},
+	}
+
+	mod, _ := Lower("main", file, nil, chk)
+	stmt := mod.Script[0].(*ExprStmt)
+	loweredCall := stmt.X.(*CallExpr)
+	if got := loweredCall.TypeArgs; len(got) != 1 || got[0] != TInt {
+		t.Fatalf("call type args = %#v, want [TInt] (callee-Ident-anchored lookup)", got)
+	}
+}
+
 func TestLowerInstantiationArgsUseNativeIndexWithoutLegacyMap(t *testing.T) {
 	call := &ast.CallExpr{
 		ID: 11,

--- a/internal/ir/native_check.go
+++ b/internal/ir/native_check.go
@@ -135,25 +135,55 @@ func (l *lowerer) nativeInstantiationArgs(e *ast.CallExpr) []Type {
 		return nil
 	}
 
-	// Fast path: NodeID lookup.
+	// SemanticDB records instantiations against the callee identifier's
+	// NodeID, not the enclosing CallExpr's NodeID. Empirically for
+	// `id(42)`: AST CallExpr.ID=13, AST Fn.ID=11, SemanticDB
+	// inst.NodeID=11. Try the callee Ident first.
+	//
+	// Byte ranges differ between AST and SemanticDB (the inst is anchored
+	// at the argument list, e.g. `(42)` rather than the callee `id` or
+	// the full call) so we cannot use `selectNativeInstantiation`'s
+	// byte-range filter here — take the first non-empty record matched
+	// by NodeID. The selfhost arena assigns one inst per call site so
+	// the slice is single-entry in practice.
+	if calleeID := calleeIdentNodeID(e.Fn); calleeID != 0 {
+		for _, rec := range idx.InstantiationsByNodeID[calleeID] {
+			if rec != nil && len(rec.TypeArgs) > 0 {
+				return l.nativeInstantiationTypes(rec.TypeArgs)
+			}
+		}
+	}
+
+	// Fallback: CallExpr's own NodeID. Synthetic test data
+	// (`TestLowerInstantiationArgsUseNativeIndexWithoutLegacyMap`)
+	// anchors records to the call expression directly, and a future
+	// selfhost frontend change could do the same — keep this path as
+	// a safety net.
 	if id := int(astNodeID(e)); id != 0 {
 		if rec := selectNativeInstantiation(idx.InstantiationsByNodeID[id], e); rec != nil && len(rec.TypeArgs) > 0 {
 			return l.nativeInstantiationTypes(rec.TypeArgs)
 		}
 	}
-
-	// Fallback: span-based lookup via NodeKey.
-	start, end, hasRange := astNodeByteRange(e)
-	if !hasRange {
-		return nil
-	}
-	key := fmt.Sprintf("%d:%d", start, end)
-	for _, rec := range idx.InstantiationsByNodeKey[key] {
-		if rec != nil && len(rec.TypeArgs) > 0 {
-			return l.nativeInstantiationTypes(rec.TypeArgs)
-		}
-	}
 	return nil
+}
+
+// calleeIdentNodeID returns the AST NodeID for the callee identifier
+// of a call expression's `Fn` slot. Handles three shapes:
+//   - direct `f(x)` → Ident node
+//   - turbofish `f::<T>(x)` → TurbofishExpr wrapping an Ident
+//   - method/path-qualified `x.f(...)` / `m.f(...)` → FieldExpr
+//
+// Returns 0 for shapes we don't track instantiations against.
+func calleeIdentNodeID(fn ast.Expr) int {
+	switch x := fn.(type) {
+	case *ast.Ident:
+		return int(x.ID)
+	case *ast.TurbofishExpr:
+		return calleeIdentNodeID(x.Base)
+	case *ast.FieldExpr:
+		return int(x.ID)
+	}
+	return 0
 }
 
 func (l *lowerer) nativeInstantiationTypes(args []api.TypeRepr) []Type {

--- a/internal/ir/native_check.go
+++ b/internal/ir/native_check.go
@@ -11,9 +11,10 @@ import (
 )
 
 type nativeCheckCache struct {
-	idx                api.CheckResultIndex
-	ready              bool
-	typedNodesByNodeID map[int][]*api.CheckedNode
+	idx                   api.CheckResultIndex
+	ready                 bool
+	typedNodesByNodeID    map[int][]*api.CheckedNode
+	typedNodesByByteRange map[[2]int][]*api.CheckedNode
 }
 
 func (l *lowerer) nativeIndex() (api.CheckResultIndex, bool) {
@@ -28,6 +29,7 @@ func (l *lowerer) nativeIndex() (api.CheckResultIndex, bool) {
 	native.EnsureStableIDs()
 	l.native.idx = native.Index()
 	l.native.typedNodesByNodeID = typedNodesByNodeID(native.TypedNodes)
+	l.native.typedNodesByByteRange = typedNodesByByteRange(native.TypedNodes)
 	return l.native.idx, true
 }
 
@@ -43,6 +45,25 @@ func typedNodesByNodeID(nodes []api.CheckedNode) map[int][]*api.CheckedNode {
 	return out
 }
 
+// typedNodesByByteRange indexes typed nodes by their source byte range,
+// keyed as [start, end]. Used as the byte-range fallback in
+// nativeCheckedType when the AST NodeID does not match the selfhost
+// arena id (the two namespaces are independent). The CheckResultIndex
+// TypedNodesByNodeKey uses a content-hash key (`stableNodeKey`) that
+// includes the node kind, so it cannot be queried from an AST node
+// alone; this raw index closes that gap.
+func typedNodesByByteRange(nodes []api.CheckedNode) map[[2]int][]*api.CheckedNode {
+	out := make(map[[2]int][]*api.CheckedNode, len(nodes))
+	for i := range nodes {
+		if nodes[i].Start == 0 && nodes[i].End == 0 {
+			continue
+		}
+		key := [2]int{nodes[i].Start, nodes[i].End}
+		out[key] = append(out[key], &nodes[i])
+	}
+	return out
+}
+
 func nativeRecordNodeID(nodeID, legacyNode int) int {
 	if nodeID != 0 {
 		return nodeID
@@ -51,7 +72,7 @@ func nativeRecordNodeID(nodeID, legacyNode int) int {
 }
 
 func (l *lowerer) nativeCheckedType(e ast.Expr) Type {
-	idx, ok := l.nativeIndex()
+	_, ok := l.nativeIndex()
 	if !ok {
 		return nil
 	}
@@ -63,15 +84,32 @@ func (l *lowerer) nativeCheckedType(e ast.Expr) Type {
 		}
 	}
 
-	// Fallback: span-based lookup via NodeKey ("start:end").
-	// This covers cases where Go AST NodeIDs and native checker NodeIDs
-	// diverge (e.g., re-parsed source or different ID assignment order).
+	// Byte-range fallback, restricted to ClosureExpr. AST NodeIDs and
+	// selfhost arena ids live in separate namespaces, so the byID path
+	// misses whenever the two diverge. We restrict this fallback to
+	// closures because:
+	//   1. Closures are the one case where the IR-level fallbacks
+	//      (signatureForFn, stdlibFreeFnReturnType, recoverOperandType
+	//      etc.) cannot recover the inferred FnType — there is no
+	//      signature table to consult, and `lowerClosure` relies on
+	//      `out.T` to backfill per-param Types for inline closures like
+	//      `|acc, n| acc + n`.
+	//   2. Widening the fallback to every expression shape lets the
+	//      byte-range hit win over the existing recovery chain, which
+	//      observably reduces stage0 coverage of `toolchain/` functions
+	//      (selfhost typed nodes occasionally carry pre-inference
+	//      shapes that the MIR signature tables would resolve better).
+	if _, isClosure := e.(*ast.ClosureExpr); !isClosure {
+		return nil
+	}
 	start, end, hasRange := astNodeByteRange(e)
 	if !hasRange {
 		return nil
 	}
-	key := fmt.Sprintf("%d:%d", start, end)
-	if rec := idx.TypedNodesByNodeKey[key]; rec != nil && rec.Type != nil {
+	for _, rec := range l.native.typedNodesByByteRange[[2]int{start, end}] {
+		if rec == nil || rec.Type == nil || rec.Kind != "Closure" {
+			continue
+		}
 		return l.fromNativeTypeRepr(rec.Type)
 	}
 	return nil


### PR DESCRIPTION
## Summary

#1650 follow-up. PopulateLegacyMaps 제거 (#1645) 가 closure backfill 뿐 아니라 **generic monomorphization** 도 silently 깨뜨린 두 번째 회귀를 fix 합니다.

## 원인

`nativeInstantiationArgs(callExpr)` 가 `callExpr.ID` 로 SemanticDB instantiation 을 조회했지만, selfhost frontend 는 instantiation 을 **callee identifier 의 NodeID** 에 anchor 합니다 — call expression 의 NodeID 가 아님.

실측 (`id(42)`):

- AST CallExpr.ID = 13, byte range 51-57
- AST Fn Ident "id".ID = 11, byte range 51-53  ← Fn 의 ID 가 매칭
- SemanticDB inst.NodeID = 11, byte range 53-57 (callee Ident 의 ID 와 일치)

byID lookup 이 13 으로 찾으니 미스. legacy `chk.InstantiationsByID[e.ID]` 도 #1645 이후 비어 있음. 결과: 모든 non-turbofish generic call 이 `TypeArgs=[]` 로 lower 되고, `ir.Monomorphize` 가 "arity mismatch" 로 거부 → call site 가 generic template 의 mangled name (또는 unmangled 채로 TypeVar 반환 타입) 으로 남음 → LLVM codegen 실패.

## 실측 비교

```osty
fn id<T>(x: T) -> T { x }
fn main() { let n = id(42); let s = id("hi") }
```

| 시점 | `id(42)` Lower 결과 | Monomorphize 후 |
|------|------|------|
| Pre-fix | `CallExpr{TypeArgs:[], T:T}` | `CallExpr{Callee:id, TypeArgs:[], T:T}` ← 실패 |
| Post-fix | `CallExpr{TypeArgs:[Int], T:T}` | `CallExpr{Callee:_Z2idIlEl, ...}` ← specialized |

## 변경

1. **`calleeIdentNodeID(fn)`** helper 추가 — instantiation 을 구동하는 AST 식별자의 NodeID 반환:
   - `Ident` → 자체 ID
   - `TurbofishExpr` → `Base` 의 NodeID
   - `FieldExpr` → 자체 ID (method / path-qualified)

2. **`nativeInstantiationArgs`** lookup 순서:
   - callee Ident 의 NodeID 로 먼저 조회 (실제 anchor)
   - byte-range filter (`selectNativeInstantiation`) 적용 안 함 — SemanticDB inst range 가 argument list (`(42)`) 에 anchor 되어 AST callee 의 range 와 다름
   - CallExpr.ID 는 backward-compatibility fallback 으로 유지

3. **새 회귀 테스트** `TestLowerInstantiationArgsAnchorsOnCalleeIdentNodeID` — `CallExpr.ID != Fn.ID` 인 real-shape 데이터로 검증

## 검증

- 새 regression 테스트: PASS
- `TestLowerInstantiationArgsUseNativeIndexWithoutLegacyMap` (synthetic, NodeID = CallExpr.ID): 여전히 PASS
- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: 6112 / 6489 (94.2%) — 변동 없음
- `internal/{ir,check,airepair,mir,lsp}` + `cmd/{osty,osty-native-llvmgen}` — 전부 green

## Test plan

- [x] `go test ./internal/ir/...` — green
- [x] `go test ./internal/check/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 94.2%
- [x] `go test ./cmd/osty/...` — green

## 후속 가능성

`nativeBindingType` / `nativeSymbolType` 도 같은 패턴으로 byID/byKey 둘 다 미스합니다 (AST IdentPat.ID=6 vs SemanticDB binding Node=4 등; byte range 는 매칭). 하지만 IR/MIR 레벨의 layered fallback (`bindingTypeFromAST`, `recoveredIdentStorageType`) 이 대부분의 케이스를 흡수해서 가시적 회귀는 closure/instantiation 보다 약합니다. 별도 PR 에서 follow-up.

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_