### PR TITLE
fix(mir): recover stale IndexExpr.T for slice let bindings

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -849,6 +849,24 @@ func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 			}
 		}
 	}
+	// Stale IndexExpr.T recovery. `let head = name[0..N]` on a String
+	// receives `IndexExpr{T: Char}` from check (see
+	// TestLowerStringSliceRecoversStaleRangeIndexType), and ir.lowerLet
+	// then inherits that Char into `let.Type` via `out.Type =
+	// out.Value.Type()`. The value-side emitter recovers via
+	// `string_substring` so the assigned operand is actually String;
+	// the local has to match that. Always consult `indexExprType` for
+	// IndexExpr-rooted values so the slice case overrides the stale
+	// scalar element type — the recovery returns the original `x.T`
+	// when no slicing/list rule applies, so non-slice indexes are
+	// unaffected.
+	if let.Value != nil {
+		if ix, ok := let.Value.(*ir.IndexExpr); ok {
+			if recovered := bs.indexExprType(ix); !isPoisonType(recovered) {
+				t = recovered
+			}
+		}
+	}
 	if t == nil {
 		t = ir.ErrTypeVal
 	}

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -2809,6 +2809,62 @@ func TestLowerStringSliceRecoversStaleRangeIndexType(t *testing.T) {
 	}
 }
 
+// TestLowerStringSliceLetBindingTypeRecoveredFromIndexExpr verifies the
+// `let head = name[0..N]` shape: when the check pass leaves
+// `IndexExpr.T = Char` even though the slice yields String, the
+// let-binding local must take the recovered String type so the
+// `string_substring` intrinsic's String result stores into a matching
+// slot. Pre-patch the binding inherited Char and produced a type
+// mismatch that downstream String operations rejected.
+func TestLowerStringSliceLetBindingTypeRecoveredFromIndexExpr(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "sliceLet",
+		Return: ir.TString,
+		Params: []*ir.Param{
+			{Name: "s", Type: ir.TString},
+			{Name: "n", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name: "head",
+					// No type annotation — stale Char from check leaks
+					// into the IndexExpr value's T.
+					Value: &ir.IndexExpr{
+						X: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+						Index: &ir.RangeLit{
+							Start: &ir.IntLit{Text: "0", T: ir.TInt},
+							End:   &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt},
+							T:     &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TInt}, Builtin: true},
+						},
+						T: ir.TChar, // ← stale; should be String
+					},
+				},
+			},
+			Result: &ir.Ident{Name: "head", Kind: ir.IdentLocal, T: ir.TString},
+		},
+	}
+	out := lowerHIR(t, fn)
+	mirFn := out.LookupFunction("sliceLet")
+	if mirFn == nil {
+		t.Fatal("missing sliceLet")
+	}
+	// Find the `head` local and assert its type is String, not Char.
+	var headLocal *Local
+	for _, l := range mirFn.Locals {
+		if l != nil && l.Name == "head" {
+			headLocal = l
+			break
+		}
+	}
+	if headLocal == nil {
+		t.Fatalf("expected `head` local in MIR:\n%s", PrintFunction(mirFn))
+	}
+	if prim, ok := headLocal.Type.(*ir.PrimType); !ok || prim.Kind != ir.PrimString {
+		t.Fatalf("head local should be String, got %T (%v):\n%s", headLocal.Type, headLocal.Type, PrintFunction(mirFn))
+	}
+}
+
 func TestLowerStdlibStringsTrimSpaceFreeFn(t *testing.T) {
 	useDecl := &ir.UseDecl{
 		Path:    []string{"std", "strings"},


### PR DESCRIPTION
## Summary

`let head = name[0..N]` 형태에서 IndexExpr의 stale Char 타입이 let-binding local로 그대로 상속되던 type-info 버그 fix. `mir.lowerLet`가 IndexExpr value에 대해 `indexExprType` recovery를 거치도록 변경.

## Context

상위 PR (#1686, FnConst arg) 의 후속. 부트스트랩 차단 해소 우산 ([LLVM_BACKEND_GAP_PLAN.md](LLVM_BACKEND_GAP_PLAN.md) Phase 0-A) 의 두 번째 슬라이스.

원인 분석:
- toolchain의 `mirIs*AggregateName` predicate family (9 함수) 가 `let head = name[0..prefix.len()]` 패턴
- check pass가 IndexExpr.T = Char 설정 (`String[Int]` 처럼)
- `internal/ir/lower.go:1612` 의 `out.Type = out.Value.Type()` 로 Char가 LetStmt.Type에 그대로 상속
- MIR value-side는 `string_substring` intrinsic으로 정확히 lower 하지만 local 타입은 Char 그대로 → `head: Char = substring(...) (String)` 타입 미스매치
- stage0 매처가 이 미스매치를 정확히 거부

기존 `TestLowerStringSliceRecoversStaleRangeIndexType` (method-call shape) 이 같은 버그를 인지하고 recovery path를 검증. 본 PR은 let-binding shape에 같은 recovery 확장.

## 측정

- audit cover: **94.3% → 98.2%** (+1295 functions covered)
- install-self decline: **191 → 147** (-44 functions, -23%)
- 누적 (PR #1686 + 이 PR): 시작점 1340 → 147 (**89% 감소**)

## Tests
- 새 테스트 `TestLowerStringSliceLetBindingTypeRecoveredFromIndexExpr` — let-binding의 head local 타입이 String인지 직접 assert
- 기존 `TestLowerStringSliceRecoversStaleRangeIndexType` 회귀 없음
- `go test ./internal/mir/` 회귀 없음
- `go test -short ./internal/backend/` 회귀 없음 (253s 통과)
- `go test -short ./internal/ir/` 회귀 없음

## Follow-ups
남은 147 declines는 long-tail (서로 다른 shape). 추가 P-phase 후보:
- `selfPkgPathDependency` 류 — upstream MIR 타입 미스매치 (anySemReq returns Bool but field expects SemReq)
- `selfCheck*` 17-block functions
- Optional + Map + struct-proj cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)