### PR TITLE
feat: G20 function-value parameter-name preservation + E0769 diagnostic

### DIFF
--- a/CHANGELOG_v0.5.md
+++ b/CHANGELOG_v0.5.md
@@ -158,7 +158,7 @@ half of these forms still round-trips through the regen path.
 - Enum integer discriminants `pub enum X: Int { A = 1, ... }` (G31)
 - `#[op(+)]` operator overload (G35) — six-operator allow-list
 - Lossless numeric widening (G34)
-- Function-value parameter-name preservation (G20)
+- Function-value parameter-name preservation (G20) — infrastructure shipped: FnType.ParamNames, TyNode.fnParamNames, FrontTypeRepr.paramNames, tyFnWithNames, fnSigToTy/collectFnDecl propagation, String() rendering, diagnostic E0769
 - `#[cfg]` composition forms `all(...)` / `any(...)` / `not(...)` (G29 partial)
 
 ## Native checker status

--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -995,6 +995,14 @@ CodeConstFnGeneric: a `const fn` declaration carries type parameters (`const fn 
 
 **Fix**: declare a separate `const fn` per concrete type, or drop
 
+### E0769 — `CodeFnValueKeywordNameMismatch`
+
+CodeFnValueKeywordNameMismatch: a keyword argument in a call through a function value does not match any parameter name recorded on the fn-type. Per G20, fn-types carry parameter names as type-equality-neutral metadata; when names are available and match, keyword calls are allowed. This diagnostic fires when a keyword is supplied but the fn-type either has no names or none of them match the keyword. The argument is treated as positional for type-checking purposes. v0.5 (G20).
+
+originates from a declaration whose parameter names match.
+
+**Fix**: use a positional argument, or ensure the function value
+
 ### E0754 — `CodeOpAnnotationBadSignature`
 
 CodeOpAnnotationBadSignature: a method carrying `#[op(X)]` does not match the required shape for operator X (wrong parameter count, wrong self-position, wrong return type). v0.5 (G35) §3.1.

--- a/internal/check/host_boundary_overlay.go
+++ b/internal/check/host_boundary_overlay.go
@@ -254,7 +254,7 @@ func typeReprToType(repr *api.TypeRepr) types.Type {
 		if ret == nil {
 			ret = types.Unit
 		}
-		return &types.FnType{Params: params, Return: ret}
+		return &types.FnType{Params: params, ParamNames: repr.ParamNames, Return: ret}
 	case "unit":
 		return types.Unit
 	case "never":

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -843,16 +843,30 @@ const (
 	//      `const` and use an ordinary generic function at runtime.
 	CodeConstFnGeneric = "E0768"
 
+	// CodeFnValueKeywordNameMismatch: a keyword argument in a call
+	// through a function value does not match any parameter name
+	// recorded on the fn-type. Per G20, fn-types carry parameter names
+	// as type-equality-neutral metadata; when names are available and
+	// match, keyword calls are allowed. This diagnostic fires when a
+	// keyword is supplied but the fn-type either has no names or none
+	// of them match the keyword. The argument is treated as positional
+	// for type-checking purposes.
+	// v0.5 (G20).
+	// Fix: use a positional argument, or ensure the function value
+	//      originates from a declaration whose parameter names match.
+	CodeFnValueKeywordNameMismatch = "E0769"
+
 	// v0.5 additions (G20-G35). The following codes extend the E07xx
 	// band for numeric widening, operator overloading, enum
 	// discriminants, and label/loop control flow. Module-resolution
 	// additions for `pub use` re-export and scoped imports live in
 	// the E055x band. `#[cfg(...)]` key validation lives in E0405.
 	//
-	// Free slots claimed: E0754-E0759 (typecheck), E0765-E0768
-	// (control flow; E0766-E0768 are `const fn` validation, §3.1.1),
-	// E0552-E0554 (name resolution), E0405 (imports). E0769 remains
-	// free in the control-flow band. The E0770-E0772 slots are
+	// Free slots claimed: E0754-E0759 (typecheck), E0765-E0769
+	// (control flow; E0766-E0768 are `const fn` validation, §3.1.1;
+	// E0769 is fn-value keyword-name mismatch, G20),
+	// E0552-E0554 (name resolution), E0405 (imports).
+	// The E0770-E0772 slots are
 	// occupied by §19 runtime sublanguage diagnostics
 	// (CodeRuntimePrivilegeViolation, CodePodShapeViolation,
 	// CodeNoAllocViolation) defined below.
@@ -1149,7 +1163,6 @@ const (
 	//
 	// Fix: check write permissions and free space.
 	CodeScaffoldWriteError = "E2052"
-
 )
 
 const (

--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -60,6 +60,11 @@ func CloneType(t Type) Type {
 				out.Params[i] = CloneType(p)
 			}
 		}
+		// G20: clone param names
+		if len(t.ParamNames) > 0 {
+			out.ParamNames = make([]string, len(t.ParamNames))
+			copy(out.ParamNames, t.ParamNames)
+		}
 		return out
 	case *TypeVar:
 		return &TypeVar{Name: t.Name, Owner: t.Owner}

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -244,10 +244,12 @@ func (t *TupleType) String() string {
 	return b.String()
 }
 
-// FnType is `fn(A, B) -> R`.
+// FnType is `fn(A, B) -> R` in the IR. G20: ParamNames carries per-parameter
+// names as type-equality-neutral metadata (nil when unavailable).
 type FnType struct {
-	Params []Type
-	Return Type
+	Params     []Type
+	ParamNames []string // G20: fn-type parameter names; nil when unavailable
+	Return     Type
 }
 
 func (*FnType) typeNode() {}
@@ -258,6 +260,11 @@ func (f *FnType) String() string {
 	for i, p := range f.Params {
 		if i > 0 {
 			b.WriteString(", ")
+		}
+		// G20: include param name when available.
+		if f.ParamNames != nil && i < len(f.ParamNames) && f.ParamNames[i] != "" {
+			b.WriteString(f.ParamNames[i])
+			b.WriteString(": ")
 		}
 		b.WriteString(typeString(p))
 	}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -842,7 +842,7 @@ func (l *lowerer) fromCheckerType(t types.Type) Type {
 		if ret == nil {
 			ret = TUnit
 		}
-		return &FnType{Params: params, Return: ret}
+		return &FnType{Params: params, ParamNames: t.ParamNames, Return: ret}
 	case *types.Named:
 		name := "?"
 		builtin := false

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -42,11 +42,12 @@ type CheckSummary struct {
 // host bridge. The Osty side emits a TypeRepr for every typed node; the
 // Go side converts it directly to types.Type without string parsing.
 type TypeRepr struct {
-	Kind   string     `json:"kind"`             // "primitive", "named", "tuple", "optional", "fn", "unit", "never", "typevar", "self", "error", "poison"
-	Name   string     `json:"name,omitempty"`   // primitive/named/typevar name: "Int", "List", "T"
-	Path   string     `json:"path,omitempty"`   // qualified path (reserved, currently empty)
-	Args   []TypeRepr `json:"args,omitempty"`   // named generic args / tuple elems / fn params
-	Return *TypeRepr  `json:"return,omitempty"` // fn return type / optional inner
+	Kind       string     `json:"kind"`                  // "primitive", "named", "tuple", "optional", "fn", "unit", "never", "typevar", "self", "error", "poison"
+	Name       string     `json:"name,omitempty"`        // primitive/named/typevar name: "Int", "List", "T"
+	Path       string     `json:"path,omitempty"`        // qualified path (reserved, currently empty)
+	Args       []TypeRepr `json:"args,omitempty"`        // named generic args / tuple elems / fn params
+	Return     *TypeRepr  `json:"return,omitempty"`      // fn return type / optional inner
+	ParamNames []string   `json:"param_names,omitempty"` // G20: fn-type parameter names; nil when unavailable
 }
 
 // String renders a TypeRepr back to a human-readable type string matching the
@@ -99,7 +100,12 @@ func (tr *TypeRepr) String() string {
 	case "fn":
 		parts := make([]string, 0, len(tr.Args))
 		for i := range tr.Args {
-			parts = append(parts, tr.Args[i].String())
+			// G20: include param name when available.
+			if tr.ParamNames != nil && i < len(tr.ParamNames) && tr.ParamNames[i] != "" {
+				parts = append(parts, tr.ParamNames[i]+": "+tr.Args[i].String())
+			} else {
+				parts = append(parts, tr.Args[i].String())
+			}
 		}
 		s := "fn(" + joinTypeReprStrings(parts, ", ") + ")"
 		if tr.Return != nil {

--- a/internal/selfhost/front_type_repr.go
+++ b/internal/selfhost/front_type_repr.go
@@ -11,11 +11,12 @@ import (
 // Go seed. It keeps structured types intact until the public api.TypeRepr
 // boundary instead of forcing checker results through a type-name string.
 type FrontTypeRepr struct {
-	kind string
-	name string
-	path string
-	args []*FrontTypeRepr
-	ret  *FrontTypeRepr
+	kind       string
+	name       string
+	path       string
+	args       []*FrontTypeRepr
+	ret        *FrontTypeRepr
+	paramNames []string // G20: fn-type parameter names; nil when unavailable
 }
 
 func tyToRepr(arena *TyArena, idx int) *FrontTypeRepr {
@@ -44,6 +45,9 @@ func tyToRepr(arena *TyArena, idx int) *FrontTypeRepr {
 	case *TyKind_TkTuple:
 		return &FrontTypeRepr{kind: "tuple", args: tyReprArgs(arena, node.args)}
 	case *TyKind_TkFn:
+		// G20: param names come from the Osty-native checker boundary
+		// (host_boundary_overlay.go), not from the frozen Go seed. The
+		// seed's TyNode has no fnParamNames field.
 		return &FrontTypeRepr{
 			kind: "fn",
 			args: tyReprArgs(arena, node.args),
@@ -94,9 +98,10 @@ func frontTypeReprToAPI(repr *FrontTypeRepr) *api.TypeRepr {
 		return nil
 	}
 	out := &api.TypeRepr{
-		Kind: repr.kind,
-		Name: repr.name,
-		Path: repr.path,
+		Kind:       repr.kind,
+		Name:       repr.name,
+		Path:       repr.path,
+		ParamNames: repr.paramNames, // G20
 	}
 	if len(repr.args) > 0 {
 		out.Args = make([]api.TypeRepr, 0, len(repr.args))

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -362,9 +362,16 @@ func (o *Optional) String() string { return o.Inner.String() + "?" }
 // representation. Receiver types are NOT recorded here — the receiver is
 // modelled as the first parameter at call-synthesis time, but for method
 // *references* the receiver has already been bound.
+//
+// G20: ParamNames carries per-parameter names as type-equality-neutral
+// metadata. Identical/Assignable ignore ParamNames; String includes
+// them when present. Keyword calls through fn-values consult ParamNames
+// to match named arguments; when names are absent or mismatched the call
+// falls back to positional semantics.
 type FnType struct {
-	Params []Type
-	Return Type // Unit for fn with no return
+	Params     []Type
+	ParamNames []string // G20: per-parameter names; nil when unavailable
+	Return     Type     // Unit for fn with no return
 }
 
 func (*FnType) typeNode() {}
@@ -375,6 +382,11 @@ func (f *FnType) String() string {
 	for i, p := range f.Params {
 		if i > 0 {
 			b.WriteString(", ")
+		}
+		// G20: include param name when available.
+		if f.ParamNames != nil && i < len(f.ParamNames) && f.ParamNames[i] != "" {
+			b.WriteString(f.ParamNames[i])
+			b.WriteString(": ")
 		}
 		b.WriteString(p.String())
 	}

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -42,53 +42,58 @@ pub struct FrontTypeRepr {
     pub path: String,
     pub args: List<FrontTypeRepr>,
     pub ret: Option<FrontTypeRepr>,
+    /// paramNames: G20. For fn-type reprs, carries parameter names.
+    /// Empty when no names are available.
+    pub paramNames: List<String>,
 }
 /// tyToRepr converts a TyArena index into a structured FrontTypeRepr,
 /// eliminating the string-based round-trip on the Go ↔ Osty boundary.
 pub fn tyToRepr(arena: TyArena, idx: Int) -> FrontTypeRepr {
     if idx < 0 {
-        return FrontTypeRepr {kind: "error", name: "Invalid", path: "", args: [], ret: None}
+        return FrontTypeRepr {kind: "error", name: "Invalid", path: "", args: [], ret: None, paramNames: []}
     }
     let node = tyGet(arena, idx)
     match node.kind {
-        TkErr -> FrontTypeRepr {kind: "error", name: "Invalid", path: "", args: [], ret: None},
-        TkPoison -> FrontTypeRepr {kind: "poison", name: "Poison", path: "", args: [], ret: None},
-        TkPrim -> FrontTypeRepr {kind: "primitive", name: primKindName(node.prim), path: "", args: [], ret: None},
+        TkErr -> FrontTypeRepr {kind: "error", name: "Invalid", path: "", args: [], ret: None, paramNames: []},
+        TkPoison -> FrontTypeRepr {kind: "poison", name: "Poison", path: "", args: [], ret: None, paramNames: []},
+        TkPrim -> FrontTypeRepr {kind: "primitive", name: primKindName(node.prim), path: "", args: [], ret: None, paramNames: []},
         TkNamed -> {
             let mut reprArgs: List<FrontTypeRepr> = []
             for arg in node.args {
                 reprArgs.push(tyToRepr(arena, arg))
             }
-            FrontTypeRepr {kind: "named", name: node.head, path: "", args: reprArgs, ret: None}
+            FrontTypeRepr {kind: "named", name: node.head, path: "", args: reprArgs, ret: None, paramNames: []}
         },
-        TkOptional -> FrontTypeRepr {kind: "optional", name: "", path: "", args: [], ret: Some(tyToRepr(arena, node.ret))},
+        TkOptional -> FrontTypeRepr {kind: "optional", name: "", path: "", args: [], ret: Some(tyToRepr(arena, node.ret)), paramNames: []},
         TkTuple -> {
             let mut elems: List<FrontTypeRepr> = []
             for e in node.args {
                 elems.push(tyToRepr(arena, e))
             }
-            FrontTypeRepr {kind: "tuple", name: "", path: "", args: elems, ret: None}
+            FrontTypeRepr {kind: "tuple", name: "", path: "", args: elems, ret: None, paramNames: []}
         },
         TkFn -> {
             let mut paramReprs: List<FrontTypeRepr> = []
             for p in node.args {
                 paramReprs.push(tyToRepr(arena, p))
             }
-            FrontTypeRepr {kind: "fn", name: "", path: "", args: paramReprs, ret: Some(tyToRepr(arena, node.ret))}
+            // G20: propagate param names from the TyNode.
+            let names = node.fnParamNames
+            FrontTypeRepr {kind: "fn", name: "", path: "", args: paramReprs, ret: Some(tyToRepr(arena, node.ret)), paramNames: names}
         },
         TkVar -> {
             let vName = node.varName
             if vName == "" {
-                FrontTypeRepr {kind: "typevar", name: "?{node.varId}", path: "", args: [], ret: None}
+                FrontTypeRepr {kind: "typevar", name: "?{node.varId}", path: "", args: [], ret: None, paramNames: []}
             } else {
-                FrontTypeRepr {kind: "typevar", name: vName, path: "", args: [], ret: None}
+                FrontTypeRepr {kind: "typevar", name: vName, path: "", args: [], ret: None, paramNames: []}
             }
         },
-        TkSelf -> FrontTypeRepr {kind: "self", name: "Self", path: "", args: [], ret: None},
+        TkSelf -> FrontTypeRepr {kind: "self", name: "Self", path: "", args: [], ret: None, paramNames: []},
     }
 }
 pub fn frontInvalidTypeRepr() -> FrontTypeRepr {
-    FrontTypeRepr {kind: "error", name: "Invalid", path: "", args: [], ret: None}
+    FrontTypeRepr {kind: "error", name: "Invalid", path: "", args: [], ret: None, paramNames: []}
 }
 /// frontTypeReprToString converts a structured FrontTypeRepr back into
 /// a human-readable string for legacy callers that still expect String
@@ -119,8 +124,20 @@ pub fn frontTypeReprToString(repr: FrontTypeRepr) -> String {
         "({strings.join(parts, ", ")})"
     } else if repr.kind == "fn" {
         let mut parts: List<String> = []
+        let mut i = 0
         for p in repr.args {
-            parts.push(frontTypeReprToString(p))
+            // G20: include param name when available.
+            if repr.paramNames.len() > 0 && i < repr.paramNames.len() {
+                let name = repr.paramNames[i]
+                if name != "" {
+                    parts.push("{name}: {frontTypeReprToString(p)}")
+                } else {
+                    parts.push(frontTypeReprToString(p))
+                }
+            } else {
+                parts.push(frontTypeReprToString(p))
+            }
+            i = i + 1
         }
         let retStr = match repr.ret {
             Some(r) -> frontTypeReprToString(r),
@@ -682,7 +699,21 @@ fn collectFnDecl(cx: ElabCx, declIdx: Int, node: AstNode, owner: String, ownerGe
     } else {
         let _ = node
     }
-    let fnTy = tyFn(cx.env.tys, sig.paramTys, sig.retTy)
+    // G20: build fn-type with param names. Strip the "?" prefix
+    // that arity-tracking uses — the fn-type metadata wants clean names.
+    let fnTy = if sig.paramNames.len() > 0 {
+        let mut cleanNames: List<String> = []
+        for pn in sig.paramNames {
+            if pn.startsWith("?") {
+                cleanNames.push(pn.slice(1))
+            } else {
+                cleanNames.push(pn)
+            }
+        }
+        tyFnWithNames(cx.env.tys, sig.paramTys, sig.retTy, cleanNames)
+    } else {
+        tyFn(cx.env.tys, sig.paramTys, sig.retTy)
+    }
     checkRecordSymbol(cx.env, declIdx, "fn", name, owner, fnTy, node.start, node.end)
 }
 // Build paramTys / paramNames from node.children (AstNParam entries).

--- a/toolchain/diag_examples.osty
+++ b/toolchain/diag_examples.osty
@@ -3,6 +3,7 @@
 //
 // Consumed by toolchain/diag_harvest.osty — one record per code that
 // ships a minimal reproduction in its doc comment.
+
 /// DiagHarvestCase pairs a stable diagnostic code with a minimal source
 /// snippet from its `Example:` doc block, plus the self-host pipeline
 /// phase expected to observe it.
@@ -11,7 +12,49 @@ pub struct DiagHarvestCase {
     pub example: String,
     pub phase: String,
 }
+
 /// diagHarvestCases returns the generated list. Order matches codes.go.
 pub fn diagHarvestCases() -> List<DiagHarvestCase> {
-    [DiagHarvestCase {code: "E0001", example: "let s = \"hello", phase: "resolve"}, DiagHarvestCase {code: "E0002", example: "let n = 0X1F  // rejected", phase: "resolve"}, DiagHarvestCase {code: "E0003", example: "let c = '\\u\{D800\}'  // rejected", phase: "resolve"}, DiagHarvestCase {code: "E0004", example: "/* never closed", phase: "resolve"}, DiagHarvestCase {code: "E0008", example: "let a = 1_            // trailing\nlet b = 0x_FF         // after base prefix\nlet c = 1__000        // consecutive", phase: "resolve"}, DiagHarvestCase {code: "E0009", example: "let a = ''             // empty\nlet b = b'\\u\{1F600\}'   // non-ASCII byte\nlet c = 'ab'           // multiple scalars", phase: "resolve"}, DiagHarvestCase {code: "E0101", example: "use go \"net/http\" \{\n    fn Get(url: String) -> String \{ \"x\" \}  // rejected\n\}", phase: "resolve"}, DiagHarvestCase {code: "E0106", example: "fn connect(t: Int = computeTimeout()) \{\}  // rejected", phase: "resolve"}, DiagHarvestCase {code: "E0107", example: "pub struct S \{\n    123,   // rejected -- field or method declaration required\n\}", phase: "resolve"}, DiagHarvestCase {code: "E0108", example: "pub enum E \{\n    123,   // rejected\n\}", phase: "resolve"}, DiagHarvestCase {code: "E0109", example: "pub interface I \{\n    123,   // rejected\n\}", phase: "resolve"}, DiagHarvestCase {code: "E0200", example: "a < b < c      // rejected\n0..10..20      // rejected", phase: "resolve"}, DiagHarvestCase {code: "E0201", example: "foo::bar()     // rejected -- did you mean `foo.bar()`?", phase: "resolve"}, DiagHarvestCase {code: "E0203", example: "let f = |x: Int| -> Int x * 2       // rejected\nlet f = |x: Int| -> Int \{ x * 2 \}   // ok", phase: "resolve"}, DiagHarvestCase {code: "E0205", example: "let f = |123| x           // rejected\nlet g = |a, _, (k, v)| v  // ok", phase: "resolve"}, DiagHarvestCase {code: "E0604", example: "let x = _  // rejected", phase: "check"}, DiagHarvestCase {code: "E0609", example: "#[deprecated]\n#[deprecated]           // rejected\npub fn f() \{\}", phase: "check"}, DiagHarvestCase {code: "E0721", example: "let x: UInt8 = 300  // rejected", phase: "check"}, DiagHarvestCase {code: "E0739", example: "#[json(key = 42)]   // `key` expects a String", phase: "check"}, DiagHarvestCase {code: "E0774", example: "pub struct Point \{ pub x: Int, pub y: Int \}\nlet p = Point.builder().x(3).build()\n                              ^^^^^ missing: y", phase: "check"}, DiagHarvestCase {code: "L0001", example: "fn f() \{\n    let unused = 42   // warning: binding `unused` is never used\n    println(\"hi\")\n\}", phase: "lint"}, DiagHarvestCase {code: "L0002", example: "fn greet(name: String, times: Int) \{   // warning on `times`\n    println(name)\n\}", phase: "lint"}, DiagHarvestCase {code: "L0003", example: "use foo.bar.baz\n\nfn main() \{ println(\"hi\") \}   // warning: imported `baz` never used", phase: "lint"}, DiagHarvestCase {code: "L0008", example: "let mut x = heavy()   // warning: value overwritten before use\nx = 1\nprintln(x)", phase: "lint"}, DiagHarvestCase {code: "L0010", example: "fn f() \{\n    let x = 1\n    \{\n        let x = 2   // warning: `x` shadows an outer binding\n        println(x)\n    \}\n\}", phase: "lint"}, DiagHarvestCase {code: "L0020", example: "fn f() -> Int \{\n    return 1\n    let dead = 2     // warning: unreachable code\n    dead\n\}", phase: "lint"}, DiagHarvestCase {code: "L0021", example: "if c \{\n    return 1\n\} else \{                 // warning: redundant `else`\n    return 2\n\}", phase: "lint"}, DiagHarvestCase {code: "L0022", example: "if true \{ do() \}    // warning: always-true condition", phase: "lint"}, DiagHarvestCase {code: "L0023", example: "if c \{\n    work()\n\} else \{                 // warning: empty else branch\n\}", phase: "lint"}, DiagHarvestCase {code: "L0024", example: "fn f() -> Int \{\n    return 42   // warning: use the bare expression instead\n\}", phase: "lint"}, DiagHarvestCase {code: "L0025", example: "let y = if c \{ 1 \} else \{ 1 \}   // warning: both branches identical", phase: "lint"}, DiagHarvestCase {code: "L0026", example: "for x in work() \{ \}   // warning: empty loop body", phase: "lint"}, DiagHarvestCase {code: "L0030", example: "struct my_struct \{ x: Int \}   // warning: should be `MyStruct`", phase: "lint"}, DiagHarvestCase {code: "L0031", example: "fn LoadConfig() \{ \}          // warning: should be `loadConfig`\nfn f(User_Id: Int) \{\}        // warning: should be `userId`", phase: "lint"}, DiagHarvestCase {code: "L0032", example: "enum Color \{ red, Green \}   // warning on `red`", phase: "lint"}, DiagHarvestCase {code: "L0045", example: "let x = !true      // warning: use `false` directly", phase: "lint"}, DiagHarvestCase {code: "L0046", example: "fn parse(s: String) -> Result<Int, Error> \{\n    Ok(s.len())              // warning: fn never returns Err\n\}", phase: "lint"}, DiagHarvestCase {code: "L0047", example: "fn double(n: Int) -> Int \{\n    let out = n * 2     // warning: useless binding before tail return\n    out\n\}", phase: "lint"}, DiagHarvestCase {code: "L0049", example: "for true \{ tick() \}   // warning: redundant `true`", phase: "lint"}, DiagHarvestCase {code: "L0080", example: "fn test_parsesEmpty() \{\n    let r = parse(\"\")          // warning: no testing assertion\n\}", phase: "lint"}]
+    [
+        DiagHarvestCase { code: "E0001", example: "let s = \"hello", phase: "resolve" },
+        DiagHarvestCase { code: "E0002", example: "let n = 0X1F  // rejected", phase: "resolve" },
+        DiagHarvestCase { code: "E0003", example: "let c = '\\u\{D800\}'  // rejected", phase: "resolve" },
+        DiagHarvestCase { code: "E0004", example: "/* never closed", phase: "resolve" },
+        DiagHarvestCase { code: "E0008", example: "let a = 1_            // trailing\nlet b = 0x_FF         // after base prefix\nlet c = 1__000        // consecutive", phase: "resolve" },
+        DiagHarvestCase { code: "E0009", example: "let a = ''             // empty\nlet b = b'\\u\{1F600\}'   // non-ASCII byte\nlet c = 'ab'           // multiple scalars", phase: "resolve" },
+        DiagHarvestCase { code: "E0101", example: "use go \"net/http\" \{\n    fn Get(url: String) -> String \{ \"x\" \}  // rejected\n\}", phase: "resolve" },
+        DiagHarvestCase { code: "E0106", example: "fn connect(t: Int = computeTimeout()) \{\}  // rejected", phase: "resolve" },
+        DiagHarvestCase { code: "E0107", example: "pub struct S \{\n    123,   // rejected -- field or method declaration required\n\}", phase: "resolve" },
+        DiagHarvestCase { code: "E0108", example: "pub enum E \{\n    123,   // rejected\n\}", phase: "resolve" },
+        DiagHarvestCase { code: "E0109", example: "pub interface I \{\n    123,   // rejected\n\}", phase: "resolve" },
+        DiagHarvestCase { code: "E0200", example: "a < b < c      // rejected\n0..10..20      // rejected", phase: "resolve" },
+        DiagHarvestCase { code: "E0201", example: "foo::bar()     // rejected -- did you mean `foo.bar()`?", phase: "resolve" },
+        DiagHarvestCase { code: "E0203", example: "let f = |x: Int| -> Int x * 2       // rejected\nlet f = |x: Int| -> Int \{ x * 2 \}   // ok", phase: "resolve" },
+        DiagHarvestCase { code: "E0205", example: "let f = |123| x           // rejected\nlet g = |a, _, (k, v)| v  // ok", phase: "resolve" },
+        DiagHarvestCase { code: "E0604", example: "let x = _  // rejected", phase: "check" },
+        DiagHarvestCase { code: "E0609", example: "#[deprecated]\n#[deprecated]           // rejected\npub fn f() \{\}", phase: "check" },
+        DiagHarvestCase { code: "E0721", example: "let x: UInt8 = 300  // rejected", phase: "check" },
+        DiagHarvestCase { code: "E0739", example: "#[json(key = 42)]   // `key` expects a String", phase: "check" },
+        DiagHarvestCase { code: "E0774", example: "pub struct Point \{ pub x: Int, pub y: Int \}\nlet p = Point.builder().x(3).build()\n                              ^^^^^ missing: y", phase: "check" },
+        DiagHarvestCase { code: "L0001", example: "fn f() \{\n    let unused = 42   // warning: binding `unused` is never used\n    println(\"hi\")\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0002", example: "fn greet(name: String, times: Int) \{   // warning on `times`\n    println(name)\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0003", example: "use foo.bar.baz\n\nfn main() \{ println(\"hi\") \}   // warning: imported `baz` never used", phase: "lint" },
+        DiagHarvestCase { code: "L0008", example: "let mut x = heavy()   // warning: value overwritten before use\nx = 1\nprintln(x)", phase: "lint" },
+        DiagHarvestCase { code: "L0010", example: "fn f() \{\n    let x = 1\n    \{\n        let x = 2   // warning: `x` shadows an outer binding\n        println(x)\n    \}\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0020", example: "fn f() -> Int \{\n    return 1\n    let dead = 2     // warning: unreachable code\n    dead\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0021", example: "if c \{\n    return 1\n\} else \{                 // warning: redundant `else`\n    return 2\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0022", example: "if true \{ do() \}    // warning: always-true condition", phase: "lint" },
+        DiagHarvestCase { code: "L0023", example: "if c \{\n    work()\n\} else \{                 // warning: empty else branch\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0024", example: "fn f() -> Int \{\n    return 42   // warning: use the bare expression instead\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0025", example: "let y = if c \{ 1 \} else \{ 1 \}   // warning: both branches identical", phase: "lint" },
+        DiagHarvestCase { code: "L0026", example: "for x in work() \{ \}   // warning: empty loop body", phase: "lint" },
+        DiagHarvestCase { code: "L0030", example: "struct my_struct \{ x: Int \}   // warning: should be `MyStruct`", phase: "lint" },
+        DiagHarvestCase { code: "L0031", example: "fn LoadConfig() \{ \}          // warning: should be `loadConfig`\nfn f(User_Id: Int) \{\}        // warning: should be `userId`", phase: "lint" },
+        DiagHarvestCase { code: "L0032", example: "enum Color \{ red, Green \}   // warning on `red`", phase: "lint" },
+        DiagHarvestCase { code: "L0045", example: "let x = !true      // warning: use `false` directly", phase: "lint" },
+        DiagHarvestCase { code: "L0046", example: "fn parse(s: String) -> Result<Int, Error> \{\n    Ok(s.len())              // warning: fn never returns Err\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0047", example: "fn double(n: Int) -> Int \{\n    let out = n * 2     // warning: useless binding before tail return\n    out\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0049", example: "for true \{ tick() \}   // warning: redundant `true`", phase: "lint" },
+        DiagHarvestCase { code: "L0080", example: "fn test_parsesEmpty() \{\n    let r = parse(\"\")          // warning: no testing assertion\n\}", phase: "lint" },
+    ]
 }

--- a/toolchain/diag_manifest.osty
+++ b/toolchain/diag_manifest.osty
@@ -4,553 +4,217 @@
 // Consumed by toolchain/diagnostic.osty's diagnosticFamily function
 // so the self-hosted tooling gets the same classification the Go side
 // uses without maintaining a parallel range table.
+
 /// diagnosticFamilyForCode returns the phase family for a stable code.
 /// Generated exhaustively from the phase groupings in codes.go.
 /// Unknown codes return FamilyUnknown — extend codes.go rather than
 /// editing this file.
 pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
-    if code == "E0001" {
-        return FamilyLexical
-    }
-    if code == "E0002" {
-        return FamilyLexical
-    }
-    if code == "E0003" {
-        return FamilyLexical
-    }
-    if code == "E0004" {
-        return FamilyLexical
-    }
-    if code == "E0005" {
-        return FamilyLexical
-    }
-    if code == "E0006" {
-        return FamilyLexical
-    }
-    if code == "E0007" {
-        return FamilyLexical
-    }
-    if code == "E0008" {
-        return FamilyLexical
-    }
-    if code == "E0009" {
-        return FamilyLexical
-    }
-    if code == "E0100" {
-        return FamilyDeclaration
-    }
-    if code == "E0101" {
-        return FamilyDeclaration
-    }
-    if code == "E0102" {
-        return FamilyDeclaration
-    }
-    if code == "E0103" {
-        return FamilyDeclaration
-    }
-    if code == "E0104" {
-        return FamilyDeclaration
-    }
-    if code == "E0105" {
-        return FamilyDeclaration
-    }
-    if code == "E0106" {
-        return FamilyDeclaration
-    }
-    if code == "E0107" {
-        return FamilyDeclaration
-    }
-    if code == "E0108" {
-        return FamilyDeclaration
-    }
-    if code == "E0109" {
-        return FamilyDeclaration
-    }
-    if code == "E0200" {
-        return FamilyExpression
-    }
-    if code == "E0201" {
-        return FamilyExpression
-    }
-    if code == "E0202" {
-        return FamilyExpression
-    }
-    if code == "E0203" {
-        return FamilyExpression
-    }
-    if code == "E0204" {
-        return FamilyExpression
-    }
-    if code == "E0205" {
-        return FamilyExpression
-    }
-    if code == "E0300" {
-        return FamilyTypePattern
-    }
-    if code == "E0301" {
-        return FamilyTypePattern
-    }
-    if code == "E0400" {
-        return FamilyAnnotation
-    }
-    if code == "E0500" {
-        return FamilyResolution
-    }
-    if code == "E0501" {
-        return FamilyResolution
-    }
-    if code == "E0502" {
-        return FamilyResolution
-    }
-    if code == "E0503" {
-        return FamilyResolution
-    }
-    if code == "E0504" {
-        return FamilyResolution
-    }
-    if code == "E0505" {
-        return FamilyResolution
-    }
-    if code == "E0506" {
-        return FamilyResolution
-    }
-    if code == "E0507" {
-        return FamilyResolution
-    }
-    if code == "E0508" {
-        return FamilyResolution
-    }
-    if code == "E0509" {
-        return FamilyResolution
-    }
-    if code == "E0600" {
-        return FamilyControlFlow
-    }
-    if code == "E0601" {
-        return FamilyControlFlow
-    }
-    if code == "E0602" {
-        return FamilyControlFlow
-    }
-    if code == "E0603" {
-        return FamilyControlFlow
-    }
-    if code == "E0604" {
-        return FamilyControlFlow
-    }
-    if code == "E0605" {
-        return FamilyControlFlow
-    }
-    if code == "E0606" {
-        return FamilyControlFlow
-    }
-    if code == "E0607" {
-        return FamilyControlFlow
-    }
-    if code == "E0608" {
-        return FamilyControlFlow
-    }
-    if code == "E0609" {
-        return FamilyControlFlow
-    }
-    if code == "E0700" {
-        return FamilyTypeChecking
-    }
-    if code == "E0701" {
-        return FamilyTypeChecking
-    }
-    if code == "E0702" {
-        return FamilyTypeChecking
-    }
-    if code == "E0703" {
-        return FamilyTypeChecking
-    }
-    if code == "E0704" {
-        return FamilyTypeChecking
-    }
-    if code == "E0705" {
-        return FamilyTypeChecking
-    }
-    if code == "E0706" {
-        return FamilyTypeChecking
-    }
-    if code == "E0707" {
-        return FamilyTypeChecking
-    }
-    if code == "E0708" {
-        return FamilyTypeChecking
-    }
-    if code == "E0709" {
-        return FamilyTypeChecking
-    }
-    if code == "E0710" {
-        return FamilyTypeChecking
-    }
-    if code == "E0711" {
-        return FamilyTypeChecking
-    }
-    if code == "E0712" {
-        return FamilyTypeChecking
-    }
-    if code == "E0713" {
-        return FamilyTypeChecking
-    }
-    if code == "E0714" {
-        return FamilyTypeChecking
-    }
-    if code == "E0715" {
-        return FamilyTypeChecking
-    }
-    if code == "E0716" {
-        return FamilyTypeChecking
-    }
-    if code == "E0717" {
-        return FamilyTypeChecking
-    }
-    if code == "E0718" {
-        return FamilyTypeChecking
-    }
-    if code == "E0719" {
-        return FamilyTypeChecking
-    }
-    if code == "E0720" {
-        return FamilyTypeChecking
-    }
-    if code == "E0721" {
-        return FamilyTypeChecking
-    }
-    if code == "E0722" {
-        return FamilyTypeChecking
-    }
-    if code == "E0723" {
-        return FamilyTypeChecking
-    }
-    if code == "E0724" {
-        return FamilyTypeChecking
-    }
-    if code == "E0725" {
-        return FamilyTypeChecking
-    }
-    if code == "E0726" {
-        return FamilyTypeChecking
-    }
-    if code == "E0727" {
-        return FamilyTypeChecking
-    }
-    if code == "E0728" {
-        return FamilyTypeChecking
-    }
-    if code == "E0729" {
-        return FamilyTypeChecking
-    }
-    if code == "E0730" {
-        return FamilyTypeChecking
-    }
-    if code == "E0731" {
-        return FamilyTypeChecking
-    }
-    if code == "E0732" {
-        return FamilyTypeChecking
-    }
-    if code == "E0733" {
-        return FamilyTypeChecking
-    }
-    if code == "E0734" {
-        return FamilyTypeChecking
-    }
-    if code == "E0735" {
-        return FamilyTypeChecking
-    }
-    if code == "E0736" {
-        return FamilyTypeChecking
-    }
-    if code == "E0737" {
-        return FamilyTypeChecking
-    }
-    if code == "E0738" {
-        return FamilyTypeChecking
-    }
-    if code == "E0739" {
-        return FamilyTypeChecking
-    }
-    if code == "E0740" {
-        return FamilyTypeChecking
-    }
-    if code == "E0741" {
-        return FamilyTypeChecking
-    }
-    if code == "E0742" {
-        return FamilyTypeChecking
-    }
-    if code == "E0743" {
-        return FamilyTypeChecking
-    }
-    if code == "E0744" {
-        return FamilyTypeChecking
-    }
-    if code == "E0745" {
-        return FamilyTypeChecking
-    }
-    if code == "E0746" {
-        return FamilyTypeChecking
-    }
-    if code == "E0747" {
-        return FamilyTypeChecking
-    }
-    if code == "E0748" {
-        return FamilyTypeChecking
-    }
-    if code == "E0749" {
-        return FamilyTypeChecking
-    }
-    if code == "E0751" {
-        return FamilyTypeChecking
-    }
-    if code == "E0752" {
-        return FamilyTypeChecking
-    }
-    if code == "E0753" {
-        return FamilyTypeChecking
-    }
-    if code == "W0750" {
-        return FamilyWarning
-    }
-    if code == "E0760" {
-        return FamilyTypeChecking
-    }
-    if code == "E0761" {
-        return FamilyTypeChecking
-    }
-    if code == "E0762" {
-        return FamilyTypeChecking
-    }
-    if code == "E0763" {
-        return FamilyTypeChecking
-    }
-    if code == "E0764" {
-        return FamilyTypeChecking
-    }
-    if code == "E0766" {
-        return FamilyTypeChecking
-    }
-    if code == "E0767" {
-        return FamilyTypeChecking
-    }
-    if code == "E0768" {
-        return FamilyTypeChecking
-    }
-    if code == "E0754" {
-        return FamilyTypeChecking
-    }
-    if code == "E0755" {
-        return FamilyTypeChecking
-    }
-    if code == "E0756" {
-        return FamilyTypeChecking
-    }
-    if code == "E0757" {
-        return FamilyTypeChecking
-    }
-    if code == "E0758" {
-        return FamilyTypeChecking
-    }
-    if code == "E0759" {
-        return FamilyTypeChecking
-    }
-    if code == "E0765" {
-        return FamilyTypeChecking
-    }
-    if code == "E0552" {
-        return FamilyResolution
-    }
-    if code == "E0553" {
-        return FamilyResolution
-    }
-    if code == "E0554" {
-        return FamilyResolution
-    }
-    if code == "E0405" {
-        return FamilyAnnotation
-    }
-    if code == "E0771" {
-        return FamilyTypeChecking
-    }
-    if code == "E0770" {
-        return FamilyTypeChecking
-    }
-    if code == "E0772" {
-        return FamilyTypeChecking
-    }
-    if code == "E0773" {
-        return FamilyTypeChecking
-    }
-    if code == "E0774" {
-        return FamilyTypeChecking
-    }
-    if code == "E0775" {
-        return FamilyTypeChecking
-    }
-    if code == "E2000" {
-        return FamilyManifest
-    }
-    if code == "E2001" {
-        return FamilyManifest
-    }
-    if code == "E2002" {
-        return FamilyManifest
-    }
-    if code == "E2003" {
-        return FamilyManifest
-    }
-    if code == "E2004" {
-        return FamilyManifest
-    }
-    if code == "E2010" {
-        return FamilyManifest
-    }
-    if code == "E2011" {
-        return FamilyManifest
-    }
-    if code == "E2012" {
-        return FamilyManifest
-    }
-    if code == "E2013" {
-        return FamilyManifest
-    }
-    if code == "E2014" {
-        return FamilyManifest
-    }
-    if code == "E2015" {
-        return FamilyManifest
-    }
-    if code == "E2016" {
-        return FamilyManifest
-    }
-    if code == "E2017" {
-        return FamilyManifest
-    }
-    if code == "E2018" {
-        return FamilyManifest
-    }
-    if code == "E2030" {
-        return FamilyManifest
-    }
-    if code == "E2031" {
-        return FamilyManifest
-    }
-    if code == "E2032" {
-        return FamilyManifest
-    }
-    if code == "E2050" {
-        return FamilyScaffold
-    }
-    if code == "E2051" {
-        return FamilyScaffold
-    }
-    if code == "E2052" {
-        return FamilyScaffold
-    }
-    if code == "L0001" {
-        return FamilyLint
-    }
-    if code == "L0002" {
-        return FamilyLint
-    }
-    if code == "L0003" {
-        return FamilyLint
-    }
-    if code == "L0004" {
-        return FamilyLint
-    }
-    if code == "L0008" {
-        return FamilyLint
-    }
-    if code == "L0005" {
-        return FamilyLint
-    }
-    if code == "L0006" {
-        return FamilyLint
-    }
-    if code == "L0007" {
-        return FamilyLint
-    }
-    if code == "L0010" {
-        return FamilyLint
-    }
-    if code == "L0020" {
-        return FamilyLint
-    }
-    if code == "L0021" {
-        return FamilyLint
-    }
-    if code == "L0022" {
-        return FamilyLint
-    }
-    if code == "L0023" {
-        return FamilyLint
-    }
-    if code == "L0024" {
-        return FamilyLint
-    }
-    if code == "L0025" {
-        return FamilyLint
-    }
-    if code == "L0026" {
-        return FamilyLint
-    }
-    if code == "L0030" {
-        return FamilyLint
-    }
-    if code == "L0031" {
-        return FamilyLint
-    }
-    if code == "L0032" {
-        return FamilyLint
-    }
-    if code == "L0040" {
-        return FamilyLint
-    }
-    if code == "L0041" {
-        return FamilyLint
-    }
-    if code == "L0042" {
-        return FamilyLint
-    }
-    if code == "L0043" {
-        return FamilyLint
-    }
-    if code == "L0044" {
-        return FamilyLint
-    }
-    if code == "L0045" {
-        return FamilyLint
-    }
-    if code == "L0046" {
-        return FamilyLint
-    }
-    if code == "L0047" {
-        return FamilyLint
-    }
-    if code == "L0048" {
-        return FamilyLint
-    }
-    if code == "L0049" {
-        return FamilyLint
-    }
-    if code == "L0050" {
-        return FamilyLint
-    }
-    if code == "L0052" {
-        return FamilyLint
-    }
-    if code == "L0053" {
-        return FamilyLint
-    }
-    if code == "L0070" {
-        return FamilyLint
-    }
-    if code == "L0080" {
-        return FamilyLint
-    }
+    // Lexical (E0001–E0009)
+    if code == "E0001" { return FamilyLexical }
+    if code == "E0002" { return FamilyLexical }
+    if code == "E0003" { return FamilyLexical }
+    if code == "E0004" { return FamilyLexical }
+    if code == "E0005" { return FamilyLexical }
+    if code == "E0006" { return FamilyLexical }
+    if code == "E0007" { return FamilyLexical }
+    if code == "E0008" { return FamilyLexical }
+    if code == "E0009" { return FamilyLexical }
+    // Declarations & statements (E0100–E0109)
+    if code == "E0100" { return FamilyDeclaration }
+    if code == "E0101" { return FamilyDeclaration }
+    if code == "E0102" { return FamilyDeclaration }
+    if code == "E0103" { return FamilyDeclaration }
+    if code == "E0104" { return FamilyDeclaration }
+    if code == "E0105" { return FamilyDeclaration }
+    if code == "E0106" { return FamilyDeclaration }
+    if code == "E0107" { return FamilyDeclaration }
+    if code == "E0108" { return FamilyDeclaration }
+    if code == "E0109" { return FamilyDeclaration }
+    // Expressions (E0200–E0205)
+    if code == "E0200" { return FamilyExpression }
+    if code == "E0201" { return FamilyExpression }
+    if code == "E0202" { return FamilyExpression }
+    if code == "E0203" { return FamilyExpression }
+    if code == "E0204" { return FamilyExpression }
+    if code == "E0205" { return FamilyExpression }
+    // Types & patterns (E0300–E0301)
+    if code == "E0300" { return FamilyTypePattern }
+    if code == "E0301" { return FamilyTypePattern }
+    // Annotations (E0400)
+    if code == "E0400" { return FamilyAnnotation }
+    // Name resolution (E0500–E0509)
+    if code == "E0500" { return FamilyResolution }
+    if code == "E0501" { return FamilyResolution }
+    if code == "E0502" { return FamilyResolution }
+    if code == "E0503" { return FamilyResolution }
+    if code == "E0504" { return FamilyResolution }
+    if code == "E0505" { return FamilyResolution }
+    if code == "E0506" { return FamilyResolution }
+    if code == "E0507" { return FamilyResolution }
+    if code == "E0508" { return FamilyResolution }
+    if code == "E0509" { return FamilyResolution }
+    // Control flow / context (E0600–E0609)
+    if code == "E0600" { return FamilyControlFlow }
+    if code == "E0601" { return FamilyControlFlow }
+    if code == "E0602" { return FamilyControlFlow }
+    if code == "E0603" { return FamilyControlFlow }
+    if code == "E0604" { return FamilyControlFlow }
+    if code == "E0605" { return FamilyControlFlow }
+    if code == "E0606" { return FamilyControlFlow }
+    if code == "E0607" { return FamilyControlFlow }
+    if code == "E0608" { return FamilyControlFlow }
+    if code == "E0609" { return FamilyControlFlow }
+    // Type checking (E0700–E0753)
+    if code == "E0700" { return FamilyTypeChecking }
+    if code == "E0701" { return FamilyTypeChecking }
+    if code == "E0702" { return FamilyTypeChecking }
+    if code == "E0703" { return FamilyTypeChecking }
+    if code == "E0704" { return FamilyTypeChecking }
+    if code == "E0705" { return FamilyTypeChecking }
+    if code == "E0706" { return FamilyTypeChecking }
+    if code == "E0707" { return FamilyTypeChecking }
+    if code == "E0708" { return FamilyTypeChecking }
+    if code == "E0709" { return FamilyTypeChecking }
+    if code == "E0710" { return FamilyTypeChecking }
+    if code == "E0711" { return FamilyTypeChecking }
+    if code == "E0712" { return FamilyTypeChecking }
+    if code == "E0713" { return FamilyTypeChecking }
+    if code == "E0714" { return FamilyTypeChecking }
+    if code == "E0715" { return FamilyTypeChecking }
+    if code == "E0716" { return FamilyTypeChecking }
+    if code == "E0717" { return FamilyTypeChecking }
+    if code == "E0718" { return FamilyTypeChecking }
+    if code == "E0719" { return FamilyTypeChecking }
+    if code == "E0720" { return FamilyTypeChecking }
+    if code == "E0721" { return FamilyTypeChecking }
+    if code == "E0722" { return FamilyTypeChecking }
+    if code == "E0723" { return FamilyTypeChecking }
+    if code == "E0724" { return FamilyTypeChecking }
+    if code == "E0725" { return FamilyTypeChecking }
+    if code == "E0726" { return FamilyTypeChecking }
+    if code == "E0727" { return FamilyTypeChecking }
+    if code == "E0728" { return FamilyTypeChecking }
+    if code == "E0729" { return FamilyTypeChecking }
+    if code == "E0730" { return FamilyTypeChecking }
+    if code == "E0731" { return FamilyTypeChecking }
+    if code == "E0732" { return FamilyTypeChecking }
+    if code == "E0733" { return FamilyTypeChecking }
+    if code == "E0734" { return FamilyTypeChecking }
+    if code == "E0735" { return FamilyTypeChecking }
+    if code == "E0736" { return FamilyTypeChecking }
+    if code == "E0737" { return FamilyTypeChecking }
+    if code == "E0738" { return FamilyTypeChecking }
+    if code == "E0739" { return FamilyTypeChecking }
+    if code == "E0740" { return FamilyTypeChecking }
+    if code == "E0741" { return FamilyTypeChecking }
+    if code == "E0742" { return FamilyTypeChecking }
+    if code == "E0743" { return FamilyTypeChecking }
+    if code == "E0744" { return FamilyTypeChecking }
+    if code == "E0745" { return FamilyTypeChecking }
+    if code == "E0746" { return FamilyTypeChecking }
+    if code == "E0747" { return FamilyTypeChecking }
+    if code == "E0748" { return FamilyTypeChecking }
+    if code == "E0749" { return FamilyTypeChecking }
+    if code == "E0751" { return FamilyTypeChecking }
+    if code == "E0752" { return FamilyTypeChecking }
+    if code == "E0753" { return FamilyTypeChecking }
+    // Deprecation warning (W0750)
+    if code == "W0750" { return FamilyWarning }
+    // Type checking — control flow & const fn (E0760–E0765)
+    if code == "E0760" { return FamilyTypeChecking }
+    if code == "E0761" { return FamilyTypeChecking }
+    if code == "E0762" { return FamilyTypeChecking }
+    if code == "E0763" { return FamilyTypeChecking }
+    if code == "E0764" { return FamilyTypeChecking }
+    if code == "E0766" { return FamilyTypeChecking }
+    if code == "E0767" { return FamilyTypeChecking }
+    if code == "E0768" { return FamilyTypeChecking }
+    if code == "E0769" { return FamilyTypeChecking }
+    if code == "E0754" { return FamilyTypeChecking }
+    if code == "E0755" { return FamilyTypeChecking }
+    if code == "E0756" { return FamilyTypeChecking }
+    if code == "E0757" { return FamilyTypeChecking }
+    if code == "E0758" { return FamilyTypeChecking }
+    if code == "E0759" { return FamilyTypeChecking }
+    if code == "E0765" { return FamilyTypeChecking }
+    // Name resolution — re-exports & scoped imports (E0552–E0554)
+    if code == "E0552" { return FamilyResolution }
+    if code == "E0553" { return FamilyResolution }
+    if code == "E0554" { return FamilyResolution }
+    // Annotations — cfg (E0405)
+    if code == "E0405" { return FamilyAnnotation }
+    // Runtime sublanguage (E0771–E0775)
+    if code == "E0771" { return FamilyTypeChecking }
+    if code == "E0770" { return FamilyTypeChecking }
+    if code == "E0772" { return FamilyTypeChecking }
+    if code == "E0773" { return FamilyTypeChecking }
+    if code == "E0774" { return FamilyTypeChecking }
+    if code == "E0775" { return FamilyTypeChecking }
+    // Manifest — TOML syntax (E2000–E2004)
+    if code == "E2000" { return FamilyManifest }
+    if code == "E2001" { return FamilyManifest }
+    if code == "E2002" { return FamilyManifest }
+    if code == "E2003" { return FamilyManifest }
+    if code == "E2004" { return FamilyManifest }
+    // Manifest — schema (E2010–E2018)
+    if code == "E2010" { return FamilyManifest }
+    if code == "E2011" { return FamilyManifest }
+    if code == "E2012" { return FamilyManifest }
+    if code == "E2013" { return FamilyManifest }
+    if code == "E2014" { return FamilyManifest }
+    if code == "E2015" { return FamilyManifest }
+    if code == "E2016" { return FamilyManifest }
+    if code == "E2017" { return FamilyManifest }
+    if code == "E2018" { return FamilyManifest }
+    // Manifest — I/O (E2030–E2032)
+    if code == "E2030" { return FamilyManifest }
+    if code == "E2031" { return FamilyManifest }
+    if code == "E2032" { return FamilyManifest }
+    // Scaffolding (E2050–E2052)
+    if code == "E2050" { return FamilyScaffold }
+    if code == "E2051" { return FamilyScaffold }
+    if code == "E2052" { return FamilyScaffold }
+    // Lint — unused declarations (L0001–L0007)
+    if code == "L0001" { return FamilyLint }
+    if code == "L0002" { return FamilyLint }
+    if code == "L0003" { return FamilyLint }
+    if code == "L0004" { return FamilyLint }
+    if code == "L0008" { return FamilyLint }
+    if code == "L0005" { return FamilyLint }
+    if code == "L0006" { return FamilyLint }
+    if code == "L0007" { return FamilyLint }
+    // Lint — shadowing (L0010)
+    if code == "L0010" { return FamilyLint }
+    // Lint — unreachable / dead code (L0020–L0026)
+    if code == "L0020" { return FamilyLint }
+    if code == "L0021" { return FamilyLint }
+    if code == "L0022" { return FamilyLint }
+    if code == "L0023" { return FamilyLint }
+    if code == "L0024" { return FamilyLint }
+    if code == "L0025" { return FamilyLint }
+    if code == "L0026" { return FamilyLint }
+    // Lint — naming conventions (L0030–L0032)
+    if code == "L0030" { return FamilyLint }
+    if code == "L0031" { return FamilyLint }
+    if code == "L0032" { return FamilyLint }
+    // Lint — redundant forms (L0040–L0049)
+    if code == "L0040" { return FamilyLint }
+    if code == "L0041" { return FamilyLint }
+    if code == "L0042" { return FamilyLint }
+    if code == "L0043" { return FamilyLint }
+    if code == "L0044" { return FamilyLint }
+    if code == "L0045" { return FamilyLint }
+    if code == "L0046" { return FamilyLint }
+    if code == "L0047" { return FamilyLint }
+    if code == "L0048" { return FamilyLint }
+    if code == "L0049" { return FamilyLint }
+    // Lint — complexity (L0050–L0053)
+    if code == "L0050" { return FamilyLint }
+    if code == "L0052" { return FamilyLint }
+    if code == "L0053" { return FamilyLint }
+    // Lint — documentation (L0070–L0080)
+    if code == "L0070" { return FamilyLint }
+    if code == "L0080" { return FamilyLint }
     FamilyUnknown
 }

--- a/toolchain/diagnostic_test.osty
+++ b/toolchain/diagnostic_test.osty
@@ -71,7 +71,8 @@ fn testDiagnosticExamplesClassifyBackendCodes() {
 fn testDiagnosticExamplesClassifyUnknownFamilyGaps() {
     assertDiagnosticFamily("E0000", "unknown")
     assertDiagnosticFamily("E0099", "unknown")
-    assertDiagnosticFamily("E0769", "unknown")
+    // E0769 was "unknown" but now carries G20 fn-value keyword-name mismatch.
+    assertDiagnosticFamily("E0769", "typechecking")
     assertDiagnosticFamily("E2040", "unknown")
     assertDiagnosticFamily("L0000", "unknown")
     assertDiagnosticFamily("Z0000", "unknown")

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -353,8 +353,22 @@ fn elabVariantOwnerType(cx: ElabCx, variant: CheckVariantSig) -> Int {
     tyNamed(cx.env.tys, variant.owner, args)
 }
 /// fnSigToTy builds an `fn(params) -> ret` type from a CheckFnSig.
+/// G20: propagates parameter names as type-equality-neutral metadata.
 fn fnSigToTy(env: CheckEnv, sig: CheckFnSig) -> Int {
-    tyFn(env.tys, sig.paramTys, sig.retTy)
+    // Strip the "?" prefix that arity-tracking uses.
+    let mut cleanNames: List<String> = []
+    for pn in sig.paramNames {
+        if pn.startsWith("?") {
+            cleanNames.push(pn.slice(1))
+        } else {
+            cleanNames.push(pn)
+        }
+    }
+    if cleanNames.len() > 0 {
+        tyFnWithNames(env.tys, sig.paramTys, sig.retTy, cleanNames)
+    } else {
+        tyFn(env.tys, sig.paramTys, sig.retTy)
+    }
 }
 // ---------------------------------------------------------------------
 // Unary operators.

--- a/toolchain/ty.osty
+++ b/toolchain/ty.osty
@@ -86,6 +86,10 @@ pub struct TyNode {
     pub varId: Int,
     pub varName: String,
     pub varOwner: String,
+    /// fnParamNames: G20. For TkFn nodes, carries the parameter names as
+    /// type-equality-neutral metadata. Empty when no names are available.
+    /// Type equality (tyEq) ignores this field; tyFnToString includes it.
+    pub fnParamNames: List<String>,
 }
 /// TyArena owns every `TyNode` produced during elaboration. Canonical
 /// primitive indices are pre-populated by `emptyTyArena` so callers
@@ -128,7 +132,7 @@ pub struct TyArena {
 /// is out of range. Callers should not observe this unless a bug is
 /// passing a bogus handle.
 pub fn emptyTyNode() -> TyNode {
-    TyNode {kind: TkErr, prim: PkInvalid, head: "", args: [], ret: -1, varId: 0, varName: "", varOwner: ""}
+    TyNode {kind: TkErr, prim: PkInvalid, head: "", args: [], ret: -1, varId: 0, varName: "", varOwner: "", fnParamNames: []}
 }
 /// emptyTyArena builds an arena pre-populated with canonical primitive
 /// nodes. Every primitive is allocated exactly once so callers can
@@ -162,19 +166,19 @@ pub fn emptyTyArena() -> TyArena {
 }
 fn tyAllocErr(arena: TyArena) -> Int {
     let idx = tyNodeCount(arena)
-    let node = TyNode {kind: TkErr, prim: PkInvalid, head: "", args: [], ret: -1, varId: 0, varName: "", varOwner: ""}
+    let node = TyNode {kind: TkErr, prim: PkInvalid, head: "", args: [], ret: -1, varId: 0, varName: "", varOwner: "", fnParamNames: []}
     arena.nodes.push(node)
     idx
 }
 fn tyAllocPoison(arena: TyArena) -> Int {
     let idx = tyNodeCount(arena)
-    let node = TyNode {kind: TkPoison, prim: PkInvalid, head: "", args: [], ret: -1, varId: 0, varName: "", varOwner: ""}
+    let node = TyNode {kind: TkPoison, prim: PkInvalid, head: "", args: [], ret: -1, varId: 0, varName: "", varOwner: "", fnParamNames: []}
     arena.nodes.push(node)
     idx
 }
 fn tyAllocPrim(arena: TyArena, prim: PrimKind) -> Int {
     let idx = tyNodeCount(arena)
-    let node = TyNode {kind: TkPrim, prim, head: "", args: [], ret: -1, varId: 0, varName: "", varOwner: ""}
+    let node = TyNode {kind: TkPrim, prim, head: "", args: [], ret: -1, varId: 0, varName: "", varOwner: "", fnParamNames: []}
     arena.nodes.push(node)
     idx
 }
@@ -292,26 +296,34 @@ pub fn tyPrim(arena: TyArena, prim: PrimKind) -> Int {
 /// tyNamed allocates a named type `head<args...>` node. `args` may be
 /// empty, meaning a plain type like `String` used in type position.
 pub fn tyNamed(arena: TyArena, head: String, args: List<Int>) -> Int {
-    let node = TyNode {kind: TkNamed, prim: PkInvalid, head, args, ret: -1, varId: 0, varName: "", varOwner: ""}
+    let node = TyNode {kind: TkNamed, prim: PkInvalid, head, args, ret: -1, varId: 0, varName: "", varOwner: "", fnParamNames: []}
     tyInternNode(arena, tyKeyNamed(node.head, node.args), node)
 }
 /// tyTuple allocates a tuple-type node. `()` is represented by an empty
 /// elems list; callers that want the canonical unit type should use
 /// `tUnit` instead.
 pub fn tyTuple(arena: TyArena, elems: List<Int>) -> Int {
-    let node = TyNode {kind: TkTuple, prim: PkInvalid, head: "", args: elems, ret: -1, varId: 0, varName: "", varOwner: ""}
+    let node = TyNode {kind: TkTuple, prim: PkInvalid, head: "", args: elems, ret: -1, varId: 0, varName: "", varOwner: "", fnParamNames: []}
     tyInternNode(arena, tyKeyTuple(node.args), node)
 }
 /// tyFn allocates an `fn(params...) -> ret` node. `ret` may be
 /// `tUnit(arena)` for Unit-returning functions and `tNever(arena)` for
 /// diverging ones; callers must pre-canonicalise.
 pub fn tyFn(arena: TyArena, params: List<Int>, ret: Int) -> Int {
-    let node = TyNode {kind: TkFn, prim: PkInvalid, head: "", args: params, ret, varId: 0, varName: "", varOwner: ""}
+    let node = TyNode {kind: TkFn, prim: PkInvalid, head: "", args: params, ret, varId: 0, varName: "", varOwner: "", fnParamNames: []}
+    tyInternNode(arena, tyKeyFn(node.args, node.ret), node)
+}
+/// tyFnWithNames is like tyFn but attaches parameter names as G20
+/// type-equality-neutral metadata. The names do not affect interning or
+/// equality; they are preserved for keyword-call resolution in the
+/// elaborator.
+pub fn tyFnWithNames(arena: TyArena, params: List<Int>, ret: Int, names: List<String>) -> Int {
+    let node = TyNode {kind: TkFn, prim: PkInvalid, head: "", args: params, ret, varId: 0, varName: "", varOwner: "", fnParamNames: names}
     tyInternNode(arena, tyKeyFn(node.args, node.ret), node)
 }
 /// tyOptional allocates a `T?` node with `inner` as the wrapped index.
 pub fn tyOptional(arena: TyArena, inner: Int) -> Int {
-    let node = TyNode {kind: TkOptional, prim: PkInvalid, head: "", args: [], ret: inner, varId: 0, varName: "", varOwner: ""}
+    let node = TyNode {kind: TkOptional, prim: PkInvalid, head: "", args: [], ret: inner, varId: 0, varName: "", varOwner: "", fnParamNames: []}
     tyInternNode(arena, tyKeyOptional(node.ret), node)
 }
 /// tyVarFresh allocates a fresh unification variable. `owner` is the
@@ -319,7 +331,7 @@ pub fn tyOptional(arena: TyArena, inner: Int) -> Int {
 /// collide during diagnostics.
 pub fn tyVarFresh(arena: TyArena, owner: String, name: String) -> Int {
     let idx = tyNodeCount(arena)
-    let node = TyNode {kind: TkVar, prim: PkInvalid, head: "", args: [], ret: -1, varId: idx + 1, varName: name, varOwner: owner}
+    let node = TyNode {kind: TkVar, prim: PkInvalid, head: "", args: [], ret: -1, varId: idx + 1, varName: name, varOwner: owner, fnParamNames: []}
     arena.nodes.push(node)
     idx
 }
@@ -327,13 +339,22 @@ pub fn tyVarFresh(arena: TyArena, owner: String, name: String) -> Int {
 /// impl). The elaborator substitutes it away once the receiver type is
 /// known.
 pub fn tySelf(arena: TyArena, owner: String) -> Int {
-    let node = TyNode {kind: TkSelf, prim: PkInvalid, head: owner, args: [], ret: -1, varId: 0, varName: "", varOwner: ""}
+    let node = TyNode {kind: TkSelf, prim: PkInvalid, head: owner, args: [], ret: -1, varId: 0, varName: "", varOwner: "", fnParamNames: []}
     tyInternNode(arena, tyKeySelf(node.head), node)
 }
 fn tyInternNode(arena: TyArena, key: String, node: TyNode) -> Int {
     let keyHash = checkHashKey(key)
     let existing = tyLookupInterned(arena, key, keyHash)
     if existing >= 0 {
+        // G20: if the new node carries fn param names but the existing
+        // one doesn't, attach them. First-writer wins.
+        if node.kind == TkFn && node.fnParamNames.len() > 0 {
+            let existingNode = arena.nodes[existing]
+            if existingNode.fnParamNames.len() == 0 {
+                existingNode.fnParamNames = node.fnParamNames
+                arena.nodes[existing] = existingNode
+            }
+        }
         return existing
     }
     let idx = tyNodeCount(arena)
@@ -551,7 +572,7 @@ pub fn tyToString(arena: TyArena, idx: Int) -> String {
         TkNamed -> tyNamedToString(arena, node),
         TkOptional -> "{tyToString(arena, node.ret)}?",
         TkTuple -> tyTupleToString(arena, node.args),
-        TkFn -> tyFnToString(arena, node.args, node.ret),
+        TkFn -> tyFnToString(arena, node),
         TkVar -> {
             if node.varName == "" {
                 "?{node.varId}"
@@ -581,13 +602,25 @@ fn tyTupleToString(arena: TyArena, elems: List<Int>) -> String {
     }
     "({strings.join(parts, sep)})"
 }
-fn tyFnToString(arena: TyArena, params: List<Int>, ret: Int) -> String {
+fn tyFnToString(arena: TyArena, node: TyNode) -> String {
     let sep = ", "
     let mut parts: List<String> = []
-    for p in params {
-        parts.push(tyToString(arena, p))
+    let mut i = 0
+    for p in node.args {
+        // G20: include param name when available.
+        if node.fnParamNames.len() > 0 && i < node.fnParamNames.len() {
+            let name = node.fnParamNames[i]
+            if name != "" {
+                parts.push("{name}: {tyToString(arena, p)}")
+            } else {
+                parts.push(tyToString(arena, p))
+            }
+        } else {
+            parts.push(tyToString(arena, p))
+        }
+        i = i + 1
     }
-    "fn({strings.join(parts, sep)}) -> {tyToString(arena, ret)}"
+    "fn({strings.join(parts, sep)}) -> {tyToString(arena, node.ret)}"
 }
 pub fn primKindName(prim: PrimKind) -> String {
     match prim {


### PR DESCRIPTION
## Summary

Implements **G20 — Function-value parameter-name preservation**: `fn(...)` types carry parameter names as type-equality-neutral metadata, enabling future keyword-call support through fn-values while keeping type equality purely structural.

## Changes

### Core type system
- **`types.FnType.ParamNames`** — new `[]string` field (nil = unavailable)
- **`ir.FnType.ParamNames`** — mirrored in IR layer + clone propagation
- **`api.TypeRepr.ParamNames`** — serialized as `param_names` in JSON bridge
- **`TyNode.fnParamNames`** (Osty) — per-parameter names in the type arena

### Propagation
- **`tyFnWithNames()`** — new builder that attaches names; `tyInternNode` merges on first-writer
- **`collectFnDecl`** — strips `?` arity-tracking prefix, passes clean names to `tyFnWithNames`
- **`fnSigToTy`** — propagates names from `CheckFnSig` to fn-type
- **`tyToRepr`** — carries names through `FrontTypeRepr.paramNames`
- **`frontTypeReprToAPI`** — bridges names to `api.TypeRepr`
- **`fromCheckerType`** — propagates names to IR `FnType`

### Rendering
- `FnType.String()`, `TypeRepr.String()`, `tyFnToString`, `frontTypeReprToString` all render `fn(host: String, port: Int) -> R` when names are available

### Type equality
- `Identical()`, `tyEq`, interning keys all **ignore** param names — per G20 spec

### Diagnostics
- **E0769** `CodeFnValueKeywordNameMismatch` — defined for keyword-name mismatch in fn-value calls
- `diag_manifest.osty`, `diag_examples.osty`, `ERROR_CODES.md` regenerated

### Tests
- `diagnostic_test.osty`: E0769 now classifies as "typechecking" (was "unknown")
- All existing tests pass: `internal/types`, `internal/ir`, `internal/check`, `internal/selfhost/api`

## Spec reference
- G20 decision: `SPEC_GAPS.md` L253–263, L279–289
- Change history: `LANG_SPEC_v0.5/18-change-history.md` L44–46