### PR TITLE
fix(ir): byte-range fallback for native binding + symbol type lookups

### DIFF
--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -146,6 +146,70 @@ func TestLowerCallTypeUsesNativeIndexWithoutLegacyTypeMap(t *testing.T) {
 // identifier's NodeID (not the CallExpr's). `instantiationArgs` must
 // follow that anchor or generic monomorphization regresses to "arity
 // mismatch" for every non-turbofish generic call site.
+// Real selfhost output anchors CheckedBinding records by byte range,
+// with a NodeID that does not match the AST IdentPat's ID (they live in
+// separate namespaces). `nativeBindingType` must look up by byte range
+// + name when byID misses, or every let binding whose RHS type can only
+// be recovered from SemanticDB (method call result, struct field
+// access) regresses to `Type=<error>` after #1645 zeroed the legacy
+// Result.Types map.
+func TestLowerBindingTypeAnchorsOnByteRange(t *testing.T) {
+	src := `pub struct Buf {
+    items: List<Int>,
+
+    pub fn sum(self) -> Int {
+        let mut acc = 0
+        acc
+    }
+}
+
+fn main() {
+    let b = Buf { items: [1, 2, 3] }
+    let total = b.sum()
+    let items = b.items
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse: %v", parseDiags)
+	}
+	res := resolve.ResolveFileSourceDefault([]byte(src), file, stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, _ := Lower("main", file, res, chk)
+
+	want := map[string]string{
+		"b":     "Buf",
+		"total": "Int",
+		"items": "List<Int>",
+	}
+	got := map[string]string{}
+	Inspect(mod, func(n Node) bool {
+		fn, ok := n.(*FnDecl)
+		if !ok || fn.Name != "main" {
+			return true
+		}
+		Inspect(fn.Body, func(n Node) bool {
+			if ls, ok := n.(*LetStmt); ok {
+				got[ls.Name] = typeString(ls.Type)
+			}
+			return true
+		})
+		return true
+	})
+	for name, expect := range want {
+		if got[name] != expect {
+			t.Errorf("let %s: Type=%q, want %q (byte-range fallback regression)", name, got[name], expect)
+		}
+	}
+}
+
 func TestLowerInstantiationArgsAnchorsOnCalleeIdentNodeID(t *testing.T) {
 	fnIdent := &ast.Ident{ID: 11, Name: "id"}
 	call := &ast.CallExpr{

--- a/internal/ir/native_check.go
+++ b/internal/ir/native_check.go
@@ -1,7 +1,6 @@
 package ir
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -15,6 +14,8 @@ type nativeCheckCache struct {
 	ready                 bool
 	typedNodesByNodeID    map[int][]*api.CheckedNode
 	typedNodesByByteRange map[[2]int][]*api.CheckedNode
+	bindingsByByteRange   map[[2]int][]*api.CheckedBinding
+	symbolsByByteRange    map[[2]int][]*api.CheckedSymbol
 }
 
 func (l *lowerer) nativeIndex() (api.CheckResultIndex, bool) {
@@ -30,6 +31,8 @@ func (l *lowerer) nativeIndex() (api.CheckResultIndex, bool) {
 	l.native.idx = native.Index()
 	l.native.typedNodesByNodeID = typedNodesByNodeID(native.TypedNodes)
 	l.native.typedNodesByByteRange = typedNodesByByteRange(native.TypedNodes)
+	l.native.bindingsByByteRange = bindingsByByteRange(native.Bindings)
+	l.native.symbolsByByteRange = symbolsByByteRange(native.Symbols)
 	return l.native.idx, true
 }
 
@@ -60,6 +63,35 @@ func typedNodesByByteRange(nodes []api.CheckedNode) map[[2]int][]*api.CheckedNod
 		}
 		key := [2]int{nodes[i].Start, nodes[i].End}
 		out[key] = append(out[key], &nodes[i])
+	}
+	return out
+}
+
+// bindingsByByteRange / symbolsByByteRange index CheckedBinding /
+// CheckedSymbol records by `[start, end]`. Same rationale as
+// typedNodesByByteRange — `CheckResultIndex.BindingsByNodeKey` /
+// `SymbolsByNodeKey` use content-hash keys that include kind/name so
+// they cannot be queried from an AST node alone.
+func bindingsByByteRange(bs []api.CheckedBinding) map[[2]int][]*api.CheckedBinding {
+	out := make(map[[2]int][]*api.CheckedBinding, len(bs))
+	for i := range bs {
+		if bs[i].Start == 0 && bs[i].End == 0 {
+			continue
+		}
+		key := [2]int{bs[i].Start, bs[i].End}
+		out[key] = append(out[key], &bs[i])
+	}
+	return out
+}
+
+func symbolsByByteRange(ss []api.CheckedSymbol) map[[2]int][]*api.CheckedSymbol {
+	out := make(map[[2]int][]*api.CheckedSymbol, len(ss))
+	for i := range ss {
+		if ss[i].Start == 0 && ss[i].End == 0 {
+			continue
+		}
+		key := [2]int{ss[i].Start, ss[i].End}
+		out[key] = append(out[key], &ss[i])
 	}
 	return out
 }
@@ -228,13 +260,18 @@ func (l *lowerer) nativeBindingType(n ast.Node, name string) Type {
 		}
 	}
 
-	// Fallback: span-based lookup via NodeKey.
+	// Byte-range fallback. AST NodeIDs and selfhost arena ids live in
+	// separate namespaces, so byID misses for real selfhost output (the
+	// AST IdentPat for `acc` may have ID=6 while SemanticDB records the
+	// binding under Node=4). Byte ranges do align, so look up by
+	// `[start, end]` and disambiguate by `name`. The historical
+	// `idx.BindingsByNodeKey[fmt.Sprintf("%d:%d", ...)]` lookup was a
+	// no-op — that map is keyed on content-hash strings, not raw spans.
 	start, end, hasRange := astNodeByteRange(n)
 	if !hasRange {
 		return nil
 	}
-	key := fmt.Sprintf("%d:%d", start, end)
-	for _, rec := range idx.BindingsByNodeKey[key] {
+	for _, rec := range l.native.bindingsByByteRange[[2]int{start, end}] {
 		if rec != nil && rec.Type != nil && (name == "" || rec.Name == name) {
 			return l.fromNativeTypeRepr(rec.Type)
 		}
@@ -276,13 +313,16 @@ func (l *lowerer) nativeSymbolTypeForNode(n ast.Node, name string) Type {
 		}
 	}
 
-	// Fallback: span-based lookup via NodeKey.
+	// Byte-range fallback. Same rationale as nativeBindingType: AST
+	// NodeIDs and selfhost arena ids diverge in practice (AST FnDecl
+	// `sum`.ID=12 vs SemanticDB CheckedSymbol Node=10 for the same span)
+	// and `SymbolsByNodeKey` is content-hashed, not span-keyed. Match by
+	// byte range and disambiguate by symbol name.
 	start, end, hasRange := astNodeByteRange(n)
 	if !hasRange {
 		return nil
 	}
-	key := fmt.Sprintf("%d:%d", start, end)
-	for _, rec := range idx.SymbolsByNodeKey[key] {
+	for _, rec := range l.native.symbolsByByteRange[[2]int{start, end}] {
 		if rec != nil && rec.Type != nil && (name == "" || rec.Name == name) {
 			return l.fromNativeTypeRepr(rec.Type)
 		}


### PR DESCRIPTION
## Summary

#1650 / #1651 follow-up. PopulateLegacyMaps 제거 (#1645) 가 노출시킨 세 번째 회귀: `let` 바인딩의 RHS 타입이 SemanticDB 에서만 복원 가능한 케이스 (메서드 호출 결과, struct 필드 액세스) 가 `Type=<error>` 로 lower 됨.

## Repro

```osty
pub struct Buf {
    items: List<Int>,
    pub fn sum(self) -> Int { ... }
}
fn main() {
    let b = Buf { items: [1, 2, 3] }
    let total = b.sum()    // 사전 fix: Type=<error>
    let items = b.items    // 사전 fix: Type=<error>
}
```

## 원인

`nativeBindingType` 과 `nativeSymbolType` 둘 다 byID lookup 미스 후 `BindingsByNodeKey[fmt.Sprintf("%d:%d", ...)]` / `SymbolsByNodeKey[...]` 로 fallback 했지만 **두 경로 모두 항상 미스**:

1. **byID 미스**: AST NodeID 와 selfhost arena id 가 별개 네임스페이스. AST `acc` IdentPat ID=6 vs SemanticDB CheckedBinding Node=4 (같은 바인딩).
2. **byKey 미스**: `BindingsByNodeKey` / `SymbolsByNodeKey` 가 content-hash 맵 (`stableID("binding:NAME", start, end)`) — raw `"start:end"` 키가 아님. 기존 `fmt.Sprintf` 룩업은 항상 no-op.

#1645 가 `chk.SymTypes` / `chk.Types` legacy 맵 채움을 멈추면서 fallback 이 죽었지만, 코드 경로상 native 룩업이 살아 있다고 가정 → silent 회귀.

## 변경

- `nativeCheckCache` 에 `bindingsByByteRange` / `symbolsByByteRange` 인덱스 추가 (`[start, end] → []*record`). Byte range 는 AST 노드와 SemanticDB record 간에 alignment 가 유지됨 (namespace 미스매치는 NodeID 만).
- `nativeBindingType` / `nativeSymbolType` 의 fallback 경로를 byte-range 인덱스 + name filter 로 교체.
- `fmt.Sprintf("%d:%d", ...)` 룩업 (no-op) 제거. `fmt` import 삭제.

## 검증

- 새 회귀 테스트 `TestLowerBindingTypeAnchorsOnByteRange` — parse → resolve → check → lower 전체 파이프라인에서 `b: Buf`, `total: Int`, `items: List<Int>` 검증. 사전 fix 에서 후자 둘이 `<error>` 였음.
- 기존 closure / instantiation 회귀 테스트들도 모두 PASS.
- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: 6112 / 6489 (94.2%) — 변동 없음
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit`: 0 errors
- `internal/{ir,check,airepair,mir,lsp,format,resolve,stdlib,query}` + `cmd/{osty,osty-native-llvmgen}` — 전부 green

## Test plan

- [x] `go test ./internal/ir/...` — green
- [x] `go test ./internal/check/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 94.2%
- [x] `OSTY_CHECK_PARITY_AUDIT=1 go test -run TestCheckPackageParityAudit ./internal/check/` — 0 errors
- [x] `go test ./cmd/osty/...` — green

## 회귀 시리즈 정리

#1645 가 노출시킨 회귀 3건 모두 fix:

1. ✅ #1650 — closure inferred FnType (ClosureExpr byte-range fallback)
2. ✅ #1651 — generic call TypeArgs (callee Ident NodeID anchor)
3. ✅ 본 PR — binding / symbol type (byte-range fallback)

세 fix 모두 SemanticDB 룩업 메커니즘이 byID/byKey 둘 다 깨졌던 동일 root cause 의 변종이고, 각각 다른 user-visible regression 으로 노출.

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_