### PR TITLE
fix(ir): bundle 4 — 40+ more trailing-call recovery gaps (math, bit ops, list/string extras)

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -3672,16 +3672,23 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			"concat", "reverse", "toUpperCase", "toLowerCase",
 			"replaceAll", "replaceFirst":
 			return TString
-		case "count":
+		case "count", "byteSize":
 			return TInt
 		case "first", "last":
 			return &OptionalType{Inner: TChar}
 		case "stripPrefix", "stripSuffix":
 			return &OptionalType{Inner: TString}
+		case "byteAt":
+			return &OptionalType{Inner: TByte}
+		case "charAt":
+			return &OptionalType{Inner: TChar}
+		case "splitFirst", "splitLast":
+			return &OptionalType{Inner: &TupleType{Elems: []Type{TString, TString}}}
 		}
 	}
-	// Range<Int> intrinsic returns.
-	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "Range" {
+	// Range<Int> intrinsic returns. `Builtin` flag may or may not be
+	// set depending on call site; accept either form.
+	if nt, ok := rt.(*NamedType); ok && nt.Name == "Range" {
 		switch name {
 		case "toList":
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{TInt}}
@@ -3709,7 +3716,9 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 	// Int primitive method returns.
 	if isPrim(rt, PrimInt) {
 		switch name {
-		case "abs", "min", "max", "neg", "pow", "clamp":
+		case "abs", "min", "max", "neg", "pow", "clamp", "gcd", "lcm", "sign":
+			return TInt
+		case "countOnes", "countZeros", "leadingZeros", "trailingZeros":
 			return TInt
 		case "toFloat":
 			return TFloat
@@ -3722,7 +3731,10 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 	// Float primitive method returns.
 	if isPrim(rt, PrimFloat) {
 		switch name {
-		case "abs", "sqrt", "floor", "ceil", "round", "min", "max", "pow", "neg":
+		case "abs", "sqrt", "floor", "ceil", "round", "min", "max", "pow", "neg",
+			"log", "log2", "log10", "exp", "sin", "cos", "tan",
+			"asin", "acos", "atan", "atan2", "sinh", "cosh", "tanh",
+			"cbrt", "ln":
 			return TFloat
 		case "toInt":
 			return TInt
@@ -3744,6 +3756,14 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return &OptionalType{Inner: TInt}
 		case "len":
 			return TInt
+		case "concat", "slice", "repeat":
+			return TBytes
+		case "toHex":
+			return TString
+		case "toString":
+			return &NamedType{Name: "Result", Builtin: true, Args: []Type{
+				TString, &NamedType{Name: "Error", Builtin: true},
+			}}
 		}
 	}
 	// Element-type returns: List<T>.first / .last / .get → T?, .push → Unit.
@@ -3775,6 +3795,18 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return &NamedType{Name: "Set", Builtin: true, Args: []Type{elem}}
 		case "iter":
 			return &NamedType{Name: "Iterator", Builtin: true, Args: []Type{elem}}
+		case "reduce":
+			return &OptionalType{Inner: elem}
+		case "distinct":
+			return nt
+		case "partition":
+			return &TupleType{Elems: []Type{nt, nt}}
+		}
+	}
+	// List<List<T>>.flatten() → List<T>.
+	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "List" && len(nt.Args) == 1 {
+		if inner, ok := nt.Args[0].(*NamedType); ok && inner.Builtin && inner.Name == "List" && len(inner.Args) == 1 && name == "flatten" {
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{inner.Args[0]}}
 		}
 	}
 	// Iterator<T> methods. Iterator is a stdlib protocol type whose
@@ -3812,17 +3844,14 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return TInt
 		}
 	}
-	// Map<K, V> method returns: .get(k) → V?, .keys() → List<K>,
-	// .values() → List<V>, .insert / .remove → V?, .containsKey →
-	// Bool. Without this, untyped map literals (`let m = {1: "a"}`)
-	// landed at MIR with `m.get(1).Type() = V?` (the generic
-	// signature's TypeVar leaked) and downstream `println` walled
-	// on `non-primitive V`.
+	// Map<K, V> method returns.
 	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "Map" && len(nt.Args) == 2 {
 		k, v := nt.Args[0], nt.Args[1]
 		switch name {
 		case "get", "remove":
 			return &OptionalType{Inner: v}
+		case "getOr":
+			return v
 		case "keys":
 			return &NamedType{Name: "List", Builtin: true, Args: []Type{k}}
 		case "values":
@@ -3865,9 +3894,9 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 		switch name {
 		case "isSome", "isNone":
 			return TBool
-		case "unwrapOr", "unwrap", "expect":
+		case "unwrapOr", "unwrap", "expect", "unwrapOrElse":
 			return ot.Inner
-		case "orElse", "filter":
+		case "orElse", "filter", "or", "and":
 			return ot
 		}
 	}
@@ -3877,7 +3906,7 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 		switch name {
 		case "isOk", "isErr":
 			return TBool
-		case "unwrapOr", "unwrap", "expect":
+		case "unwrapOr", "unwrap", "expect", "unwrapOrElse":
 			return t
 		case "unwrapErr":
 			return e

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,70 @@ fn main() {}`,
 	}
 }
 
+// Bundle 4: 40+ more trailing-call shapes — Math/Float (log, sin,
+// exp, etc.), Int bit ops (gcd, sign, countOnes, leadingZeros),
+// List<T> functional helpers (reduce, flatten, distinct, partition),
+// String byte/char access (byteAt, charAt, splitFirst, byteSize),
+// Option/Result extras (unwrapOrElse, or, and), Map.getOr,
+// Bytes.toString/toHex/concat.
+func TestLowerTrailingMethodCallBundle4(t *testing.T) {
+	tests := []struct {
+		name, src, wantType string
+	}{
+		{"math_log", `fn lg(x: Float) -> Float { x.log() } fn main() {}`, "Float"},
+		{"math_sin", `fn s(x: Float) -> Float { x.sin() } fn main() {}`, "Float"},
+		{"math_exp", `fn e(x: Float) -> Float { x.exp() } fn main() {}`, "Float"},
+		{"int_gcd", `fn g(a: Int, b: Int) -> Int { a.gcd(b) } fn main() {}`, "Int"},
+		{"int_sign", `fn sg(n: Int) -> Int { n.sign() } fn main() {}`, "Int"},
+		{"int_countOnes", `fn co(n: Int) -> Int { n.countOnes() } fn main() {}`, "Int"},
+		{"int_leadingZeros", `fn lz(n: Int) -> Int { n.leadingZeros() } fn main() {}`, "Int"},
+		{"list_reduce", `fn r(xs: List<Int>) -> Int? { xs.reduce(|a, b| a + b) } fn main() {}`, "Int?"},
+		{"list_flatten", `fn f(xs: List<List<Int>>) -> List<Int> { xs.flatten() } fn main() {}`, "List<Int>"},
+		{"list_distinct", `fn d(xs: List<Int>) -> List<Int> { xs.distinct() } fn main() {}`, "List<Int>"},
+		{"list_partition", `fn p(xs: List<Int>) -> (List<Int>, List<Int>) { xs.partition(|x| x > 0) } fn main() {}`, "(List<Int>, List<Int>)"},
+		{"string_splitFirst", `fn sf(s: String, c: Char) -> (String, String)? { s.splitFirst(c) } fn main() {}`, "(String, String)?"},
+		{"string_byteAt", `fn b(s: String, i: Int) -> Byte? { s.byteAt(i) } fn main() {}`, "Byte?"},
+		{"string_charAt", `fn c(s: String, i: Int) -> Char? { s.charAt(i) } fn main() {}`, "Char?"},
+		{"string_byteSize", `fn bs(s: String) -> Int { s.byteSize() } fn main() {}`, "Int"},
+		{"option_or", `fn o(a: Int?, b: Int?) -> Int? { a.or(b) } fn main() {}`, "Int?"},
+		{"option_and", `fn a_(a: Int?, b: Int?) -> Int? { a.and(b) } fn main() {}`, "Int?"},
+		{"option_unwrapOrElse", `fn ue(o: Int?, d: Int) -> Int { o.unwrapOrElse(|| d) } fn main() {}`, "Int"},
+		{"result_unwrapOrElse", `fn oe(r: Result<Int, Error>, d: Int) -> Int { r.unwrapOrElse(|_| d) } fn main() {}`, "Int"},
+		{"map_getOr", `fn go_(m: Map<String, Int>, k: String, d: Int) -> Int { m.getOr(k, d) } fn main() {}`, "Int"},
+		{"bytes_toString", `fn b2s(b: Bytes) -> Result<String, Error> { b.toString() } fn main() {}`, "Result<String, Error>"},
+		{"bytes_toHex", `fn h(b: Bytes) -> String { b.toHex() } fn main() {}`, "String"},
+		{"bytes_concat", `fn bc(a: Bytes, b: Bytes) -> Bytes { a.concat(b) } fn main() {}`, "Bytes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, _ := parser.ParseDiagnostics([]byte(tt.src))
+			res := resolve.ResolveFileSourceDefault([]byte(tt.src), file, stdlib.LoadCached())
+			reg := stdlib.LoadCached()
+			chk := check.SelfhostFile(file, res, check.Opts{
+				Stdlib:        reg,
+				Primitives:    reg.Primitives,
+				ResultMethods: reg.ResultMethods,
+				Source:        []byte(tt.src),
+				Privileged:    true,
+			})
+			mod, _ := Lower("main", file, res, chk)
+			for _, decl := range mod.Decls {
+				fn, ok := decl.(*FnDecl)
+				if !ok || fn.Name == "main" {
+					continue
+				}
+				if fn.Body == nil || fn.Body.Result == nil {
+					t.Errorf("fn %s: body.Result = nil", fn.Name)
+					continue
+				}
+				if got := typeString(fn.Body.Result.Type()); got != tt.wantType {
+					t.Errorf("fn %s: body.Result.Type = %q, want %q", fn.Name, got, tt.wantType)
+				}
+			}
+		})
+	}
+}
+
 // Bundle 3: 40+ more trailing-call shapes covering Int/Float
 // predicates+formatting, String mutation/predicate helpers, List<T>
 // mutation operations (pop/remove/indexOf/iter/extend), Iterator<T>


### PR DESCRIPTION
## Summary

#1645 회귀 시리즈 13번째: 40+ more trailing-call 회귀 fix.

## 변경 카테고리

### Float math 함수
- log/log2/log10/ln/exp → Float
- sin/cos/tan/asin/acos/atan/atan2 → Float
- sinh/cosh/tanh/cbrt → Float

### Int bit operations
- gcd/lcm/sign → Int
- countOnes/countZeros/leadingZeros/trailingZeros → Int

### String byte/char access
- byteAt → Byte?
- charAt → Char?
- splitFirst/splitLast → (String, String)?
- byteSize → Int

### Bytes 확장
- concat/slice/repeat → Bytes
- toHex → String
- toString → Result<String, Error>

### List<T> 확장
- reduce → T?
- distinct → List<T>
- partition → (List<T>, List<T>)
- flatten (on List<List<T>>) → List<T>

### Map<K,V> 확장
- getOr → V

### Option<T> / Result<T,E> 확장
- unwrapOrElse → T
- or/and → Option<T> (Option only)

### Range matcher 완화
- `nt.Builtin` 요구 제거 — 사용자 소스의 type annotation 이 builtin flag 없이 선언되는 경우 처리

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: 7363/7547 (97.6%) — 불변
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit`: 0 errors
- 새 `TestLowerTrailingMethodCallBundle4` — 23 sub-cases exact-type 검증 모두 PASS
- 전체 패키지 green

## 회귀 시리즈 누적

이번 묶음 포함 누적 120+ trailing-call 회귀 fix.

## Test plan

- [x] `go test ./internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit` — 97.6%
- [x] `go test -run TestLowerTrailingMethodCallBundle4 ./internal/ir/...` — green
- [x] `go test ./cmd/osty/...` — green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_