### PR TITLE
fix(ir+mir+runtime): cover toolchain runCompile/runLirProtoLower in stage0

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -29640,6 +29640,67 @@ void *osty_rt_audit_i64_placeholder(void) {
     return osty_rt_string_dup_site("", 0, "stage0.audit.i64_placeholder");
 }
 
+/* std.fs.readToString(path) — read the entire file at `path` as a
+ * UTF-8 String. Returns a heap-allocated `%stage0.Result.ptr`
+ * ({ i64 tag, ptr value }): tag=0 (Ok) with the contents on success,
+ * tag=1 (Err) with a NULL payload on any I/O failure (open, seek,
+ * read short, allocation). Matches `Some/Ok=0, None/Err=1` per
+ * `internal/mir/lower.go:7757`.
+ *
+ * Needed by stage0 binary's `runCompile` and `runLirProtoLower`
+ * which call `fs.readToString(args[1])` before invoking the rest
+ * of the self-host pipeline; without a stub the link step fails
+ * with `undefined reference to std.fs.readToString` and the
+ * stage0 dispatch ceiling moves back from "binary handled
+ * --selfhost-doctor" to "binary fails to link". */
+void *osty_rt_audit_fs_readToString(const char *path) __asm__("std.fs.readToString");
+void *osty_rt_audit_fs_readToString(const char *path) {
+    int64_t *box = (int64_t *)osty_rt_stage0_alloc((int64_t)(sizeof(int64_t) * 2));
+    if (box == NULL) {
+        return NULL;
+    }
+    box[0] = 1; /* Err */
+    box[1] = 0;
+    if (path == NULL) {
+        return box;
+    }
+    char path_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+    const char *path_ptr = path;
+    osty_rt_string_decode_to_buf_if_inline(&path_ptr, path_buf);
+    FILE *f = fopen(path_ptr, "rb");
+    if (f == NULL) {
+        return box;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return box;
+    }
+    long fsize = ftell(f);
+    if (fsize < 0) {
+        fclose(f);
+        return box;
+    }
+    if (fseek(f, 0, SEEK_SET) != 0) {
+        fclose(f);
+        return box;
+    }
+    char *content = (char *)osty_gc_allocate_managed((size_t)fsize + 1,
+        OSTY_GC_KIND_STRING, "stage0.audit.fs.readToString", NULL, NULL);
+    if (content == NULL) {
+        fclose(f);
+        return box;
+    }
+    size_t got = fread(content, 1, (size_t)fsize, f);
+    fclose(f);
+    if (got != (size_t)fsize) {
+        return box;
+    }
+    content[fsize] = '\0';
+    box[0] = 0; /* Ok */
+    memcpy(&box[1], &content, sizeof(content));
+    return box;
+}
+
 #endif /* defined(__GNUC__) || defined(__clang__) */
 
 /* osty_rt_stage0_declined — banner helper for stage0 decline-stubs.

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -4619,11 +4619,122 @@ func (l *lowerer) lowerMatchExpr(m *ast.MatchExpr) Expr {
 	if out.T == nil || out.T == ErrTypeVal {
 		if recovered := recoverMatchType(out.Arms); recovered != nil && recovered != ErrTypeVal {
 			out.T = recovered
+		} else {
+			// Fallback: each arm's body Result type was poisoned (ErrType)
+			// but the body is a single ident bound by a known sum-type
+			// variant pattern. Derive the binding's type from the
+			// scrutinee's NamedType args and re-attempt unification.
+			// Covers the common `match r { Ok(s) -> s, Err(_) -> {…} }`
+			// shape where `s`'s type the checker didn't record.
+			if scrutT := out.Scrutinee.Type(); scrutT != nil && scrutT != ErrTypeVal {
+				var candidate Type
+				disagree := false
+				for _, arm := range out.Arms {
+					t := recoverVariantBindingArmType(scrutT, arm)
+					if t == nil || t == ErrTypeVal {
+						continue
+					}
+					if candidate == nil {
+						candidate = t
+						continue
+					}
+					if !typesEquivalent(candidate, t) {
+						disagree = true
+						break
+					}
+				}
+				if !disagree && candidate != nil {
+					out.T = candidate
+				}
+			}
 		}
 	}
 	// Compile a decision tree when the arm shapes are specialisable.
 	out.Tree = CompileDecisionTree(out.Scrutinee.Type(), out.Arms)
 	return out
+}
+
+// recoverVariantBindingArmType derives the result type of a match arm
+// whose body is `body == arm.Body.Result.(*Ident)` referring to a
+// name introduced by `arm.Pattern.(*VariantPat)`, by looking up the
+// payload slot in the scrutinee's NamedType args. Returns nil for
+// shapes outside the supported envelope or when the scrutinee
+// isn't a recognised sum type.
+//
+// Used as a secondary fallback by `lowerMatchExpr` when
+// `recoverMatchType` can't unify because every arm's body type was
+// poisoned at the checker stage (observed on `runCompile` and
+// `runLirProtoLower` in `toolchain/main.osty` where
+// `match fs.readToString(path) { Ok(s) -> s, Err(_) -> {…} }`
+// dropped `s`'s String type through the SemanticDB→IR seam — same
+// family as the trailing-stdlib-call recovery in
+// `internal/ir/lower.go:bindingTypeFromAST`).
+//
+// Currently supports the prelude sum types `Result<T, E>` and
+// `Option<T>`; non-builtin enums need their variant→payload index
+// pulled from `resolve.Symbol.Decl` and stay out of scope here
+// because the binding-→type pipeline for user enums runs through
+// a different recovery path (`lowerLetStmt:nativeBindingType`).
+func recoverVariantBindingArmType(scrutT Type, arm *MatchArm) Type {
+	if arm == nil || arm.Body == nil || arm.Body.Result == nil {
+		return nil
+	}
+	bodyIdent, ok := arm.Body.Result.(*Ident)
+	if !ok {
+		return nil
+	}
+	if len(arm.Body.Stmts) != 0 {
+		// Only single-expression arm bodies — multi-statement blocks
+		// belong to the existing recoverMatchType path (which already
+		// understands trailing-expression yield).
+		return nil
+	}
+	vpat, ok := arm.Pattern.(*VariantPat)
+	if !ok {
+		return nil
+	}
+	bindingIdx := -1
+	for i, a := range vpat.Args {
+		ip, ok := a.(*IdentPat)
+		if !ok {
+			continue
+		}
+		if ip.Name == bodyIdent.Name {
+			bindingIdx = i
+			break
+		}
+	}
+	if bindingIdx < 0 {
+		return nil
+	}
+	named, ok := scrutT.(*NamedType)
+	if !ok {
+		return nil
+	}
+	switch named.Name {
+	case "Result":
+		if len(named.Args) < 2 {
+			return nil
+		}
+		switch vpat.Variant {
+		case "Ok":
+			if bindingIdx == 0 {
+				return named.Args[0]
+			}
+		case "Err":
+			if bindingIdx == 0 {
+				return named.Args[1]
+			}
+		}
+	case "Option":
+		if len(named.Args) < 1 {
+			return nil
+		}
+		if vpat.Variant == "Some" && bindingIdx == 0 {
+			return named.Args[0]
+		}
+	}
+	return nil
 }
 
 // recoverMatchType returns the common body type across a set of

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -156,6 +156,31 @@ func (l *lowerer) collectSignatures() {
 			l.emitUse(x)
 		}
 	}
+	// Promote module-level `let` statements that the parser routed into
+	// `Script` (e.g. unannotated top-level lets in `toolchain/ci.osty`)
+	// to globals BEFORE function lowering, so cross-file ident references
+	// like `Runner__Run`'s `skipped(CheckFormat)` resolve to a real
+	// `GlobalRefRV` instead of falling through to an unresolved
+	// `FnConst{Symbol: "CheckFormat"}`. The matching script-side promotion
+	// in `emitScript` (Globals output) handles the actual `Global` value
+	// emission; this pass only seeds the lookup table early enough for
+	// `bs.lowerIdent`'s fallback to find them.
+	for _, s := range l.src.Script {
+		ls, ok := s.(*ir.LetStmt)
+		if !ok || ls.Name == "" {
+			continue
+		}
+		if _, already := l.globals[ls.Name]; already {
+			continue
+		}
+		l.globals[ls.Name] = &ir.LetDecl{
+			Name:  ls.Name,
+			Mut:   ls.Mut,
+			Type:  ls.Type,
+			Value: ls.Value,
+			SpanV: ls.SpanV,
+		}
+	}
 }
 
 func (l *lowerer) buildLayouts() {
@@ -370,31 +395,79 @@ func (l *lowerer) emitScript() {
 	if len(l.src.Script) == 0 {
 		return
 	}
-	// If the user already declared `fn main()` explicitly, don't
-	// synthesize a second one — duplicate-symbol breaks LLVM linking
-	// and the backend (`backend: MIR coverage incomplete: function
-	// "main": duplicate symbol`). The toolchain's own
-	// `toolchain/main.osty` declares a real `main` while several other
-	// files (e.g. `toolchain/ci.osty`, `toolchain/scaffold_policy.osty`)
-	// have top-level `let` constants that the parser routes into
-	// `file.Stmts` → `mod.Script`. Without this guard, both the user
-	// `main` and the auto-synthesised initialiser end up as `main`.
+	// Step 1: promote module-level `let` constants to Globals so
+	// they are visible across functions (e.g. `let CheckFormat:
+	// CheckName = "format"` in `toolchain/ci.osty` is referenced by
+	// `Runner__Run` / `Runner__checkFormat` in the same file). Without
+	// this promotion the parser leaves them in `file.Stmts → mod.Script`,
+	// the IR-side `lowerLetDecl` never runs, and `bs.lowerIdent`'s
+	// fallback emits `FnConst{Symbol: "CheckFormat"}` instead of a
+	// `GlobalRefRV` — stage0 then renders an unresolved `@CheckFormat`
+	// reference that fails clang at link.
 	//
-	// Long-term fix: route module-level `let` constants into
-	// `mod.Decls` (as `Global`s) instead of `mod.Script`, OR wrap
-	// script statements in a `__init__`-named entry that the user
-	// `main` calls. For now the conservative fix is to skip the
-	// synthetic when the user's main is present.
+	// The promotion synthesises a minimal `ir.LetDecl` shell from the
+	// `ir.LetStmt`, runs the existing `lowerGlobal` pipeline, and
+	// removes the LetStmt from the script slice so the synthetic main
+	// (next step) doesn't double-emit it.
+	remainingScript := make([]ir.Stmt, 0, len(l.src.Script))
+	for _, s := range l.src.Script {
+		ls, ok := s.(*ir.LetStmt)
+		if !ok || ls.Name == "" {
+			remainingScript = append(remainingScript, s)
+			continue
+		}
+		// `collectSignatures` already seeded `l.globals[ls.Name]` with
+		// a synthetic LetDecl so cross-file refs in user functions
+		// resolved during `emitDeclarations`. Now emit the actual
+		// `Global` value via the shared `lowerGlobal` pipeline. Skip
+		// the entry if `collectSignatures` saw a real LetDecl with the
+		// same name (file with a `pub let X = ...` at top-level
+		// alongside the cross-file ref).
+		ld, ok := l.globals[ls.Name]
+		if !ok {
+			ld = &ir.LetDecl{
+				Name:  ls.Name,
+				Mut:   ls.Mut,
+				Type:  ls.Type,
+				Value: ls.Value,
+				SpanV: ls.SpanV,
+			}
+			l.globals[ls.Name] = ld
+		}
+		alreadyEmitted := false
+		for _, g := range l.out.Globals {
+			if g != nil && g.Name == ld.Name {
+				alreadyEmitted = true
+				break
+			}
+		}
+		if !alreadyEmitted {
+			if g := l.lowerGlobal(ld); g != nil {
+				l.out.Globals = append(l.out.Globals, g)
+			}
+		}
+	}
+
+	// Step 2: if any non-let script statements remain, wrap them in a
+	// synthetic `main()` — but only when the user hasn't declared their
+	// own `fn main()` explicitly. Two `main` definitions break LLVM
+	// linking (`backend: MIR coverage incomplete: function "main":
+	// duplicate symbol`). The toolchain's `toolchain/main.osty` does
+	// declare a real `main`; with the step-1 promotion in place, the
+	// only remaining script content in other files (e.g.
+	// `toolchain/scaffold_policy.osty`) is incidental and safely
+	// dropped here.
+	if len(remainingScript) == 0 {
+		return
+	}
 	for _, existing := range l.out.Functions {
 		if existing != nil && existing.Name == "main" {
 			return
 		}
 	}
-	// Treat script statements as the body of a synthetic main(). The
-	// backend conventionally does the same thing.
 	fn := l.newFunction("main", nil, TUnit, ir.Span{}, false)
 	bs := newBodyState(l, fn)
-	for _, s := range l.src.Script {
+	for _, s := range remainingScript {
 		bs.lowerStmt(s)
 	}
 	bs.finishNoReturn()
@@ -4137,8 +4210,36 @@ func (bs *bodyState) lowerIdent(id *ir.Ident) Operand {
 		return &CopyOp{Place: Place{Local: tmp}, T: t}
 	}
 	// Unknown identifier — possibly a top-level fn not captured in our
-	// signature table; fall back to FnConst.
+	// signature table; fall back to FnConst. First, though, check
+	// whether this is actually a top-level `let` whose IR `id.Kind`
+	// didn't make it to `IdentGlobal` (cross-file resolves on toolchain
+	// drop the `IdentKind` on a few sites — see the `CheckFormat` /
+	// `CheckPolicy` references in `toolchain/ci.osty:Runner__Run`).
+	// Without this guard, the generic-CFG path in
+	// `internal/backend/stage0/emit.go:resolveOperandWithPrelude`
+	// emits `@CheckFormat` as a function pointer, which fails clang
+	// with `error: use of undefined value '@CheckFormat'`.
 	if id.Name != "" {
+		if decl, ok := bs.l.globals[id.Name]; ok && decl != nil {
+			t := id.T
+			if t == nil || isPoisonType(t) {
+				if decl.Type != nil && !isPoisonType(decl.Type) {
+					t = decl.Type
+				} else if decl.Value != nil {
+					t = decl.Value.Type()
+				}
+			}
+			if t == nil {
+				t = ir.ErrTypeVal
+			}
+			tmp := bs.freshTemp(t, id.SpanV)
+			bs.emit(&AssignInstr{
+				Dest:  Place{Local: tmp},
+				Src:   &GlobalRefRV{Name: id.Name, T: t},
+				SpanV: id.SpanV,
+			})
+			return &CopyOp{Place: Place{Local: tmp}, T: t}
+		}
 		t := bs.fnValueType(id.Name, id.T)
 		return &ConstOp{Const: &FnConst{Symbol: id.Name, T: t}, T: t}
 	}


### PR DESCRIPTION
## Summary

Three coupled fixes that unblock stage0's coverage of the toolchain's
`runCompile` / `runLirProtoLower` (`toolchain/main.osty`), advancing
the L4 fp-verify ceiling past the `--selfhost-doctor` baseline. The
audit's `lir-proto-lower` smoke now actually executes the source →
HIR → MIR → LIR Proto pipeline inside the produced binary before
bottoming out in a deeper crash (separate ceiling, tracked).

## Three coordinated fixes

### 1. IR (`internal/ir/lower.go`) — match-arm variant-binding type recovery

`match fs.readToString(path) { Ok(s) -> s, Err(_) -> { eprint(...); return 2 } }` lost the result type at the IR seam because `Ok(s) -> s`'s body is a single `*Ident` whose checker type came back as `<error>` (the SemanticDB drops the binding-→ident type chain for variant-pattern args). `recoverMatchType` skipped arm[0] (poisoned ident type) and arm[1] (no `Result`) and gave up.

New `recoverVariantBindingArmType`: when every arm body resolved to `<error>` but the arm pattern is a known sum-type variant (`Result`'s `Ok`/`Err`, `Option`'s `Some`) and the body is a single `*Ident` referring to one of the pattern's args, derive the type from the scrutinee's `NamedType` args.

### 2. MIR (`internal/mir/lower.go`) — top-level `let` statement promotion

The parser routes top-level lets without `pub` into `file.Stmts` → `ir.Module.Script` rather than `file.Decls` → `ir.Module.Decls`. MIR's `collectSignatures` only walks `Decls`, so `let CheckFormat: CheckName = "format"` (and `CheckLint`, `CheckPolicy`, ...) in `toolchain/ci.osty` were never registered. Cross-file references like `Runner__Run`'s `skipped(CheckFormat)` then fell through to MIR's `lowerIdent` fallback and produced `&FnConst{Symbol: "CheckFormat"}`. Stage0 rendered that as `@CheckFormat` with no `define` / `declare`, failing clang with `error: use of undefined value '@CheckFormat'`.

- `collectSignatures` now scans `l.src.Script` for `*ir.LetStmt`s and seeds `l.globals` with a synthetic `*ir.LetDecl` before function lowering.
- `lowerIdent`'s fallback consults `l.globals` and emits a `GlobalRefRV` via a temp local instead of `&FnConst` when found.
- `emitScript` filters out the now-promoted `LetStmt`s so the synthetic `main` doesn't double-emit them.

### 3. Runtime (`internal/backend/runtime/osty_runtime.c`) — `std.fs.readToString` stub

With (1)+(2) in place, the stage0 binary compiles `runCompile` / `runLirProtoLower` cleanly. `lir-proto-lower <file>` then exercises `fs.readToString(args[1])` which had no runtime stub and failed at link with `undefined reference to std.fs.readToString`.

New `osty_rt_audit_fs_readToString(path)` — real `fopen` + `fread` implementation returning `%stage0.Result.ptr` ({ i64 tag, ptr value }) with `Ok=0, Err=1`. Allocates contents via `osty_gc_allocate_managed(len+1, OSTY_GC_KIND_STRING, …)` so the returned string is GC-traced.

## Audit progression

| Level | Before | After |
|---|---|---|
| L1 per-function | 7363 / 7547 (97.5%), 0 emit-broken | **7373 / 7547 (97.7%)**, 0 emit-broken |
| L2 module-verify | clean | clean |
| L3 exec-verify | `--selfhost-doctor` ✓ exit 0 | `--selfhost-doctor` ✓ exit 0 |
| L4 fp-verify deepest | `--selfhost-doctor` | `--selfhost-doctor` |
| L4 fp-verify `lir-proto-lower` | banner-match (decline stub) | **actually runs the toolchain pipeline**; segfaults deeper inside `hirLowerSource` / `lirLowerMirModule` — separate ceiling |
| L4 fp-verify `compile` | banner-match (decline stub) | same shape as `lir-proto-lower` |

L4 `deepest reached` will advance once the deeper crash is fixed — tracked as the next ceiling.

## Test plan

- [x] `OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_CLANG_VERIFY=1 OSTY_STAGE0_AUDIT_MODULE_VERIFY=1 OSTY_STAGE0_AUDIT_EXEC_VERIFY=1 OSTY_STAGE0_AUDIT_FP_VERIFY=1 go test -count=1 -vet=off -run TestStage0ToolchainAudit ./internal/backend/` PASS
- [x] `go test ./internal/ir/... ./internal/mir/... ./internal/check/...` clean
- [x] Backend test failure count unchanged (82 → 82)
- [x] `go vet ./internal/...` clean
- [x] `gofmt -l` clean

https://claude.ai/code/session_01C4hC1RTMmofdZm8R3nPbh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4hC1RTMmofdZm8R3nPbh9)_