### PR TITLE
fix(ir): real-world regressions from examples/ audit (+48 stage0 coverage)

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1059,6 +1059,16 @@ func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
 				if rt := l.closureDependentMethodReturnTypeFromAST(fx, call.Args); rt != nil && expressionTypeYieldsValue(rt) {
 					return true
 				}
+				// `use go "X" as alias { fn Y(...) -> T }` FFI call:
+				// `alias.Y(...)`. Receiver is a UseDecl alias symbol;
+				// look up the listed fn's return type in the UseDecl
+				// body. Without this, trailing `strings.ToUpper(...)`
+				// in `fn banner(name: String) -> String { strings.
+				// ToUpper(strings.Repeat(name, 2)) }` drops to
+				// ExprStmt → MIR UnreachableTerm.
+				if rt := l.useAliasFnReturnTypeFromAST(fx); rt != nil && expressionTypeYieldsValue(rt) {
+					return true
+				}
 			}
 			// Free-fn calls (`helper()`): promote when the resolved
 			// declaration has a non-unit return type. We restrict this
@@ -1221,10 +1231,13 @@ func (l *lowerer) closureDependentMethodReturnTypeFromAST(fx *ast.FieldExpr, arg
 
 // builtinMethodReturnTypeFromAST mirrors `userMethodReturnTypeFromAST`
 // for receivers whose static type is a builtin container or primitive
-// (`List<T>`, `Map<K,V>`, `Set<T>`, `String`, `Bytes`). It defers to
-// the existing `recoverMethodReturnTypeFromType` intrinsic table so
-// trailing `xs.filter(...)`, `s.toUpper()` etc. promote to the block's
-// Result instead of being dropped to ExprStmt.
+// (`List<T>`, `Map<K,V>`, `Set<T>`, `String`, `Bytes`,
+// `Option<T>`, `Result<T,E>`). It defers to the existing
+// `recoverMethodReturnTypeFromType` intrinsic table so trailing
+// `xs.filter(...)`, `s.toUpper()`, `opt.unwrap()` etc. promote to
+// the block's Result instead of being dropped to ExprStmt. Receiver
+// is resolved via `resolveExprStaticType`, which also handles
+// chained method calls (`x.foo().bar()`).
 func (l *lowerer) builtinMethodReturnTypeFromAST(fx *ast.FieldExpr) Type {
 	if l == nil || fx == nil {
 		return nil
@@ -1238,9 +1251,10 @@ func (l *lowerer) builtinMethodReturnTypeFromAST(fx *ast.FieldExpr) Type {
 
 // resolveExprStaticType returns a best-effort static type for the
 // expression, using resolver + AST decl shapes when SemanticDB lookups
-// miss. Limited to the receiver shapes commonly used as method-call
-// receivers: bare Ident (binding/parameter) and FieldExpr (struct
-// field access). Returns nil when the type can't be recovered.
+// miss. Covers the receiver shapes commonly used as method-call
+// receivers: bare Ident, FieldExpr (struct field access), and
+// CallExpr (method-chain / free-fn return type). Returns nil when the
+// type can't be recovered.
 func (l *lowerer) resolveExprStaticType(e ast.Expr) Type {
 	if l == nil || e == nil || l.res == nil {
 		return nil
@@ -1267,6 +1281,50 @@ func (l *lowerer) resolveExprStaticType(e ast.Expr) Type {
 			if ls := l.findLetStmtByPattern(ip); ls != nil && ls.Type != nil {
 				if t := l.lowerType(ls.Type); t != nil && t != ErrTypeVal {
 					return t
+				}
+			}
+		}
+	case *ast.CallExpr:
+		// Method-chain receiver: `recv.foo(...).bar()`. The outer
+		// `.bar()` needs `foo(...)`'s return type to look up `bar`.
+		// Delegate to userMethodReturnTypeFromAST / builtinMethodReturn-
+		// TypeFromAST / freeFnReturnTypeFromAST based on the callee
+		// shape. Without this, every chained method call (which is
+		// the dominant shape in toolchain code like
+		// `self.tryAllocate(k, n).unwrap()`) fails receiver type
+		// resolution → promotion misses → MIR UnreachableTerm.
+		if fx, ok := x.Fn.(*ast.FieldExpr); ok && fx != nil {
+			if t := l.userMethodReturnTypeFromAST(fx); t != nil && t != ErrTypeVal {
+				return t
+			}
+			if t := l.builtinMethodReturnTypeFromAST(fx); t != nil && t != ErrTypeVal {
+				return t
+			}
+			if t := l.useAliasFnReturnTypeFromAST(fx); t != nil && t != ErrTypeVal {
+				return t
+			}
+			if t := l.closureDependentMethodReturnTypeFromAST(fx, x.Args); t != nil && t != ErrTypeVal {
+				return t
+			}
+		}
+		if id, ok := x.Fn.(*ast.Ident); ok && id != nil {
+			if t := l.freeFnReturnTypeFromAST(id); t != nil && t != ErrTypeVal {
+				return t
+			}
+		}
+	case *ast.FieldExpr:
+		// `r.field` chain: recover the field's declared type from the
+		// receiver's struct decl.
+		recv := l.resolveExprStaticType(x.X)
+		if nt, ok := recv.(*NamedType); ok && nt != nil && !nt.Builtin {
+			if sd := l.structDeclByName(nt.Name); sd != nil {
+				for _, f := range sd.Fields {
+					if f == nil || f.Name != x.Name {
+						continue
+					}
+					if t := l.lowerType(f.Type); t != nil && t != ErrTypeVal {
+						return t
+					}
 				}
 			}
 		}
@@ -1357,6 +1415,29 @@ func (l *lowerer) findLetStmtByPattern(pat *ast.IdentPat) *ast.LetStmt {
 	return found
 }
 
+// useAliasFnReturnTypeFromAST resolves an `alias.Fn(...)` call whose
+// receiver is a `use go "..." as alias { fn Fn(...) -> T }` import
+// alias. Returns the declared return type from the UseDecl body, or
+// nil when the receiver isn't a use-alias or no matching fn is found.
+func (l *lowerer) useAliasFnReturnTypeFromAST(fx *ast.FieldExpr) Type {
+	if l == nil || fx == nil || l.res == nil {
+		return nil
+	}
+	id, ok := fx.X.(*ast.Ident)
+	if !ok || id == nil {
+		return nil
+	}
+	sym := l.res.RefsByID[id.ID]
+	if sym == nil {
+		return nil
+	}
+	ud, ok := sym.Decl.(*ast.UseDecl)
+	if !ok || ud == nil {
+		return nil
+	}
+	return l.lookupUseDeclFnReturn(ud, fx.Name)
+}
+
 // userMethodReturnTypeFromAST resolves the receiver expression of a
 // `recv.method(...)` call to its user-defined struct/enum decl and
 // returns the named method's lowered return type. Returns nil when the
@@ -1365,29 +1446,13 @@ func (l *lowerer) userMethodReturnTypeFromAST(fx *ast.FieldExpr) Type {
 	if l == nil || fx == nil {
 		return nil
 	}
-	id, ok := fx.X.(*ast.Ident)
-	if !ok || id == nil || l.res == nil {
+	if l.res == nil {
 		return nil
 	}
-	sym := l.res.RefsByID[id.ID]
-	if sym == nil {
-		return nil
-	}
-	recvType := l.nativeBindingTypeForSymbol(sym)
-	if recvType == nil || recvType == ErrTypeVal {
-		recvType = l.nativeSymbolType(sym)
-	}
-	if recvType == nil || recvType == ErrTypeVal {
-		// Fall back to the symbol's Decl AST type when SemanticDB
-		// lookups miss (e.g. parameters whose declared Type is known
-		// from AST alone).
-		switch d := sym.Decl.(type) {
-		case *ast.Param:
-			if d.Type != nil {
-				recvType = l.lowerType(d.Type)
-			}
-		}
-	}
+	// Receiver may be an Ident (`x.method()`), a chained call
+	// (`x.foo().bar()`), or another FieldExpr (`x.y.bar()`).
+	// `resolveExprStaticType` handles all three.
+	recvType := l.resolveExprStaticType(fx.X)
 	if recvType == nil || recvType == ErrTypeVal {
 		return nil
 	}
@@ -2341,7 +2406,25 @@ func (l *lowerer) lowerUnary(e *ast.UnaryExpr) Expr {
 		l.note("unsupported unary op %v at %v", e.Op, e.Pos())
 		return &ErrorExpr{Note: "unary op", T: ErrTypeVal, SpanV: nodeSpan(e)}
 	}
-	return &UnaryExpr{Op: op, X: l.lowerExpr(e.X), T: l.exprType(e), SpanV: nodeSpan(e)}
+	x := l.lowerExpr(e.X)
+	t := l.exprType(e)
+	// Type recovery: when the checker is silent, fall back to the
+	// operand's type. Unary minus / plus / bitwise-not preserve the
+	// numeric type; `!` always yields Bool. Without this, `-n` where
+	// `n: Int` leaves `UnaryExpr.T = <error>` and any wrapping `if -n
+	// > 0 { ... } else { ... }` propagates the poison through to the
+	// IfExpr's Result.
+	if t == nil || t == ErrTypeVal || hasPoisonedTypeArg(t) {
+		switch op {
+		case UnNot:
+			t = TBool
+		case UnNeg, UnPlus, UnBitNot:
+			if xt := x.Type(); xt != nil && xt != ErrTypeVal && !hasPoisonedTypeArg(xt) {
+				t = xt
+			}
+		}
+	}
+	return &UnaryExpr{Op: op, X: x, T: t, SpanV: nodeSpan(e)}
 }
 
 func unaryOp(k token.Kind) (UnOp, bool) {

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,102 @@ fn main() {}`,
 	}
 }
 
+// Bundle 5: real-world regressions found by auditing examples/ for
+// IR `<error>` types. Three independent cases:
+//
+//  1. **Unary minus** (`if n < 0 { -n } else { n }` in calc/lib.osty):
+//     `UnaryExpr.T` was `<error>` post-#1645 because the checker
+//     didn't populate per-node types. The lowerer now falls back to
+//     the operand's type for negation / bit-not / plus, and TBool for
+//     logical not.
+//
+//  2. **Chained method calls** (`self.tryAllocate(k, n).unwrap()` in
+//     examples/gc/lib.osty): the outer `.unwrap()` needs the inner
+//     call's return type to look up `unwrap`. `resolveExprStaticType`
+//     now handles `*ast.CallExpr` and `*ast.FieldExpr` receivers,
+//     delegating to userMethod / builtinMethod /
+//     closureDependentMethod / useAliasFn return-type recovery.
+//
+//  3. **`use go` FFI alias calls** (`strings.ToUpper(...)` in
+//     examples/ffi/main.osty): trailing FFI call lost promotion
+//     because `userMethodReturnTypeFromAST` filtered out builtin
+//     types and never looked at use-decl bodies. New
+//     `useAliasFnReturnTypeFromAST` helper bridges that gap.
+//
+// Validation tied to `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`:
+// 7363 → 7411 covered (+48 toolchain helpers newly pass through
+// stage0 because their nested-method-chain shapes promote correctly).
+func TestLowerRealWorldRegressions(t *testing.T) {
+	tests := []struct {
+		name, src, fnName, wantType string
+	}{
+		{
+			"unary_neg_in_if",
+			`fn abs(n: Int) -> Int { if n < 0 { -n } else { n } } fn main() {}`,
+			"abs", "Int",
+		},
+		{
+			"chained_builtin_unwrap",
+			`fn at(xs: List<Int>) -> Int { xs.first().unwrap() }
+fn main() {}`,
+			"at", "Int",
+		},
+		{
+			"use_go_ffi_call",
+			`use go "strings" as strings {
+    fn ToUpper(s: String) -> String
+}
+fn banner(name: String) -> String { strings.ToUpper(name) }
+fn main() {}`,
+			"banner", "String",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, _ := parser.ParseDiagnostics([]byte(tt.src))
+			res := resolve.ResolveFileSourceDefault([]byte(tt.src), file, stdlib.LoadCached())
+			reg := stdlib.LoadCached()
+			chk := check.SelfhostFile(file, res, check.Opts{
+				Stdlib:        reg,
+				Primitives:    reg.Primitives,
+				ResultMethods: reg.ResultMethods,
+				Source:        []byte(tt.src),
+				Privileged:    true,
+			})
+			mod, _ := Lower("main", file, res, chk)
+			var target *FnDecl
+			for _, decl := range mod.Decls {
+				if fn, ok := decl.(*FnDecl); ok && fn.Name == tt.fnName {
+					target = fn
+					break
+				}
+			}
+			if target == nil {
+				// Method may be inside a struct; walk decls.
+				for _, decl := range mod.Decls {
+					if sd, ok := decl.(*StructDecl); ok {
+						for _, m := range sd.Methods {
+							if m != nil && m.Name == tt.fnName {
+								target = m
+								break
+							}
+						}
+					}
+					if target != nil {
+						break
+					}
+				}
+			}
+			if target == nil || target.Body == nil || target.Body.Result == nil {
+				t.Fatalf("fn %s: body.Result missing", tt.fnName)
+			}
+			if got := typeString(target.Body.Result.Type()); got != tt.wantType {
+				t.Errorf("fn %s: body.Result.Type = %q, want %q", tt.fnName, got, tt.wantType)
+			}
+		})
+	}
+}
+
 // Bundle 4: 40+ more trailing-call shapes — Math/Float (log, sin,
 // exp, etc.), Int bit ops (gcd, sign, countOnes, leadingZeros),
 // List<T> functional helpers (reduce, flatten, distinct, partition),


### PR DESCRIPTION
## Summary

User-driven audit 결과: synthetic probe 가 아닌 **`examples/*` 와 `toolchain/`** 에서 실제로 `<error>` 가 lowered IR 에 남는 케이스를 찾아 fix. 작은 diff, 큰 impact.

**Stage0 toolchain audit: 7363 → 7411 (97.6% → 98.1%)** — +48 toolchain functions 신규 cover. #1656 이후 가장 큰 real-regression coverage 향상.

## 3개 회귀 fix (root cause 분석)

### 1. Unary type recovery (`examples/calc/lib.osty`)

```osty
fn abs(n: Int) -> Int { if n < 0 { -n } else { n } }
```

`-n` 의 `UnaryExpr.T = <error>`. checker silent + syntactic fallback 없음. enclosing `IfExpr` 도 poison.

→ `lowerUnary` 가 operand type 으로 fallback: `UnNeg`/`UnPlus`/`UnBitNot` 는 operand type, `UnNot` 은 `TBool`. 항상 안전.

### 2. Chained method calls (`examples/gc/lib.osty`)

```osty
fn use_(self) -> Int { self.tryAllocate(k, n).unwrap() }
```

outer `.unwrap()` 이 receiver 의 `Option<Int>` 를 못 찾음 — `resolveExprStaticType` 가 bare `Ident` 만 처리.

→ `resolveExprStaticType` 가 `*ast.CallExpr` (user / builtin / use-alias / closure-dependent return-type recovery 위임) + `*ast.FieldExpr` (struct decl 의 field type lookup) 처리. `userMethodReturnTypeFromAST` 도 같은 helper 사용 — chained user-method 도 resolve.

### 3. `use go` FFI alias calls (`examples/ffi/main.osty`)

```osty
use go "strings" as strings { fn ToUpper(s: String) -> String }
fn banner(name: String) -> String { strings.ToUpper(name) }
```

trailing `strings.ToUpper(name)` 가 ExprStmt 로 drop — user-method path 는 builtin 필터링, builtin path 는 `strings` intrinsic 없음.

→ 새 `useAliasFnReturnTypeFromAST` — receiver Ident 의 UseDecl symbol resolve 후 기존 `lookupUseDeclFnReturn` 으로 fn signature lookup.

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: **7411 / 7554 (98.1%)** ← 7363 / 7547 (97.6%) — **+48 covered**
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit`: 0 errors
- 새 회귀 테스트 `TestLowerRealWorldRegressions`:
  - `unary_neg_in_if` (calc 케이스)
  - `chained_builtin_unwrap` (`xs.first().unwrap()`)
  - `use_go_ffi_call` (FFI strings.ToUpper)
- `internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}` + `cmd/osty` — 전부 green

## 회귀 시리즈 누적

이번 PR 은 synthetic probe 가 아닌 **실제 user code audit** 기반 root-cause fix. 작은 diff (~200 lines), 큰 impact (+48 toolchain coverage). 이전 mega-bundle 들이 hypothetical pattern coverage 였다면 본 PR 은 measurable 회귀 회복.

## Test plan

- [x] `go test ./internal/{ir,check,airepair,mir,lsp,format,stdlib,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — **98.1% (+48)**
- [x] `go test -run TestLowerRealWorldRegressions ./internal/ir/...` — green
- [x] `go test ./cmd/osty/...` — green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_