### PR TITLE
fix(mir): recover stale FieldExpr.T for let bindings via struct layout

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -933,9 +933,21 @@ func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 	// scalar element type — the recovery returns the original `x.T`
 	// when no slicing/list rule applies, so non-slice indexes are
 	// unaffected.
+	//
+	// The same stale-Type pattern bites `let kind = parser.peek().kind`:
+	// FieldExpr.T may be a defaulted String when the checker's
+	// post-unification step forced kind's type to match an enum-variant
+	// comparison RHS that lowered as a String const. `fieldExprType`
+	// resolves via the struct layout (authoritative) and falls through
+	// to x.T otherwise, so non-stale FieldExprs are unaffected.
 	if let.Value != nil {
-		if ix, ok := let.Value.(*ir.IndexExpr); ok {
-			if recovered := bs.indexExprType(ix); !isPoisonType(recovered) {
+		switch v := let.Value.(type) {
+		case *ir.IndexExpr:
+			if recovered := bs.indexExprType(v); !isPoisonType(recovered) {
+				t = recovered
+			}
+		case *ir.FieldExpr:
+			if recovered := bs.fieldExprType(v); !isPoisonType(recovered) {
 				t = recovered
 			}
 		}

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -2865,6 +2865,67 @@ func TestLowerStringSliceLetBindingTypeRecoveredFromIndexExpr(t *testing.T) {
 	}
 }
 
+// TestLowerLetFieldExprRecoversStaleType verifies the `let kind =
+// token.kind` shape: when the check pass forces FieldExpr.T to a
+// defaulted String (post-unification with an enum-variant comparison
+// RHS), the let-binding must reach into the struct layout for the
+// authoritative field type. Pre-patch the binding inherited the stale
+// String even though the actual field projection produced FrontTokenKind.
+func TestLowerLetFieldExprRecoversStaleType(t *testing.T) {
+	tokenTy := &ir.NamedType{Name: "Token"}
+	kindTy := &ir.NamedType{Name: "TokenKind"}
+	fn := &ir.FnDecl{
+		Name:   "kindOf",
+		Return: kindTy,
+		Params: []*ir.Param{{Name: "tok", Type: tokenTy}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name: "kind",
+					Value: &ir.FieldExpr{
+						X:    &ir.Ident{Name: "tok", Kind: ir.IdentParam, T: tokenTy},
+						Name: "kind",
+						T:    ir.TString, // stale — should be TokenKind
+					},
+				},
+			},
+			Result: &ir.Ident{Name: "kind", Kind: ir.IdentLocal, T: kindTy},
+		},
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.StructDecl{
+				Name:   "Token",
+				Fields: []*ir.Field{{Name: "kind", Type: kindTy}},
+			},
+			&ir.EnumDecl{
+				Name:     "TokenKind",
+				Variants: []*ir.Variant{{Name: "VDot"}, {Name: "VSlash"}},
+			},
+			fn,
+		},
+	}
+	out := Lower(mod)
+	mirFn := out.LookupFunction("kindOf")
+	if mirFn == nil {
+		t.Fatal("missing kindOf")
+	}
+	var kindLocal *Local
+	for _, l := range mirFn.Locals {
+		if l != nil && l.Name == "kind" {
+			kindLocal = l
+			break
+		}
+	}
+	if kindLocal == nil {
+		t.Fatalf("expected `kind` local:\n%s", PrintFunction(mirFn))
+	}
+	if named, ok := kindLocal.Type.(*ir.NamedType); !ok || named.Name != "TokenKind" {
+		t.Fatalf("kind local should be TokenKind, got %T (%v):\n%s", kindLocal.Type, kindLocal.Type, PrintFunction(mirFn))
+	}
+}
+
 // TestRecoverOperandTypeBinaryArithRecursesIntoFieldExprs verifies the
 // recovery path for `let size = node.end - node.start` where both
 // operands are FieldExpr with stale `.T` (ErrType after the checker


### PR DESCRIPTION
## Summary

\`let kind = token.kind\` 형태에서 FieldExpr.T 가 checker post-unification 으로 defaulted String 등으로 떨어질 때 let-binding 이 stale 타입 상속하던 버그 fix.

부트스트랩 차단 해소 우산 ([LLVM_BACKEND_GAP_PLAN.md](LLVM_BACKEND_GAP_PLAN.md) Phase 0-A) 의 5번째 슬라이스.

## Context

\`opUsePathSep(p: OstyParser) -> String\`:
\`\`\`osty
let kind = opPeek(p).kind  // FieldExpr.T = String (stale, should be FrontTokenKind)
if kind == FrontDot { ... }
\`\`\`

MIR 가 field projection 은 layout-기반 \`type=named:FrontTokenKind\` 으로 정확히 lower 하지만, let-binding local#2 는 stale String 으로 declare → \`Binary(==, String, FrontTokenKind)\` 타입 미스매치.

## Fix

\`mir.lowerLet\` 의 IndexExpr 케이스와 동일 패턴 (PR #1695) 으로 FieldExpr 도 unconditional 하게 \`fieldExprType\` 호출. \`fieldExprType\` 는 struct layout 에서 authoritative lookup 하고 lookup 실패 시 x.T 로 fall-through → stale 케이스만 fix.

## 측정

- audit cover: **98.9% → 99.0%** (+5 함수, **99% 돌파**)
- 누적 (5 PR): audit 94.2% → 99.0% (+1366 함수, 4.8pp)

## Tests
- 새 회귀 테스트 \`TestLowerLetFieldExprRecoversStaleType\` 통과
- \`go test ./internal/mir/\` 회귀 없음
- \`go test -short ./internal/backend/\` 회귀 없음 (147s 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)