### PR TITLE
fix: restore strings/os/exec imports in host_boundary.go (main build broken)

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/osty/osty/internal/ast"


### PR DESCRIPTION
## Summary

[main 빌드 broken hotfix.](https://github.com/choiceoh/osty/actions)

[#1662](https://github.com/choiceoh/osty/pull/1662) (subproc 추출) 가 `strings` / `os/exec` import 를 제거할 때, [#1659](https://github.com/choiceoh/osty/pull/1659) (native checker factory 중앙화) 가 같은 파일에 `strings.TrimSpace` + `exec.LookPath` 사용처를 추가하고 있었음. 두 PR 이 동시 머지되면서 main 의 `host_boundary.go` 가 `undefined: strings` / `undefined: exec` 로 깨짐.

import 두 줄 복원만 함.

## Test plan
- [x] `go build ./...` 통과
- [x] `just prepush` 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)