### PR TITLE
feat: subprocess stdout/stderr 분리 + 구조화된 에러 노출

### DIFF
--- a/examples/regex_backward_dfa/main.osty
+++ b/examples/regex_backward_dfa/main.osty
@@ -27,7 +27,7 @@ fn main() {
             let n = list.len()
             println("multi-sparse: {n}")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let m = list[i]
                 let t = m.text
                 let s = m.start
@@ -67,7 +67,7 @@ fn main() {
             let n = list.len()
             println("clamp: {n}")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let m = list[i]
                 let t = m.text
                 let s = m.start

--- a/examples/regex_captures_all/main.osty
+++ b/examples/regex_captures_all/main.osty
@@ -8,7 +8,7 @@ fn main() {
             let n = list.len()
             println("digits: {n} match(es)")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let c = list[i]
                 match c.get(0) {
                     Some(s) -> println("  whole: {s}"),
@@ -27,7 +27,7 @@ fn main() {
             let n = list.len()
             println("kv: {n} match(es)")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let c = list[i]
                 match c.get(1) {
                     Some(s) -> println("  k={s}"),
@@ -50,7 +50,7 @@ fn main() {
             let n = list.len()
             println("anchored: {n} match(es)")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let c = list[i]
                 match c.get(0) {
                     Some(s) -> println("  {s}"),
@@ -79,7 +79,7 @@ fn main() {
             let n = list.len()
             println("alt: {n} match(es)")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let c = list[i]
                 match c.get(0) {
                     Some(s) -> println("  whole={s}"),

--- a/examples/regex_dfa_check/main.osty
+++ b/examples/regex_dfa_check/main.osty
@@ -26,7 +26,7 @@ fn main() {
             let n = list.len()
             println("words: {n}")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let m = list[i]
                 let t = m.text
                 let s = m.start

--- a/examples/regex_extensions/main.osty
+++ b/examples/regex_extensions/main.osty
@@ -21,7 +21,7 @@ fn main() {
             let n = list.len()
             println("findAll: {n} match(es)")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let m = list[i]
                 let t = m.text
                 let s = m.start

--- a/examples/regex_find_all/main.osty
+++ b/examples/regex_find_all/main.osty
@@ -8,7 +8,7 @@ fn main() {
             let n = list.len()
             println("words: {n} match(es)")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let m = list[i]
                 let t = m.text
                 let s = m.start
@@ -54,7 +54,7 @@ fn main() {
             let n = list.len()
             println("greedy: {n} match(es)")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let m = list[i]
                 let t = m.text
                 let s = m.start

--- a/examples/regex_replace_split/main.osty
+++ b/examples/regex_replace_split/main.osty
@@ -46,7 +46,7 @@ fn main() {
             let n = parts.len()
             println("split count: {n}")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let p = parts[i]
                 println("  [{i}]={p}")
                 i += 1
@@ -76,7 +76,7 @@ fn main() {
             let n = parts.len()
             println("empties count: {n}")
             let mut i = 0
-            while i < n {
+            for i < n {
                 let p = parts[i]
                 println("  [{i}]='{p}'")
                 i += 1

--- a/internal/airepair/airepair.go
+++ b/internal/airepair/airepair.go
@@ -479,10 +479,10 @@ func checkOptsForSource(src []byte) check.Opts {
 	reg := stdlib.LoadCached()
 	return check.Opts{
 
-		Stdlib:             reg,
-		Primitives:         reg.Primitives,
-		ResultMethods:      reg.ResultMethods,
-		Source:             src,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        src,
 	}
 }
 

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -84,10 +84,10 @@ func parseBackendFile(t *testing.T, src string) (*ast.File, *resolve.Result, *ch
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
 
-		Stdlib:             reg,
-		Primitives:         reg.Primitives,
-		ResultMethods:      reg.ResultMethods,
-		Source:             []byte(src),
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
 	})
 	return file, res, chk
 }

--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -50,9 +50,9 @@ func TestStage0ToolchainAudit(t *testing.T) {
 	}
 	res := resolve.ResolvePackageDefault(pkg)
 	chk := check.Package(pkg, res, check.Opts{
-		Stdlib:             reg,
-		Primitives:         reg.Primitives,
-		ResultMethods:      reg.ResultMethods,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
 	})
 
 	entry, err := PreparePackage("toolchain", filepath.Join(pkgDir, "main.osty"), pkg, nil, chk)

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -174,7 +174,6 @@ type Opts struct {
 	// File() must supply the flag explicitly; the default false is
 	// correct for ordinary user code.
 	Privileged bool
-
 }
 
 // firstOpt returns the first Opts in the slice, or a zero value when

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -3,11 +3,11 @@ package check
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"sync"
 
 	"github.com/osty/osty/internal/ast"
@@ -48,6 +48,32 @@ func (e nativeCheckerExec) CheckPackageStructured(input api.PackageCheckInput) (
 	return e.run(api.CheckRequest{Package: &input})
 }
 
+// Subprocess output preview caps. stderr keeps the tail (panic stacks are most
+// useful at the bottom); stdout keeps the head (JSON parse errors fire near the
+// start, and a 256B prefix is enough to recognize what shape the response had).
+const (
+	subprocStdoutPreviewBytes = 256
+	subprocStderrPreviewBytes = 2048
+)
+
+// subprocessError carries the structured failure of a native-checker exec so
+// callers can surface stdout/stderr as separate diagnostic notes instead of
+// mashing everything into a single string.
+type subprocessError struct {
+	Path      string
+	Err       error
+	Stdout    []byte // truncated head, up to subprocStdoutPreviewBytes
+	Stderr    []byte // truncated tail, up to subprocStderrPreviewBytes
+	StdoutLen int    // original stdout length before truncation
+	StderrLen int    // original stderr length before truncation
+}
+
+func (e *subprocessError) Error() string {
+	return fmt.Sprintf("native checker %s: %v", e.Path, e.Err)
+}
+
+func (e *subprocessError) Unwrap() error { return e.Err }
+
 func (e nativeCheckerExec) run(req api.CheckRequest) (api.CheckResult, error) {
 	payload, err := json.Marshal(req)
 	if err != nil {
@@ -55,20 +81,74 @@ func (e nativeCheckerExec) run(req api.CheckRequest) (api.CheckResult, error) {
 	}
 	cmd := exec.Command(e.path)
 	cmd.Stdin = bytes.NewReader(payload)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		msg := strings.TrimSpace(string(out))
-		if msg == "" {
-			msg = "<no output>"
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	runErr := cmd.Run()
+	stdout := stdoutBuf.Bytes()
+	stderr := stderrBuf.Bytes()
+	if runErr != nil {
+		return api.CheckResult{}, &subprocessError{
+			Path:      e.path,
+			Err:       runErr,
+			Stdout:    headBytes(stdout, subprocStdoutPreviewBytes),
+			Stderr:    tailBytes(stderr, subprocStderrPreviewBytes),
+			StdoutLen: len(stdout),
+			StderrLen: len(stderr),
 		}
-		return api.CheckResult{}, fmt.Errorf("exec %s: %w (%s)", e.path, err, msg)
 	}
 	var checked api.CheckResult
-	if err := json.Unmarshal(out, &checked); err != nil {
-		return api.CheckResult{}, fmt.Errorf("decode native checker response: %w", err)
+	if err := json.Unmarshal(stdout, &checked); err != nil {
+		return api.CheckResult{}, &subprocessError{
+			Path:      e.path,
+			Err:       fmt.Errorf("decode response: %w", err),
+			Stdout:    headBytes(stdout, subprocStdoutPreviewBytes),
+			Stderr:    tailBytes(stderr, subprocStderrPreviewBytes),
+			StdoutLen: len(stdout),
+			StderrLen: len(stderr),
+		}
 	}
 	checked.EnsureStableIDs()
 	return checked, nil
+}
+
+func headBytes(b []byte, n int) []byte {
+	if len(b) <= n {
+		return b
+	}
+	return b[:n]
+}
+
+func tailBytes(b []byte, n int) []byte {
+	if len(b) <= n {
+		return b
+	}
+	return b[len(b)-n:]
+}
+
+// subprocessFailureNotes expands a native-checker run error into diagnostic
+// notes. A *subprocessError is split into "exec failed" + separate stderr /
+// stdout preview notes; any other error becomes a single note.
+func subprocessFailureNotes(err error) []string {
+	var se *subprocessError
+	if !errors.As(err, &se) {
+		return []string{"the Osty-native checker executable failed", err.Error()}
+	}
+	notes := []string{"the Osty-native checker executable failed", se.Error()}
+	if se.StderrLen > 0 {
+		notes = append(notes, formatStreamPreview("stderr", se.Stderr, se.StderrLen, "tail"))
+	}
+	if se.StdoutLen > 0 {
+		notes = append(notes, formatStreamPreview("stdout", se.Stdout, se.StdoutLen, "head"))
+	}
+	return notes
+}
+
+func formatStreamPreview(label string, preview []byte, total int, side string) string {
+	if total <= len(preview) {
+		return fmt.Sprintf("%s (%d bytes):\n%s", label, total, preview)
+	}
+	return fmt.Sprintf("%s (%s %d of %d bytes):\n%s", label, side, len(preview), total, preview)
 }
 
 type embeddedNativeChecker struct{}
@@ -150,8 +230,7 @@ func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result,
 	if err != nil {
 		result.Diags = append(result.Diags, checkerUnavailableDiag(
 			"file",
-			"the Osty-native checker executable failed",
-			err.Error(),
+			subprocessFailureNotes(err)...,
 		))
 		return
 	}
@@ -201,8 +280,7 @@ func applySelfhostPackageResult(result *Result, pkg *resolve.Package, pr *resolv
 	if err != nil {
 		result.Diags = append(result.Diags, checkerUnavailableDiag(
 			"package",
-			"the Osty-native checker executable failed",
-			err.Error(),
+			subprocessFailureNotes(err)...,
 		))
 		return
 	}
@@ -334,8 +412,7 @@ func runSelfhostPackageResultLocked(result *Result, pkg *resolve.Package, pr *re
 		mu.Lock()
 		result.Diags = append(result.Diags, checkerUnavailableDiag(
 			"package",
-			"the Osty-native checker executable failed",
-			err.Error(),
+			subprocessFailureNotes(err)...,
 		))
 		mu.Unlock()
 		return

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -1,0 +1,182 @@
+package check
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost/api"
+)
+
+// fakeCheckerPath is set by TestMain once for the whole package; tests just
+// instantiate nativeCheckerExec{path: fakeCheckerPath} and toggle behaviour
+// through the FAKECHECKER_MODE env var.
+var fakeCheckerPath string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "osty-fakechecker-*")
+	if err != nil {
+		panic("create temp dir: " + err.Error())
+	}
+	defer os.RemoveAll(tmp)
+	binName := "fakechecker"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(tmp, binName)
+	cmd := exec.Command("go", "build", "-o", binPath, "./testdata/cmd/fakechecker")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		panic("build fakechecker: " + err.Error())
+	}
+	fakeCheckerPath = binPath
+	os.Exit(m.Run())
+}
+
+func TestSubprocessRun_OK(t *testing.T) {
+	t.Setenv("FAKECHECKER_MODE", "ok")
+	_, err := nativeCheckerExec{path: fakeCheckerPath}.run(api.CheckRequest{Source: ""})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSubprocessRun_StderrNoiseIgnoredOnSuccess(t *testing.T) {
+	t.Setenv("FAKECHECKER_MODE", "stderr-noise")
+	_, err := nativeCheckerExec{path: fakeCheckerPath}.run(api.CheckRequest{Source: ""})
+	if err != nil {
+		t.Fatalf("zero-exit + valid-JSON must succeed regardless of stderr; got: %v", err)
+	}
+}
+
+func TestSubprocessRun_PanicExposesStderr(t *testing.T) {
+	t.Setenv("FAKECHECKER_MODE", "panic")
+	_, err := nativeCheckerExec{path: fakeCheckerPath}.run(api.CheckRequest{Source: ""})
+	if err == nil {
+		t.Fatal("expected error for panic mode")
+	}
+	var se *subprocessError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *subprocessError, got %T", err)
+	}
+	if !bytes.Contains(se.Stderr, []byte("panic: runtime error")) {
+		t.Errorf("stderr should contain panic header; got: %q", se.Stderr)
+	}
+	if !bytes.Contains(se.Stderr, []byte("goroutine 1")) {
+		t.Errorf("stderr should contain goroutine dump; got: %q", se.Stderr)
+	}
+	if len(se.Stdout) != 0 {
+		t.Errorf("expected empty stdout on panic; got: %q", se.Stdout)
+	}
+}
+
+func TestSubprocessRun_BadJSONExposesStdoutPreview(t *testing.T) {
+	t.Setenv("FAKECHECKER_MODE", "bad-json")
+	_, err := nativeCheckerExec{path: fakeCheckerPath}.run(api.CheckRequest{Source: ""})
+	if err == nil {
+		t.Fatal("expected error for bad-json mode")
+	}
+	var se *subprocessError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *subprocessError, got %T", err)
+	}
+	if !bytes.Contains(se.Stdout, []byte("not json")) {
+		t.Errorf("stdout preview should carry the offending bytes; got: %q", se.Stdout)
+	}
+	if !strings.Contains(se.Err.Error(), "decode") {
+		t.Errorf("wrapped error should mention decode failure; got: %v", se.Err)
+	}
+}
+
+func TestSubprocessRun_HugeStderrTruncatedAtTail(t *testing.T) {
+	t.Setenv("FAKECHECKER_MODE", "huge-stderr")
+	_, err := nativeCheckerExec{path: fakeCheckerPath}.run(api.CheckRequest{Source: ""})
+	if err == nil {
+		t.Fatal("expected error for huge-stderr mode")
+	}
+	var se *subprocessError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *subprocessError, got %T", err)
+	}
+	if len(se.Stderr) > subprocStderrPreviewBytes {
+		t.Errorf("stderr preview %d > cap %d", len(se.Stderr), subprocStderrPreviewBytes)
+	}
+	if se.StderrLen <= len(se.Stderr) {
+		t.Errorf("StderrLen %d should exceed truncated preview %d", se.StderrLen, len(se.Stderr))
+	}
+	if !bytes.Contains(se.Stderr, []byte("TAIL_MARKER_LAST_LINE")) {
+		t.Errorf("tail truncation must preserve the bottom line; got tail: %q", se.Stderr)
+	}
+}
+
+func TestSubprocessRun_HugeStdoutTruncatedAtHead(t *testing.T) {
+	t.Setenv("FAKECHECKER_MODE", "huge-stdout")
+	_, err := nativeCheckerExec{path: fakeCheckerPath}.run(api.CheckRequest{Source: ""})
+	if err == nil {
+		t.Fatal("expected error for huge-stdout mode")
+	}
+	var se *subprocessError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *subprocessError, got %T", err)
+	}
+	if len(se.Stdout) > subprocStdoutPreviewBytes {
+		t.Errorf("stdout preview %d > cap %d", len(se.Stdout), subprocStdoutPreviewBytes)
+	}
+	if se.StdoutLen <= len(se.Stdout) {
+		t.Errorf("StdoutLen %d should exceed truncated preview %d", se.StdoutLen, len(se.Stdout))
+	}
+	if !bytes.HasPrefix(se.Stdout, []byte("HEAD_MARKER_FIRST_LINE")) {
+		t.Errorf("head truncation must preserve the top line; got head: %q", se.Stdout)
+	}
+}
+
+func TestSubprocessRun_BinaryNotFound(t *testing.T) {
+	_, err := nativeCheckerExec{path: "/does/not/exist/at/all"}.run(api.CheckRequest{Source: ""})
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	var se *subprocessError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *subprocessError even for fork failure, got %T (%v)", err, err)
+	}
+	if len(se.Stdout) != 0 || len(se.Stderr) != 0 {
+		t.Errorf("expected empty streams on fork failure; got stdout=%q stderr=%q", se.Stdout, se.Stderr)
+	}
+}
+
+func TestSubprocessFailureNotes_StructuredSplit(t *testing.T) {
+	se := &subprocessError{
+		Path:      "/bin/fake",
+		Err:       errors.New("exit status 2"),
+		Stdout:    nil,
+		Stderr:    []byte("panic: boom\ngoroutine 1\n"),
+		StdoutLen: 0,
+		StderrLen: 24,
+	}
+	notes := subprocessFailureNotes(se)
+	if len(notes) != 3 {
+		t.Fatalf("expected 3 notes (header + se.Error + stderr preview), got %d: %v", len(notes), notes)
+	}
+	if !strings.Contains(notes[2], "panic: boom") {
+		t.Errorf("stderr note should contain panic content; got: %q", notes[2])
+	}
+	if !strings.Contains(notes[2], "stderr") {
+		t.Errorf("stderr note should be labeled; got: %q", notes[2])
+	}
+}
+
+func TestSubprocessFailureNotes_PlainErrorFallback(t *testing.T) {
+	notes := subprocessFailureNotes(errors.New("some non-structured error"))
+	if len(notes) != 2 {
+		t.Fatalf("expected 2 notes for plain error, got %d: %v", len(notes), notes)
+	}
+	if !strings.Contains(notes[1], "some non-structured error") {
+		t.Errorf("plain error should be preserved; got: %q", notes[1])
+	}
+}

--- a/internal/check/parity_audit_test.go
+++ b/internal/check/parity_audit_test.go
@@ -42,9 +42,9 @@ func TestCheckPackageParityAudit(t *testing.T) {
 	res := resolve.ResolvePackageDefault(pkg)
 	reg := stdlib.LoadCached()
 	chk := check.Package(pkg, res, check.Opts{
-		Stdlib:             reg,
-		Primitives:         reg.Primitives,
-		ResultMethods:      reg.ResultMethods,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
 	})
 
 	type diagRow struct {

--- a/internal/check/testdata/cmd/fakechecker/main.go
+++ b/internal/check/testdata/cmd/fakechecker/main.go
@@ -1,0 +1,59 @@
+// fakechecker is a flag-driven stand-in for osty-native-checker used by
+// host_boundary_test.go to exercise the subprocess error-reporting paths.
+//
+// Each --mode emits a deterministic (stdout, stderr, exit code) combination
+// so the tests can assert that nativeCheckerExec.run captures and truncates
+// the streams correctly.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func main() {
+	mode := os.Getenv("FAKECHECKER_MODE")
+	if mode == "" {
+		mode = "ok"
+	}
+
+	_, _ = io.Copy(io.Discard, os.Stdin)
+
+	switch mode {
+	case "ok":
+		// Minimal valid CheckResult JSON. Empty object decodes cleanly into
+		// api.CheckResult — EnsureStableIDs handles the rest.
+		fmt.Fprint(os.Stdout, `{}`)
+	case "bad-json":
+		fmt.Fprint(os.Stdout, "this is definitely not json {[")
+	case "panic":
+		fmt.Fprintln(os.Stderr, "panic: runtime error: index out of range [4] with length 2")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "goroutine 1 [running]:")
+		fmt.Fprintln(os.Stderr, "main.checkThing(0x0, 0x0)")
+		fmt.Fprintln(os.Stderr, "\tcheck.go:42 +0x1a3")
+		os.Exit(2)
+	case "stderr-noise":
+		// Real-world bug we want to be robust against: subprocess writes a
+		// debug line to stderr but still produces a valid JSON response on
+		// stdout. The success path should ignore stderr entirely.
+		fmt.Fprintln(os.Stderr, "warning: deprecated flag --foo")
+		fmt.Fprint(os.Stdout, `{}`)
+	case "huge-stderr":
+		// 10KB of stderr, ending with a recognizable tail marker so the test
+		// can verify tail-truncation kept the bottom.
+		fmt.Fprint(os.Stderr, strings.Repeat("filler line\n", 1000))
+		fmt.Fprintln(os.Stderr, "TAIL_MARKER_LAST_LINE")
+		os.Exit(3)
+	case "huge-stdout":
+		// 10KB of stdout starting with a recognizable head marker, all
+		// non-JSON so the decode error path fires.
+		fmt.Fprint(os.Stdout, "HEAD_MARKER_FIRST_LINE\n")
+		fmt.Fprint(os.Stdout, strings.Repeat("garbage line\n", 1000))
+	default:
+		fmt.Fprintf(os.Stderr, "fakechecker: unknown mode %q\n", mode)
+		os.Exit(1)
+	}
+}

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -1149,7 +1149,6 @@ const (
 	//
 	// Fix: check write permissions and free space.
 	CodeScaffoldWriteError = "E2052"
-
 )
 
 const (

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -909,6 +909,7 @@ func isRangeIntOrCharType(t Type) bool {
 	}
 	return pt.Kind == ir.PrimInt || pt.Kind == ir.PrimChar
 }
+
 // isIteratorType reports whether t is a NamedType with Name "Iterator"
 // and exactly one type argument (the element type).
 func isIteratorType(t Type) bool {
@@ -927,7 +928,6 @@ func iteratorElementType(t Type) Type {
 	}
 	return nt.Args[0]
 }
-
 
 // isCountableIteratorType reports whether an Iterator<T> is countable
 // (exposes len() and supports direct indexing). Array<T> and Slice<T>
@@ -2119,6 +2119,7 @@ func (bs *bodyState) lowerForInChannel(f *ir.ForStmt, iterT Type) {
 	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
 	bs.cur = exit
 }
+
 // lowerForInIterator lowers `for x in iter { ... }` where iter implements
 // the Iterator<T> protocol. Each loop iteration calls iter.next() which
 // returns Option<T>. Some(val) continues the loop; None terminates it.
@@ -2206,7 +2207,6 @@ func (bs *bodyState) lowerForInIterator(f *ir.ForStmt, iterT Type) {
 	bs.cur = exit
 }
 
-
 // lowerForInCountableIterator lowers a for-in over a countable Iterator<T>
 // to an index-driven counter loop identical to the List for-in shape.
 // The LLVM vectorizer can compute trip counts from idx < len and
@@ -2241,8 +2241,8 @@ func (bs *bodyState) lowerForInCountableIterator(f *ir.ForStmt, iterT Type) {
 	bs.cur = header
 	cmp := bs.freshTemp(TBool, f.SpanV)
 	bs.emit(&AssignInstr{
-		Dest: Place{Local: cmp},
-		Src: &BinaryRV{Op: BinLt, Left: &CopyOp{Place: Place{Local: idx}, T: TInt}, Right: &CopyOp{Place: Place{Local: lenLocal}, T: TInt}, T: TBool},
+		Dest:  Place{Local: cmp},
+		Src:   &BinaryRV{Op: BinLt, Left: &CopyOp{Place: Place{Local: idx}, T: TInt}, Right: &CopyOp{Place: Place{Local: lenLocal}, T: TInt}, T: TBool},
 		SpanV: f.SpanV,
 	})
 	bs.terminate(&BranchTerm{
@@ -2276,8 +2276,8 @@ func (bs *bodyState) lowerForInCountableIterator(f *ir.ForStmt, iterT Type) {
 	bs.terminate(&GotoTerm{Target: step, SpanV: f.SpanV})
 	bs.cur = step
 	bs.emit(&AssignInstr{
-		Dest: Place{Local: idx},
-		Src: &BinaryRV{Op: BinAdd, Left: &CopyOp{Place: Place{Local: idx}, T: TInt}, Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt}, T: TInt},
+		Dest:  Place{Local: idx},
+		Src:   &BinaryRV{Op: BinAdd, Left: &CopyOp{Place: Place{Local: idx}, T: TInt}, Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt}, T: TInt},
 		SpanV: f.SpanV,
 	})
 	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})

--- a/internal/parser/frontend_authority_test.go
+++ b/internal/parser/frontend_authority_test.go
@@ -396,19 +396,6 @@ func TestParseFollowOnRecoveryA1ElseNewlinePrimary(t *testing.T) {
 	}
 }
 
-func TestParseFollowOnRecoveryA2ElseNewlineTopLevelDecl(t *testing.T) {
-	src := fixtureFollowOnAElseNewline("rfA2ElseNewlineTopLevelDecl", "rfA2Cond")
-
-	result := ParseDetailed(src)
-	fn, _ := requireFollowOnFnWithHelper(t, result, 0, 1, 1, 1, "rfA2Cond", "E0105", "E0204", "E0100")
-	requireParseDiagnosticCodePresent(t, result, "E0100")
-	stmt := requireExprStmtAt(t, fn.Body.Stmts, 0, "expression statement")
-	ifExpr, ok := stmt.X.(*ast.IfExpr)
-	if !ok || ifExpr.Else != nil {
-		t.Fatalf("stmt[0].X = %#v, want if expr with nil else after follow-on recovery", stmt.X)
-	}
-}
-
 // Axis B — declaration-layer fallout after expression recovery.
 
 func TestParseFollowOnRecoveryB1MatchAssignTopLevelDecl(t *testing.T) {

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -28764,7 +28764,6 @@ func diagIntrinsicNonEmptyBody(fnName string, start int, end int) *CheckDiagnost
 	return checkDiagWithNotes(checkCodeIntrinsicNonEmptyBody(), fmt.Sprintf("`#[intrinsic]` function `%s` must have an empty body", ostyToString(fnName)), start, end, []string{"LANG_SPEC §19.6: intrinsic implementations are supplied by the lowering layer; the source body is ignored", "hint: keep the signature and drop the body, or use an empty block"})
 }
 
-
 // Osty: /tmp/selfhost_merged.osty:11286:5
 func checkSuggestSimilar(candidates []string, name string) string {
 	// Osty: /tmp/selfhost_merged.osty:11287:5
@@ -70337,4 +70336,3 @@ func pureCopyLocals(in map[string]struct{}) map[string]struct{} {
 	}
 	return out
 }
-


### PR DESCRIPTION
## Summary

- `nativeCheckerExec.run` 이 `cmd.CombinedOutput()` 대신 두 buffer 로 stdout/stderr 분리 capture
- 새 `*subprocessError` 타입으로 호출부가 stderr tail(2KB) + stdout head(256B) 를 별도 diagnostic note 로 분할 노출 — switchover 후 default 경로가 될 코드의 디버깅 사이클 단축
- zero-exit + valid-JSON 의 stderr 는 의도적으로 버림 (정상 출력 오염 방지)
- 헬퍼 `testdata/cmd/fakechecker` 와 9개 케이스로 회귀 보호: panic stack 노출 / bad-JSON 시 stdout 프리뷰 / huge stderr tail truncation 마커 보존 / fork 실패 시 빈 buffer 등

별도 chore 커밋 3개로 사전 drift 정리 (게이트 통과용):
- `gofmt drift from #1645` — `PopulateLegacyMaps` 제거 후 호출부 stale 컬럼 정렬
- `drop duplicate A2 test` — `#1638` 이 옮기면서 원본 미제거한 redeclare
- `airepair while → for` — examples/regex_* 6개 파일

## Test plan
- [x] `just prepush` 로컬 통과 (fmt-check / vet / repair-check / ci 전부 green)
- [x] `go test ./internal/check/ -run 'TestSubprocess' -v` 9/9 pass
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)