### PR TITLE
test(check): helpers for migrating test packages off embedded default

### DIFF
--- a/SUBPROCESS_SWITCHOVER.md
+++ b/SUBPROCESS_SWITCHOVER.md
@@ -35,6 +35,28 @@ not from `TestMain`, so `go test ./...` from inside the repo doesn't
 trigger managed binary builds that would otherwise add seconds and
 clutter every test package's `.osty/toolchain/...`.
 
+Gate (b-hard) prerequisites — migrating tests off that embedded default —
+have begun. `internal/check/testsupport.go` exposes three helpers:
+
+- `BuildSharedNativeCheckerForTests()` — builds `cmd/osty-native-checker`
+  once per test binary into a temp dir, returning its absolute path.
+- `InstallSubprocessCheckerForPackageTests(binPath)` — installs the
+  subprocess factory for the lifetime of a test binary, intended for use
+  from `TestMain`.
+- `UseSubprocessCheckerForTest(t, binPath)` — per-test scope with
+  `t.Cleanup` restore, for tests that need explicit isolation.
+
+The migration recipe for downstream test packages (`internal/ir/`,
+`internal/backend/`, `internal/lsp/`, `internal/pipeline/`, etc.) is:
+
+1. Add a `TestMain` that calls `BuildSharedNativeCheckerForTests` and
+   `InstallSubprocessCheckerForPackageTests`.
+2. Verify tests still pass and measure the wall-clock delta (one-time
+   `go build` plus per-call subprocess fork).
+3. Once enough downstream packages are migrated that no consumer hits
+   the embedded default, delete `embeddedNativeChecker` and the seed it
+   depends on.
+
 The bootstrap Osty→Go transpiler has been removed (CLAUDE.md). Embedded is
 therefore *frozen* — new `toolchain/*.osty` changes only land via the
 LLVM-compiled native checker binary. Embedded must eventually retire.
@@ -48,7 +70,7 @@ is on record before any flip.
 |---|---|---|---|
 | **(a)** | Flip default from embedded to subprocess | Per-shape cold cost ratios within the thresholds listed below | shipped (PRs #1669 + #1671) |
 | **(b-soft)** | Remove the silent embedded fallback in `UseManagedSubprocessChecker` so production failures surface | Subprocess error reporting good enough that opaque fallback is not needed | shipped (this gate's PR) |
-| **(b-hard)** | Delete `embeddedNativeChecker` and the embedded path entirely | Tests migrated off the embedded factory default | not started |
+| **(b-hard)** | Delete `embeddedNativeChecker` and the embedded path entirely | Tests migrated off the embedded factory default | prep landed (test helpers in `internal/check/testsupport.go`); per-package migrations still ahead |
 
 ## Reproduction
 

--- a/internal/check/testsupport.go
+++ b/internal/check/testsupport.go
@@ -1,0 +1,109 @@
+package check
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// Test helpers for migrating individual test packages off the embedded
+// default checker toward the production managed subprocess.
+//
+// Migration recipe:
+//
+//  1. Add a TestMain to the test package (or reuse an existing one) that
+//     calls BuildSharedNativeCheckerForTests once and installs it via
+//     InstallSubprocessCheckerForPackageTests.
+//  2. For tests that need per-test isolation (e.g. multiple checker
+//     configurations in one package), call UseSubprocessCheckerForTest
+//     inside the test body instead.
+//  3. Tests using either helper must NOT call t.Parallel() — the factory
+//     is a package var and concurrent swaps would race.
+//
+// Why this exists: the production CLI flips to the managed subprocess at
+// startup (cmd/osty/main.go calls UseManagedSubprocessChecker), but test
+// binaries don't, so they run against the frozen embedded seed
+// (internal/selfhost/generated.go). Migrating tests off embedded is a
+// prerequisite for gate (b-hard) — deleting embeddedNativeChecker entirely.
+// See SUBPROCESS_SWITCHOVER.md.
+
+var (
+	sharedTestCheckerOnce sync.Once
+	sharedTestCheckerPath string
+	sharedTestCheckerErr  error
+)
+
+// BuildSharedNativeCheckerForTests builds cmd/osty-native-checker into a
+// temp directory exactly once per test binary invocation and returns its
+// absolute path. Subsequent calls reuse the same binary — the typical
+// pattern is one TestMain build shared by every test in the package.
+//
+// Returns a non-nil error only when `go build` itself fails (missing
+// toolchain, broken sources). The temp dir is left behind on success so
+// the OS can reclaim it after the test binary exits.
+func BuildSharedNativeCheckerForTests() (string, error) {
+	sharedTestCheckerOnce.Do(func() {
+		tmp, err := os.MkdirTemp("", "osty-test-native-checker-*")
+		if err != nil {
+			sharedTestCheckerErr = fmt.Errorf("create temp dir: %w", err)
+			return
+		}
+		binName := "osty-native-checker"
+		if runtime.GOOS == "windows" {
+			binName += ".exe"
+		}
+		path := filepath.Join(tmp, binName)
+		cmd := exec.Command("go", "build", "-o", path, "github.com/osty/osty/cmd/osty-native-checker")
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			sharedTestCheckerErr = fmt.Errorf("go build osty-native-checker: %w", err)
+			return
+		}
+		sharedTestCheckerPath = path
+	})
+	if sharedTestCheckerErr != nil {
+		return "", sharedTestCheckerErr
+	}
+	return sharedTestCheckerPath, nil
+}
+
+// InstallSubprocessCheckerForPackageTests swaps the process-wide check
+// factory to use the managed subprocess at binPath for the lifetime of the
+// test binary. Designed for use from TestMain — no automatic restore.
+//
+// Pair with BuildSharedNativeCheckerForTests:
+//
+//	func TestMain(m *testing.M) {
+//	    binPath, err := check.BuildSharedNativeCheckerForTests()
+//	    if err != nil {
+//	        fmt.Fprintln(os.Stderr, err)
+//	        os.Exit(1)
+//	    }
+//	    check.InstallSubprocessCheckerForPackageTests(binPath)
+//	    os.Exit(m.Run())
+//	}
+func InstallSubprocessCheckerForPackageTests(binPath string) {
+	nativeCheckerFactory = func() (nativeChecker, string) {
+		return nativeCheckerExec{path: binPath}, ""
+	}
+}
+
+// UseSubprocessCheckerForTest swaps the factory to the managed subprocess
+// at binPath for the duration of the calling test, restoring the previous
+// factory on Cleanup. Use when a single test needs the subprocess path
+// while sibling tests in the same package keep their existing behaviour.
+//
+// Tests calling this must NOT use t.Parallel() — the factory is a package
+// var and concurrent swaps would race.
+func UseSubprocessCheckerForTest(t *testing.T, binPath string) {
+	t.Helper()
+	original := nativeCheckerFactory
+	t.Cleanup(func() { nativeCheckerFactory = original })
+	nativeCheckerFactory = func() (nativeChecker, string) {
+		return nativeCheckerExec{path: binPath}, ""
+	}
+}

--- a/internal/check/testsupport_test.go
+++ b/internal/check/testsupport_test.go
@@ -1,0 +1,90 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost/api"
+)
+
+func TestBuildSharedNativeCheckerForTestsIsIdempotent(t *testing.T) {
+	pathA, err := BuildSharedNativeCheckerForTests()
+	if err != nil {
+		t.Fatalf("first build: %v", err)
+	}
+	pathB, err := BuildSharedNativeCheckerForTests()
+	if err != nil {
+		t.Fatalf("second build: %v", err)
+	}
+	if pathA != pathB {
+		t.Fatalf("second call returned different path: %q vs %q", pathA, pathB)
+	}
+	if pathA == "" {
+		t.Fatal("returned empty path")
+	}
+}
+
+func TestUseSubprocessCheckerForTestSwapsFactory(t *testing.T) {
+	original := nativeCheckerFactory
+
+	binPath, err := BuildSharedNativeCheckerForTests()
+	if err != nil {
+		t.Fatalf("build native checker: %v", err)
+	}
+
+	UseSubprocessCheckerForTest(t, binPath)
+
+	got, note := nativeCheckerFactory()
+	if note != "" {
+		t.Errorf("note = %q, want empty", note)
+	}
+	exec, ok := got.(nativeCheckerExec)
+	if !ok {
+		t.Fatalf("got %#v, want nativeCheckerExec", got)
+	}
+	if exec.path != binPath {
+		t.Errorf("exec.path = %q, want %q", exec.path, binPath)
+	}
+
+	// End-to-end: actually exercise the subprocess path through the public
+	// NativePackageCheck API. An empty input is valid and should produce an
+	// empty CheckResult; the relevant assertion is that the subprocess runs
+	// and returns a structured response rather than an exec failure.
+	result, err := NativePackageCheck(api.PackageCheckInput{})
+	if err != nil {
+		t.Fatalf("NativePackageCheck via subprocess: %v", err)
+	}
+	_ = result // shape isn't asserted; we just verify the round-trip works
+
+	// Sanity: t.Cleanup will restore the original factory after this test.
+	if nativeCheckerFactory == nil {
+		t.Fatal("factory unexpectedly nil during test")
+	}
+	t.Cleanup(func() {
+		// Defensive: the helper installs its own Cleanup that runs before
+		// this one (LIFO), so by now `original` should already be back.
+		if &nativeCheckerFactory == nil { // unreachable but documents intent
+			t.Fatal("factory pointer changed during cleanup")
+		}
+		_ = original
+	})
+}
+
+func TestInstallSubprocessCheckerForPackageTestsSwapsFactory(t *testing.T) {
+	originalFactory := nativeCheckerFactory
+	t.Cleanup(func() { nativeCheckerFactory = originalFactory })
+
+	binPath, err := BuildSharedNativeCheckerForTests()
+	if err != nil {
+		t.Fatalf("build native checker: %v", err)
+	}
+
+	InstallSubprocessCheckerForPackageTests(binPath)
+
+	got, note := nativeCheckerFactory()
+	if note != "" {
+		t.Errorf("note = %q, want empty", note)
+	}
+	if exec, ok := got.(nativeCheckerExec); !ok || exec.path != binPath {
+		t.Fatalf("got %#v, want nativeCheckerExec{path:%q}", got, binPath)
+	}
+}


### PR DESCRIPTION
## Summary

Gate (b-hard) — `embeddedNativeChecker` 자체 삭제 — 는 test 패키지들이 embedded factory default 를 의존하는 한 불가능. 이 PR 은 prep 단계: downstream test 패키지들이 TestMain 에서 managed subprocess 로 옮겨갈 수 있게 헬퍼 제공.

## 추가된 헬퍼

[internal/check/testsupport.go](internal/check/testsupport.go) (3개):

- `BuildSharedNativeCheckerForTests() (string, error)` — `cmd/osty-native-checker` 를 temp dir 에 sync.Once 로 한 번 빌드 + 경로 반환
- `InstallSubprocessCheckerForPackageTests(binPath)` — 프로세스 전역 factory 교체 (TestMain 용, cleanup 없음)
- `UseSubprocessCheckerForTest(t, binPath)` — per-test 스코프, `t.Cleanup` 자동 복원

## 영향
- **기존 테스트 동작 변화 없음** — embedded default 그대로 사용. 이 PR 은 순수 additive
- 다음 incremental 단계는 패키지별 (`internal/ir`, `internal/backend`, `internal/lsp`, `internal/pipeline` 등) 로 TestMain 도입 + 측정 + 회귀 검증
- SUBPROCESS_SWITCHOVER.md 의 (b-hard) 행 갱신 ("prep landed")

## Test plan
- [x] `just prepush` 로컬 통과
- [x] 헬퍼 자체 self-test 3/3 green: `TestBuildSharedNativeCheckerForTestsIsIdempotent`, `TestUseSubprocessCheckerForTestSwapsFactory`, `TestInstallSubprocessCheckerForPackageTestsSwapsFactory`
- [x] `NativePackageCheck` 가 새 헬퍼 경유 subprocess 로 end-to-end 라운드트립 성공
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)