### PR TITLE
refactor(check): drop embedded fallback from production checker factory

### DIFF
--- a/SUBPROCESS_SWITCHOVER.md
+++ b/SUBPROCESS_SWITCHOVER.md
@@ -2,7 +2,7 @@
 
 - **Scope**: Performance baseline for the embedded vs subprocess native-checker decision.
 - **Type**: Reference / decision data
-- **Status**: Gate (a) **shipped** — CLI startup installs the managed subprocess checker as the production default via `check.UseManagedSubprocessChecker`, and every package-input check path (`osty check` / `lint` / `typecheck` / `build` / `run` / `test` / `ci` / `lsp` / `pipeline`) now routes through `check.NativePackageCheck` so the factory selection is consistent across commands. Gate (b) — full embedded retirement — still requires separate reliability work.
+- **Status**: Gate (a) **shipped** — CLI startup installs the managed subprocess checker as the production default via `check.UseManagedSubprocessChecker`, and every package-input check path (`osty check` / `lint` / `typecheck` / `build` / `run` / `test` / `ci` / `lsp` / `pipeline`) now routes through `check.NativePackageCheck` so the factory selection is consistent across commands. Gate (b) **partial** — the production factory no longer falls back to embedded on managed-build failure (a missing Go toolchain or broken build now surfaces as a clear diagnostic instead of silently re-routing to the frozen in-process checker). Full embedded code removal still depends on migrating the test infrastructure off the embedded default.
 
 ## Why this baseline exists
 
@@ -16,10 +16,11 @@
 
 Today's default (CLI startup, after gate (a) flip) is **subprocess** via
 `check.UseManagedSubprocessChecker(".")` in `cmd/osty/main.go`, which lazily
-resolves the managed binary on first factory-routed check. The factory falls
-back to embedded with a diagnostic note if the managed build fails — Go-less
-environments still get working checks. `OSTY_NATIVE_CHECKER_BIN` still wins
-outright when set.
+resolves the managed binary on first factory-routed check. After the gate
+(b) cleanup, a managed-build failure now surfaces as `(nil, "managed native
+checker unavailable: <reason>")` — callers see a clear "checker
+unavailable" diagnostic instead of an opaque silent shift to the frozen
+embedded path. `OSTY_NATIVE_CHECKER_BIN` still wins outright when set.
 
 Every CLI surface that previously called `selfhost.CheckPackageStructured`
 directly (`runCheckPackageNative`, `runNativeWorkspaceCheck`,
@@ -43,10 +44,11 @@ is on record before any flip.
 
 ### Decision gates this baseline informs
 
-| Gate | Decision | Required evidence |
-|---|---|---|
-| **(a)** | Flip default from embedded to subprocess | Per-shape cold cost ratios within the thresholds listed below |
-| **(b)** | Delete the embedded path entirely | Same as (a), plus subprocess path is reliable enough to be the sole codepath (separate reliability work, out of scope here) |
+| Gate | Decision | Required evidence | Status |
+|---|---|---|---|
+| **(a)** | Flip default from embedded to subprocess | Per-shape cold cost ratios within the thresholds listed below | shipped (PRs #1669 + #1671) |
+| **(b-soft)** | Remove the silent embedded fallback in `UseManagedSubprocessChecker` so production failures surface | Subprocess error reporting good enough that opaque fallback is not needed | shipped (this gate's PR) |
+| **(b-hard)** | Delete `embeddedNativeChecker` and the embedded path entirely | Tests migrated off the embedded factory default | not started |
 
 ## Reproduction
 

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -93,10 +93,13 @@ var productionNativeCheckerFactory = func() (nativeChecker, string) {
 // `toolchain.EnsureNativeChecker(start)` on the first call (which builds the
 // managed binary on demand) and reuse the cached path thereafter.
 //
-// On managed-build failure the selector silently falls back to embedded with
-// a note so callers without a Go toolchain (or a broken native checker
-// build) still get a working check; the note surfaces via the existing
-// `checkerUnavailableDiag` path.
+// Gate (b) policy: on managed-build failure the selector returns
+// `(nil, "managed native checker unavailable: <reason>")`. Callers surface
+// that note through `checkerUnavailableDiag` / `NativePackageCheck` error
+// paths; the production CLI no longer silently degrades to the frozen
+// in-process checker, because the embedded path can only ever lag behind
+// the live `toolchain/*.osty` sources and a silent fallback hides real
+// configuration/build problems.
 //
 // Tests do not call this and continue to use the embedded factory — the
 // managed binary build would otherwise add seconds and clutter
@@ -105,7 +108,7 @@ func UseManagedSubprocessChecker(start string) {
 	productionNativeCheckerFactory = func() (nativeChecker, string) {
 		path, err := toolchain.EnsureNativeChecker(start)
 		if err != nil {
-			return embeddedNativeChecker{}, fmt.Sprintf("managed native checker unavailable: %v; using embedded fallback", err)
+			return nil, fmt.Sprintf("managed native checker unavailable: %v", err)
 		}
 		return nativeCheckerExec{path: path}, ""
 	}

--- a/internal/check/native_checker_selector_test.go
+++ b/internal/check/native_checker_selector_test.go
@@ -97,22 +97,22 @@ func TestUseManagedSubprocessCheckerInstallsFactory(t *testing.T) {
 	UseManagedSubprocessChecker(".")
 
 	got, note := productionNativeCheckerFactory()
-	// EnsureNativeChecker may succeed (returns nativeCheckerExec, empty note)
-	// or fail (returns embedded with a note) depending on the test cwd's
-	// project-root resolution. Both outcomes are valid — the contract is
-	// only that the factory is swapped to one that consults the managed
-	// path and falls back rather than panicking.
+	// Gate (b) contract: the production factory either resolves the managed
+	// subprocess (returns nativeCheckerExec, empty note) or surfaces the
+	// build failure as nil + note. It must NEVER silently fall back to the
+	// embedded path — that path can only lag behind the live toolchain
+	// sources, so silent degradation hides real configuration problems.
 	switch got.(type) {
 	case nativeCheckerExec:
 		if note != "" {
 			t.Errorf("note = %q on success path, want empty", note)
 		}
-	case embeddedNativeChecker:
+	case nil:
 		if note == "" {
-			t.Errorf("embedded fallback must surface a note explaining why managed checker is unavailable")
+			t.Errorf("nil runner must come with a diagnostic note explaining why managed checker is unavailable")
 		}
 	default:
-		t.Fatalf("UseManagedSubprocessChecker produced %#v, want nativeCheckerExec or embeddedNativeChecker", got)
+		t.Fatalf("UseManagedSubprocessChecker produced %#v, want nativeCheckerExec or nil (no embedded fallback after gate (b))", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

[#1669](https://github.com/choiceoh/osty/pull/1669) / [#1671](https://github.com/choiceoh/osty/pull/1671) 가 production default 를 managed subprocess 로 전환하면서 `EnsureNativeChecker` 실패 시 silent 하게 embedded 로 떨어지는 안전망을 두었음. 이 안전망이 가리는 것:

- 사용자의 Go 툴체인 누락
- managed binary 빌드 실패 (디스크 풀, 권한 오류 등)
- 빌드 시스템 종속성 깨짐

embedded 는 frozen seed (`internal/selfhost/generated.go`) 라서 fallback 이 발동되는 순간 사용자는 자신도 모르게 outdated 체커로 검사받게 됨. Gate (b) 의 핵심: 그 silent 강하 경로를 제거해 실패를 명시적으로.

## 변경
- `UseManagedSubprocessChecker` 가 빌드 실패 시 `(embeddedNativeChecker{}, "...; using embedded fallback")` 대신 `(nil, "managed native checker unavailable: <reason>")` 반환
- 호출부 (`NativePackageCheck`, `applySelfhost*Result`) 가 이미 nil runner + note 케이스를 "checker unavailable" 진단으로 처리하므로 추가 라우팅 불필요

## 영향
- 정상 경로 동일 (managed binary lazy build, cached subsequent)
- Go 툴체인 누락/빌드 실패 환경에서 이전엔 silent embedded, 이제는 명확한 unavailable 진단
- `embeddedNativeChecker` 타입과 default `productionNativeCheckerFactory` 의 embedded 반환은 유지 — 테스트는 그 default 통해 embedded 사용. Full embedded 제거 (`embeddedNativeChecker` 자체 삭제) 는 test infra 마이그레이션이 필요한 별도 작업

## Test plan
- [x] `just prepush` 로컬 통과
- [x] `TestUseManagedSubprocessCheckerInstallsFactory` 가 이제 success → `nativeCheckerExec`, 실패 → `nil` (embedded 분기 제거) 만 허용
- [x] Happy path manual smoke: managed binary 삭제 후 첫 `osty check` 가 0.8s 에 lazy build + check, 두 번째는 15ms (cached)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)