### PR TITLE
fix(ir): bundle 3 — 40+ more trailing-call recovery gaps

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1201,6 +1201,20 @@ func (l *lowerer) closureDependentMethodReturnTypeFromAST(fx *ast.FieldExpr, arg
 		return &NamedType{Name: "List", Builtin: true, Args: []Type{
 			&TupleType{Elems: []Type{nt.Args[0], ont.Args[0]}},
 		}}
+	case "mapOr":
+		// `o.mapOr(default, fn)`: result type = type of default.
+		if len(args) >= 1 && args[0] != nil && args[0].Value != nil {
+			if t := l.lowerExpr(args[0].Value).Type(); t != nil && t != ErrTypeVal {
+				return t
+			}
+		}
+	case "mapErr":
+		// `r.mapErr(fn)` on Result<T, E> → Result<T, ?closure_result>.
+		if nt, ok := recvType.(*NamedType); ok && nt.Builtin && nt.Name == "Result" && len(nt.Args) == 2 {
+			return &NamedType{Name: "Result", Builtin: true, Args: []Type{
+				nt.Args[0], &NamedType{Name: "?closure_result"},
+			}}
+		}
 	}
 	return nil
 }
@@ -3654,8 +3668,16 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return &OptionalType{Inner: TInt}
 		case "lines", "fields":
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{TString}}
-		case "padLeft", "padRight", "padStart", "padEnd":
+		case "padLeft", "padRight", "padStart", "padEnd",
+			"concat", "reverse", "toUpperCase", "toLowerCase",
+			"replaceAll", "replaceFirst":
 			return TString
+		case "count":
+			return TInt
+		case "first", "last":
+			return &OptionalType{Inner: TChar}
+		case "stripPrefix", "stripSuffix":
+			return &OptionalType{Inner: TString}
 		}
 	}
 	// Range<Int> intrinsic returns.
@@ -3684,20 +3706,28 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return TBool
 		}
 	}
-	// Int primitive method returns: abs / min / max / toString.
+	// Int primitive method returns.
 	if isPrim(rt, PrimInt) {
 		switch name {
-		case "abs", "min", "max":
+		case "abs", "min", "max", "neg", "pow", "clamp":
 			return TInt
+		case "toFloat":
+			return TFloat
+		case "toHex", "toBinary", "toOctal":
+			return TString
+		case "isPositive", "isNegative", "isZero", "isEven", "isOdd":
+			return TBool
 		}
 	}
 	// Float primitive method returns.
 	if isPrim(rt, PrimFloat) {
 		switch name {
-		case "abs", "sqrt", "floor", "ceil", "round", "min", "max":
+		case "abs", "sqrt", "floor", "ceil", "round", "min", "max", "pow", "neg":
 			return TFloat
 		case "toInt":
 			return TInt
+		case "isNan", "isFinite", "isInfinite", "isPositive", "isNegative", "isZero":
+			return TBool
 		}
 	}
 	// Bool predicates: redundant but documents.
@@ -3720,14 +3750,16 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "List" && len(nt.Args) == 1 {
 		elem := nt.Args[0]
 		switch name {
-		case "first", "last", "min", "max":
+		case "first", "last", "min", "max", "pop":
 			return &OptionalType{Inner: elem}
-		case "push", "add", "clear", "insert", "removeAt":
+		case "push", "add", "clear", "insert", "removeAt", "extend":
 			return TUnit
+		case "remove":
+			return elem
+		case "indexOf", "lastIndexOf":
+			return &OptionalType{Inner: TInt}
 		case "sorted", "reverse", "reversed", "filter",
 			"slice", "take", "drop", "concat", "append":
-			// Same-typed List return. `map(fn)` excluded — closure
-			// dependent. `take/drop/slice` keep element type.
 			return nt
 		case "contains", "any", "all", "isEmpty":
 			return TBool
@@ -3736,12 +3768,48 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 		case "sum", "product":
 			return elem
 		case "entries":
-			// List<T>.entries() → List<(Int, T)>.
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{
 				&TupleType{Elems: []Type{TInt, elem}},
 			}}
 		case "toSet":
 			return &NamedType{Name: "Set", Builtin: true, Args: []Type{elem}}
+		case "iter":
+			return &NamedType{Name: "Iterator", Builtin: true, Args: []Type{elem}}
+		}
+	}
+	// Iterator<T> methods. Iterator is a stdlib protocol type whose
+	// `Builtin` flag may or may not be set depending on how it was
+	// declared at the call site — accept either form.
+	if nt, ok := rt.(*NamedType); ok && nt.Name == "Iterator" && len(nt.Args) == 1 {
+		elem := nt.Args[0]
+		switch name {
+		case "collect":
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{elem}}
+		case "next":
+			return &OptionalType{Inner: elem}
+		case "hasNext":
+			return TBool
+		case "count":
+			return TInt
+		}
+	}
+	// Channel<T> methods.
+	if nt, ok := rt.(*NamedType); ok && nt.Name == "Channel" && len(nt.Args) == 1 {
+		elem := nt.Args[0]
+		switch name {
+		case "send", "close":
+			return TUnit
+		case "recv":
+			return &OptionalType{Inner: elem}
+		case "isClosed":
+			return TBool
+		}
+	}
+	// Duration methods.
+	if nt, ok := rt.(*NamedType); ok && nt.Name == "Duration" {
+		switch name {
+		case "toMillis", "toMicros", "toNanos", "toSeconds", "toMinutes", "toHours":
+			return TInt
 		}
 	}
 	// Map<K, V> method returns: .get(k) → V?, .keys() → List<K>,

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,70 @@ fn main() {}`,
 	}
 }
 
+// Bundle 3: 40+ more trailing-call shapes covering Int/Float
+// predicates+formatting, String mutation/predicate helpers, List<T>
+// mutation operations (pop/remove/indexOf/iter/extend), Iterator<T>
+// methods, Channel<T> send/recv, Duration unit conversions, and
+// closure-arg-dependent recovery for `mapOr` / `mapErr`.
+func TestLowerTrailingMethodCallBundle3(t *testing.T) {
+	tests := []struct {
+		name, src, wantType string
+	}{
+		{"int_pow", `fn pw(a: Int, b: Int) -> Int { a.pow(b) } fn main() {}`, "Int"},
+		{"int_toFloat", `fn tf(n: Int) -> Float { n.toFloat() } fn main() {}`, "Float"},
+		{"int_clamp", `fn cl(n: Int, lo: Int, hi: Int) -> Int { n.clamp(lo, hi) } fn main() {}`, "Int"},
+		{"int_isPositive", `fn p(n: Int) -> Bool { n.isPositive() } fn main() {}`, "Bool"},
+		{"int_isZero", `fn z(n: Int) -> Bool { n.isZero() } fn main() {}`, "Bool"},
+		{"int_toHex", `fn hx(n: Int) -> String { n.toHex() } fn main() {}`, "String"},
+		{"float_pow", `fn pw(a: Float, b: Float) -> Float { a.pow(b) } fn main() {}`, "Float"},
+		{"float_isNan", `fn n(f: Float) -> Bool { f.isNan() } fn main() {}`, "Bool"},
+		{"float_isFinite", `fn fi(f: Float) -> Bool { f.isFinite() } fn main() {}`, "Bool"},
+		{"string_concat", `fn cc(a: String, b: String) -> String { a.concat(b) } fn main() {}`, "String"},
+		{"string_repeat", `fn rp(s: String, n: Int) -> String { s.repeat(n) } fn main() {}`, "String"},
+		{"string_reverse", `fn rv(s: String) -> String { s.reverse() } fn main() {}`, "String"},
+		{"string_count", `fn ct(s: String, p: String) -> Int { s.count(p) } fn main() {}`, "Int"},
+		{"string_replaceAll", `fn rp(s: String, o: String, n: String) -> String { s.replaceAll(o, n) } fn main() {}`, "String"},
+		{"string_first", `fn fi(s: String) -> Char? { s.first() } fn main() {}`, "Char?"},
+		{"string_stripPrefix", `fn sp(s: String, p: String) -> String? { s.stripPrefix(p) } fn main() {}`, "String?"},
+		{"string_toUpperCase", `fn uc(s: String) -> String { s.toUpperCase() } fn main() {}`, "String"},
+		{"list_pop", `fn pp(mut xs: List<Int>) -> Int? { xs.pop() } fn main() {}`, "Int?"},
+		{"list_remove", `fn rm(mut xs: List<Int>, i: Int) -> Int { xs.remove(i) } fn main() {}`, "Int"},
+		{"list_indexOf", `fn ix(xs: List<Int>, n: Int) -> Int? { xs.indexOf(n) } fn main() {}`, "Int?"},
+		{"list_iter", `fn it(xs: List<Int>) -> Iterator<Int> { xs.iter() } fn main() {}`, "Iterator<Int>"},
+		{"iter_collect", `fn cl(it: Iterator<Int>) -> List<Int> { it.collect() } fn main() {}`, "List<Int>"},
+		{"chan_recv", `fn rc(ch: Channel<Int>) -> Int? { ch.recv() } fn main() {}`, "Int?"},
+		{"duration_toMillis", `fn dm(d: Duration) -> Int { d.toMillis() } fn main() {}`, "Int"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, _ := parser.ParseDiagnostics([]byte(tt.src))
+			res := resolve.ResolveFileSourceDefault([]byte(tt.src), file, stdlib.LoadCached())
+			reg := stdlib.LoadCached()
+			chk := check.SelfhostFile(file, res, check.Opts{
+				Stdlib:        reg,
+				Primitives:    reg.Primitives,
+				ResultMethods: reg.ResultMethods,
+				Source:        []byte(tt.src),
+				Privileged:    true,
+			})
+			mod, _ := Lower("main", file, res, chk)
+			for _, decl := range mod.Decls {
+				fn, ok := decl.(*FnDecl)
+				if !ok || fn.Name == "main" {
+					continue
+				}
+				if fn.Body == nil || fn.Body.Result == nil {
+					t.Errorf("fn %s: body.Result = nil", fn.Name)
+					continue
+				}
+				if got := typeString(fn.Body.Result.Type()); got != tt.wantType {
+					t.Errorf("fn %s: body.Result.Type = %q, want %q", fn.Name, got, tt.wantType)
+				}
+			}
+		})
+	}
+}
+
 // Bundle 2: 40+ more trailing-call shapes covering Int/Float/Char/Bool
 // primitive methods, Option/Result accessors, Map/Set predicates,
 // List<T> functional helpers (slice, take, drop, concat, append, zip,


### PR DESCRIPTION
## Summary

#1645 회귀 시리즈 12번째: 40+ more trailing-call 회귀를 한꺼번에 fix. 사용자 요청 ("다음 40개").

## 변경 카테고리

### Int 확장
- pow/neg/clamp → Int
- toFloat → Float
- toHex/toBinary/toOctal → String
- isPositive/isNegative/isZero/isEven/isOdd → Bool

### Float 확장
- pow/neg → Float
- isNan/isFinite/isInfinite/isPositive/isNegative/isZero → Bool

### String 확장
- concat/reverse/toUpperCase/toLowerCase → String
- replaceAll/replaceFirst → String
- count → Int
- first/last → Char?
- stripPrefix/stripSuffix → String?

### List<T> 확장
- pop → T?
- remove → T
- indexOf/lastIndexOf → Int?
- extend → Unit
- iter → Iterator<T>

### Iterator<T> (신규)
- collect → List<T>
- next → T?
- hasNext → Bool
- count → Int

### Channel<T> (신규)
- send/close → Unit
- recv → T?
- isClosed → Bool

### Duration (신규)
- toMillis/toMicros/toNanos/toSeconds/toMinutes/toHours → Int

### Closure-arg-dependent
- `o.mapOr(default, fn)` → typeof(default)
- `r.mapErr(fn)` → `Result<T, ?closure_result>` (T 유지)

## 구현 노트

`Iterator` / `Channel` / `Duration` matcher 는 `nt.Builtin` 체크 없이 이름만으로 매칭 — stdlib protocol type 이 call site 에서 builtin flag 없이 선언되는 경우 처리.

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: 7363/7547 (97.6%) — 불변
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit`: 0 errors
- 새 회귀 테스트 `TestLowerTrailingMethodCallBundle3` — 24개 sub-case, promotion + exact result type 검증
- `internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}` + `cmd/osty` — 전부 green

## 회귀 시리즈 누적

이번 묶음으로 40+ trailing-call 회귀 추가 fix (이전 묶음과 합쳐 누적 80+).

## Test plan

- [x] `go test ./internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 97.6%
- [x] `go test -run TestLowerTrailingMethodCallBundle3 ./internal/ir/...` — green (24 sub-cases)
- [x] `go test ./cmd/osty/...` — green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_