### PR TITLE
refactor(check): delete embeddedNativeChecker; subprocess is the only path

### DIFF
--- a/SUBPROCESS_SWITCHOVER.md
+++ b/SUBPROCESS_SWITCHOVER.md
@@ -6,13 +6,14 @@
 
 ## Why this baseline exists
 
-`internal/check/host_boundary.go` exposes two implementations of the same
-`nativeChecker` interface:
+`internal/check/host_boundary.go` previously exposed two implementations of
+the same `nativeChecker` interface:
 
 - **embedded** — in-process via `internal/selfhost` (the frozen 68k-line
-  `internal/selfhost/generated.go` seed).
+  `internal/selfhost/generated.go` seed). Removed in gate (b-hard); see
+  history below.
 - **subprocess** — forks `OSTY_NATIVE_CHECKER_BIN`, JSON request via stdin,
-  JSON response on stdout.
+  JSON response on stdout. Now the only checker the factory ever returns.
 
 Today's default (CLI startup, after gate (a) flip) is **subprocess** via
 `check.UseManagedSubprocessChecker(".")` in `cmd/osty/main.go`, which lazily
@@ -69,8 +70,8 @@ is on record before any flip.
 | Gate | Decision | Required evidence | Status |
 |---|---|---|---|
 | **(a)** | Flip default from embedded to subprocess | Per-shape cold cost ratios within the thresholds listed below | shipped (PRs #1669 + #1671) |
-| **(b-soft)** | Remove the silent embedded fallback in `UseManagedSubprocessChecker` so production failures surface | Subprocess error reporting good enough that opaque fallback is not needed | shipped (this gate's PR) |
-| **(b-hard)** | Delete `embeddedNativeChecker` and the embedded path entirely | Tests migrated off the embedded factory default | prep landed (test helpers in `internal/check/testsupport.go`); per-package migrations still ahead |
+| **(b-soft)** | Remove the silent embedded fallback in `UseManagedSubprocessChecker` so production failures surface | Subprocess error reporting good enough that opaque fallback is not needed | shipped (#1674) |
+| **(b-hard)** | Delete `embeddedNativeChecker` and the embedded factory default | Tests migrated off the embedded default + production paths route exclusively through the subprocess factory | shipped (this gate's PR) |
 
 ## Reproduction
 

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/sourcemap"
@@ -67,24 +66,24 @@ func (e nativeCheckerExec) run(req api.CheckRequest) (api.CheckResult, error) {
 	return checked, nil
 }
 
-type embeddedNativeChecker struct{}
-
-func (embeddedNativeChecker) CheckSourceStructured(src []byte) (api.CheckResult, error) {
-	return selfhost.CheckSourceStructured(src), nil
-}
-
-func (embeddedNativeChecker) CheckPackageStructured(input api.PackageCheckInput) (api.CheckResult, error) {
-	return selfhost.CheckPackageStructured(input)
-}
-
 // productionNativeCheckerFactory is the single production-path selector.
-// Default is embedded so that `go test ./...` from inside the repo never
-// triggers the managed-binary build (which would otherwise pollute every
-// test package's cwd with `.osty/toolchain/...`). CLI startup calls
-// UseManagedSubprocessChecker to flip to the subprocess path before any
-// check fires; the bench data in SUBPROCESS_SWITCHOVER.md gates that flip.
+// Default is "no checker installed" — callers must install one explicitly
+// via UseManagedSubprocessChecker (CLI startup) or
+// InstallSubprocessCheckerForPackageTests / UseSubprocessCheckerForTest
+// (test helpers in testsupport.go).
+//
+// Pre-gate (b-hard) this returned an embedded in-process checker as a
+// silent default. That default has been removed because:
+//   - The embedded checker is a frozen seed (internal/selfhost/generated.go)
+//     that lags every change to toolchain/*.osty.
+//   - Production code paths now route exclusively through the managed
+//     subprocess; the embedded fallback was hiding setup bugs rather than
+//     providing useful resilience.
+//   - All in-tree test packages that exercise the factory install the
+//     subprocess via TestMain (see SUBPROCESS_SWITCHOVER.md gate (b-hard)
+//     migration history).
 var productionNativeCheckerFactory = func() (nativeChecker, string) {
-	return embeddedNativeChecker{}, ""
+	return nil, "no native checker installed — call check.UseManagedSubprocessChecker (production) or check.InstallSubprocessCheckerForPackageTests / UseSubprocessCheckerForTest (tests)"
 }
 
 // UseManagedSubprocessChecker installs the managed subprocess checker as the

--- a/internal/check/main_test.go
+++ b/internal/check/main_test.go
@@ -1,0 +1,30 @@
+package check
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestMain installs the managed-subprocess checker for the whole test
+// binary so internal/check tests exercise the same factory path that
+// runs in production.
+//
+// After gate (b-hard) removed the embedded default from
+// productionNativeCheckerFactory, every test that calls Package / Workspace
+// / PackageGraph / SelfhostFile / NativePackageCheck needs an explicit
+// checker installation; doing it once here covers all current and future
+// tests in this package.
+//
+// The specialised selector tests in native_checker_selector_test.go and
+// testsupport_test.go install their own factories with t.Cleanup, which
+// transparently overrides this default for those subtests.
+func TestMain(m *testing.M) {
+	binPath, err := BuildSharedNativeCheckerForTests()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "internal/check TestMain: %v\n", err)
+		os.Exit(1)
+	}
+	InstallSubprocessCheckerForPackageTests(binPath)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

Gate (b-hard) 마무리. `embeddedNativeChecker` 타입과 그 default factory return 을 `host_boundary.go` 에서 삭제. `nativeCheckerFactory` 의 default 는 이제 `(nil, "no native checker installed — call …")` 를 반환하여 프로세스 시작 시 명시적 installation 을 강제.

전제: 이전 migration PR 들 ([#1676](https://github.com/choiceoh/osty/pull/1676), [#1677](https://github.com/choiceoh/osty/pull/1677), [#1678](https://github.com/choiceoh/osty/pull/1678), [#1680](https://github.com/choiceoh/osty/pull/1680), [#1683](https://github.com/choiceoh/osty/pull/1683)) 가 production 코드가 factory 를 사용하는 모든 in-tree 테스트 패키지에 TestMain 을 추가해 managed subprocess 를 설치하도록 마이그레이션 완료.

## 변경
- `internal/check/host_boundary.go`: `embeddedNativeChecker` 타입 + 메서드 삭제, `internal/selfhost` import 제거. `productionNativeCheckerFactory` default 가 `nil + note` 반환
- `internal/check/main_test.go` (신규): 패키지 자체 테스트들이 subprocess 를 쓰도록 TestMain 추가
- `SUBPROCESS_SWITCHOVER.md`: gate (b-hard) "shipped" 로 표기

## 영향 범위
- `selfhost.CheckSourceStructured` / `.CheckPackageStructured` 자체는 `internal/selfhost/generated.go` 에 그대로 — 다른 직접 호출자 (`cmd/osty/native_check.go` 의 `CheckFromSource` 분기, `cmd/osty-native-checker` 의 main, `internal/check/SelfhostRun` 등) 는 변경 없음
- **즉 "embedded selfhost 자체" 가 사라진 게 아니라 "nativeChecker 인터페이스를 통한 embedded 채택 경로" 가 사라진 것**
- seed 파일 (`generated.go`) 자체 제거는 더 큰 별도 작업

## Test plan
- [x] `just prepush` 로컬 통과
- [x] 5개 마이그레이션된 패키지 (check, ir, lsp, airepair, cmd/osty-native-llvmgen) 모두 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)