### PR TITLE
refactor(check): route osty check FILE through factory + drop dead pipeline helpers

### DIFF
--- a/cmd/osty/native_check.go
+++ b/cmd/osty/native_check.go
@@ -617,23 +617,20 @@ func nativeCheckFile(path string, src []byte) ([]*diag.Diagnostic, api.CheckResu
 	if hasError(parseDiags) {
 		return parseDiags, api.CheckResult{}, nil
 	}
-	imports := nativeFileImportSurfaces(run)
-	var checked api.CheckResult
-	if len(imports) > 0 {
-		var err error
-		checked, err = check.NativePackageCheck(api.PackageCheckInput{
-			Imports: imports,
-			Files: []api.PackageCheckFile{{
-				Source: append([]byte(nil), src...),
-				Name:   filepath.Base(path),
-				Path:   path,
-			}},
-		})
-		if err != nil {
-			return parseDiags, api.CheckResult{}, err
-		}
-	} else {
-		_, checked = selfhost.CheckFromSource(src)
+	// Route both with- and without-imports cases through the factory so the
+	// production subprocess sees `osty check FILE` consistently with `osty
+	// check DIR`. The subprocess re-parses the single source — cheap for one
+	// file — in exchange for parity with the workspace path.
+	checked, err := check.NativePackageCheck(api.PackageCheckInput{
+		Imports: nativeFileImportSurfaces(run),
+		Files: []api.PackageCheckFile{{
+			Source: append([]byte(nil), src...),
+			Name:   filepath.Base(path),
+			Path:   path,
+		}},
+	})
+	if err != nil {
+		return parseDiags, api.CheckResult{}, err
 	}
 	return parseDiags, checked, nil
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -117,9 +117,6 @@ type Result struct {
 	Lint     *lint.Result
 	AllDiags []*diag.Diagnostic // every diag from every phase, in phase order
 
-	nativeResolve *selfhost.ResolveResult
-	nativeCheck   *selfhost.CheckResult
-
 	// PerDecl is populated when Config.PerDecl is set. One entry per
 	// (declaration, pass) pair the type checker visited. Sorted by
 	// total descending in RenderText / RenderJSON.
@@ -135,34 +132,6 @@ type Result struct {
 	// for caret snippets even when the pipeline spans multiple files or
 	// packages.
 	Sources map[string][]byte
-}
-
-// NativeResolveResult returns the self-host resolver's structured result for
-// the retained ParseRun without touching the public *ast.File boundary. The
-// legacy Result.Resolve field remains populated for existing consumers.
-func (r *Result) NativeResolveResult() *selfhost.ResolveResult {
-	if r == nil || r.ParseRun == nil {
-		return nil
-	}
-	if r.nativeResolve == nil {
-		resolved := selfhost.ResolveStructuredFromRun(r.ParseRun)
-		r.nativeResolve = &resolved
-	}
-	return r.nativeResolve
-}
-
-// NativeCheckResult returns the self-host checker's structured result for the
-// retained ParseRun without touching the public *ast.File boundary. The legacy
-// Result.Check field remains populated for existing consumers.
-func (r *Result) NativeCheckResult() *selfhost.CheckResult {
-	if r == nil || r.ParseRun == nil {
-		return nil
-	}
-	if r.nativeCheck == nil {
-		checked := selfhost.CheckStructuredFromRun(r.ParseRun)
-		r.nativeCheck = &checked
-	}
-	return r.nativeCheck
 }
 
 // DeclTiming records how long the type checker spent on one


### PR DESCRIPTION
## Summary

생성된 `selfhost.*` 직접 호출 audit 결과 정리. 두 가지 변경:

1. **`cmd/osty/native_check.go::nativeCheckFile`** 의 no-imports 분기 (`selfhost.CheckFromSource(src)`) 를 with-imports 분기와 동일하게 `check.NativePackageCheck` 로 통일. 단일 파일 `osty check FILE` 이 이제 imports 유무와 무관하게 production subprocess 를 거침. subprocess 가 source 를 한 번 더 parse 하지만 단일 파일이라 비용 무시할 수준이고, 디렉토리 경로와 일관된 factory selection 이 더 큰 가치.

2. **`internal/pipeline/pipeline.go::Result.NativeResolveResult()` 와 `::NativeCheckResult()` 메서드** + `nativeResolve` / `nativeCheck` 캐시 필드 삭제. repo 전체 검색해도 호출자 없음 — 데드 코드. 이들이 `selfhost.ResolveStructuredFromRun` / `selfhost.CheckStructuredFromRun` 직접 호출자였으므로 삭제로 두 selfhost 직접 호출 제거.

## 남은 `selfhost.Check*` 직접 호출자 (다음 PR 후보)

| 경로 | 함수 | 비고 |
|---|---|---|
| `internal/check/check.go:205` | `SelfhostRun` → `CheckStructuredFromRun` | FrontendRun 기반, `osty lint FILE` 경로. 마이그레이션 가능 |
| `internal/airepair/airepair.go:329` | `probe` → `CheckFromSource` | repair 루프, perf-sensitive. subprocess 도입 시 측정 필요 |
| `internal/resolve/native_adapter.go:198` | `nativeResolveFactArtifacts` → `CheckPackageStructured` | `internal/check` import 시 cycle. architectural 정리 필요 |

## Test plan
- [x] `just prepush` 로컬 통과
- [x] `go test ./cmd/osty/ -short -run 'TestRunCheck|TestNative|TestLint'` 통과 (2.3s)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)