### PR TITLE
fix(stage0): cover 2-arg IntrinsicStringSubstring via implicit ByteLen end

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -2521,6 +2521,9 @@ func classifyIntrinsicValueStep(fn *mir.Function, ii *mir.IntrinsicInstr, bindin
 	if ii.Kind == mir.IntrinsicLikely || ii.Kind == mir.IntrinsicUnlikely {
 		return classifyBranchHintIntrinsic(fn, ii, destID, destType, bindings, mctx)
 	}
+	if ii.Kind == mir.IntrinsicStringSubstring && len(ii.Args) == 2 {
+		return classifyStringSubstring2ArgIntrinsic(fn, ii, destID, destType, bindings, mctx)
+	}
 
 	spec, ok := intrinsicRuntimeCallSpec(ii.Kind)
 	if !ok || spec.ret != destType || len(spec.args) != len(ii.Args) {
@@ -2544,6 +2547,51 @@ func classifyIntrinsicValueStep(fn *mir.Function, ii *mir.IntrinsicInstr, bindin
 		callArgs:   args,
 		resultType: destType,
 	}, destID, destType, true
+}
+
+// classifyStringSubstring2ArgIntrinsic handles the `s.substring(start)`
+// shape (one-arg method on `String`) which lowers to a 2-arg MIR
+// IntrinsicStringSubstring. The 3-arg form `s.substring(start, end)`
+// goes through the generic `intrinsicRuntimeCallSpec` dispatcher and
+// maps directly onto `osty_rt_strings_Slice(s, start, end)`. The
+// 2-arg form needs an additional `osty_rt_strings_ByteLen(s)` call
+// to synthesise the implicit `end` argument before the slice call.
+//
+// Surfaced when stage0 audit (`toolchain/check.osty`) tried to emit
+// `collectFnDecl` and its siblings, all of which use the bare
+// `name.substring(idx)` pattern — without this branch every checker
+// function that takes a substring of an identifier name to drop a
+// prefix declined the generic dispatcher's strict arity check.
+func classifyStringSubstring2ArgIntrinsic(fn *mir.Function, ii *mir.IntrinsicInstr, destID mir.LocalID, destType scalarType, bindings map[mir.LocalID]localBinding, mctx *moduleCtx) (pendingInstr, mir.LocalID, scalarType, bool) {
+	if destType != scalarString || len(ii.Args) != 2 {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	sPrelude, sExpr, sTy, ok := resolveOperandWithPrelude(fn, ii.Args[0], bindings, mctx)
+	if !ok || sTy != scalarString {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	startPrelude, startExpr, startTy, ok := resolveOperandWithPrelude(fn, ii.Args[1], bindings, mctx)
+	if !ok || startTy != scalarInt {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	declareRuntimePrototype(mctx, "osty_rt_strings_ByteLen", scalarInt, []callArg{{ty: "ptr"}})
+	declareRuntimePrototype(mctx, "osty_rt_strings_Slice", scalarString, []callArg{{ty: "ptr"}, {ty: "i64"}, {ty: "i64"}})
+	endReg := mctx.freshTempName("substring.end")
+	var prelude strings.Builder
+	prelude.WriteString(sPrelude)
+	prelude.WriteString(startPrelude)
+	fmt.Fprintf(&prelude, "  %s = call i64 @osty_rt_strings_ByteLen(ptr %s)\n", endReg, sExpr)
+	return pendingInstr{
+		kind:       instrCall,
+		prelude:    prelude.String(),
+		callSymbol: "osty_rt_strings_Slice",
+		callArgs: []callArg{
+			{expr: sExpr, ty: "ptr"},
+			{expr: startExpr, ty: "i64"},
+			{expr: endReg, ty: "i64"},
+		},
+		resultType: scalarString,
+	}, destID, scalarString, true
 }
 
 func classifyListIsEmptyIntrinsic(fn *mir.Function, ii *mir.IntrinsicInstr, destID mir.LocalID, destType scalarType, bindings map[mir.LocalID]localBinding, mctx *moduleCtx) (pendingInstr, mir.LocalID, scalarType, bool) {
@@ -8376,6 +8424,25 @@ func emitWhileValueIntrinsic(ctx *whileLoopEmitCtx, out *strings.Builder, ii *mi
 		}
 		declareRuntimePrototype(ctx.mctx, symbol, scalarInt, []callArg{{ty: "ptr"}, {ty: "ptr"}})
 		return emitWhileOptionI64FromRuntime(ctx, out, destID, symbol, args)
+	case mir.IntrinsicStringSubstring:
+		// 2-arg form `s.substring(start)` — synthesise `end` via
+		// `osty_rt_strings_ByteLen(s)` and route through the same
+		// `osty_rt_strings_Slice` 3-arg call as the explicit-range form.
+		// The 3-arg form falls through to the generic
+		// `intrinsicRuntimeCallSpec` dispatcher below.
+		if destType != scalarString || len(ii.Args) != 2 {
+			break
+		}
+		args, ok := resolveWhileFixedScalarArgs(ctx, out, ii.Args, []scalarType{scalarString, scalarInt})
+		if !ok {
+			return false
+		}
+		declareRuntimePrototype(ctx.mctx, "osty_rt_strings_ByteLen", scalarInt, []callArg{{ty: "ptr"}})
+		declareRuntimePrototype(ctx.mctx, "osty_rt_strings_Slice", scalarString, []callArg{{ty: "ptr"}, {ty: "i64"}, {ty: "i64"}})
+		endReg := freshReg(ctx)
+		fmt.Fprintf(out, "  %s = call i64 @osty_rt_strings_ByteLen(ptr %s)\n", endReg, args[0].expr)
+		sliceArgs := []callArg{args[0], args[1], {expr: endReg, ty: "i64"}}
+		return emitWhileCallResult(ctx, out, destID, destType, "osty_rt_strings_Slice", sliceArgs)
 	}
 
 	spec, ok := intrinsicRuntimeCallSpec(ii.Kind)


### PR DESCRIPTION
## Summary

`s.substring(start)` (one-arg method on `String`) lowers to a 2-arg MIR `IntrinsicStringSubstring`, whereas `s.substring(start, end)` lowers to 3-arg. The generic `intrinsicRuntimeCallSpec` dispatcher in `internal/backend/stage0/emit.go` is keyed on exact arity:

```go
if !ok || spec.ret != destType || len(spec.args) != len(ii.Args) {
    return ..., false
}
```

so the 2-arg form failed strict arity and declined every checker function that used the bare `name.substring(idx)` pattern. `toolchain/check.osty:collectFnDecl` was the canonical example.

## Fix

Add a 2-arg branch in two emit paths:

- **`classifyIntrinsicValueStep`** (sequential emit): new `classifyStringSubstring2ArgIntrinsic` helper resolves operands, declares `osty_rt_strings_ByteLen`, and returns a `pendingInstr` whose `prelude` synthesises `end = osty_rt_strings_ByteLen(s)` before the `osty_rt_strings_Slice(s, start, end)` call.
- **`emitWhileValueIntrinsic`** (loop emit): mirror as new `case mir.IntrinsicStringSubstring:` that allocates the byte-len register inline via `freshReg`.

Both paths leave the 3-arg form to the generic dispatcher.

## Audit progression

| Level | Before | After |
|---|---|---|
| L1 per-function | 7479 / 7555 (99.0%), declines 87 | **7481 / 7555 (99.0%)**, declines **85** |
| L2 module-verify | clean | clean |
| L3 exec-verify | `--selfhost-doctor` ✓ exit 0 | `--selfhost-doctor` ✓ exit 0 |
| L4 fp-verify deepest | `--selfhost-doctor` | `--selfhost-doctor` |

`collectFnDecl` and `checkPodStructShape` now emit cleanly. Remaining ~85 declines are dominated by a separate family: `BinaryRV{Op: Eq/Neq, Left.Type: ErrType, Right.Type: NamedType(AstNodeKind)}` where IR didn't recover the type of a field-access (`node.kind`) returning an enum. Same shape family as the runCompile `Ok(s) -> s` variant-binding recovery in #1699, just for `FieldExpr` instead of `MatchExpr` — tracked for a follow-up PR.

## Test plan

- [x] `OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_CLANG_VERIFY=1 OSTY_STAGE0_AUDIT_MODULE_VERIFY=1 OSTY_STAGE0_AUDIT_EXEC_VERIFY=1 OSTY_STAGE0_AUDIT_FP_VERIFY=1 go test -count=1 -vet=off -run TestStage0ToolchainAudit ./internal/backend/` PASS
- [x] Backend test failure count unchanged (82 → 82)
- [x] `go vet ./internal/backend/...` clean
- [x] `gofmt -l` clean

https://claude.ai/code/session_01C4hC1RTMmofdZm8R3nPbh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4hC1RTMmofdZm8R3nPbh9)_