### PR TITLE
test(lsp,airepair,query): route checker through managed subprocess

### DIFF
--- a/internal/airepair/main_test.go
+++ b/internal/airepair/main_test.go
@@ -1,0 +1,23 @@
+package airepair
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+)
+
+// TestMain routes every test in this package through the production
+// managed-subprocess checker. airepair/semantic.go calls check.SelfhostFile
+// while running its semantic-fixup loop, so this aligns those test
+// invocations with what `osty airepair` ships in production.
+func TestMain(m *testing.M) {
+	binPath, err := check.BuildSharedNativeCheckerForTests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "internal/airepair TestMain: %v\n", err)
+		os.Exit(1)
+	}
+	check.InstallSubprocessCheckerForPackageTests(binPath)
+	os.Exit(m.Run())
+}

--- a/internal/lsp/main_test.go
+++ b/internal/lsp/main_test.go
@@ -1,0 +1,24 @@
+package lsp
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+)
+
+// TestMain routes every test in this package through the production
+// managed-subprocess checker. lsp/server.go is one of the hottest
+// production factory consumers (every editor didOpen/didChange routes
+// through check.Package / check.PackageGraph), so this migration is
+// the highest-value step in gate (b-hard).
+func TestMain(m *testing.M) {
+	binPath, err := check.BuildSharedNativeCheckerForTests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "internal/lsp TestMain: %v\n", err)
+		os.Exit(1)
+	}
+	check.InstallSubprocessCheckerForPackageTests(binPath)
+	os.Exit(m.Run())
+}

--- a/internal/query/osty/main_test.go
+++ b/internal/query/osty/main_test.go
@@ -1,0 +1,23 @@
+package osty
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+)
+
+// TestMain routes every test in this package through the production
+// managed-subprocess checker. queries.go calls check.Package and
+// check.PackageGraph from inside the LSP-style query layer, so this
+// aligns query tests with the production checker selection.
+func TestMain(m *testing.M) {
+	binPath, err := check.BuildSharedNativeCheckerForTests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "internal/query/osty TestMain: %v\n", err)
+		os.Exit(1)
+	}
+	check.InstallSubprocessCheckerForPackageTests(binPath)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

3 패키지 incremental migration. ir ([#1677](https://github.com/choiceoh/osty/pull/1677)) + backend ([#1678](https://github.com/choiceoh/osty/pull/1678)) 에 이은 세 번째 묶음. 이로써 production code 가 `nativeCheckerFactory` 를 사용하는 모든 패키지가 테스트에서도 subprocess 를 거침.

## 실측
- `internal/lsp`: **3.67s → 6.67s** (+82%). LSP server 가 `didOpen` / `didChange` 마다 `check.Package` / `check.PackageGraph` 를 호출하므로 비용이 큰데, gate (b-hard) parity 가치가 가장 큰 자리
- `internal/airepair`: **4.35s → 8.67s** (+99%). `semantic.go` 가 `check.SelfhostFile` 호출
- `internal/query/osty`: `queries.go` 가 `check.Package` / `.PackageGraph` 사용. 기존 `TestEmitQueryWritesLLVMIRArtifact` 의 osty-self 미설치 실패는 pre-existing 으로 이 PR 과 무관

남은 factory 소비자는 `internal/pipeline` 과 `internal/cihost` 뿐이고 둘 다 test 파일이 없음. 즉 이 PR 이후 internal 전역에서 production code 가 사용하는 factory 와 test 가 보는 factory 가 일치.

## Gate (b-hard) 진행
- ✅ helpers ([#1676](https://github.com/choiceoh/osty/pull/1676))
- ✅ ir ([#1677](https://github.com/choiceoh/osty/pull/1677)), backend ([#1678](https://github.com/choiceoh/osty/pull/1678)), lsp/airepair/query (이번)
- ⏭ `embeddedNativeChecker` 와 `productionNativeCheckerFactory` 의 embedded default 가 더 이상 어디서도 안 쓰이는지 한 번 더 audit 후 삭제 (별도 PR)

## Test plan
- [x] `just prepush` 로컬 통과
- [x] `go test ./internal/lsp/` (subprocess) 8.5s 통과
- [x] `go test ./internal/airepair/` (subprocess) 8.7s 통과
- [x] `go test ./internal/query/osty/` pre-existing failure 외 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)