### PR TITLE
fix(ir): promote trailing bare-ident references to block result

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -998,7 +998,29 @@ func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
 	case *ast.MatchExpr:
 		return astMatchLooksLikeValueExpr(e)
 	case *ast.Ident:
-		return astIdentLooksLikeValueConstructor(e)
+		if astIdentLooksLikeValueConstructor(e) {
+			return true
+		}
+		// Trailing bare ident (`xs` after building a list, `x`
+		// returning a parameter): a binding/parameter reference is
+		// always a value. Without this branch
+		//   fn build() -> List<Int> { let mut xs = []; xs.push(1); xs }
+		// drops the trailing `xs` to ExprStmt because the type-driven
+		// path can't see `xs`'s inferred type (`let mut xs = []` is
+		// type-inferred and post-#1645 the SemanticDB lookup misses on
+		// AST Ident nodes whose ID doesn't match the selfhost arena id).
+		// Limit to bindings/parameters — top-level fn references stay
+		// in the constructor-only branch above to avoid promoting
+		// `let f = helper; f` style indirect-call boilerplate.
+		if id, ok := e.(*ast.Ident); ok && id != nil && l.res != nil {
+			if sym := l.res.RefsByID[id.ID]; sym != nil {
+				switch sym.Kind {
+				case resolve.SymLet, resolve.SymParam:
+					return true
+				}
+			}
+		}
+		return false
 	case *ast.CallExpr:
 		// CallExpr return type may be unit (e.g. `println(...)`),
 		// in which case the trailing call should stay an ExprStmt

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -815,6 +815,72 @@ func TestLowerIfExprRecoversSyntacticBranchType(t *testing.T) {
 	}
 }
 
+// A trailing bare ident (`xs`, `x`) at the end of a block must be
+// promoted to the block's `Result` so the function's return path is
+// wired up. Pre-fix, `astIdentLooksLikeValueConstructor` only matched
+// uppercase constructor-style idents (`Some`, `Color`), and the
+// type-driven branch missed for inferred-type bindings (`let mut xs =
+// []` → `xs.Type()` is `<error>` post-#1645). Net effect:
+//
+//	fn build() -> List<Int> {
+//	    let mut xs = []
+//	    xs.push(1)
+//	    xs              // <- dropped to ExprStmt, MIR UnreachableTerm
+//	}
+//
+// The fix consults the resolver: trailing idents that resolve to a
+// `SymLet` or `SymParam` are always values, regardless of whether
+// their inferred type made it into the per-node Types map.
+func TestLowerTrailingBareIdentYieldsValue(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			"inferred_list",
+			`fn build() -> List<Int> {
+    let mut xs = []
+    xs.push(1)
+    xs
+}
+fn main() {}`,
+		},
+		{
+			"param_passthrough",
+			`fn id(x: Int) -> Int { x }
+fn main() {}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, _ := parser.ParseDiagnostics([]byte(tt.src))
+			res := resolve.ResolveFileSourceDefault([]byte(tt.src), file, stdlib.LoadCached())
+			reg := stdlib.LoadCached()
+			chk := check.SelfhostFile(file, res, check.Opts{
+				Stdlib:        reg,
+				Primitives:    reg.Primitives,
+				ResultMethods: reg.ResultMethods,
+				Source:        []byte(tt.src),
+				Privileged:    true,
+			})
+			mod, _ := Lower("main", file, res, chk)
+			for _, decl := range mod.Decls {
+				fn, ok := decl.(*FnDecl)
+				if !ok || fn.Name == "main" {
+					continue
+				}
+				if fn.Body == nil || fn.Body.Result == nil {
+					t.Errorf("fn %s: body.Result = nil (trailing bare-ident regression)", fn.Name)
+					continue
+				}
+				if _, ok := fn.Body.Result.(*Ident); !ok {
+					t.Errorf("fn %s: body.Result = %T, want *Ident", fn.Name, fn.Body.Result)
+				}
+			}
+		})
+	}
+}
+
 // Tuple field access (`t.0`, `t.1`) lowers via FieldExpr with a
 // numeric name. Post-#1645 the checker no longer fills `chk.Types[e]`
 // and the SemanticDB byID/byKey lookups miss for FieldExpr-on-tuple,


### PR DESCRIPTION
## Summary

#1645 회귀 시리즈 7번째: trailing bare-ident reference 가 block Result 로 promote 안 되어 dropped.

## Repro

```osty
fn build() -> List<Int> {
    let mut xs = []
    xs.push(1)
    xs              // <- dropped to ExprStmt, MIR UnreachableTerm
}
```

trailing `xs` 가 ExprStmt 로 lower 되어 MIR 가 UnreachableTerm 을 emit. stage0 가 함수를 거부.

## 원인

`expressionYieldsValue` 의 Ident case 가 `astIdentLooksLikeValueConstructor` (uppercase constructor 만 매칭). type-driven branch 가 위에서 `l.exprType(e)` 를 시도하지만 post-#1645 에서 inferred-type binding 에 대해 미스 — `chk.Types[e]` 가 비어 있고 SemanticDB byID/byKey lookup 이 AST Ident 의 ID (selfhost arena id 와 다름) 에서 미스.

## 변경

`expressionYieldsValue` 의 Ident case 에서 resolver 를 consult. ident 가 `SymLet` / `SymParam` 으로 resolve 되면 value-yielding 으로 처리. Top-level fn 참조 (`let f = helper; f` 같은 indirect-call 보일러플레이트) 는 constructor-only branch 에 그대로 두어 promote 안 되게 유지.

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: **7358 / 7546 (97.5%)** — 이전 7355 / 7543 에서 +3 covered (이미 trailing bare-ident 모양이 있던 toolchain helper 가 stage0 통과)
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit`: 0 errors
- 새 회귀 테스트 `TestLowerTrailingBareIdentYieldsValue` — inferred binding + param passthrough 둘 다 cover
- `internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}` + `cmd/osty` — 전부 green

## 회귀 시리즈 종합

#1645 가 노출시킨 회귀 7건 모두 fix:

1. ✅ #1650 — closure inferred FnType
2. ✅ #1651 — generic call TypeArgs
3. ✅ #1653 — binding/symbol type
4. ✅ #1656 (1) — block-result detection
5. ✅ #1656 (2) — user-defined method return type
6. ✅ #1666 — tuple access + free-fn call promotion
7. ✅ 본 PR — trailing bare-ident promotion

## Test plan

- [x] `go test ./internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 97.5% (+3)
- [x] `go test -run TestLowerTrailingBareIdent ./internal/ir/...` — green
- [x] `go test ./cmd/osty/...` — green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_