### PR TITLE
fix(stage0/runtime): replace decline-stub bare unreachable with structured banner

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -29641,3 +29641,37 @@ void *osty_rt_audit_i64_placeholder(void) {
 }
 
 #endif /* defined(__GNUC__) || defined(__clang__) */
+
+/* osty_rt_stage0_declined — banner helper for stage0 decline-stubs.
+ *
+ * `emitDeclineStub` in `internal/backend/stage0/emit.go` now generates
+ * each declined function's body as
+ *
+ *     define <ret> @<fn>(...) {
+ *     entry:
+ *       call void @osty_rt_stage0_declined(ptr @.stage0.declined.<N>)
+ *       unreachable
+ *     }
+ *
+ * The previous body was a bare `unreachable` which clang lowered to
+ * `ud2`; the linker's identical-cold-code folding then merged all
+ * zero-cost stubs into the address of an unrelated abort-shaped
+ * helper (`osty_rt_option_unwrap_none`), producing the misleading
+ * `called unwrap on None` message when a stage0-built binary
+ * dispatched into a declined function. Routing through this helper
+ * forces the linker to keep each stub distinct (each call argument
+ * is a unique global) and emits a banner the L3/L4 audit harness
+ * can match.
+ *
+ * `name` is the MIR function name as a NUL-terminated UTF-8 string
+ * constant (not an Osty `String` — these are bare C literals from
+ * the LLVM `private unnamed_addr constant` globals stage0 lays down
+ * alongside each stub). NULL is tolerated for forward compatibility.
+ */
+void osty_rt_stage0_declined(const char *name) {
+    fputs("osty-self: stage0 declined function: ", stderr);
+    fputs(name != NULL ? name : "(unknown)", stderr);
+    fputc('\n', stderr);
+    fputs("osty-self: this codepath requires the LIR Proto self-host pipeline (Phase 1+)\n", stderr);
+    abort();
+}

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -344,6 +344,16 @@ type moduleCtx struct {
 	tuplePool   map[string]string
 	nextTupleID int
 	nextTempID  int
+	// declinedStubBanners tracks which decline-stub function-name string
+	// constants have already been written to extraDecls so multiple
+	// stub emits don't duplicate them. Key = MIR function name, value
+	// = the assigned LLVM global label (with leading `@`).
+	declinedStubBanners map[string]string
+	// declinedStubHelperEmitted records whether the
+	// `declare void @osty_rt_stage0_declined(ptr)` line is already in
+	// extraDecls. Single per-module declare; first stub emit lays it
+	// down, subsequent ones reuse.
+	declinedStubHelperEmitted bool
 }
 
 func newModuleCtx(module *mir.Module) *moduleCtx {
@@ -359,24 +369,41 @@ func newModuleCtx(module *mir.Module) *moduleCtx {
 		}
 	}
 	return &moduleCtx{
-		module:         module,
-		extraDecls:     &strings.Builder{},
-		stringPool:     map[string]string{},
-		emittedStructs: map[string]bool{},
-		definedFnSyms:  defined,
-		tuplePool:      map[string]string{},
+		module:              module,
+		extraDecls:          &strings.Builder{},
+		stringPool:          map[string]string{},
+		emittedStructs:      map[string]bool{},
+		definedFnSyms:       defined,
+		tuplePool:           map[string]string{},
+		declinedStubBanners: map[string]string{},
 	}
 }
 
-// emitDeclineStub renders a minimal `define <ret> @<name>(<params>)
-// { entry: unreachable }` body for a function that declined trial-
-// emit. The callers in successfully-emitted functions reference this
-// symbol via `call @<sym>(...)`; without a definition the linker
-// rejects the binary with `Undefined symbols for architecture …`.
-// `unreachable` as the only terminator is valid LLVM and asserts at
-// runtime — a stage0-built binary that hits this codepath traps
-// (which is correct: the production LIR-Proto path lowers the
-// function for real, stage0 just needs the smoke test to link).
+// emitDeclineStub renders a minimal
+// `define <ret> @<name>(<params>) { entry:
+//
+//	    call void @osty_rt_stage0_declined(ptr @.stage0.declined.<N>)
+//	    unreachable
+//	}` body for a function that declined trial-emit. The callers in
+//
+// successfully-emitted functions reference this symbol via
+// `call @<sym>(...)`; without a definition the linker rejects the
+// binary with `Undefined symbols for architecture …`.
+//
+// The body used to be a bare `unreachable`. clang lowered that to
+// `ud2` which on x86-64 is a fixed-size 2-byte trap. At link time
+// `ld --icf=safe` (the lld/GNU ld default for identical-cold-code)
+// then folded multiple zero-cost stubs into the address of an
+// unrelated abort-shaped function (`osty_rt_option_unwrap_none` in
+// practice), so a stage0 binary that dispatched into a declined
+// function aborted with `called unwrap on None` — misleading and
+// unmatchable from the audit harness.
+//
+// The structured `call + unreachable` body forces ICF to keep each
+// stub distinct (the call argument is a unique global per function
+// name) and gives the audit harness a stable banner to match.
+// `osty_rt_stage0_declined` writes the function name + a fixed
+// hint to stderr then calls `abort()`.
 //
 // Returns false when any param or return type can't be classified —
 // such functions stay declined and accept the link gap. Aggregate
@@ -449,9 +476,52 @@ func emitDeclineStub(fn *mir.Function, mctx *moduleCtx) (string, bool) {
 	}
 	b.WriteString(") {\n")
 	b.WriteString("entry:\n")
+	// Emit a one-shot declaration of the runtime helper and a
+	// per-function string global naming the declined symbol. Both
+	// land in `extraDecls` so they appear before any function body
+	// references them; idempotent across multiple stub emits via the
+	// `declinedStubHelperEmitted` flag and the `declinedStubBanners`
+	// map.
+	if !mctx.declinedStubHelperEmitted {
+		mctx.extraDecls.WriteString("declare void @osty_rt_stage0_declined(ptr)\n")
+		mctx.declinedStubHelperEmitted = true
+	}
+	bannerLabel := mctx.declinedStubBanners[fn.Name]
+	if bannerLabel == "" {
+		bannerLabel = fmt.Sprintf("@.stage0.declined.%d", len(mctx.declinedStubBanners))
+		mctx.declinedStubBanners[fn.Name] = bannerLabel
+		// LLVM `c"..."` strings need backslash escapes for quotes,
+		// backslashes, and non-printables. MIR function names are
+		// identifier-shaped so the unescaped name is safe to embed,
+		// but route through `llvmStringEscape` regardless to stay
+		// robust against unusual mangles.
+		escaped := llvmStringEscape(fn.Name)
+		fmt.Fprintf(mctx.extraDecls,
+			"%s = private unnamed_addr constant [%d x i8] c\"%s\\00\"\n",
+			bannerLabel, len(fn.Name)+1, escaped)
+	}
+	fmt.Fprintf(&b, "  call void @osty_rt_stage0_declined(ptr %s)\n", bannerLabel)
 	b.WriteString("  unreachable\n")
 	b.WriteString("}\n\n")
 	return b.String(), true
+}
+
+// llvmStringEscape returns `s` with bytes that need escaping inside
+// an LLVM `c"..."` string constant replaced by their `\HH` form.
+// Used by `emitDeclineStub`'s banner global; the same shape works
+// for any private string constant.
+func llvmStringEscape(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '"' || c == '\\' || c < 0x20 || c > 0x7e {
+			fmt.Fprintf(&b, "\\%02X", c)
+			continue
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
 }
 
 // internTupleType returns the synthetic LLVM type name (with leading

--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -1017,6 +1017,13 @@ func stage0AuditOutputHasKnownAbortMarker(output string) bool {
 		"osty-self: unsupported command",
 		"host compiler forwarding is disabled",
 		"supported subcommands:",
+		// New marker from decline-stub banner — the produced binary
+		// reached the declined function via real CLI dispatch (rather
+		// than the unsupported-command fallback) and aborted from the
+		// stub. Emitted by `osty_rt_stage0_declined` for every body
+		// `emitDeclineStub` lays down.
+		"osty-self: stage0 declined function:",
+		"requires the LIR Proto self-host pipeline",
 	}
 	for _, m := range markers {
 		if strings.Contains(output, m) {


### PR DESCRIPTION
## Summary

When a stage0-built binary dispatched into a declined function (e.g. `runLirProtoLower`, `runCompile`), the previous `define <ret> @<fn>(...) { entry: unreachable }` body produced misleading abort output. clang lowered `unreachable` to a 2-byte `ud2` trap; the linker then folded multiple identical zero-cost stubs (`--icf=safe` is on by default for cold code in lld/GNU ld) into the address of an unrelated abort-shaped helper — `osty_rt_option_unwrap_none` in this build — so the binary aborted with `called unwrap on None`.

Confirmation from this build's symbol table:

```
0x23bc30 runCompile
0x23bc30 runLirProtoLower
0x23bc30 osty_rt_option_unwrap_none
```

All three at the same address. gdb `bt` showed `osty_rt_abort` from `osty_rt_option_unwrap_none` from `main` — but the IR actually called `@runLirProtoLower`. ICF made the trace lie.

## Fix

Replace the stub body with a structured call + unreachable:

```llvm
define <ret> @<fn>(<params>) {
entry:
  call void @osty_rt_stage0_declined(ptr @.stage0.declined.N)
  unreachable
}
```

A per-function private string global with the MIR function name forces ICF to keep each stub distinct (each `call` argument is a unique global). The new runtime helper `osty_rt_stage0_declined(name)` writes a two-line banner to stderr naming the declined function plus a `requires the LIR Proto self-host pipeline (Phase 1+)` hint, then calls `abort()`.

The L3/L4 audit harness's known-abort-marker list grows two new substrings so the produced binary's `lir-proto-lower` / `compile` invocations now grade as `reached argv dispatch + printed known banner before abort` instead of `FAILED with no recognisable banner`.

## Verification — direct binary invocation

```
$ ./audit-exec lir-proto-lower /tmp/fp_fixture.osty
osty-self: stage0 declined function: runLirProtoLower
osty-self: this codepath requires the LIR Proto self-host pipeline (Phase 1+)
Aborted (exit 134)

$ ./audit-exec compile /tmp/fp_fixture.osty
osty-self: stage0 declined function: runCompile
osty-self: this codepath requires the LIR Proto self-host pipeline (Phase 1+)
Aborted (exit 134)
```

## Audit progression

| Level | Status |
|---|---|
| L1 per-function | 7363 / 7547 (97.6%), 0 emit-broken (unchanged) |
| L2 module-verify | clean (unchanged) |
| L3 exec-verify | `binary --selfhost-doctor ✓ exit 0` (unchanged) |
| L4 fp-verify | `--selfhost-doctor ✓ exit 0`, `lir-proto-lower` / `compile` now banner-match (was: no recognisable banner). deepest reached: `--selfhost-doctor` (advances when stage0 covers `runLirProtoLower` / `runCompile` for real — separate work). |

Backend test failure count: 82 → 82 (no regression). stage0 package unit tests pass clean.

## Test plan

- [x] `OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_CLANG_VERIFY=1 OSTY_STAGE0_AUDIT_MODULE_VERIFY=1 OSTY_STAGE0_AUDIT_EXEC_VERIFY=1 OSTY_STAGE0_AUDIT_FP_VERIFY=1 go test -count=1 -vet=off -run TestStage0ToolchainAudit ./internal/backend/` PASS
- [x] `go test -count=1 -vet=off ./internal/backend/stage0/...` clean
- [x] Backend test failure count unchanged (82 → 82)
- [x] `go vet ./internal/backend/...` clean
- [x] `gofmt -l` clean
- [x] Direct binary invocation of `lir-proto-lower` / `compile` prints the new banner before aborting

https://claude.ai/code/session_01C4hC1RTMmofdZm8R3nPbh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4hC1RTMmofdZm8R3nPbh9)_