### PR TITLE
test(ir): route checker through managed subprocess via TestMain

### DIFF
--- a/internal/ir/main_test.go
+++ b/internal/ir/main_test.go
@@ -1,0 +1,28 @@
+package ir
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+)
+
+// TestMain routes every test in this package through the production
+// managed-subprocess checker instead of the embedded default. This is
+// the first incremental migration toward gate (b-hard) in
+// SUBPROCESS_SWITCHOVER.md (deleting embeddedNativeChecker entirely).
+//
+// The osty-native-checker binary is built once per `go test` invocation
+// via check.BuildSharedNativeCheckerForTests; every per-test factory
+// lookup forks a subprocess thereafter. Net cost on this package is on
+// the order of a few hundred milliseconds plus the one-time build.
+func TestMain(m *testing.M) {
+	binPath, err := check.BuildSharedNativeCheckerForTests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "internal/ir TestMain: %v\n", err)
+		os.Exit(1)
+	}
+	check.InstallSubprocessCheckerForPackageTests(binPath)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

[#1676](https://github.com/choiceoh/osty/pull/1676) (test helpers) 의 첫 적용. `internal/ir/` 의 모든 테스트가 production CLI 와 동일한 managed subprocess checker 를 거치도록 TestMain 한 곳에서 한 번 빌드 + 설치. Gate (b-hard) 의 첫 incremental migration.

## 영향
- `runtime_annot_propagation_test.go` 의 9 테스트 + `lower_test.go` 의 10+ 테스트가 이제 subprocess 경로 검증
- 실측: ir 패키지 short 테스트 전체 **7.31s → 9.37s** (+2.06s, +28%). 대부분 일회성 `go build osty-native-checker` (~5s)
- 기존 테스트 결과 동일 — embedded ↔ subprocess 같은 selfhost 로직 공유, 모든 케이스 PASS 유지

## 다음 단계
- `internal/backend/` (llvm_test, llvm_multi_file_e2e_test, stage0_toolchain_audit_test)
- `internal/lsp/` (LSP 서버, 가장 hot path)
- `internal/cihost/`, `internal/pipeline/`, `internal/query/`

각각 별도 PR 로 incremental 진행.

## Test plan
- [x] `just prepush` 로컬 통과
- [x] `go test ./internal/ir/ -short -count=1` 9.37s, 모든 케이스 PASS
- [x] `go test ./internal/ir/ -run 'TestNoAlloc|TestPod|TestJSON|TestClone|TestAllRuntimeAnnotations'` 10/10 green
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)