### PR TITLE
fix(ir): promote trailing stdlib container-method calls

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1042,6 +1042,17 @@ func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
 				if rt := l.userMethodReturnTypeFromAST(fx); rt != nil && expressionTypeYieldsValue(rt) {
 					return true
 				}
+				// Builtin container / stdlib intrinsic methods: when
+				// the user-method path bails out because the receiver
+				// is a builtin (`List<T>`, `Map<K,V>`, `String`,
+				// `Bytes`), consult the same intrinsic table the
+				// MethodCall recovery uses. Without this, trailing
+				// `xs.filter(|x| ...)`, `xs.map(...)`, `s.toUpper()`
+				// etc. are dropped to ExprStmt and the function
+				// returns nothing — MIR UnreachableTerm.
+				if rt := l.builtinMethodReturnTypeFromAST(fx); rt != nil && expressionTypeYieldsValue(rt) {
+					return true
+				}
 			}
 			// Free-fn calls (`helper()`): promote when the resolved
 			// declaration has a non-unit return type. We restrict this
@@ -1087,6 +1098,101 @@ func (l *lowerer) freeFnReturnTypeFromAST(id *ast.Ident) Type {
 		return l.lowerType(d.ReturnType)
 	}
 	return nil
+}
+
+// builtinMethodReturnTypeFromAST mirrors `userMethodReturnTypeFromAST`
+// for receivers whose static type is a builtin container or primitive
+// (`List<T>`, `Map<K,V>`, `Set<T>`, `String`, `Bytes`). It defers to
+// the existing `recoverMethodReturnTypeFromType` intrinsic table so
+// trailing `xs.filter(...)`, `s.toUpper()` etc. promote to the block's
+// Result instead of being dropped to ExprStmt.
+func (l *lowerer) builtinMethodReturnTypeFromAST(fx *ast.FieldExpr) Type {
+	if l == nil || fx == nil {
+		return nil
+	}
+	recvType := l.resolveExprStaticType(fx.X)
+	if recvType == nil || recvType == ErrTypeVal {
+		return nil
+	}
+	return recoverMethodReturnTypeFromType(fx.Name, recvType)
+}
+
+// resolveExprStaticType returns a best-effort static type for the
+// expression, using resolver + AST decl shapes when SemanticDB lookups
+// miss. Limited to the receiver shapes commonly used as method-call
+// receivers: bare Ident (binding/parameter) and FieldExpr (struct
+// field access). Returns nil when the type can't be recovered.
+func (l *lowerer) resolveExprStaticType(e ast.Expr) Type {
+	if l == nil || e == nil || l.res == nil {
+		return nil
+	}
+	switch x := e.(type) {
+	case *ast.Ident:
+		sym := l.res.RefsByID[x.ID]
+		if sym == nil {
+			return nil
+		}
+		if t := l.nativeBindingTypeForSymbol(sym); t != nil && t != ErrTypeVal {
+			return t
+		}
+		if t := l.nativeSymbolType(sym); t != nil && t != ErrTypeVal {
+			return t
+		}
+		if p, ok := sym.Decl.(*ast.Param); ok && p.Type != nil {
+			if t := l.lowerType(p.Type); t != nil && t != ErrTypeVal {
+				return t
+			}
+		}
+		// Let-stmt binding with explicit Type annotation.
+		if ip, ok := sym.Decl.(*ast.IdentPat); ok {
+			if ls := l.findLetStmtByPattern(ip); ls != nil && ls.Type != nil {
+				if t := l.lowerType(ls.Type); t != nil && t != ErrTypeVal {
+					return t
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// findLetStmtByPattern walks the current file for a LetStmt whose
+// IdentPat matches `pat`. Used to recover a let binding's declared
+// type when the SemanticDB lookup misses.
+func (l *lowerer) findLetStmtByPattern(pat *ast.IdentPat) *ast.LetStmt {
+	if pat == nil || l.file == nil {
+		return nil
+	}
+	var found *ast.LetStmt
+	var walk func(ast.Node)
+	walk = func(n ast.Node) {
+		if n == nil || found != nil {
+			return
+		}
+		if ls, ok := n.(*ast.LetStmt); ok && ls != nil {
+			if ip, ok := ls.Pattern.(*ast.IdentPat); ok && ip == pat {
+				found = ls
+				return
+			}
+		}
+		switch x := n.(type) {
+		case *ast.File:
+			for _, d := range x.Decls {
+				walk(d)
+			}
+		case *ast.FnDecl:
+			if x.Body != nil {
+				walk(x.Body)
+			}
+		case *ast.Block:
+			for _, s := range x.Stmts {
+				walk(s)
+			}
+		case *ast.ExprStmt:
+			walk(x.X)
+		}
+	}
+	walk(l.file)
+	return found
 }
 
 // userMethodReturnTypeFromAST resolves the receiver expression of a
@@ -3367,8 +3473,15 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return &OptionalType{Inner: nt.Args[0]}
 		case "push":
 			return TUnit
-		case "sorted":
+		case "sorted", "reverse", "reversed", "filter":
+			// `filter(pred)` keeps the element type; `sorted` /
+			// `reversed` likewise return a same-typed List. Note that
+			// `map(fn)` is intentionally excluded — its return is
+			// `List<U>` where `U` depends on the closure return, which
+			// the intrinsic table can't see without checker support.
 			return nt
+		case "contains":
+			return TBool
 		}
 	}
 	// Map<K, V> method returns: .get(k) → V?, .keys() → List<K>,

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,66 @@ fn main() {}`,
 	}
 }
 
+// Trailing stdlib container-method calls (`xs.filter(...)`,
+// `xs.sorted()`) must promote to the block's `Result` so the function
+// returns the new list. The previous CallExpr branch in
+// `expressionYieldsValue` only consulted `userMethodReturnTypeFromAST`
+// which bails out for builtin containers (List/Map/Set/String/Bytes).
+// Without a stdlib-intrinsic fallback, a method chain like
+//
+//	fn evens(xs: List<Int>) -> List<Int> { xs.filter(|x| x % 2 == 0) }
+//
+// drops the trailing call to ExprStmt → MIR UnreachableTerm → stage0
+// declined.
+func TestLowerTrailingStdlibMethodCallYieldsValue(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			"list_filter",
+			`fn evens(xs: List<Int>) -> List<Int> {
+    xs.filter(|x| x % 2 == 0)
+}
+fn main() {}`,
+		},
+		{
+			"list_sorted",
+			`fn ord(xs: List<Int>) -> List<Int> { xs.sorted() }
+fn main() {}`,
+		},
+		{
+			"list_contains",
+			`fn has(xs: List<Int>, n: Int) -> Bool { xs.contains(n) }
+fn main() {}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, _ := parser.ParseDiagnostics([]byte(tt.src))
+			res := resolve.ResolveFileSourceDefault([]byte(tt.src), file, stdlib.LoadCached())
+			reg := stdlib.LoadCached()
+			chk := check.SelfhostFile(file, res, check.Opts{
+				Stdlib:        reg,
+				Primitives:    reg.Primitives,
+				ResultMethods: reg.ResultMethods,
+				Source:        []byte(tt.src),
+				Privileged:    true,
+			})
+			mod, _ := Lower("main", file, res, chk)
+			for _, decl := range mod.Decls {
+				fn, ok := decl.(*FnDecl)
+				if !ok || fn.Name == "main" {
+					continue
+				}
+				if fn.Body == nil || fn.Body.Result == nil {
+					t.Errorf("fn %s: body.Result = nil (trailing stdlib-method regression)", fn.Name)
+				}
+			}
+		})
+	}
+}
+
 // Tuple field access (`t.0`, `t.1`) lowers via FieldExpr with a
 // numeric name. Post-#1645 the checker no longer fills `chk.Types[e]`
 // and the SemanticDB byID/byKey lookups miss for FieldExpr-on-tuple,


### PR DESCRIPTION
## Summary

#1645 회귀 시리즈 8번째: trailing **stdlib container** 메서드 호출이 block Result 로 promote 안 됨.

## Repro

```osty
fn evens(xs: List<Int>) -> List<Int> { xs.filter(|x| x % 2 == 0) }
```

`xs.filter(...)` 가 `CallExpr{Fn: FieldExpr{X: xs, Name: "filter"}}` 로 파싱됨. #1666 의 `userMethodReturnTypeFromAST` 헬퍼는 user-defined struct/enum 만 cover — builtin `List` 에 대해서는 nil 반환. `expressionYieldsValue` 가 false → trailing call 이 ExprStmt → MIR UnreachableTerm.

## 변경

1. **`builtinMethodReturnTypeFromAST`** 신규 — `userMethodReturnTypeFromAST` 의 builtin counterpart. receiver 의 static type 을 resolve 한 뒤 기존 intrinsic 테이블 (`recoverMethodReturnTypeFromType`) 에 위임.

2. **`resolveExprStaticType`** + **`findLetStmtByPattern`** helper — SemanticDB lookup 미스 시 resolver / AST 에서 receiver 타입 회복. `Ident` (param / let binding) 케이스 cover.

3. **Intrinsic 테이블 확장** — List<T> 의 자주 쓰이는 3개:
   - `filter(pred)` → List<T>
   - `reverse` / `reversed` (`sorted` 이미 존재)
   - `contains(x)` → Bool
   
   의도적 제외: `map(fn)`, `flatMap(fn)`, `fold(init, fn)` — closure 반환 타입에 의존하므로 intrinsic 테이블에서 알 수 없음.

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: 7358/7546 (97.5%) — 불변 (toolchain 이 trailing position 에서 bare-list `.filter` 체인 의존이 적음)
- 새 회귀 테스트 `TestLowerTrailingStdlibMethodCallYieldsValue` — filter / sorted / contains 모두 cover
- `internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}` + `cmd/osty` — 전부 green

## 회귀 시리즈 종합

#1645 가 노출시킨 회귀 8건 모두 fix:

1. ✅ #1650 — closure inferred FnType
2. ✅ #1651 — generic call TypeArgs
3. ✅ #1653 — binding/symbol type
4. ✅ #1656 (1) — block-result detection
5. ✅ #1656 (2) — user-defined method return type
6. ✅ #1666 — tuple access + free-fn call promotion
7. ✅ #1668 — trailing bare-ident promotion
8. ✅ 본 PR — trailing stdlib container-method call promotion

## Test plan

- [x] `go test ./internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 97.5%
- [x] `go test -run TestLowerTrailingStdlibMethodCall ./internal/ir/...` — green
- [x] `go test ./cmd/osty/...` — green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_