### PR TITLE
fix(ir): AST-side receiver fallback in lowerFieldExpr

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -4532,6 +4532,19 @@ func (l *lowerer) lowerFieldExpr(e *ast.FieldExpr) Expr {
 				t = recovered
 			}
 		}
+		// AST-side receiver recovery: when the IR receiver's T is
+		// `<error>` (chained method receivers, `self`, idents whose
+		// inferred type didn't make it through), resolve the receiver
+		// statically and retry the struct-decl field lookup. Without
+		// this, every `recv.field` chain where the receiver is itself
+		// a non-trivial expression keeps T=<error> and cascades.
+		if !usableRecoveredType(t) {
+			if astRecvT := l.resolveExprStaticType(e.X); astRecvT != nil && astRecvT != ErrTypeVal {
+				if recovered := l.recoverFieldType(astRecvT, e.Name); recovered != nil {
+					t = recovered
+				}
+			}
+		}
 	}
 	return &FieldExpr{
 		X:        x,


### PR DESCRIPTION
## Summary

`lowerFieldExpr` 에 AST-side receiver fallback 추가. `e.X.Type()` 가 `<error>` 인 경우 (chained method receiver, `self`, inferred 실패 ident 등) `resolveExprStaticType(e.X)` 로 receiver type 회복 후 struct-decl field lookup 재시도.

## Stage0 / 회귀 impact

- Stage0 audit: 7509/7580 (99.1%) — **변동 없음**. toolchain receivers 는 기존 chain 으로 이미 회복.
- examples errs: 9403 → 9403 — 변동 없음. examples 회귀의 root cause 는 selfhost resolver 가 cross-file ident 를 못 resolve 하는 것 (IR layer 가 cover 못함).

이 fix 는 conservative — 기존 type-driven path 와 struct-decl recovery 가 둘 다 실패한 후에만 fire. Single-file user code shape 중 receiver IR T 는 `<error>` 지만 AST static type 은 회복 가능한 코너 케이스에 도움.

## 정직한 평가

지금까지의 회귀 시리즈는 stage0 audit 가 94.2% → 99.1% (+~5%, ~370 toolchain functions) 회복했지만, 남은 1% 와 examples 의 회귀는 root cause 가 selfhost resolver 에 있어 Go IR layer fix 한계 도달. 더 큰 회복은 selfhost-resolver level 작업 필요.

## Test plan

- [x] `go test ./internal/{ir,check,airepair,mir,lsp,backend}/...` — green
- [x] `OSTY_STAGE0_AUDIT=1` — 99.1% (불변)

https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfMy3nvVz6mek7yiE5vZdT)_