### PR TITLE
fix(ir): promote trailing std module calls (+30 stage0 coverage)

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1079,6 +1079,13 @@ func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
 				if rt := l.enumVariantCallReturnTypeFromAST(fx); rt != nil && expressionTypeYieldsValue(rt) {
 					return true
 				}
+				// `use std.strings` module call: `strings.toLower(s)`.
+				// Receiver Ident resolves to `SymPackage` whose Decl
+				// is a `*ast.UseDecl` with Path = ["std", "strings", ...].
+				// Look up the fn declaration in the stdlib registry.
+				if rt := l.stdModuleFnReturnTypeFromAST(fx); rt != nil && expressionTypeYieldsValue(rt) {
+					return true
+				}
 			}
 			// Free-fn calls (`helper()`): promote when the resolved
 			// declaration has a non-unit return type. We restrict this
@@ -1423,6 +1430,48 @@ func (l *lowerer) findLetStmtByPattern(pat *ast.IdentPat) *ast.LetStmt {
 	}
 	walk(l.file)
 	return found
+}
+
+// stdModuleFnReturnTypeFromAST resolves `module.fn(...)` calls where
+// `module` is a `use std.X` import alias. Looks up the fn's declared
+// return type via the existing `lookupUseDeclFnReturn` /
+// `lookupPackageFnReturn` chain, with a stdlib-registry fallback for
+// single-file contexts where `sym.Package` isn't populated.
+func (l *lowerer) stdModuleFnReturnTypeFromAST(fx *ast.FieldExpr) Type {
+	if l == nil || fx == nil || l.res == nil {
+		return nil
+	}
+	id, ok := fx.X.(*ast.Ident)
+	if !ok || id == nil {
+		return nil
+	}
+	sym := l.res.RefsByID[id.ID]
+	if sym == nil || sym.Kind != resolve.SymPackage {
+		return nil
+	}
+	ud, ok := sym.Decl.(*ast.UseDecl)
+	if !ok || ud == nil {
+		return nil
+	}
+	if t := l.lookupUseDeclFnReturn(ud, fx.Name); t != nil && t != ErrTypeVal {
+		return t
+	}
+	if sym.Package != nil {
+		if t := l.lookupPackageFnReturn(sym.Package, fx.Name); t != nil && t != ErrTypeVal {
+			return t
+		}
+	}
+	// stdlib registry direct lookup.
+	if reg := stdlib.LoadCached(); reg != nil && len(ud.Path) >= 2 && ud.Path[0] == "std" {
+		modKey := strings.Join(ud.Path[1:], ".")
+		if fn := reg.LookupFnDecl(modKey, fx.Name); fn != nil {
+			if fn.ReturnType == nil {
+				return TUnit
+			}
+			return l.lowerType(fn.ReturnType)
+		}
+	}
+	return nil
 }
 
 // enumVariantCallReturnTypeFromAST resolves `Enum.Variant(...)` calls

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -881,6 +881,44 @@ fn main() {}`,
 	}
 }
 
+// `use std.X` module call (`strings.toLower(s)`, `debug.dbg(n)`) at
+// trailing position must promote. The receiver Ident resolves to a
+// `SymPackage` whose Decl is `*ast.UseDecl` with Path = ["std", "X"].
+// The fn's declared return type is looked up via the stdlib registry
+// (single-file context) or `sym.Package` (package context). Without
+// this, trailing `strings.toLower(strings.trim(raw))` lowers as
+// ExprStmt → MIR UnreachableTerm.
+func TestLowerStdModuleCallPromotes(t *testing.T) {
+	src := `use std.strings
+fn norm(s: String) -> String {
+    strings.toLower(strings.trim(s))
+}
+fn main() {}`
+	file, _ := parser.ParseDiagnostics([]byte(src))
+	res := resolve.ResolveFileSourceDefault([]byte(src), file, stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, _ := Lower("main", file, res, chk)
+	for _, decl := range mod.Decls {
+		fn, ok := decl.(*FnDecl)
+		if !ok || fn.Name != "norm" {
+			continue
+		}
+		if fn.Body == nil || fn.Body.Result == nil {
+			t.Fatal("body.Result missing")
+		}
+		if got := typeString(fn.Body.Result.Type()); got != "String" {
+			t.Errorf("body.Result.Type = %q, want String", got)
+		}
+	}
+}
+
 // Enum-qualified variant calls (`Color.Red(255)`, `Value.IntVal(n)`)
 // must promote to the block's Result when at trailing position. The
 // receiver Ident resolves to a `SymEnum`, the field name to one of


### PR DESCRIPTION
## Summary

Stage0 audit **7479 → 7509 (+30)**, 99.1%. `use std.X` 모듈 호출 trailing 위치 promotion.

## 원인

`use std.X` 모듈 함수 호출 (`strings.toLower(s)`, `debug.dbg(n)`) 이 trailing 위치에서 promotion 안 됨. receiver Ident → `SymPackage`, Decl = `*ast.UseDecl` (Path=["std", "X", ...]). 하지만 `expressionYieldsValue` 에 이 shape 처리 branch 없음 — `useAliasFnReturnTypeFromAST` 는 `use go { fn }` inline FFI 만.

trailing `strings.toLower(strings.trim(raw))` 가 ExprStmt 로 drop → MIR UnreachableTerm → stage0 거부.

## 변경

새 `stdModuleFnReturnTypeFromAST` helper. `lowerMethodCall` 가 이미 stdlib module call 에 쓰는 lookup chain 사용:

1. `lookupUseDeclFnReturn(ud, name)` — inline UseDecl body
2. `lookupPackageFnReturn(sym.Package, name)` — resolved package
3. `stdlib.LookupFnDecl(modKey, name)` — registry direct (single-file context)

`expressionYieldsValue` 의 enum-variant-call fallback 다음에 wire-in.

## 검증

- `OSTY_STAGE0_AUDIT=1 TestStage0ToolchainAudit`: **7509 / 7580 (99.1%)** — 이전 7479 / 7555 에서 +30 covered
- `OSTY_CHECK_PARITY_AUDIT=1 TestCheckPackageParityAudit`: 0 errors
- 새 회귀 테스트 `TestLowerStdModuleCallPromotes`: PASS
- `internal/{ir,check,airepair,mir,lsp,backend}` 전부 green

## Test plan

- [x] `go test -run TestLowerStdModuleCallPromotes ./internal/ir/...` — green
- [x] `OSTY_STAGE0_AUDIT=1` — **99.1% (+30)**
- [x] All affected packages green

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_