### PR TITLE
fix(mir): recurse recoverOperandType into BinaryExpr operands

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3214,7 +3214,12 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 			return ir.TBool
 		}
 		// Arithmetic / bitwise: recover from whichever operand still
-		// carries a concrete type.
+		// carries a concrete type. Try the raw `.Type()` first (cheap),
+		// then recurse through `recoverOperandType` for operands whose
+		// IR-level Type is poisoned but whose shape (FieldExpr,
+		// MethodCall, …) can still be recovered. Without this, `let
+		// size = node.end - node.start` keeps stale ErrType when both
+		// FieldExpr operands had their checker types dropped.
 		lt := x.Left.Type()
 		rt := x.Right.Type()
 		if !isPoisonType(lt) {
@@ -3222,6 +3227,12 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		}
 		if !isPoisonType(rt) {
 			return rt
+		}
+		if recovered := bs.recoverOperandType(x.Left); !isPoisonType(recovered) {
+			return recovered
+		}
+		if recovered := bs.recoverOperandType(x.Right); !isPoisonType(recovered) {
+			return recovered
 		}
 	case *ir.StructLit:
 		// `StructName { ... }` whose checker-side type got poisoned.

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -2865,6 +2865,71 @@ func TestLowerStringSliceLetBindingTypeRecoveredFromIndexExpr(t *testing.T) {
 	}
 }
 
+// TestRecoverOperandTypeBinaryArithRecursesIntoFieldExprs verifies the
+// recovery path for `let size = node.end - node.start` where both
+// operands are FieldExpr with stale `.T` (ErrType after the checker
+// dropped them). recoverOperandType's BinaryExpr case must recurse
+// through the operand FieldExprs via `bs.fieldExprType` instead of
+// trusting the raw `x.Left.Type()`. Without this recovery the
+// let-binding inherits ErrType and stage0 cannot lower the function.
+func TestRecoverOperandTypeBinaryArithRecursesIntoFieldExprs(t *testing.T) {
+	nodeTy := &ir.NamedType{Name: "Node"}
+	fn := &ir.FnDecl{
+		Name:   "spanSize",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "node", Type: nodeTy}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name: "size",
+					// No annotation — let-stmt should infer from value.
+					Value: &ir.BinaryExpr{
+						Op:    ir.BinSub,
+						T:     ir.ErrTypeVal, // stale: should be Int
+						Left:  &ir.FieldExpr{X: &ir.Ident{Name: "node", Kind: ir.IdentParam, T: nodeTy}, Name: "end", T: ir.ErrTypeVal},
+						Right: &ir.FieldExpr{X: &ir.Ident{Name: "node", Kind: ir.IdentParam, T: nodeTy}, Name: "start", T: ir.ErrTypeVal},
+					},
+				},
+			},
+			Result: &ir.Ident{Name: "size", Kind: ir.IdentLocal, T: ir.TInt},
+		},
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.StructDecl{
+				Name: "Node",
+				Fields: []*ir.Field{
+					{Name: "start", Type: ir.TInt},
+					{Name: "end", Type: ir.TInt},
+				},
+			},
+			fn,
+		},
+	}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	mirFn := out.LookupFunction("spanSize")
+	if mirFn == nil {
+		t.Fatal("missing spanSize")
+	}
+	var sizeLocal *Local
+	for _, l := range mirFn.Locals {
+		if l != nil && l.Name == "size" {
+			sizeLocal = l
+			break
+		}
+	}
+	if sizeLocal == nil {
+		t.Fatalf("expected `size` local:\n%s", PrintFunction(mirFn))
+	}
+	if prim, ok := sizeLocal.Type.(*ir.PrimType); !ok || prim.Kind != ir.PrimInt {
+		t.Fatalf("size local should be Int, got %T (%v):\n%s", sizeLocal.Type, sizeLocal.Type, PrintFunction(mirFn))
+	}
+}
+
 func TestLowerStdlibStringsTrimSpaceFreeFn(t *testing.T) {
 	useDecl := &ir.UseDecl{
 		Path:    []string{"std", "strings"},


### PR DESCRIPTION
## Summary

\`let size = node.end - node.start\` 형태에서 BinaryExpr.T 와 FieldExpr.T 양쪽 모두 checker 가 ErrType으로 떨어뜨릴 때 recovery 실패하던 버그 fix.

부트스트랩 차단 해소 우산 ([LLVM_BACKEND_GAP_PLAN.md](LLVM_BACKEND_GAP_PLAN.md) Phase 0-A) 의 4번째 슬라이스.

## Context

\`recoverOperandType\` 의 BinaryExpr arithmetic 케이스가 operand의 raw \`.Type()\` 만 확인. operand가 FieldExpr / MethodCall 등 자체적으로 recoverable 한 shape일 때, 그 IR-level T가 stale ErrType이면 양쪽 모두 poison으로 떨어져 recovery가 nil 반환.

\`selfCheck*\` 17-block functions 류가 정확히 이 패턴:
\`\`\`osty
for node in result.typedNodes {
    if selfCheckOffsetContains(node.start, node.end, offset) {
        let size = node.end - node.start  // ← BinaryExpr.T = ErrType
        ...
    }
}
\`\`\`

## Fix

operand의 raw \`.Type()\` 가 poison일 때 \`recoverOperandType\` 을 재귀 호출. FieldExpr / MethodCall / IndexExpr 의 자체 recovery 가 stale ErrType 우회.

## 측정

- audit cover: **98.8% → 98.9%** (+10 함수)
- 누적 (3 PR): audit 94.2% → 98.9% (+1361 함수, 4.7pp)

## 영향 함수 (unblock 예시)

- selfCheckTypeNameAtOffset
- selfCheckSymbolNameAtOffset
- selfCheckHoverAtOffset
- (다른 \`node.end - node.start\` 패턴 함수들)

## Tests
- 새 회귀 테스트 \`TestRecoverOperandTypeBinaryArithRecursesIntoFieldExprs\` 통과
- \`go test ./internal/mir/\` 회귀 없음
- \`go test -short ./internal/backend/\` 회귀 없음 (149s 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)