### PR TITLE
test(backend): route checker through managed subprocess via TestMain

### DIFF
--- a/internal/backend/main_test.go
+++ b/internal/backend/main_test.go
@@ -1,0 +1,27 @@
+package backend
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+)
+
+// TestMain routes every test in this package through the production
+// managed-subprocess checker instead of the embedded default. The two
+// factory consumers in this package — llvm_test.go and
+// llvm_multi_file_e2e_test.go — exercise check.Package /
+// check.SelfhostFile, so this migration makes them parity-equivalent to
+// the production `osty build` path.
+//
+// Incremental step in gate (b-hard) per SUBPROCESS_SWITCHOVER.md.
+func TestMain(m *testing.M) {
+	binPath, err := check.BuildSharedNativeCheckerForTests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "internal/backend TestMain: %v\n", err)
+		os.Exit(1)
+	}
+	check.InstallSubprocessCheckerForPackageTests(binPath)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

[#1676](https://github.com/choiceoh/osty/pull/1676) 의 헬퍼 + [#1677](https://github.com/choiceoh/osty/pull/1677) 의 ir 파일럿에 이은 두 번째 incremental migration. `internal/backend` 의 두 factory 소비자 (`llvm_test.go`, `llvm_multi_file_e2e_test.go`) 가 이제 production CLI 와 동일한 managed subprocess 를 거침.

## 영향
- 실측: factory 경유 backend 테스트 (`TestRunLLVMBackend*`, `TestMultiFile*`, `TestLLVMBackend*`) **17.5s**, 통과
- 추가 비용은 일회성 `go build` 와 2개 subprocess fork (~30ms) — backend 패키지의 7분급 전체 베이스라인 대비 무시할 수준
- Pre-existing 한 darwin-arm64 binary-runner 실패 (`TestONBBackendBinaryRunsStdlibIntrinsicsOnDarwinARM64` 등) 와 무관

## Gate (b-hard) 진행 상황
- ✅ helpers ([#1676](https://github.com/choiceoh/osty/pull/1676))
- ✅ ir ([#1677](https://github.com/choiceoh/osty/pull/1677))
- ✅ backend (이번)
- ⏭ 다음 후보: `internal/lsp` (LSP 서버, hot path), `internal/pipeline`, `internal/cihost`, `internal/query`

## Test plan
- [x] `just prepush` 로컬 통과
- [x] `go test ./internal/backend/ -run 'TestRunLLVMBackend|TestMultiFile|TestLLVMBackend' -short` 17.5s, 모든 케이스 PASS
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)