### PR TITLE
test(cmd): route checker through managed subprocess in CLI test binaries

### DIFF
--- a/cmd/osty-native-llvmgen/main_subprocess_test.go
+++ b/cmd/osty-native-llvmgen/main_subprocess_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+)
+
+// TestMain installs the managed-subprocess checker for the test binary.
+// main_test.go uses check.SelfhostFile via the same factory path the
+// production binary exercises after main() calls
+// UseManagedSubprocessChecker.
+//
+// Part of the gate (b-hard) test migration tracked in SUBPROCESS_SWITCHOVER.md.
+func TestMain(m *testing.M) {
+	binPath, err := check.BuildSharedNativeCheckerForTests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmd/osty-native-llvmgen TestMain: %v\n", err)
+		os.Exit(1)
+	}
+	check.InstallSubprocessCheckerForPackageTests(binPath)
+	os.Exit(m.Run())
+}

--- a/cmd/osty/main_subprocess_test.go
+++ b/cmd/osty/main_subprocess_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+)
+
+// TestMain installs the managed-subprocess checker for the whole test
+// binary so cmd/osty tests exercise the same factory path that runs in
+// production. The production main() also calls UseManagedSubprocessChecker
+// but main() never runs from inside `go test`, so we install it here.
+//
+// Part of the gate (b-hard) test migration tracked in SUBPROCESS_SWITCHOVER.md.
+func TestMain(m *testing.M) {
+	binPath, err := check.BuildSharedNativeCheckerForTests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmd/osty TestMain: %v\n", err)
+		os.Exit(1)
+	}
+	check.InstallSubprocessCheckerForPackageTests(binPath)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

`cmd/osty` 와 `cmd/osty-native-llvmgen` 의 테스트도 production CLI 와 동일한 managed subprocess 를 거치도록 TestMain 추가. `main()` 의 `check.UseManagedSubprocessChecker` 호출은 test binary 에서는 실행되지 않으므로 TestMain 에서 명시적으로 설치.

## 실측
- `cmd/osty` short: **51s → 79s** (+55%). production CLI 의 모든 entry point 가 subprocess 로 검증됨
- `cmd/osty-native-llvmgen`: **4.6s**, 통과

이로써 production code 가 factory 를 사용하는 모든 패키지의 test 바이너리가 subprocess 를 거침. 남은 embedded 의존성은 `internal/check` 패키지의 default `productionNativeCheckerFactory` 뿐이고, `parity_audit_test.go` (skip-by-default) 외에는 그것을 실제 사용하는 테스트가 없음.

## Gate (b-hard) 진행
- ✅ helpers ([#1676](https://github.com/choiceoh/osty/pull/1676))
- ✅ ir ([#1677](https://github.com/choiceoh/osty/pull/1677)), backend ([#1678](https://github.com/choiceoh/osty/pull/1678)), lsp/airepair/query ([#1680](https://github.com/choiceoh/osty/pull/1680)), cmd (이번)
- ⏭ `embeddedNativeChecker` 와 `selfhost.CheckPackageStructured` 직접 호출 경로 (productionNativeCheckerFactory default + embeddedNativeChecker 타입) 삭제 — 별도 PR

## Test plan
- [x] `just prepush` 로컬 통과
- [x] `go test ./cmd/osty/ -short -count=1` 79s, 모든 케이스 PASS
- [x] `go test ./cmd/osty-native-llvmgen/ -short -count=1` 4.6s, 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)