### PR TITLE
fix(ir): recover tuple-access element type + promote free-fn calls

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1021,10 +1021,50 @@ func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
 					return true
 				}
 			}
+			// Free-fn calls (`helper()`): promote when the resolved
+			// declaration has a non-unit return type. We restrict this
+			// to top-level fn decls because:
+			//   - let-bound closures (`let g = |n| n + 1; g(x)`) are
+			//     correct to promote but altering this site for them
+			//     measurably regresses stage0 toolchain coverage
+			//     (some toolchain helpers rely on the current
+			//     Stmt-positioned shape).
+			//   - free-fn return types are stable (no inference), so
+			//     `expressionTypeYieldsValue` decides reliably.
+			if id, ok := call.Fn.(*ast.Ident); ok && id != nil {
+				if rt := l.freeFnReturnTypeFromAST(id); rt != nil && expressionTypeYieldsValue(rt) {
+					return true
+				}
+			}
 		}
 		return false
 	}
 	return false
+}
+
+// freeFnReturnTypeFromAST resolves the callee identifier of a free-fn
+// call (`helper()`) to its declared return type via the resolver.
+// Used by `expressionYieldsValue` to decide whether a trailing call
+// promotes to the block's Result. Returns nil when the symbol does not
+// resolve to a top-level FnDecl. Closure / let-bound function callees
+// are intentionally excluded — they parse and resolve but their bodies
+// are sometimes Stmt-positioned in the toolchain, and promoting them
+// regresses stage0 audit coverage.
+func (l *lowerer) freeFnReturnTypeFromAST(id *ast.Ident) Type {
+	if l == nil || id == nil || l.res == nil {
+		return nil
+	}
+	sym := l.res.RefsByID[id.ID]
+	if sym == nil {
+		return nil
+	}
+	if d, ok := sym.Decl.(*ast.FnDecl); ok && d != nil {
+		if d.ReturnType == nil {
+			return TUnit
+		}
+		return l.lowerType(d.ReturnType)
+	}
+	return nil
 }
 
 // userMethodReturnTypeFromAST resolves the receiver expression of a
@@ -3636,10 +3676,25 @@ func (l *lowerer) lowerFieldExpr(e *ast.FieldExpr) Expr {
 	// it with a FieldExpr; lift it to TupleAccess to keep backends
 	// simple.
 	if idx, ok := tupleIndex(e.Name); ok {
+		x := l.lowerExpr(e.X)
+		t := l.exprType(e)
+		// AST recovery: when the checker didn't populate the tuple-
+		// access type (post-#1645 `chk.Types[e]` is empty and the
+		// SemanticDB byID/byKey lookups miss for FieldExpr-on-tuple),
+		// pull the element type off the receiver's TupleType. Without
+		// this `fn f(t: (Int, Int)) -> Int { t.0 + t.1 }` lowers with
+		// every TupleAccess at T=<error>, poisoning the BinaryExpr.
+		if t == nil || t == ErrTypeVal || hasPoisonedTypeArg(t) {
+			if tt, ok := x.Type().(*TupleType); ok && tt != nil && idx >= 0 && idx < len(tt.Elems) {
+				if elem := tt.Elems[idx]; elem != nil && elem != ErrTypeVal {
+					t = elem
+				}
+			}
+		}
 		return &TupleAccess{
-			X:     l.lowerExpr(e.X),
+			X:     x,
 			Index: idx,
-			T:     l.exprType(e),
+			T:     t,
 			SpanV: nodeSpan(e),
 		}
 	}

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -685,6 +685,87 @@ func TestLowerIfExprRecoversSyntacticBranchType(t *testing.T) {
 	}
 }
 
+// Tuple field access (`t.0`, `t.1`) lowers via FieldExpr with a
+// numeric name. Post-#1645 the checker no longer fills `chk.Types[e]`
+// and the SemanticDB byID/byKey lookups miss for FieldExpr-on-tuple,
+// so `TupleAccess.T` regressed to `<error>` — poisoning any enclosing
+// `BinaryExpr` (`t.0 + t.1`). The lowerer now derives the element
+// type from the receiver's TupleType when the checker is silent.
+func TestLowerTupleAccessRecoversElementTypeFromReceiver(t *testing.T) {
+	src := `fn sumPair(t: (Int, Int)) -> Int { t.0 + t.1 }
+fn main() {}`
+	file, _ := parser.ParseDiagnostics([]byte(src))
+	res := resolve.ResolveFileSourceDefault([]byte(src), file, stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, _ := Lower("main", file, res, chk)
+	var sumPair *FnDecl
+	for _, decl := range mod.Decls {
+		if fn, ok := decl.(*FnDecl); ok && fn.Name == "sumPair" {
+			sumPair = fn
+			break
+		}
+	}
+	if sumPair == nil || sumPair.Body == nil || sumPair.Body.Result == nil {
+		t.Fatal("sumPair body result missing")
+	}
+	bx, ok := sumPair.Body.Result.(*BinaryExpr)
+	if !ok {
+		t.Fatalf("body result = %T, want *BinaryExpr", sumPair.Body.Result)
+	}
+	if got := typeString(bx.T); got != "Int" {
+		t.Errorf("BinaryExpr.T = %q, want Int (tuple-access type-recovery regression)", got)
+	}
+	left, ok := bx.Left.(*TupleAccess)
+	if !ok {
+		t.Fatalf("Left = %T, want *TupleAccess", bx.Left)
+	}
+	if got := typeString(left.T); got != "Int" {
+		t.Errorf("TupleAccess.T = %q, want Int", got)
+	}
+}
+
+// Trailing free-fn call (`helper()`) with a non-unit return type must
+// promote to the block's Result. `expressionYieldsValue` previously
+// only handled constructor-shaped calls (uppercase Ident callee),
+// dropping `fn main() -> Int { helper() }` to an ExprStmt and emitting
+// MIR UnreachableTerm.
+func TestLowerTrailingFreeFnCallYieldsValue(t *testing.T) {
+	src := `fn helper() -> Int { 42 }
+fn caller() -> Int { helper() }
+fn main() {}`
+	file, _ := parser.ParseDiagnostics([]byte(src))
+	res := resolve.ResolveFileSourceDefault([]byte(src), file, stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, _ := Lower("main", file, res, chk)
+	var caller *FnDecl
+	for _, decl := range mod.Decls {
+		if fn, ok := decl.(*FnDecl); ok && fn.Name == "caller" {
+			caller = fn
+			break
+		}
+	}
+	if caller == nil || caller.Body == nil || caller.Body.Result == nil {
+		t.Fatal("caller body result missing (trailing free-fn call regression)")
+	}
+	if _, ok := caller.Body.Result.(*CallExpr); !ok {
+		t.Fatalf("body result = %T, want *CallExpr", caller.Body.Result)
+	}
+}
+
 func TestLowerFieldExprRecoversTypeFromRecordedBinding(t *testing.T) {
 	binding := &ast.IdentPat{Name: "p"}
 	pRef := &ast.Ident{ID: 1, Name: "p"}


### PR DESCRIPTION
## Summary

#1650 / #1651 / #1653 / #1656 follow-up. PopulateLegacyMaps 제거 (#1645) 가 노출시킨 회귀 시리즈 6번째:

1. **Tuple field access (`t.0`, `t.1`)** — TupleAccess.T = `<error>`
2. **Trailing free-fn call (`helper()`)** — Body.Result = nil → MIR UnreachableTerm

## Repro

```osty
fn sumPair(t: (Int, Int)) -> Int { t.0 + t.1 }   // BinaryExpr.T=<error>
fn caller() -> Int { helper() }                   // Body.Result=nil
```

## 원인

**Tuple access**: AST 가 `t.0` 을 `FieldExpr{Name:"0"}` 로 파싱하고 `lowerFieldExpr` 가 `TupleAccess` 로 lift. `T` slot 은 `l.exprType(e)` 에서 가져왔는데 post-#1645 SemanticDB byID/byKey lookup 이 tuple-access 노드에 대해 미스 → `<error>`. enclosing `BinaryExpr` 까지 poisoning.

**Trailing free-fn call**: `expressionYieldsValue` 의 CallExpr branch 가 constructor 모양 (uppercase Ident callee) 만 promote. `fn caller() -> Int { helper() }` 에서 trailing `helper()` 가 ExprStmt 로 lower → MIR UnreachableTerm.

## 변경

1. **`lowerFieldExpr`** (tuple-index path): checker 가 silent 이면 receiver 의 `*TupleType.Elems[idx]` 에서 element type 회복. Tuple 의 element type 은 receiver 의 static type 에서 fully determined 이므로 항상 안전.

2. **`expressionYieldsValue`** CallExpr branch + 새 helper `freeFnReturnTypeFromAST`: callee Ident 가 top-level `*ast.FnDecl` 로 resolve 되고 ReturnType 이 non-unit 이면 promote. `println(...)` 같은 unit-returning 케이스는 보수적으로 유지 (stage0 패턴 깨지지 않게).

## 의도적 제외

- **Let-bound closure (`let g = |n| n + 1; g(x)`)**: 자체로는 옳은 fix 이나 stage0 toolchain coverage 가 측정 가능하게 떨어짐 — toolchain 의 일부 helper 가 현재 Stmt-positioned 모양에 의존. 미래에 별도 PR.
- **VariantLit (`Some(x)`, `Ok(x)`)**: 보수적으로 (payload 가 concrete 일 때만 `OptionalType{Inner: T}` 복원) 도입해봤지만 stage0 coverage 가 -21 으로 떨어짐. monomorphize 가 우리 합성된 `OptionalType` 과 자기 추론과 다르게 처리. follow-up.

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: **7355 / 7543 (97.5%)** — 변동 없음
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit`: 0 errors
- 새 회귀 테스트 2개: `TestLowerTupleAccessRecoversElementTypeFromReceiver`, `TestLowerTrailingFreeFnCallYieldsValue`
- `internal/{ir,check,airepair,mir,lsp,format,resolve,stdlib,backend}` + `cmd/osty` — 전부 green

## 회귀 시리즈 종합

#1645 가 노출시킨 회귀 6건 모두 fix:

1. ✅ #1650 — closure inferred FnType
2. ✅ #1651 — generic call TypeArgs
3. ✅ #1653 — binding / symbol type
4. ✅ #1656 (commit 1) — block-result detection (stage0 94.2% → 97.5%)
5. ✅ #1656 (commit 2) — user-defined method return type
6. ✅ 본 PR — tuple access + free-fn call promotion

## Test plan

- [x] `go test ./internal/{ir,check,airepair,mir,lsp,format,resolve,stdlib}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 97.5% (불변)
- [x] `go test -run TestLowerTupleAccess|TestLowerTrailingFreeFn ./internal/ir/...` — green
- [x] `go test ./cmd/osty/...` — green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_