### PR TITLE
fix(ir): bundle of 40+ stdlib intrinsic + closure-call recovery gaps

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1113,6 +1113,30 @@ func (l *lowerer) freeFnReturnTypeFromAST(id *ast.Ident) Type {
 			}
 			return l.lowerType(ft.ReturnType)
 		}
+	case *ast.IdentPat:
+		// Let-bound closure: `let f = || P { n: 1 }; f()`. Walk the
+		// owning LetStmt to find the closure expression and lower its
+		// declared / inferred return type. Limited to closures with an
+		// explicit `-> T` return annotation OR a body whose tail shape
+		// unambiguously yields a value (literal / struct-lit / binary
+		// op). Without this, trailing `f()` calls in non-unit-return
+		// fns drop to ExprStmt → MIR UnreachableTerm. Earlier rounds
+		// excluded this path due to stage0 audit regressions; the
+		// conservative form (only promotes when the closure body
+		// shape is value-yielding) avoids those regressions.
+		if cl := l.findLetClosureByPattern(d); cl != nil {
+			if cl.ReturnType != nil {
+				if lt := l.lowerType(cl.ReturnType); lt != nil && lt != ErrTypeVal {
+					return lt
+				}
+			}
+			switch cl.Body.(type) {
+			case *ast.StructLit, *ast.TupleExpr, *ast.ListExpr, *ast.MapExpr,
+				*ast.BinaryExpr, *ast.UnaryExpr, *ast.IntLit, *ast.FloatLit,
+				*ast.StringLit, *ast.CharLit, *ast.BoolLit:
+				return &NamedType{Name: "?closure_result"}
+			}
+		}
 	}
 	return nil
 }
@@ -1122,10 +1146,14 @@ func (l *lowerer) freeFnReturnTypeFromAST(id *ast.Ident) Type {
 // the receiver alone. Covers the common shapes:
 //
 //   - `xs.fold(init, fn)` → typeof(init)
+//   - `xs.map(fn)`        → List<typeof(fn(x))>, approximated as List<?>
 //   - `o.map(fn)`         → Option<typeof(fn(x))>, approximated as Option<?>
 //
 // Returns nil when the call doesn't match a known shape. Used by
 // `expressionYieldsValue` to decide promotion at trailing position.
+// For `.map` we return a sentinel non-unit type so promotion fires
+// without committing to a wrong inner type; MIR/backend then run
+// their own recovery on the closure body.
 func (l *lowerer) closureDependentMethodReturnTypeFromAST(fx *ast.FieldExpr, args []*ast.Arg) Type {
 	if l == nil || fx == nil {
 		return nil
@@ -1135,13 +1163,44 @@ func (l *lowerer) closureDependentMethodReturnTypeFromAST(fx *ast.FieldExpr, arg
 		return nil
 	}
 	switch fx.Name {
-	case "fold":
+	case "fold", "reduce":
 		// `xs.fold(init, fn)`: result type = type of init.
-		if len(args) >= 1 && args[0] != nil && args[0].Value != nil {
+		// `xs.reduce(fn)`: result type = element type (skip for now,
+		// would need receiver introspection).
+		if fx.Name == "fold" && len(args) >= 1 && args[0] != nil && args[0].Value != nil {
 			if t := l.lowerExpr(args[0].Value).Type(); t != nil && t != ErrTypeVal {
 				return t
 			}
 		}
+	case "map", "flatMap":
+		// `xs.map(fn)` / `o.map(fn)`: promotion-only — wrap a
+		// `?closure_result` sentinel in the appropriate container so
+		// `expressionTypeYieldsValue` reports true.
+		switch r := recvType.(type) {
+		case *NamedType:
+			if r.Builtin && r.Name == "List" {
+				return &NamedType{Name: "List", Builtin: true, Args: []Type{&NamedType{Name: "?closure_result"}}}
+			}
+			if r.Builtin && r.Name == "Result" && len(r.Args) == 2 {
+				return &NamedType{Name: "Result", Builtin: true, Args: []Type{&NamedType{Name: "?closure_result"}, r.Args[1]}}
+			}
+		case *OptionalType:
+			return &OptionalType{Inner: &NamedType{Name: "?closure_result"}}
+		}
+	case "zip":
+		// `xs.zip(ys)`: List<T>.zip(List<U>) → List<(T, U)>.
+		nt, ok := recvType.(*NamedType)
+		if !ok || !nt.Builtin || nt.Name != "List" || len(nt.Args) != 1 || len(args) < 1 || args[0] == nil || args[0].Value == nil {
+			return nil
+		}
+		other := l.lowerExpr(args[0].Value).Type()
+		ont, ok := other.(*NamedType)
+		if !ok || !ont.Builtin || ont.Name != "List" || len(ont.Args) != 1 {
+			return nil
+		}
+		return &NamedType{Name: "List", Builtin: true, Args: []Type{
+			&TupleType{Elems: []Type{nt.Args[0], ont.Args[0]}},
+		}}
 	}
 	return nil
 }
@@ -1199,6 +1258,49 @@ func (l *lowerer) resolveExprStaticType(e ast.Expr) Type {
 		}
 	}
 	return nil
+}
+
+// findLetClosureByPattern walks the current file looking for a
+// LetStmt whose IdentPat matches `pat` and whose value is a
+// ClosureExpr. Used by `freeFnReturnTypeFromAST` to peek at the
+// closure's declared / inferred return type for promotion decisions.
+func (l *lowerer) findLetClosureByPattern(pat *ast.IdentPat) *ast.ClosureExpr {
+	if pat == nil || l.file == nil {
+		return nil
+	}
+	var found *ast.ClosureExpr
+	var walk func(ast.Node)
+	walk = func(n ast.Node) {
+		if n == nil || found != nil {
+			return
+		}
+		if ls, ok := n.(*ast.LetStmt); ok && ls != nil {
+			if ip, ok := ls.Pattern.(*ast.IdentPat); ok && ip == pat {
+				if cl, ok := ls.Value.(*ast.ClosureExpr); ok {
+					found = cl
+				}
+				return
+			}
+		}
+		switch x := n.(type) {
+		case *ast.File:
+			for _, d := range x.Decls {
+				walk(d)
+			}
+		case *ast.FnDecl:
+			if x.Body != nil {
+				walk(x.Body)
+			}
+		case *ast.Block:
+			for _, s := range x.Stmts {
+				walk(s)
+			}
+		case *ast.ExprStmt:
+			walk(x.X)
+		}
+	}
+	walk(l.file)
+	return found
 }
 
 // findLetStmtByPattern walks the current file for a LetStmt whose
@@ -1991,6 +2093,24 @@ func (l *lowerer) lowerExpr(e ast.Expr) Expr {
 		out := &TupleLit{T: l.exprType(e), SpanV: nodeSpan(e)}
 		for _, el := range e.Elems {
 			out.Elems = append(out.Elems, l.lowerExpr(el))
+		}
+		// Recover the tuple type from the lowered element types when the
+		// checker didn't supply one. Tuples are fully determined by
+		// their elements, so this is always safe.
+		if out.T == nil || out.T == ErrTypeVal || hasPoisonedTypeArg(out.T) {
+			elems := make([]Type, len(out.Elems))
+			ok := true
+			for i, el := range out.Elems {
+				et := el.Type()
+				if et == nil || et == ErrTypeVal {
+					ok = false
+					break
+				}
+				elems[i] = et
+			}
+			if ok {
+				out.T = &TupleType{Elems: elems}
+			}
 		}
 		return out
 	case *ast.MapExpr:
@@ -3530,6 +3650,23 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{TChar}}
 		case "bytes":
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{TByte}}
+		case "indexOf", "lastIndexOf":
+			return &OptionalType{Inner: TInt}
+		case "lines", "fields":
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{TString}}
+		case "padLeft", "padRight", "padStart", "padEnd":
+			return TString
+		}
+	}
+	// Range<Int> intrinsic returns.
+	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "Range" {
+		switch name {
+		case "toList":
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{TInt}}
+		case "len":
+			return TInt
+		case "isEmpty", "contains":
+			return TBool
 		}
 	}
 	// Char / Byte primitive method returns.
@@ -3539,29 +3676,72 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return TInt
 		}
 	}
+	// Char-specific predicate methods.
+	if isPrim(rt, PrimChar) {
+		switch name {
+		case "isDigit", "isAlpha", "isWhitespace", "isUpper", "isLower",
+			"isAlnum", "isAscii":
+			return TBool
+		}
+	}
+	// Int primitive method returns: abs / min / max / toString.
+	if isPrim(rt, PrimInt) {
+		switch name {
+		case "abs", "min", "max":
+			return TInt
+		}
+	}
+	// Float primitive method returns.
+	if isPrim(rt, PrimFloat) {
+		switch name {
+		case "abs", "sqrt", "floor", "ceil", "round", "min", "max":
+			return TFloat
+		case "toInt":
+			return TInt
+		}
+	}
+	// Bool predicates: redundant but documents.
+	if isPrim(rt, PrimBool) {
+		switch name {
+		case "not":
+			return TBool
+		}
+	}
+	// Bytes-specific intrinsic returns.
+	if isPrim(rt, PrimBytes) {
+		switch name {
+		case "indexOf", "lastIndexOf":
+			return &OptionalType{Inner: TInt}
+		case "len":
+			return TInt
+		}
+	}
 	// Element-type returns: List<T>.first / .last / .get → T?, .push → Unit.
 	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "List" && len(nt.Args) == 1 {
+		elem := nt.Args[0]
 		switch name {
-		case "first", "last":
-			return &OptionalType{Inner: nt.Args[0]}
-		case "push":
+		case "first", "last", "min", "max":
+			return &OptionalType{Inner: elem}
+		case "push", "add", "clear", "insert", "removeAt":
 			return TUnit
-		case "sorted", "reverse", "reversed", "filter":
-			// `filter(pred)` keeps the element type; `sorted` /
-			// `reversed` likewise return a same-typed List. Note that
-			// `map(fn)` is intentionally excluded — its return is
-			// `List<U>` where `U` depends on the closure return, which
-			// the intrinsic table can't see without checker support.
+		case "sorted", "reverse", "reversed", "filter",
+			"slice", "take", "drop", "concat", "append":
+			// Same-typed List return. `map(fn)` excluded — closure
+			// dependent. `take/drop/slice` keep element type.
 			return nt
-		case "contains":
+		case "contains", "any", "all", "isEmpty":
 			return TBool
+		case "count":
+			return TInt
+		case "sum", "product":
+			return elem
 		case "entries":
 			// List<T>.entries() → List<(Int, T)>.
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{
-				&TupleType{Elems: []Type{TInt, nt.Args[0]}},
+				&TupleType{Elems: []Type{TInt, elem}},
 			}}
 		case "toSet":
-			return &NamedType{Name: "Set", Builtin: true, Args: []Type{nt.Args[0]}}
+			return &NamedType{Name: "Set", Builtin: true, Args: []Type{elem}}
 		}
 	}
 	// Map<K, V> method returns: .get(k) → V?, .keys() → List<K>,
@@ -3595,10 +3775,48 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 		switch name {
 		case "toList":
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{nt.Args[0]}}
-		case "add", "remove":
+		case "add", "remove", "clear":
 			return TUnit
-		case "contains":
+		case "contains", "isEmpty":
 			return TBool
+		case "len":
+			return TInt
+		}
+	}
+	// Map<K,V> generic isEmpty/len.
+	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "Map" && len(nt.Args) == 2 {
+		switch name {
+		case "isEmpty":
+			return TBool
+		case "len":
+			return TInt
+		}
+	}
+	// Option<T> methods. `OptionalType{Inner}` carries T directly.
+	if ot, ok := rt.(*OptionalType); ok && ot != nil {
+		switch name {
+		case "isSome", "isNone":
+			return TBool
+		case "unwrapOr", "unwrap", "expect":
+			return ot.Inner
+		case "orElse", "filter":
+			return ot
+		}
+	}
+	// Result<T, E> methods.
+	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "Result" && len(nt.Args) == 2 {
+		t, e := nt.Args[0], nt.Args[1]
+		switch name {
+		case "isOk", "isErr":
+			return TBool
+		case "unwrapOr", "unwrap", "expect":
+			return t
+		case "unwrapErr":
+			return e
+		case "ok":
+			return &OptionalType{Inner: t}
+		case "err":
+			return &OptionalType{Inner: e}
 		}
 	}
 	return nil

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1053,6 +1053,12 @@ func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
 				if rt := l.builtinMethodReturnTypeFromAST(fx); rt != nil && expressionTypeYieldsValue(rt) {
 					return true
 				}
+				// Closure-dependent methods (`xs.fold(init, fn)`,
+				// `o.map(fn)`): result type comes from an argument
+				// rather than the receiver alone.
+				if rt := l.closureDependentMethodReturnTypeFromAST(fx, call.Args); rt != nil && expressionTypeYieldsValue(rt) {
+					return true
+				}
 			}
 			// Free-fn calls (`helper()`): promote when the resolved
 			// declaration has a non-unit return type. We restrict this
@@ -1076,11 +1082,12 @@ func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
 }
 
 // freeFnReturnTypeFromAST resolves the callee identifier of a free-fn
-// call (`helper()`) to its declared return type via the resolver.
-// Used by `expressionYieldsValue` to decide whether a trailing call
-// promotes to the block's Result. Returns nil when the symbol does not
-// resolve to a top-level FnDecl. Closure / let-bound function callees
-// are intentionally excluded — they parse and resolve but their bodies
+// call (`helper()`) or a parameter whose declared type is a function
+// type (`fn apply(f: fn(Int) -> Int, x: Int) -> Int { f(x) }`) to its
+// declared return type via the resolver. Used by
+// `expressionYieldsValue` to decide whether a trailing call promotes
+// to the block's Result. Closure / let-bound function callees are
+// intentionally excluded — they parse and resolve but their bodies
 // are sometimes Stmt-positioned in the toolchain, and promoting them
 // regresses stage0 audit coverage.
 func (l *lowerer) freeFnReturnTypeFromAST(id *ast.Ident) Type {
@@ -1091,11 +1098,50 @@ func (l *lowerer) freeFnReturnTypeFromAST(id *ast.Ident) Type {
 	if sym == nil {
 		return nil
 	}
-	if d, ok := sym.Decl.(*ast.FnDecl); ok && d != nil {
+	switch d := sym.Decl.(type) {
+	case *ast.FnDecl:
 		if d.ReturnType == nil {
 			return TUnit
 		}
 		return l.lowerType(d.ReturnType)
+	case *ast.Param:
+		// Function-typed parameter — return the FnType's declared
+		// return so `f(x)` at trailing position promotes.
+		if ft, ok := d.Type.(*ast.FnType); ok && ft != nil {
+			if ft.ReturnType == nil {
+				return TUnit
+			}
+			return l.lowerType(ft.ReturnType)
+		}
+	}
+	return nil
+}
+
+// closureDependentMethodReturnTypeFromAST handles the methods whose
+// return type is derived from a function-typed argument rather than
+// the receiver alone. Covers the common shapes:
+//
+//   - `xs.fold(init, fn)` → typeof(init)
+//   - `o.map(fn)`         → Option<typeof(fn(x))>, approximated as Option<?>
+//
+// Returns nil when the call doesn't match a known shape. Used by
+// `expressionYieldsValue` to decide promotion at trailing position.
+func (l *lowerer) closureDependentMethodReturnTypeFromAST(fx *ast.FieldExpr, args []*ast.Arg) Type {
+	if l == nil || fx == nil {
+		return nil
+	}
+	recvType := l.resolveExprStaticType(fx.X)
+	if recvType == nil || recvType == ErrTypeVal {
+		return nil
+	}
+	switch fx.Name {
+	case "fold":
+		// `xs.fold(init, fn)`: result type = type of init.
+		if len(args) >= 1 && args[0] != nil && args[0].Value != nil {
+			if t := l.lowerExpr(args[0].Value).Type(); t != nil && t != ErrTypeVal {
+				return t
+			}
+		}
 	}
 	return nil
 }
@@ -3477,6 +3523,22 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return TString
 		}
 	}
+	// String-specific element-type returns.
+	if isPrim(rt, PrimString) {
+		switch name {
+		case "chars":
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{TChar}}
+		case "bytes":
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{TByte}}
+		}
+	}
+	// Char / Byte primitive method returns.
+	if isPrim(rt, PrimChar) || isPrim(rt, PrimByte) {
+		switch name {
+		case "toInt":
+			return TInt
+		}
+	}
 	// Element-type returns: List<T>.first / .last / .get → T?, .push → Unit.
 	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "List" && len(nt.Args) == 1 {
 		switch name {
@@ -3493,6 +3555,13 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return nt
 		case "contains":
 			return TBool
+		case "entries":
+			// List<T>.entries() → List<(Int, T)>.
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{
+				&TupleType{Elems: []Type{TInt, nt.Args[0]}},
+			}}
+		case "toSet":
+			return &NamedType{Name: "Set", Builtin: true, Args: []Type{nt.Args[0]}}
 		}
 	}
 	// Map<K, V> method returns: .get(k) → V?, .keys() → List<K>,
@@ -3510,10 +3579,26 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{k}}
 		case "values":
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{v}}
+		case "entries":
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{
+				&TupleType{Elems: []Type{k, v}},
+			}}
 		case "containsKey":
 			return TBool
 		case "insert":
 			return TUnit
+		}
+	}
+	// Set<T> method returns: .toList() → List<T>, .add/.remove → Unit,
+	// .contains → Bool. Mirrors the List/Map intrinsic tables.
+	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "Set" && len(nt.Args) == 1 {
+		switch name {
+		case "toList":
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{nt.Args[0]}}
+		case "add", "remove":
+			return TUnit
+		case "contains":
+			return TBool
 		}
 	}
 	return nil

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,106 @@ fn main() {}`,
 	}
 }
 
+// Bundle 2: 40+ more trailing-call shapes covering Int/Float/Char/Bool
+// primitive methods, Option/Result accessors, Map/Set predicates,
+// List<T> functional helpers (slice, take, drop, concat, append, zip,
+// min, max, sum, count, any, all), Range methods, and String extras
+// (padLeft, padRight, lines, fields, indexOf).
+func TestLowerTrailingMethodCallBundle2(t *testing.T) {
+	tests := []struct {
+		name, src, wantType string
+	}{
+		{"int_abs", `fn ab(n: Int) -> Int { n.abs() }
+fn main() {}`, "Int"},
+		{"int_max", `fn mx(a: Int, b: Int) -> Int { a.max(b) }
+fn main() {}`, "Int"},
+		{"float_sqrt", `fn sq(f: Float) -> Float { f.sqrt() }
+fn main() {}`, "Float"},
+		{"float_toInt", `fn cnv(f: Float) -> Int { f.toInt() }
+fn main() {}`, "Int"},
+		{"list_take", `fn t(xs: List<Int>) -> List<Int> { xs.take(3) }
+fn main() {}`, "List<Int>"},
+		{"list_concat", `fn cc(xs: List<Int>, ys: List<Int>) -> List<Int> { xs.concat(ys) }
+fn main() {}`, "List<Int>"},
+		{"list_min", `fn mn(xs: List<Int>) -> Int? { xs.min() }
+fn main() {}`, "Int?"},
+		{"list_sum", `fn sm(xs: List<Int>) -> Int { xs.sum() }
+fn main() {}`, "Int"},
+		{"map_isEmpty", `fn em(m: Map<String, Int>) -> Bool { m.isEmpty() }
+fn main() {}`, "Bool"},
+		{"map_len", `fn le(m: Map<String, Int>) -> Int { m.len() }
+fn main() {}`, "Int"},
+		{"set_len", `fn le(s: Set<Int>) -> Int { s.len() }
+fn main() {}`, "Int"},
+		{"option_orElse", `fn oe(a: Int?, b: Int?) -> Int? { a.orElse(b) }
+fn main() {}`, "Int?"},
+		{"option_filter", `fn ft(o: Int?) -> Int? { o.filter(|n| n > 0) }
+fn main() {}`, "Int?"},
+		{"option_isSome", `fn has(o: Int?) -> Bool { o.isSome() }
+fn main() {}`, "Bool"},
+		{"option_unwrapOr", `fn pick(o: Int?, d: Int) -> Int { o.unwrapOr(d) }
+fn main() {}`, "Int"},
+		{"result_isOk", `fn ok(r: Result<Int, Error>) -> Bool { r.isOk() }
+fn main() {}`, "Bool"},
+		{"result_unwrapOr", `fn pick(r: Result<Int, Error>, d: Int) -> Int { r.unwrapOr(d) }
+fn main() {}`, "Int"},
+		{"closure_all", `fn allpos(xs: List<Int>) -> Bool { xs.all(|x| x > 0) }
+fn main() {}`, "Bool"},
+		{"closure_any", `fn anyneg(xs: List<Int>) -> Bool { xs.any(|x| x < 0) }
+fn main() {}`, "Bool"},
+		{"char_isDigit", `fn dg(c: Char) -> Bool { c.isDigit() }
+fn main() {}`, "Bool"},
+		{"char_isAlpha", `fn al(c: Char) -> Bool { c.isAlpha() }
+fn main() {}`, "Bool"},
+		{"char_isWhitespace", `fn sp(c: Char) -> Bool { c.isWhitespace() }
+fn main() {}`, "Bool"},
+		{"string_padLeft", `fn pad(s: String, n: Int) -> String { s.padLeft(n, ' ') }
+fn main() {}`, "String"},
+		{"string_indexOf", `fn idx(s: String, n: String) -> Int? { s.indexOf(n) }
+fn main() {}`, "Int?"},
+		{"string_lines", `fn ln(s: String) -> List<String> { s.lines() }
+fn main() {}`, "List<String>"},
+		{"tuple_in_let", `fn split(s: String) -> (String, String) { (s, s) }
+fn main() {}`, "(String, String)"},
+		{"closure_returning_struct", `pub struct P { pub n: Int }
+fn make() -> P {
+    let f = || P { n: 1 }
+    f()
+}
+fn main() {}`, "P"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, _ := parser.ParseDiagnostics([]byte(tt.src))
+			res := resolve.ResolveFileSourceDefault([]byte(tt.src), file, stdlib.LoadCached())
+			reg := stdlib.LoadCached()
+			chk := check.SelfhostFile(file, res, check.Opts{
+				Stdlib:        reg,
+				Primitives:    reg.Primitives,
+				ResultMethods: reg.ResultMethods,
+				Source:        []byte(tt.src),
+				Privileged:    true,
+			})
+			mod, _ := Lower("main", file, res, chk)
+			for _, decl := range mod.Decls {
+				fn, ok := decl.(*FnDecl)
+				if !ok || fn.Name == "main" {
+					continue
+				}
+				if fn.Body == nil || fn.Body.Result == nil {
+					t.Errorf("fn %s: body.Result = nil (trailing call regression)", fn.Name)
+					continue
+				}
+				if tt.wantType != "" {
+					if got := typeString(fn.Body.Result.Type()); got != tt.wantType {
+						t.Errorf("fn %s: body.Result.Type = %q, want %q", fn.Name, got, tt.wantType)
+					}
+				}
+			}
+		})
+	}
+}
+
 // Bundle: ten trailing-call shapes that the post-#1645 `expression-
 // YieldsValue` path dropped to ExprStmt → MIR UnreachableTerm. Each
 // case is a real user-code pattern that the stdlib intrinsic table

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,67 @@ fn main() {}`,
 	}
 }
 
+// Bundle: ten trailing-call shapes that the post-#1645 `expression-
+// YieldsValue` path dropped to ExprStmt → MIR UnreachableTerm. Each
+// case is a real user-code pattern that the stdlib intrinsic table
+// previously didn't cover, plus the `f(x)` fn-typed-parameter call.
+func TestLowerTrailingMethodCallBundle(t *testing.T) {
+	tests := []struct {
+		name, src, wantType string
+	}{
+		{"list_fold_promote", `fn total(xs: List<Int>) -> Int { xs.fold(0, |a, x| a + x) }
+fn main() {}`, ""},
+		{"map_entries", `fn ents(m: Map<String, Int>) -> List<(String, Int)> { m.entries() }
+fn main() {}`, "List<(String, Int)>"},
+		{"set_to_list", `fn arr(s: Set<Int>) -> List<Int> { s.toList() }
+fn main() {}`, "List<Int>"},
+		{"set_contains", `fn has(s: Set<Int>, n: Int) -> Bool { s.contains(n) }
+fn main() {}`, "Bool"},
+		{"string_chars", `fn ch(s: String) -> List<Char> { s.chars() }
+fn main() {}`, "List<Char>"},
+		{"string_bytes", `fn bs(s: String) -> List<Byte> { s.bytes() }
+fn main() {}`, "List<Byte>"},
+		{"char_to_int", `fn ord(c: Char) -> Int { c.toInt() }
+fn main() {}`, "Int"},
+		{"byte_to_int", `fn b2i(b: Byte) -> Int { b.toInt() }
+fn main() {}`, "Int"},
+		{"closure_param_call", `fn apply(f: fn(Int) -> Int, x: Int) -> Int { f(x) }
+fn main() {}`, "Int"},
+		{"list_entries", `fn ents(xs: List<Int>) -> List<(Int, Int)> { xs.entries() }
+fn main() {}`, "List<(Int, Int)>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, _ := parser.ParseDiagnostics([]byte(tt.src))
+			res := resolve.ResolveFileSourceDefault([]byte(tt.src), file, stdlib.LoadCached())
+			reg := stdlib.LoadCached()
+			chk := check.SelfhostFile(file, res, check.Opts{
+				Stdlib:        reg,
+				Primitives:    reg.Primitives,
+				ResultMethods: reg.ResultMethods,
+				Source:        []byte(tt.src),
+				Privileged:    true,
+			})
+			mod, _ := Lower("main", file, res, chk)
+			for _, decl := range mod.Decls {
+				fn, ok := decl.(*FnDecl)
+				if !ok || fn.Name == "main" {
+					continue
+				}
+				if fn.Body == nil || fn.Body.Result == nil {
+					t.Errorf("fn %s: body.Result = nil (trailing call promotion regression)", fn.Name)
+					continue
+				}
+				if tt.wantType != "" {
+					if got := typeString(fn.Body.Result.Type()); got != tt.wantType {
+						t.Errorf("fn %s: body.Result.Type = %q, want %q", fn.Name, got, tt.wantType)
+					}
+				}
+			}
+		})
+	}
+}
+
 // `if let Some(x) = opt { x } else { default }` is a value expression
 // just like a regular `if ... else`. The pre-fix
 // `astIfLooksLikeValueExpr` short-circuited on `IsIfLet → false`,


### PR DESCRIPTION
## Summary

#1645 회귀 시리즈 11번째: 40+ trailing-call 회귀 한꺼번에 fix. 사용자 요청 ("한번에 10개씩 fix").

## 변경 카테고리

### 1. Primitive method intrinsics

**Int**: abs/min/max → Int  
**Float**: abs/sqrt/floor/ceil/round/min/max → Float; toInt → Int  
**Char**: isDigit/isAlpha/isWhitespace/isUpper/isLower/isAlnum/isAscii → Bool  
**Bool**: not → Bool  
**Bytes**: indexOf/lastIndexOf → Int?; len → Int

### 2. List<T> functional helpers

first/last/min/max → T?  
push/add/clear/insert/removeAt → Unit  
sorted/reverse/reversed/filter/slice/take/drop/concat/append → List<T>  
contains/any/all/isEmpty → Bool  
count → Int  
sum/product → T  
entries → List<(Int, T)>  
toSet → Set<T>

### 3. Map<K,V> / Set<T> predicates

Map: isEmpty/len/entries  
Set: isEmpty/len/clear

### 4. Option<T> / Result<T, E> accessors

Option: isSome/isNone, unwrap/unwrapOr/expect, orElse/filter  
Result: isOk/isErr, unwrap/unwrapOr/expect, unwrapErr, ok/err

### 5. String extras

indexOf/lastIndexOf → Int?  
lines/fields → List<String>  
padLeft/padRight/padStart/padEnd → String

### 6. Range<Int> intrinsics

toList → List<Int>  
len → Int  
isEmpty/contains → Bool

### 7. Closure-argument-dependent recovery

`xs.zip(ys)` → `List<(T, U)>` (구체적 element type 인 경우)  
`xs.map(fn)` / `flatMap(fn)` → promotion-only sentinel `List<?closure_result>`  
`o.map(fn)` → `Option<?closure_result>`  
`r.map(fn)` → `Result<?closure_result, E>` (error 타입 유지)

### 8. TupleExpr type recovery

checker 가 silent 일 때 lowered element type 들로부터 `*TupleType{Elems}` 구성. Tuple 은 element 로 fully determined 라 항상 안전.

### 9. Let-bound closure call promotion

`let f = || P { n: 1 }; f()` 패턴 — `freeFnReturnTypeFromAST` 가 `*ast.IdentPat` callee 처리. owning LetStmt 의 closure value 를 peek, 선언된 return type 사용 (또는 value-yielding body 의 syntactic shape 추론). 보수적으로 unambiguous value body 일 때만 promote — earlier 시도에서 stage0 audit -21 했던 regression 회피.

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: **7363 / 7547 (97.6%)** — 7362 baseline 에서 +1
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit`: 0 errors
- 새 회귀 테스트 `TestLowerTrailingMethodCallBundle2` — 27개 패턴 cover
- `internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}` + `cmd/osty` — 전부 green

## 회귀 시리즈 누적

40+ trailing-call 회귀 fix 누적 (이번 묶음 + 이전 묶음들):
- 이전 PR 까지: 7개 PR (#1650, #1651, #1653, #1656, #1666, #1668, #1672, #1675)
- 본 PR: 40+ stdlib intrinsics + closure call promotion + tuple recovery 한꺼번에

## Test plan

- [x] `go test ./internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 97.6%
- [x] `go test -run TestLowerTrailingMethodCallBundle ./internal/ir/...` — green (27 sub-cases)
- [x] `go test ./cmd/osty/...` — green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_