### PR TITLE
refactor(check): migrate SelfhostRun + airepair probe + resolve fact artifacts to factory

### DIFF
--- a/internal/airepair/airepair.go
+++ b/internal/airepair/airepair.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/repair"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/stdlib"
 	"github.com/osty/osty/internal/token"
 )
@@ -315,20 +316,32 @@ func (r Result) ResidualPrimaryHabit() string {
 }
 
 func probe(src []byte) (ProbeStats, []*diag.Diagnostic) {
-	// Phase 1c.4: drive the self-host checker directly. selfhost.CheckFromSource
-	// merges resolver + checker diagnostics into one CheckResult, so we split
-	// them back apart by diag code prefix (E05xx = resolve, everything else =
-	// check) to preserve the per-stage count contract ProbeStats exposes to
-	// accept/reject heuristics in Analyze().
-	//
-	// The E05xx = resolve contract is enforced at the codebase level: CLAUDE.md
-	// namespaces E0500-E0599 to name-resolution errors, and internal/diag/codes.go
-	// tracks every one. A resolve-phase diagnostic emitted outside that band
-	// would already break other tooling, so relying on the prefix here doesn't
-	// add a new fragility axis.
-	parseDiags, checked := selfhost.CheckFromSource(src)
-	convertedCheck := selfhost.CheckDiagnosticsAsDiag(src, checked.Diagnostics)
+	// Locally parse for the parse-phase ProbeStats — subprocess
+	// CheckPackageStructured rejects sources with parse errors outright,
+	// so the parse phase has to be observable here before the round-trip
+	// even attempts to run.
+	run := selfhost.Run(src)
+	parseDiags := run.Diagnostics()
 
+	// Resolve + check phases come from the factory (managed subprocess in
+	// production). When parse already errored, skip the subprocess call —
+	// CheckPackageStructured would reject the input and we'd lose the
+	// per-phase break-down that ProbeStats exposes to accept/reject
+	// heuristics in Analyze().
+	var checkedDiags []api.CheckDiagnosticRecord
+	if !probeDiagsHaveError(parseDiags) {
+		checked, err := check.NativePackageCheck(api.PackageCheckInput{
+			Files: []api.PackageCheckFile{{Source: src}},
+		})
+		if err == nil {
+			checkedDiags = checked.Diagnostics
+		}
+	}
+	convertedCheck := selfhost.CheckDiagnosticsAsDiag(src, checkedDiags)
+
+	// CLAUDE.md namespaces E0500-E0599 to name-resolution diagnostics, so we
+	// split converted records into resolve vs check by code prefix to
+	// preserve the per-stage count contract.
 	resolveDiags := make([]*diag.Diagnostic, 0, len(convertedCheck))
 	checkDiags := make([]*diag.Diagnostic, 0, len(convertedCheck))
 	for _, d := range convertedCheck {
@@ -354,6 +367,15 @@ func probe(src []byte) (ProbeStats, []*diag.Diagnostic) {
 	all = append(all, parseDiags...)
 	all = append(all, convertedCheck...)
 	return stats, all
+}
+
+func probeDiagsHaveError(diags []*diag.Diagnostic) bool {
+	for _, d := range diags {
+		if d != nil && d.Severity == diag.Error {
+			return true
+		}
+	}
+	return false
 }
 
 func count(diags []*diag.Diagnostic) StageStats {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/semanticdb"
+	"github.com/osty/osty/internal/subproc"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
 )
@@ -193,6 +194,13 @@ func firstOpt(opts []Opts) Opts {
 // Use this for new front-end consumers that can stay on stable selfhost node
 // IDs. Keep SelfhostFile for compatibility paths that still need Types /
 // LetTypes / SymTypes keyed by Go AST and resolver symbols.
+//
+// Routes through NativePackageCheck so the production subprocess sees the
+// same single-file check that `osty check FILE` does. The subprocess re-
+// parses opt.Source — cheap for a single file and the only way to keep the
+// embedded path off this surface. Parse errors short-circuit before the
+// subprocess call because `selfhost.CheckPackageStructured` rejects sources
+// whose parse arena carries any error.
 func SelfhostRun(run *selfhost.FrontendRun, opts ...Opts) *Result {
 	opt := firstOpt(opts)
 	result := newResult()
@@ -201,8 +209,22 @@ func SelfhostRun(run *selfhost.FrontendRun, opts ...Opts) *Result {
 	}
 	src := append([]byte(nil), opt.Source...)
 	result.inspectSource = append(result.inspectSource[:0], src...)
-	result.Diags = append(result.Diags, run.Diagnostics()...)
-	checked := selfhost.CheckStructuredFromRun(run)
+	parseDiags := run.Diagnostics()
+	result.Diags = append(result.Diags, parseDiags...)
+	if diagsHaveError(parseDiags) {
+		diag.StampFile(result.Diags, opt.Path)
+		return result
+	}
+	checked, err := NativePackageCheck(api.PackageCheckInput{
+		Files: []api.PackageCheckFile{{Source: src, Path: opt.Path}},
+	})
+	if err != nil {
+		result.Diags = append(result.Diags, checkerUnavailableDiag(
+			"file",
+			subproc.FailureNotes("the Osty-native checker executable failed", err)...,
+		))
+		return result
+	}
 	policy := nativeDiagPolicy{privileged: opt.Privileged}
 	result.Diags = append(result.Diags, nativeCheckerDiags(src, checked, policy)...)
 	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
@@ -210,6 +232,15 @@ func SelfhostRun(run *selfhost.FrontendRun, opts ...Opts) *Result {
 	result.SemanticDB = semanticdb.FromCheck(checked)
 	diag.StampFile(result.Diags, opt.Path)
 	return result
+}
+
+func diagsHaveError(diags []*diag.Diagnostic) bool {
+	for _, d := range diags {
+		if d != nil && d.Severity == diag.Error {
+			return true
+		}
+	}
+	return false
 }
 
 // SelfhostFile runs type checking for one resolved source file through

--- a/internal/check/resolve_hook.go
+++ b/internal/check/resolve_hook.go
@@ -1,0 +1,14 @@
+package check
+
+import "github.com/osty/osty/internal/resolve"
+
+// init wires resolve's native-check hook to the production factory.
+// Importing internal/check anywhere — production CLI or test binary — is
+// enough to swap the default embedded path for the factory-routed one;
+// after UseManagedSubprocessChecker / InstallSubprocessCheckerForPackageTests
+// installs a subprocess factory, resolve's fact-artifact computation
+// (NativeResolveFacts → nativeResolveFactArtifacts) follows the same
+// selection as the rest of the checker boundary.
+func init() {
+	resolve.NativePackageCheckHook = NativePackageCheck
+}

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -189,13 +189,25 @@ func nativeResolveArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFil
 	return pkg.nativeResolve.result, pkg.nativeResolve.files, pkg.nativeResolve.err
 }
 
+// NativePackageCheckHook is the seam through which package-check requests
+// reach the production native checker (managed subprocess installed by
+// check.UseManagedSubprocessChecker). The internal/check package's init
+// wires it to check.NativePackageCheck so the resolver's fact-artifact
+// pipeline sees the same factory as `osty check` / `lint` / `typecheck`.
+//
+// Default falls back to the in-process selfhost path so pure resolve unit
+// tests that don't import check still get a working checker.
+var NativePackageCheckHook = func(input api.PackageCheckInput) (api.CheckResult, error) {
+	return selfhost.CheckPackageStructured(input)
+}
+
 func nativeResolveFactArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFileInfo, api.CheckResult, error) {
 	result, files, err := nativeResolveArtifacts(pkg)
 	if err != nil || pkg == nil {
 		return result, files, api.CheckResult{}, err
 	}
 	pkg.nativeResolve.checkOnce.Do(func() {
-		checked, err := selfhost.CheckPackageStructured(pkg.nativeResolve.checkInput)
+		checked, err := NativePackageCheckHook(pkg.nativeResolve.checkInput)
 		if err == nil {
 			pkg.nativeResolve.check = checked
 		}


### PR DESCRIPTION
## Summary

남은 `selfhost.Check*` 직접 호출 3건 모두 production native checker factory 를 거치도록 정리. 이로써 production code 가 selfhost 의 in-process check 함수를 직접 호출하는 자리는 더 이상 없음 (남은 1건은 resolve 의 default fallback hook 으로 의도적).

## 변경

1. **[check.go::SelfhostRun](internal/check/check.go)** — `selfhost.CheckStructuredFromRun` → `check.NativePackageCheck`
   - subprocess 가 parse 에러 있는 source 를 거부하므로 `run.Diagnostics()` 가 에러를 포함하면 early return — 단일 파일 `osty lint FILE` 의 parse-only 진단 경로 보존
   - 기존 lint 테스트 모두 통과

2. **[airepair.go::probe](internal/airepair/airepair.go)** — `selfhost.CheckFromSource` → 로컬 parse + `check.NativePackageCheck`
   - parse 단계는 로컬 유지, resolve / check 진단은 subprocess
   - parse 에러 시 subprocess 스킵하여 per-phase ProbeStats 계약 보존
   - repair 루프의 perf 영향은 fork ~10ms × probe 호출 횟수 — 측정 필요 시 별도 작업

3. **[native_adapter.go::nativeResolveFactArtifacts](internal/resolve/native_adapter.go)** — `selfhost.CheckPackageStructured` → `resolve.NativePackageCheckHook`
   - **Cycle 해결**: `internal/check` 가 `internal/resolve` 를 import 하는 상태에서 reverse direction 으로 hook 을 set 하려면 init 패턴 필요
   - `internal/check/resolve_hook.go::init()` 이 production factory 로 hook 교체
   - check 를 import 하는 어떤 binary 든 자동으로 production 경로 활성
   - 순수 resolve 단위 테스트는 default 임베디드 fallback 유지

## Test plan
- [x] `just prepush` 로컬 통과
- [x] `go test ./internal/resolve/ ./internal/check/ ./internal/airepair/ ./internal/lsp/ -short -count=1` 4/4 green
- [x] grep audit 결과: production 직접 호출 0건, 의도된 fallback 1건만 남음
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)