### PR TITLE
fix(ir): promote trailing enum-qualified variant calls (+68 stage0 coverage)

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1069,6 +1069,16 @@ func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
 				if rt := l.useAliasFnReturnTypeFromAST(fx); rt != nil && expressionTypeYieldsValue(rt) {
 					return true
 				}
+				// Enum-qualified variant call (`Color.Red(255)`,
+				// `Value.IntVal(n)`): receiver Ident resolves to a
+				// `SymEnum`, field name is one of the enum's variants.
+				// The call returns the enum's nominal type. Without
+				// this, `pub fn newInt(n: Int) -> Value { Value.IntVal(n) }`
+				// drops the trailing variant call to ExprStmt → MIR
+				// UnreachableTerm.
+				if rt := l.enumVariantCallReturnTypeFromAST(fx); rt != nil && expressionTypeYieldsValue(rt) {
+					return true
+				}
 			}
 			// Free-fn calls (`helper()`): promote when the resolved
 			// declaration has a non-unit return type. We restrict this
@@ -1413,6 +1423,28 @@ func (l *lowerer) findLetStmtByPattern(pat *ast.IdentPat) *ast.LetStmt {
 	}
 	walk(l.file)
 	return found
+}
+
+// enumVariantCallReturnTypeFromAST resolves `Enum.Variant(...)` calls
+// to the enum's nominal type. Receiver Ident must resolve to a
+// `SymEnum` whose declaration lists `Variant` among its variants.
+// Returns nil when the call doesn't match the enum-qualified shape.
+func (l *lowerer) enumVariantCallReturnTypeFromAST(fx *ast.FieldExpr) Type {
+	if l == nil || fx == nil || l.res == nil {
+		return nil
+	}
+	id, ok := fx.X.(*ast.Ident)
+	if !ok || id == nil {
+		return nil
+	}
+	sym := l.res.RefsByID[id.ID]
+	if sym == nil || sym.Kind != resolve.SymEnum {
+		return nil
+	}
+	if !l.isVariantOfEnum(sym, fx.Name) {
+		return nil
+	}
+	return &NamedType{Name: sym.Name}
 }
 
 // useAliasFnReturnTypeFromAST resolves an `alias.Fn(...)` call whose

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,51 @@ fn main() {}`,
 	}
 }
 
+// Enum-qualified variant calls (`Color.Red(255)`, `Value.IntVal(n)`)
+// must promote to the block's Result when at trailing position. The
+// receiver Ident resolves to a `SymEnum`, the field name to one of
+// the enum's variants, and the call returns the enum's nominal type.
+// Without this, the very common pattern of "enum method that
+// constructs another variant" leaves the trailing call as ExprStmt
+// → MIR UnreachableTerm → stage0 declines the method. This single
+// fix moves toolchain audit coverage from 97.6% → 99.0% (+68 fns).
+func TestLowerEnumVariantCallPromotes(t *testing.T) {
+	src := `pub enum Value {
+    IntVal(Int),
+    BoolVal(Bool),
+
+    pub fn newInt(n: Int) -> Value { Value.IntVal(n) }
+    pub fn newBool(b: Bool) -> Value { Value.BoolVal(b) }
+}
+fn main() {}`
+	file, _ := parser.ParseDiagnostics([]byte(src))
+	res := resolve.ResolveFileSourceDefault([]byte(src), file, stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, _ := Lower("main", file, res, chk)
+	for _, decl := range mod.Decls {
+		ed, ok := decl.(*EnumDecl)
+		if !ok {
+			continue
+		}
+		for _, m := range ed.Methods {
+			if m.Body == nil || m.Body.Result == nil {
+				t.Errorf("method %s: body.Result missing (enum variant call promotion regression)", m.Name)
+				continue
+			}
+			if got := typeString(m.Body.Result.Type()); got != "Value" {
+				t.Errorf("method %s: body.Result.Type = %q, want Value", m.Name, got)
+			}
+		}
+	}
+}
+
 // `self` inside a struct method body must resolve to the owner
 // struct's nominal type. The resolver records the `self` ident with
 // `Decl = *ast.Receiver`, which carries no type info on its own. The


### PR DESCRIPTION
## Summary

**Stage0 toolchain audit: 7411 → 7479 (97.6% → 99.0%)** — +68 functions. #1656 이후 단일 PR 로 가장 큰 coverage 향상.

## 원인

`Enum.Variant(args)` 패턴 (예: `Color.Red(255)`, `Value.IntVal(n)`, `HirCallKind.Free(name)`) 이 trailing position 에서 block Result 로 promote 안 됨.

`expressionYieldsValue` 의 CallExpr branch:
- user method (FieldExpr.X = value ident on struct)
- builtin container method
- closure-arg-dependent
- use-alias FFI

receiver 가 **enum decl** 인 케이스 (`SymEnum`) 처리 누락. trailing variant construction → ExprStmt → MIR UnreachableTerm → stage0 거부.

이 패턴은 toolchain 에서 매우 흔함 — 자신의 enum 의 다른 variant 를 생성하는 helper method.

## 변경

새 `enumVariantCallReturnTypeFromAST` helper:
1. receiver Ident resolve → `SymEnum` 확인
2. field name 이 enum 의 variant 인지 `isVariantOfEnum` 으로 확인
3. `&NamedType{Name: enum}` 반환

`expressionYieldsValue` 의 use-alias fallback 뒤에 wire-in.

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: **7479 / 7555 (99.0%)** — 이전 7411 / 7555 (97.6%) 에서 **+68 covered**
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit`: 0 errors
- 새 회귀 테스트 `TestLowerEnumVariantCallPromotes`: PASS
- `internal/{ir,check,airepair,mir,lsp,backend}` — 전부 green

## 회귀 시리즈 성과

Real-world audit 기반 fix:
- #1693: +48 (chained method calls, use-go FFI, unary recovery)
- 본 PR: +68 (enum-qualified variant calls)

작은 helper 하나로 매우 큰 toolchain coverage 회복.

## Test plan

- [x] `go test -run TestLowerEnumVariantCallPromotes ./internal/ir/...` — green
- [x] `go test ./internal/{ir,check,airepair,mir,lsp,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1` — **99.0% (+68)**

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_