### PR TITLE
fix(ir): promote trailing if-let + accept bare-ident block tails

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1277,7 +1277,7 @@ func astCallLooksLikeValueConstructor(e ast.Expr) bool {
 
 func astIfLooksLikeValueExpr(e ast.Expr) bool {
 	ife, ok := e.(*ast.IfExpr)
-	if !ok || ife == nil || ife.IsIfLet {
+	if !ok || ife == nil {
 		return false
 	}
 	if ife.Then == nil || len(ife.Then.Stmts) == 0 {
@@ -1286,6 +1286,13 @@ func astIfLooksLikeValueExpr(e ast.Expr) bool {
 	if !astBlockTailLooksLikeValueConstructor(ife.Then) {
 		return false
 	}
+	// `if let Some(x) = opt { x } else { -1 }` is a perfectly valid
+	// value expression — same shape as a regular `if cond { ... } else
+	// { ... }`. The earlier `IsIfLet → false` short-circuit was
+	// over-restrictive; rely on branch-shape analysis to decide whether
+	// the whole expression yields a value. Without this, trailing
+	// `if let` at block-final position drops to ExprStmt → MIR
+	// UnreachableTerm.
 	return astElseLooksLikeValueConstructor(ife.Else)
 }
 
@@ -1368,7 +1375,11 @@ func astBlockTailLooksLikeValueConstructor(b *ast.Block) bool {
 	case *ast.TupleExpr, *ast.ListExpr, *ast.MapExpr, *ast.StructLit, *ast.RangeExpr,
 		*ast.IntLit, *ast.FloatLit, *ast.StringLit, *ast.CharLit, *ast.BoolLit,
 		*ast.BinaryExpr, *ast.UnaryExpr, *ast.FieldExpr, *ast.IndexExpr,
-		*ast.QuestionExpr, *ast.TurbofishExpr:
+		*ast.QuestionExpr, *ast.TurbofishExpr, *ast.Ident:
+		// `*ast.Ident` covers `if cond { x } else { -1 }` where `x` is a
+		// binding/parameter reference. Bare ident at block-tail is
+		// almost always a value (function references are a theoretical
+		// false positive but harmless — they're FnType-valued).
 		return true
 	}
 	return false

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,59 @@ fn main() {}`,
 	}
 }
 
+// `if let Some(x) = opt { x } else { default }` is a value expression
+// just like a regular `if ... else`. The pre-fix
+// `astIfLooksLikeValueExpr` short-circuited on `IsIfLet → false`,
+// dropping the trailing if-let expression to ExprStmt → MIR
+// UnreachableTerm. Also covers the case where a then-branch's tail
+// is a bare ident reference (`{ x }`) which previously failed
+// `astBlockTailLooksLikeValueConstructor`'s syntactic switch.
+func TestLowerTrailingIfLetYieldsValue(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			"ident_tail",
+			`fn unwrap(o: Int?) -> Int {
+    if let Some(x) = o { x } else { -1 }
+}
+fn main() {}`,
+		},
+		{
+			"expr_tail",
+			`fn plusOne(o: Int?) -> Int {
+    if let Some(x) = o { x + 1 } else { 0 }
+}
+fn main() {}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, _ := parser.ParseDiagnostics([]byte(tt.src))
+			res := resolve.ResolveFileSourceDefault([]byte(tt.src), file, stdlib.LoadCached())
+			reg := stdlib.LoadCached()
+			chk := check.SelfhostFile(file, res, check.Opts{
+				Stdlib:        reg,
+				Primitives:    reg.Primitives,
+				ResultMethods: reg.ResultMethods,
+				Source:        []byte(tt.src),
+				Privileged:    true,
+			})
+			mod, _ := Lower("main", file, res, chk)
+			for _, decl := range mod.Decls {
+				fn, ok := decl.(*FnDecl)
+				if !ok || fn.Name == "main" {
+					continue
+				}
+				if fn.Body == nil || fn.Body.Result == nil {
+					t.Errorf("fn %s: body.Result = nil (trailing if-let regression)", fn.Name)
+				}
+			}
+		})
+	}
+}
+
 // Trailing stdlib container-method calls (`xs.filter(...)`,
 // `xs.sorted()`) must promote to the block's `Result` so the function
 // returns the new list. The previous CallExpr branch in


### PR DESCRIPTION
## Summary

#1645 회귀 시리즈 9번째: trailing `if let { x } else { ... }` 가 block Result 로 promote 안 됨 + bare ident block-tail 처리 누락.

## Repro

```osty
fn unwrap(o: Int?) -> Int {
    if let Some(x) = o { x } else { -1 }
}
```

trailing `if let` 이 ExprStmt 로 lower → MIR UnreachableTerm → stage0 거부.

## 원인

두 곳에 promotion 누락:

1. **`astIfLooksLikeValueExpr`** 가 `IsIfLet → false` 로 short-circuit. 하지만 `if let` 도 정상적인 value expression.
2. **`astBlockTailLooksLikeValueConstructor`** 의 syntactic switch 에서 `*ast.Ident` 누락 — 그래서 `if cond { x } else { -1 }` 의 then-block tail `x` (lowercase Ident) 가 reject. #1668 가 top-level `expressionYieldsValue` 의 Ident case 에서 resolver lookup 으로 해결했지만 if/match branch 분석에 사용되는 helper 에는 같은 로직 없었음.

## 변경

1. **`astIfLooksLikeValueExpr`**: `IsIfLet` short-circuit 제거. branch shape 분석에 위임.
2. **`astBlockTailLooksLikeValueConstructor`**: syntactic switch 에 `*ast.Ident` 추가. 함수 참조 같은 false positive 는 harmless (FnType-valued).

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: **7360 / 7546 (97.5%)** — 이전 7358 baseline 에서 +2 (toolchain helper 가 trailing if-let / bare-ident 모양으로 stage0 통과)
- 새 회귀 테스트 `TestLowerTrailingIfLetYieldsValue` — ident-tail / expr-tail then-branch 둘 다 cover
- `internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}` + `cmd/osty` — 전부 green

## 회귀 시리즈 종합

#1645 가 노출시킨 회귀 9건 모두 fix:

1. ✅ #1650 — closure inferred FnType
2. ✅ #1651 — generic call TypeArgs
3. ✅ #1653 — binding/symbol type
4. ✅ #1656 (1) — block-result detection
5. ✅ #1656 (2) — user-defined method return type
6. ✅ #1666 — tuple access + free-fn call promotion
7. ✅ #1668 — trailing bare-ident promotion
8. ✅ #1672 — trailing stdlib container-method
9. ✅ 본 PR — trailing if-let + bare-ident block tail

## Test plan

- [x] `go test ./internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 97.5% (+2)
- [x] `go test -run TestLowerTrailingIfLet ./internal/ir/...` — green
- [x] `go test ./cmd/osty/...` — green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_