### PR TITLE
test(stdlib): assert on NativeCheckResult.TypedNodes instead of legacy Types

### DIFF
--- a/internal/backend/stdlib_check_test.go
+++ b/internal/backend/stdlib_check_test.go
@@ -26,8 +26,20 @@ func TestStdlibCheckResultStringsModule(t *testing.T) {
 	// non-empty stdlib module. Exact count varies with the checker
 	// coverage, so assert "more than a handful" rather than a precise
 	// number.
-	if len(chk.Types) < 10 {
-		t.Errorf("chk.Types has %d entries, expected the checker to cover more of the strings module", len(chk.Types))
+	//
+	// Post-#1645 the legacy `chk.Types` AST-keyed map is no longer
+	// populated in production paths (the `overlaySelfhostResult` calls
+	// that used to mirror native check facts into it were dropped, and
+	// putting them back regresses ONB int-literal lowering by
+	// overwriting context-inferred types with raw untyped-int records).
+	// Read from `NativeCheckResult.TypedNodes`, the authoritative
+	// structured checker output, instead.
+	native := chk.NativeCheckResult
+	if native == nil {
+		t.Fatalf("chk.NativeCheckResult is nil, want non-nil native check result")
+	}
+	if got := len(native.TypedNodes); got < 10 {
+		t.Errorf("native.TypedNodes has %d entries, expected the checker to cover more of the strings module", got)
 	}
 }
 

--- a/internal/backend/stdlib_keychain_check_test.go
+++ b/internal/backend/stdlib_keychain_check_test.go
@@ -13,8 +13,13 @@ func TestStdlibCheckResultKeychainAndSecrets(t *testing.T) {
 		if chk == nil {
 			t.Fatalf("stdlibCheckResult(%s) = nil, want non-nil *check.Result", module)
 		}
-		if module == "keychain" && len(chk.Types) == 0 {
-			t.Fatalf("stdlibCheckResult(%s) recorded no expression types", module)
+		// Read from `NativeCheckResult.TypedNodes` post-#1645 — see
+		// TestStdlibCheckResultStringsModule for the rationale.
+		if module == "keychain" {
+			native := chk.NativeCheckResult
+			if native == nil || len(native.TypedNodes) == 0 {
+				t.Fatalf("stdlibCheckResult(%s) recorded no native typed nodes", module)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Two stdlib check tests started failing on origin/main after PR #1645 removed the production-path `overlaySelfhostResult` calls that used to mirror native check facts into `check.Result.Types`:

- `TestStdlibCheckResultStringsModule` — `chk.Types has 0 entries`
- `TestStdlibCheckResultKeychainAndSecrets` — `stdlibCheckResult(keychain) recorded no expression types`

## Why not just restore the overlay calls?

Tried that locally first — it regresses ONB int-literal lowering:

```
onb: unsupported mir shape: call argument has type UntypedInt outside ABI
```

The overlay copies raw `rec.Type` records (`UntypedInt` for an int literal) over context-inferred types (`Int` after propagation through `println(_: Int)`), and ONB's calling-convention check rejects untyped values. The production code paths read types through `nativeCheckedType` (span-index → inferred type) and `SemanticDB`, which produces the right answer; the legacy `Types` overlay produces the wrong answer.

So the fix is on the test side: stop asserting on the legacy map, assert on the authoritative structured output instead.

## Change

| Test | Before | After |
|---|---|---|
| `TestStdlibCheckResultStringsModule` | `len(chk.Types) < 10` | `len(chk.NativeCheckResult.TypedNodes) < 10` |
| `TestStdlibCheckResultKeychainAndSecrets` | `len(chk.Types) == 0` | `chk.NativeCheckResult == nil \|\| len(...TypedNodes) == 0` |

Both tests express the same semantic intent ("the checker recorded some types for this stdlib module") on the correct post-#1645 surface.

## Out of scope

`TestStage0StringIndexOfOptionBox` is also failing on origin/main with a related-looking message (`function "find" does not match any stage0 pattern`), but the root cause is a deeper stage0 emit-pattern gap on `match Option<Int>` — separate PR.

## Test plan

- [x] `go test ./internal/backend -run 'TestStdlibCheckResult*' -count=1` — 4 tests pass (including `Nil`/`Cached` which weren't touched)
- [x] `go test ./internal/backend ./internal/check ./internal/ir -count=1 -short` — only `TestStage0StringIndexOfOptionBox` fails (pre-existing, out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)