### PR TITLE
fix(ir): recover `self` receiver type from owning struct/enum decl

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -2378,6 +2378,43 @@ func (l *lowerer) identTypeFromDecl(decl ast.Node) Type {
 		return nil
 	case *ast.Variant:
 		return l.enumTypeForVariantDecl(d)
+	case *ast.Receiver:
+		// `self` inside a method body. The resolver records the
+		// `self` ident with `Decl = *ast.Receiver`, which carries no
+		// type info on its own. Walk the file's struct/enum decls
+		// looking for the method that owns this receiver, then
+		// return the owner's nominal type. Without this, every
+		// `self` reference inside a struct method body lowers as
+		// `Ident.T = <error>` and cascades through every enclosing
+		// expression — especially `self.method()` chains in
+		// examples/gc/lib.osty style code.
+		return l.selfReceiverType(d)
+	}
+	return nil
+}
+
+// selfReceiverType locates the struct/enum declaration that owns the
+// given Receiver node and returns its nominal type, or nil when the
+// receiver can't be matched to any decl in the current file.
+func (l *lowerer) selfReceiverType(recv *ast.Receiver) Type {
+	if l == nil || recv == nil || l.file == nil {
+		return nil
+	}
+	for _, decl := range l.file.Decls {
+		switch d := decl.(type) {
+		case *ast.StructDecl:
+			for _, m := range d.Methods {
+				if m != nil && m.Recv == recv {
+					return &NamedType{Name: d.Name}
+				}
+			}
+		case *ast.EnumDecl:
+			for _, m := range d.Methods {
+				if m != nil && m.Recv == recv {
+					return &NamedType{Name: d.Name}
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,49 @@ fn main() {}`,
 	}
 }
 
+// `self` inside a struct method body must resolve to the owner
+// struct's nominal type. The resolver records the `self` ident with
+// `Decl = *ast.Receiver`, which carries no type info on its own. The
+// lowerer now matches the receiver against each StructDecl/EnumDecl's
+// Methods to find the owner, then returns its NamedType. Without
+// this, every `self` reference inside a method body lowers as
+// `Ident.T = <error>` and cascades through `self.field`, `self.method()`,
+// `self.method().unwrap()` etc.
+func TestLowerSelfReceiverType(t *testing.T) {
+	src := `pub struct Buf {
+    capacity: Int,
+    pub fn use_(self) -> Int { self.capacity }
+    pub fn dbl(self) -> Int { self.capacity * 2 }
+}
+fn main() {}`
+	file, _ := parser.ParseDiagnostics([]byte(src))
+	res := resolve.ResolveFileSourceDefault([]byte(src), file, stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, _ := Lower("main", file, res, chk)
+	for _, decl := range mod.Decls {
+		sd, ok := decl.(*StructDecl)
+		if !ok {
+			continue
+		}
+		for _, m := range sd.Methods {
+			if m.Body == nil || m.Body.Result == nil {
+				t.Errorf("method %s: body.Result missing (self regression)", m.Name)
+				continue
+			}
+			if got := typeString(m.Body.Result.Type()); got != "Int" {
+				t.Errorf("method %s: body.Result.Type = %q, want Int", m.Name, got)
+			}
+		}
+	}
+}
+
 // Bundle 6: small incremental fixes after #1693. Two additions:
 //
 //  1. `lowerIdent` consults `resolveExprStaticType` as a final


### PR DESCRIPTION
## Summary

`self` 가 struct/enum method body 안에서 owner type 으로 회복되도록. `self.field`, `self.method()`, `self.method().unwrap()` 같은 chain 이 단일 파일 패키지에서 정상 lower 됨.

## 원인

`self` ident → `Symbol{Decl: *ast.Receiver}` 로 resolve. `Receiver` 자체에는 type 정보 없음. `identTypeFromDecl` 에 케이스 없어서 `Ident.T = <error>` 로 lower. 그 결과 `self.field` (FieldExpr.T=`<error>`), `self.method()` (MethodCall.T=`<error>`), `self.tryAllocate(k, n).unwrap()` 같은 chain 전부 poison.

## 변경

`identTypeFromDecl` 에 `*ast.Receiver` 케이스 추가 → 새 `selfReceiverType` helper. `l.file.Decls` walk 하면서 StructDecl/EnumDecl 의 `Methods` 중 `Recv == recv` 인 FnDecl 찾고 owner 의 `&NamedType{Name: owner}` 반환.

## 제한

- 같은 `*ast.File` 안에 method 와 owner struct 가 있을 때만 작동. 다중 파일 패키지에서 method body 와 struct decl 이 별 파일에 있으면 selfhost-resolver 단계 issue 라서 별도 fix 필요.
- 단일 파일 회귀 테스트 `TestLowerSelfReceiverType` 추가 (가장 흔한 케이스 cover).

## 검증

- 새 회귀 테스트 `TestLowerSelfReceiverType` — PASS
- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: 7411/7555 (98.1%) — 불변 (toolchain 은 multi-file)
- `internal/{ir,check,airepair,mir,lsp,backend}` — 전부 green

## Test plan

- [x] `go test -run TestLowerSelfReceiverType ./internal/ir/...` — green
- [x] `go test ./internal/{ir,check,airepair,mir,lsp,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1` — 98.1% (불변)

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_