### PR TITLE
refactor: route clang invocations through internal/subproc

### DIFF
--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/llvmabi"
 	"github.com/osty/osty/internal/nativellvmgen"
+	"github.com/osty/osty/internal/subproc"
 )
 
 // ErrLLVMNotImplemented marks source shapes that the early LLVM lowering slice
@@ -504,17 +505,30 @@ func runClang(ctx context.Context, action string, args []string) error {
 	if err != nil {
 		return fmt.Errorf("%s: %w", llvmabi.MissingClangMessage(), err)
 	}
-	cmd := exec.CommandContext(ctx, path, args...)
-	combined, err := cmd.CombinedOutput()
-	if err == nil {
+	stdout, stderr, runErr := subproc.RunCommand(ctx, path, args, nil)
+	if runErr == nil {
 		return nil
 	}
-	msg := strings.TrimSpace(string(combined))
-	if msg == "" {
-		msg = "<no output>"
-	}
+	msg := joinClangOutput(stderr, stdout)
 	command := "clang " + strings.Join(args, " ")
-	return fmt.Errorf("%s: %w", llvmabi.ClangFailureMessage(action, command, msg), err)
+	return fmt.Errorf("%s: %w", llvmabi.ClangFailureMessage(action, command, msg), runErr)
+}
+
+// joinClangOutput stitches stderr and stdout into a single human-readable
+// blob for ClangFailureMessage. stderr leads because clang sends diagnostics
+// there; stdout is appended only when non-empty (rare — `-o file` is the norm).
+func joinClangOutput(stderr, stdout []byte) string {
+	parts := make([]string, 0, 2)
+	if s := strings.TrimSpace(string(stderr)); s != "" {
+		parts = append(parts, s)
+	}
+	if s := strings.TrimSpace(string(stdout)); s != "" {
+		parts = append(parts, s)
+	}
+	if len(parts) == 0 {
+		return "<no output>"
+	}
+	return strings.Join(parts, "\n")
 }
 
 // useMIRBackend reports whether LLVM emission should use the

--- a/internal/subproc/subproc.go
+++ b/internal/subproc/subproc.go
@@ -9,6 +9,7 @@ package subproc
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -57,8 +58,23 @@ func (e *Error) Unwrap() error { return e.Err }
 // json.Unmarshal returning an error on the captured stdout) should call
 // WrapResponseError with the underlying error and the same streams.
 func Run(path string, stdin []byte) (stdout, stderr []byte, err error) {
-	cmd := exec.Command(path)
-	cmd.Stdin = bytes.NewReader(stdin)
+	return RunCommand(context.Background(), path, nil, stdin)
+}
+
+// RunCommand is the general-purpose form of Run: it accepts a context (for
+// cancellation), command-line args, and optional stdin bytes. Stream capture,
+// truncation policy, and structured-error semantics match Run.
+//
+// When `stdin` is nil the subprocess inherits no input (suitable for tools
+// that read args/files rather than stdin, like clang or lld).
+func RunCommand(ctx context.Context, path string, args []string, stdin []byte) (stdout, stderr []byte, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, path, args...)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf

--- a/internal/subproc/subproc_test.go
+++ b/internal/subproc/subproc_test.go
@@ -2,6 +2,7 @@ package subproc
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 var fakePath string
@@ -178,6 +180,43 @@ func TestFailureNotes_PlainErrorFallback(t *testing.T) {
 	}
 	if !strings.Contains(notes[1], "some non-structured error") {
 		t.Errorf("plain error should be preserved; got: %q", notes[1])
+	}
+}
+
+func TestRunCommand_PassesArgs(t *testing.T) {
+	t.Setenv("FAKESUBPROC_MODE", "echo-args")
+	stdout, _, err := RunCommand(context.Background(), fakePath, []string{"alpha", "beta", "gamma"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(stdout) != "alpha|beta|gamma" {
+		t.Errorf("stdout=%q, want %q", stdout, "alpha|beta|gamma")
+	}
+}
+
+func TestRunCommand_NilStdinDoesNotBlock(t *testing.T) {
+	t.Setenv("FAKESUBPROC_MODE", "ok")
+	stdout, _, err := RunCommand(context.Background(), fakePath, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(stdout) != "{}" {
+		t.Errorf("stdout=%q, want %q", stdout, "{}")
+	}
+}
+
+func TestRunCommand_ContextCancellationKillsChild(t *testing.T) {
+	t.Setenv("FAKESUBPROC_MODE", "sleep")
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, _, err := RunCommand(ctx, fakePath, nil, nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected error when context times out before subprocess finishes")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("context cancellation should have killed the 30s sleep quickly; took %v", elapsed)
 	}
 }
 

--- a/internal/subproc/testdata/cmd/fakesubproc/main.go
+++ b/internal/subproc/testdata/cmd/fakesubproc/main.go
@@ -1,7 +1,8 @@
 // fakesubproc is a flag-driven stand-in for the Osty-native subprocess
-// binaries (osty-native-checker / lirproto / llvmgen). It emits deterministic
-// (stdout, stderr, exit code) combinations keyed by FAKESUBPROC_MODE so the
-// subproc package tests can assert capture + truncation correctness.
+// binaries (osty-native-checker / lirproto / llvmgen) and the external
+// toolchain (clang / lld). It emits deterministic (stdout, stderr, exit code)
+// combinations keyed by FAKESUBPROC_MODE so the subproc package tests can
+// assert capture + truncation + cancellation correctness.
 package main
 
 import (
@@ -9,6 +10,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 )
 
 func main() {
@@ -41,6 +43,10 @@ func main() {
 	case "huge-stdout":
 		fmt.Fprint(os.Stdout, "HEAD_MARKER_FIRST_LINE\n")
 		fmt.Fprint(os.Stdout, strings.Repeat("garbage line\n", 1000))
+	case "echo-args":
+		fmt.Fprint(os.Stdout, strings.Join(os.Args[1:], "|"))
+	case "sleep":
+		time.Sleep(30 * time.Second)
 	default:
 		fmt.Fprintf(os.Stderr, "fakesubproc: unknown mode %q\n", mode)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

[#1662](https://github.com/choiceoh/osty/pull/1662) (subproc 추출) 후속. LLVM 백엔드의 `runClang` 이 마지막 남은 `cmd.CombinedOutput` 호출부 — clang/lld 는 외부 toolchain 이라 셀프호스트 바이너리만큼 panic-stack 시나리오는 없지만:

- **코드베이스 일관성**: 모든 subprocess 호출이 한 helper 를 거침
- **미래 확장성**: truncation / 구조화된 에러 노출 시 한 곳만 건드리면 됨
- **진단 메시지 순서**: stderr (clang 의 메인 채널) 가 stdout (보통 비어있음) 보다 먼저 나오도록 명시. 머지된 출력의 임의 순서 의존 제거

`subproc` 패키지에 일반 형식 `RunCommand(ctx, path, args, stdin)` 추가 + 기존 `Run(path, stdin)` 을 그 thin wrapper 로 재정의. 새 케이스 3개: args 전달 / nil stdin 비차단 / 컨텍스트 타임아웃 자식 정리.

## Test plan
- [x] `just prepush` 로컬 통과
- [x] `go test ./internal/subproc/ -run 'TestRunCommand' -v` 3/3 새 케이스 green
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)