### PR TITLE
fix(stage0): box named-aggregate returns through ptr ABI to match call sites

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -679,6 +679,46 @@ func (m *moduleCtx) freshTempName(label string) string {
 	return name
 }
 
+// aggregateReturnIsHeapPtr reports whether stage0 should box a
+// function's aggregate return value through `osty_rt_stage0_alloc`
+// and return the pointer. Named struct / payloadful-enum returns go
+// through the pointer ABI so the rest of stage0 (which treats user
+// struct/enum values as opaque `ptr` at call sites) sees a matching
+// ABI. Tuple returns keep their in-register struct-by-value ABI
+// because tuple-aware call sites bind the SSA register directly.
+//
+// See: the segfault audit at `frontIdentScan` → `frontScanResult`
+// where `define %FrontScanResult` collided with `call ptr` and LLVM
+// silently lowered the def with sret + the call without. The fix is
+// to make every NamedType aggregate return go through the same
+// pointer convention as the call sites already expect.
+func aggregateReturnIsHeapPtr(retT mir.Type) bool {
+	_, isTuple := retT.(*ir.TupleType)
+	return !isTuple
+}
+
+// emitAggregateValueToPtrReturn closes out an aggregate-returning
+// function body by allocating a managed slot, storing the SSA struct
+// value, and emitting `ret ptr <slot>`. Used by the 6 aggregate
+// emitters whose function signature became `define ptr @fn(...)` —
+// the in-register `%T` value built by the existing insertvalue chain
+// is boxed exactly once at the return seam.
+//
+// `retval` is the SSA register holding the fully populated `%T`
+// struct value (e.g. `%7` or `%retval`). `typeName` is the struct's
+// LLVM type name (without `%`).
+func emitAggregateValueToPtrReturn(out *strings.Builder, mctx *moduleCtx, typeName, retval string) {
+	declareRuntimePrototype(mctx, "osty_rt_stage0_alloc", scalarOpaquePtr, []callArg{{ty: "i64"}})
+	sizePtr := mctx.freshTempName("agg.ret.sizeof.ptr")
+	size := mctx.freshTempName("agg.ret.sizeof")
+	slot := mctx.freshTempName("agg.ret.slot")
+	fmt.Fprintf(out, "  %s = getelementptr %%%s, ptr null, i32 1\n", sizePtr, typeName)
+	fmt.Fprintf(out, "  %s = ptrtoint ptr %s to i64\n", size, sizePtr)
+	fmt.Fprintf(out, "  %s = call ptr @osty_rt_stage0_alloc(i64 %s)\n", slot, size)
+	fmt.Fprintf(out, "  store %%%s %s, ptr %s\n", typeName, retval, slot)
+	fmt.Fprintf(out, "  ret ptr %s\n", slot)
+}
+
 // internStringConst interns `value` and returns the LLVM operand
 // expression for it (e.g., `@.str.0`). The byte sequence is emitted
 // into `mctx.extraDecls` as a private unnamed_addr constant
@@ -855,7 +895,7 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 		return emitListLiteralLen(out, fn, pat)
 	}
 	if pat, ok := matchAggregateConstructor(fn, mctx); ok {
-		return emitAggregateConstructor(out, fn, pat)
+		return emitAggregateConstructor(out, fn, pat, mctx)
 	}
 	if pat, ok := matchListLiteralIndexGet(fn, mctx); ok {
 		return emitListLiteralIndexGet(out, fn, pat)
@@ -6061,7 +6101,12 @@ func classifyAggregateBranch(fn *mir.Function, bb *mir.BasicBlock, label string,
 
 func emitIfElseAggregateReturn(out *strings.Builder, fn *mir.Function, pat ifElseAggregatePattern, mctx *moduleCtx) error {
 	mctx.emitStructDef(pat.typeName, pat.fieldTypes)
-	fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	heapPtr := aggregateReturnIsHeapPtr(fn.ReturnType)
+	if heapPtr {
+		fmt.Fprintf(out, "define ptr @%s(", fn.Name)
+	} else {
+		fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	}
 	for i, name := range pat.paramNames {
 		if i > 0 {
 			out.WriteString(", ")
@@ -6099,7 +6144,11 @@ func emitIfElseAggregateReturn(out *strings.Builder, fn *mir.Function, pat ifEls
 		pat.thenBranch.resultExpr, pat.thenBranch.predLabelOut,
 		pat.elseBranch.resultExpr, pat.elseBranch.predLabelOut,
 	)
-	fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	if heapPtr {
+		emitAggregateValueToPtrReturn(out, mctx, pat.typeName, "%retval")
+	} else {
+		fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	}
 	out.WriteString("}\n\n")
 	return nil
 }
@@ -6370,7 +6419,12 @@ func matchOrShortCircuitIfElseAggregate(fn *mir.Function, mctx *moduleCtx) (orSh
 
 func emitOrShortCircuitIfElseAggregate(out *strings.Builder, fn *mir.Function, pat orShortCircuitPattern, mctx *moduleCtx) error {
 	mctx.emitStructDef(pat.typeName, pat.fieldTypes)
-	fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	heapPtr := aggregateReturnIsHeapPtr(fn.ReturnType)
+	if heapPtr {
+		fmt.Fprintf(out, "define ptr @%s(", fn.Name)
+	} else {
+		fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	}
 	for i, name := range pat.paramNames {
 		if i > 0 {
 			out.WriteString(", ")
@@ -6423,7 +6477,11 @@ func emitOrShortCircuitIfElseAggregate(out *strings.Builder, fn *mir.Function, p
 		pat.thenBranch.resultExpr, pat.thenBranch.predLabelOut,
 		pat.elseBranch.resultExpr, pat.elseBranch.predLabelOut,
 	)
-	fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	if heapPtr {
+		emitAggregateValueToPtrReturn(out, mctx, pat.typeName, "%retval")
+	} else {
+		fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	}
 	out.WriteString("}\n\n")
 	return nil
 }
@@ -6709,7 +6767,12 @@ func classifyChainAggregateArm(fn *mir.Function, arm, returnBlock *mir.BasicBloc
 
 func emitElseIfChainAggregate(out *strings.Builder, fn *mir.Function, pat elseIfChainPattern, mctx *moduleCtx) error {
 	mctx.emitStructDef(pat.typeName, pat.fieldTypes)
-	fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	heapPtr := aggregateReturnIsHeapPtr(fn.ReturnType)
+	if heapPtr {
+		fmt.Fprintf(out, "define ptr @%s(", fn.Name)
+	} else {
+		fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	}
 	for i, name := range pat.paramNames {
 		if i > 0 {
 			out.WriteString(", ")
@@ -6755,7 +6818,11 @@ func emitElseIfChainAggregate(out *strings.Builder, fn *mir.Function, pat elseIf
 		fmt.Fprintf(out, " [ %s, %%%s ]", arm.resultExpr, arm.label)
 	}
 	out.WriteString("\n")
-	fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	if heapPtr {
+		emitAggregateValueToPtrReturn(out, mctx, pat.typeName, "%retval")
+	} else {
+		fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	}
 	out.WriteString("}\n\n")
 	return nil
 }
@@ -7062,7 +7129,12 @@ func matchOrChainAggregate(fn *mir.Function, mctx *moduleCtx) (orChainPattern, b
 
 func emitOrChainAggregate(out *strings.Builder, fn *mir.Function, pat orChainPattern, mctx *moduleCtx) error {
 	mctx.emitStructDef(pat.typeName, pat.fieldTypes)
-	fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	heapPtr := aggregateReturnIsHeapPtr(fn.ReturnType)
+	if heapPtr {
+		fmt.Fprintf(out, "define ptr @%s(", fn.Name)
+	} else {
+		fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	}
 	for i, name := range pat.paramNames {
 		if i > 0 {
 			out.WriteString(", ")
@@ -7135,7 +7207,11 @@ func emitOrChainAggregate(out *strings.Builder, fn *mir.Function, pat orChainPat
 		fmt.Fprintf(out, " [ %s, %%%s ]", arm.resultExpr, arm.label)
 	}
 	out.WriteString("\n")
-	fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	if heapPtr {
+		emitAggregateValueToPtrReturn(out, mctx, pat.typeName, "%retval")
+	} else {
+		fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	}
 	out.WriteString("}\n\n")
 	return nil
 }
@@ -7259,7 +7335,14 @@ func matchDirectAggregateCall(fn *mir.Function, mctx *moduleCtx) (directAggregat
 	// Always declare the callee prototype before the call site. This keeps
 	// partial/list-all-declines modules parseable even when the referenced
 	// helper function declined and therefore has no local `define` body.
-	declareAggregateFunctionPrototype(mctx, ref.Symbol, typeName, args)
+	// Named-aggregate callees (struct / payloadful-enum) return ptr after
+	// the ABI fix in aggregateReturnIsHeapPtr; tuple callees keep the
+	// in-register struct-by-value ABI.
+	if aggregateReturnIsHeapPtr(fn.ReturnType) {
+		declareAggregateFunctionPrototype(mctx, ref.Symbol, "ptr", args)
+	} else {
+		declareAggregateFunctionPrototype(mctx, ref.Symbol, "%"+typeName, args)
+	}
 
 	pat.callSymbol = ref.Symbol
 	pat.callArgs = args
@@ -7267,11 +7350,12 @@ func matchDirectAggregateCall(fn *mir.Function, mctx *moduleCtx) (directAggregat
 	return pat, true
 }
 
-// declareAggregateFunctionPrototype emits a `declare %TypeName @symbol(...)`
+// declareAggregateFunctionPrototype emits a `declare <retLLVM> @symbol(...)`
 // line into extraDecls for callee functions whose return type is an aggregate
-// (struct or tuple) rather than a scalar.
-func declareAggregateFunctionPrototype(mctx *moduleCtx, symbol, typeName string, args []callArg) {
-	if mctx == nil || symbol == "" || typeName == "" {
+// (struct or tuple) rather than a scalar. `retLLVM` is the literal LLVM
+// return-type token (e.g. `ptr` or `%TypeName`).
+func declareAggregateFunctionPrototype(mctx *moduleCtx, symbol, retLLVM string, args []callArg) {
+	if mctx == nil || symbol == "" || retLLVM == "" {
 		return
 	}
 	if mctx.definedFnSyms[symbol] {
@@ -7286,7 +7370,7 @@ func declareAggregateFunctionPrototype(mctx *moduleCtx, symbol, typeName string,
 		return
 	}
 	mctx.emittedStructs[key] = true
-	fmt.Fprintf(mctx.extraDecls, "declare %%%s @%s(", typeName, symbol)
+	fmt.Fprintf(mctx.extraDecls, "declare %s @%s(", retLLVM, symbol)
 	for i, a := range args {
 		if i > 0 {
 			mctx.extraDecls.WriteString(", ")
@@ -7298,7 +7382,12 @@ func declareAggregateFunctionPrototype(mctx *moduleCtx, symbol, typeName string,
 
 func emitDirectAggregateCall(out *strings.Builder, fn *mir.Function, pat directAggregateCallPattern, mctx *moduleCtx) error {
 	mctx.emitStructDef(pat.typeName, pat.fieldTypes)
-	fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	heapPtr := aggregateReturnIsHeapPtr(fn.ReturnType)
+	retLLVM := "%" + pat.typeName
+	if heapPtr {
+		retLLVM = "ptr"
+	}
+	fmt.Fprintf(out, "define %s @%s(", retLLVM, fn.Name)
 	for i, name := range pat.paramNames {
 		if i > 0 {
 			out.WriteString(", ")
@@ -7309,9 +7398,7 @@ func emitDirectAggregateCall(out *strings.Builder, fn *mir.Function, pat directA
 	out.WriteString("entry:\n")
 
 	out.WriteString(pat.callPrelude)
-	out.WriteString("  %0 = call %")
-	out.WriteString(pat.typeName)
-	fmt.Fprintf(out, " @%s(", pat.callSymbol)
+	fmt.Fprintf(out, "  %%0 = call %s @%s(", retLLVM, pat.callSymbol)
 	for i, a := range pat.callArgs {
 		if i > 0 {
 			out.WriteString(", ")
@@ -7319,7 +7406,7 @@ func emitDirectAggregateCall(out *strings.Builder, fn *mir.Function, pat directA
 		fmt.Fprintf(out, "%s %s", a.ty, a.expr)
 	}
 	out.WriteString(")\n")
-	fmt.Fprintf(out, "  ret %%%s %%0\n", pat.typeName)
+	fmt.Fprintf(out, "  ret %s %%0\n", retLLVM)
 	out.WriteString("}\n\n")
 	return nil
 }
@@ -12984,9 +13071,18 @@ func payloadlessEnumVariantIndexByName(mctx *moduleCtx, enumName, variantName st
 	return 0, false
 }
 
-func emitAggregateConstructor(out *strings.Builder, fn *mir.Function, pat aggregateConstructorPattern) error {
-	// Function signature.
-	fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+func emitAggregateConstructor(out *strings.Builder, fn *mir.Function, pat aggregateConstructorPattern, mctx *moduleCtx) error {
+	// Function signature. Named struct / enum returns are boxed
+	// through `osty_rt_stage0_alloc` and returned as `ptr` so call
+	// sites (which already treat user-named aggregates as opaque
+	// pointers — see `scalarFromTypeInternal`) see a matching ABI.
+	// Tuple returns keep the in-register struct-by-value ABI.
+	heapPtr := aggregateReturnIsHeapPtr(fn.ReturnType)
+	if heapPtr {
+		fmt.Fprintf(out, "define ptr @%s(", fn.Name)
+	} else {
+		fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	}
 	for i, name := range pat.paramNames {
 		if i > 0 {
 			out.WriteString(", ")
@@ -13009,7 +13105,11 @@ func emitAggregateConstructor(out *strings.Builder, fn *mir.Function, pat aggreg
 		fmt.Fprintf(out, "  %%%d = insertvalue %%%s %s, %s %s, %d\n", reg, pat.typeName, prev, pat.fieldTypes[i].llvm(), fieldExpr, i)
 		prev = fmt.Sprintf("%%%d", reg)
 	}
-	fmt.Fprintf(out, "  ret %%%s %s\n", pat.typeName, prev)
+	if heapPtr {
+		emitAggregateValueToPtrReturn(out, mctx, pat.typeName, prev)
+	} else {
+		fmt.Fprintf(out, "  ret %%%s %s\n", pat.typeName, prev)
+	}
 	out.WriteString("}\n\n")
 	return nil
 }

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -1756,11 +1756,17 @@ func TestStage0AggregateResolvesOnbFnConstAndEmptyDefaults(t *testing.T) {
 	}
 	got := string(gotBytes)
 	for _, want := range []string{
-		"define %OnbInstr @onbInstrAddReg(ptr %dst, ptr %lhs, ptr %rhs)",
+		// Named struct returns go through the heap-pointer ABI now so call
+		// sites (which treat user struct values as opaque ptr) see a
+		// matching return type. The in-register insertvalue chain still
+		// builds the struct value; emitAggregateValueToPtrReturn boxes it
+		// once at the return seam.
+		"define ptr @onbInstrAddReg(ptr %dst, ptr %lhs, ptr %rhs)",
 		"insertvalue %OnbInstr poison, i64 2, 0",
 		"insertvalue %OnbInstr %0, ptr %dst, 1",
 		"insertvalue %OnbInstr %8, i64 -1, 9",
-		"ret %OnbInstr",
+		"store %OnbInstr %11, ptr %stage0.agg.ret.slot",
+		"ret ptr %stage0.agg.ret.slot",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("emitted IR missing %q:\n%s", want, got)
@@ -1825,11 +1831,13 @@ func TestStage0AggregateUsesErrTypedEnumPayloadCall(t *testing.T) {
 	got := string(gotBytes)
 	for _, want := range []string{
 		"declare ptr @KStr(ptr)",
-		"define %TomlValue @tomlValueStr(ptr %s, i64 %line)",
+		// Named struct return → heap-pointer ABI (see emitAggregateConstructor).
+		"define ptr @tomlValueStr(ptr %s, i64 %line)",
 		"%0 = call ptr @KStr(ptr %s)",
 		"insertvalue %TomlValue poison, ptr %0, 0",
 		"insertvalue %TomlValue %1, i64 %line, 1",
-		"ret %TomlValue %2",
+		"store %TomlValue %2, ptr %stage0.agg.ret.slot",
+		"ret ptr %stage0.agg.ret.slot",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("emitted IR missing %q:\n%s", want, got)
@@ -2695,7 +2703,10 @@ func TestStage0P25AggregateReturnAfterCalls(t *testing.T) {
 		"%1 = call ptr @externalLabel()",
 		"%2 = insertvalue %Fixture poison, ptr %0, 0",
 		"%3 = insertvalue %Fixture %2, ptr %1, 1",
-		"ret %Fixture %3",
+		// Named struct return → heap-pointer ABI.
+		"define ptr @fixture()",
+		"store %Fixture %3, ptr %stage0.agg.ret.slot",
+		"ret ptr %stage0.agg.ret.slot",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("emitted IR missing %q:\n%s", want, got)
@@ -2755,7 +2766,10 @@ func TestStage0AggregateReturnCanReadBaseFields(t *testing.T) {
 		"%1 = insertvalue %Rec poison, i64 4, 0",
 		"%2 = insertvalue %Rec %1, ptr %label, 1",
 		"%3 = insertvalue %Rec %2, i64 %stage0.field.1, 2",
-		"ret %Rec %3",
+		// Named struct return → heap-pointer ABI.
+		"define ptr @makeRec(ptr %label)",
+		"store %Rec %3, ptr %stage0.agg.ret.slot",
+		"ret ptr %stage0.agg.ret.slot",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("emitted IR missing %q:\n%s", want, got)

--- a/internal/backend/stage0_p17_test.go
+++ b/internal/backend/stage0_p17_test.go
@@ -34,13 +34,18 @@ fn main() {}
 	}
 	wants := []string{
 		"%Result = type { ptr, i1 }",
-		"define %Result @parseMode(",
+		// Named struct returns go through the heap-pointer ABI (see
+		// aggregateReturnIsHeapPtr). The in-register phi still builds the
+		// struct value; emitAggregateValueToPtrReturn boxes it once at the
+		// return seam.
+		"define ptr @parseMode(",
 		"call i1 @osty_rt_strings_Equal(",
 		"br i1",
 		"insertvalue %Result poison",
 		"insertvalue %Result %",
 		`%retval = phi %Result [`,
-		"ret %Result %retval",
+		"store %Result %retval, ptr %stage0.agg.ret.slot",
+		"ret ptr %stage0.agg.ret.slot",
 	}
 	got := string(out)
 	for _, want := range wants {
@@ -108,7 +113,8 @@ fn main() {}
 	got := string(out)
 	wants := []string{
 		"%Pair = type { ptr, i1 }",
-		"define %Pair @label(ptr %value)",
+		// Named struct return → ptr ABI.
+		"define ptr @label(ptr %value)",
 		// else arm should reference the param register directly
 		"insertvalue %Pair poison, ptr %value, 0",
 	}

--- a/internal/backend/stage0_p18_test.go
+++ b/internal/backend/stage0_p18_test.go
@@ -39,7 +39,8 @@ fn main() {}
 	got := string(out)
 	wants := []string{
 		"%R = type { ptr, i1 }",
-		"define %R @parseMode(ptr %value) {",
+		// Named struct return → heap-pointer ABI.
+		"define ptr @parseMode(ptr %value) {",
 		// left cond evaluation in entry
 		"call i1 @osty_rt_strings_Equal",
 		// short-circuit branch
@@ -52,9 +53,10 @@ fn main() {}
 		"%or = phi i1 [ true, %or_short.",
 		// branch to if-else arms
 		"br i1 %or, label %then.",
-		// final struct phi
+		// final struct phi still uses %R; boxed to ptr at the ret seam.
 		"%retval = phi %R",
-		"ret %R %retval",
+		"store %R %retval, ptr %stage0.agg.ret.slot",
+		"ret ptr %stage0.agg.ret.slot",
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {

--- a/internal/backend/stage0_p19_test.go
+++ b/internal/backend/stage0_p19_test.go
@@ -32,7 +32,8 @@ fn main() {}
 	got := string(out)
 	wants := []string{
 		"%R = type { ptr, i1 }",
-		"define %R @parseMode(ptr %value) {",
+		// Named struct return → heap-pointer ABI.
+		"define ptr @parseMode(ptr %value) {",
 		// Two String== runtime calls + one phi over 3 arms.
 		"call i1 @osty_rt_strings_Equal",
 		// First rung branches to its arm or the second rung's cond block.
@@ -42,9 +43,10 @@ fn main() {}
 		"arm0.",
 		"arm1.",
 		"fallback.",
-		// 3-incoming phi.
+		// 3-incoming phi (still %R-typed; boxed to ptr at the ret seam).
 		"%retval = phi %R [",
-		"ret %R %retval",
+		"store %R %retval, ptr %stage0.agg.ret.slot",
+		"ret ptr %stage0.agg.ret.slot",
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {

--- a/internal/backend/stage0_p20_test.go
+++ b/internal/backend/stage0_p20_test.go
@@ -36,7 +36,8 @@ fn main() {}
 	got := string(out)
 	wants := []string{
 		"%R = type { ptr, i1 }",
-		"define %R @parseMode(ptr %value) {",
+		// Named struct return → heap-pointer ABI.
+		"define ptr @parseMode(ptr %value) {",
 		// `||` head
 		"or_short.",
 		"or_right.",
@@ -52,9 +53,10 @@ fn main() {}
 		"arm2.",
 		"arm3.",
 		"fallback.",
-		// 5-incoming phi
+		// 5-incoming phi (still %R-typed; boxed to ptr at the ret seam).
 		"%retval = phi %R [",
-		"ret %R %retval",
+		"store %R %retval, ptr %stage0.agg.ret.slot",
+		"ret ptr %stage0.agg.ret.slot",
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {

--- a/internal/backend/stage0_p21_test.go
+++ b/internal/backend/stage0_p21_test.go
@@ -31,10 +31,12 @@ fn main() {}
 	got := string(out)
 	wants := []string{
 		"%R = type { ptr, i1 }",
-		"define %R @wrap(ptr %a) {",
+		// Named struct returns flow through the heap-pointer ABI now.
+		// Both wrap and innerFn return ptr; the wrapper just chains.
+		"define ptr @wrap(ptr %a) {",
 		"entry:",
-		"%0 = call %R @innerFn(ptr %a)",
-		"ret %R %0",
+		"%0 = call ptr @innerFn(ptr %a)",
+		"ret ptr %0",
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {
@@ -68,9 +70,9 @@ fn main() {}
 	got := string(out)
 	wants := []string{
 		"%R = type { ptr, i1 }",
-		"define %R @wrap(ptr %a, i1 %b) {",
-		"%0 = call %R @innerFn(ptr %a, i1 %b)",
-		"ret %R %0",
+		"define ptr @wrap(ptr %a, i1 %b) {",
+		"%0 = call ptr @innerFn(ptr %a, i1 %b)",
+		"ret ptr %0",
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {
@@ -105,9 +107,9 @@ fn main() {}
 	got := string(out)
 	wants := []string{
 		"%Config = type { i64, ptr, i1 }",
-		"define %Config @wrap(i64 %n, ptr %name, i1 %active) {",
-		"%0 = call %Config @makeConfig(i64 %n, ptr %name, i1 %active)",
-		"ret %Config %0",
+		"define ptr @wrap(i64 %n, ptr %name, i1 %active) {",
+		"%0 = call ptr @makeConfig(i64 %n, ptr %name, i1 %active)",
+		"ret ptr %0",
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {
@@ -172,9 +174,9 @@ fn main() {}
 	got := string(out)
 	wants := []string{
 		"%R = type { ptr, i1 }",
-		"define %R @wrap() {",
-		"%0 = call %R @defaultR()",
-		"ret %R %0",
+		"define ptr @wrap() {",
+		"%0 = call ptr @defaultR()",
+		"ret ptr %0",
 	}
 	for _, want := range wants {
 		if !strings.Contains(got, want) {

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -359,10 +359,15 @@ fn origin() -> Point { Point { x: 0, y: 0 } }
 fn main() {}`,
 			wantIR: []string{
 				"%Point = type { i64, i64 }",
-				"define %Point @origin()",
+				// Named struct returns are boxed through osty_rt_stage0_alloc
+				// and returned as ptr (see aggregateReturnIsHeapPtr) so call
+				// sites — which treat user struct values as opaque ptr — see
+				// a matching ABI.
+				"define ptr @origin()",
 				"%0 = insertvalue %Point poison, i64 0, 0",
 				"%1 = insertvalue %Point %0, i64 0, 1",
-				"ret %Point %1",
+				"store %Point %1, ptr %stage0.agg.ret.slot",
+				"ret ptr %stage0.agg.ret.slot",
 			},
 		},
 		{
@@ -372,10 +377,11 @@ fn make(x: Int, y: Int) -> Point { Point { x: x, y: y } }
 fn main() {}`,
 			wantIR: []string{
 				"%Point = type { i64, i64 }",
-				"define %Point @make(i64 %x, i64 %y)",
+				"define ptr @make(i64 %x, i64 %y)",
 				"%0 = insertvalue %Point poison, i64 %x, 0",
 				"%1 = insertvalue %Point %0, i64 %y, 1",
-				"ret %Point %1",
+				"store %Point %1, ptr %stage0.agg.ret.slot",
+				"ret ptr %stage0.agg.ret.slot",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Resolves the deeper crash flagged at the end of #1699: `osty lir-proto-lower` / `osty compile` on the stage0-produced binary segfaulted inside the toolchain's `hirLowerSource` → `astParse` → `frontendLexStream` → `frontIdentScan` → `frontScanResult` chain. The audit harness now reports a clean stage0 decline-stub banner instead of `signal: segmentation fault`.

## Root cause — ABI mismatch between aggregate-returning function definitions and their call sites

- Six stage0 emitters (`emitAggregateConstructor`, `emitIfElseAggregateReturn`, `emitOrShortCircuitIfElseAggregate`, `emitElseIfChainAggregate`, `emitOrChainAggregate`, `emitDirectAggregateCall`) wrote `define %T @fn(...) ... ret %T %x` for named-struct / payloadful-enum returns — i.e. struct-by-value.
- Call sites resolve user-named aggregate types as `scalarOpaquePtr` (`scalarFromTypeInternal` with `allowUserNamed=true`) and therefore emit `call ptr @fn(...)` plus `getelementptr inbounds %T, ptr %x` for every downstream field read.

When the struct exceeds the SysV register-return budget (which `FrontScanResult { i64, i64, i1, i64, i1, i64, i1, i1 }` does, at ~56 bytes), LLVM silently lowers the definition with a hidden sret pointer in `rdi` while leaving the call site without one. `rdi` then holds the enum kind value (e.g. `0xC`) instead of a destination pointer, and the callee's prologue `mov %rdx, 0x8(%rdi)` segfaults on the first store.

Confirmed empirically under gdb:

```
Program received signal SIGSEGV, Segmentation fault.
0x00005555555df113 in frontScanResult ()
#0  0x00005555555df113 in frontScanResult ()
#1  0x00005555555e0805 in frontIdentScan ()
#2  0x00005555555d8bf8 in frontendLexStream ()
#3  0x0000555555776b6d in astParse ()
#4  0x00005555556050fb in hirLowerSource ()
#5  0x00005555556c3996 in runLirProtoLower ()
rdi=0xc rax=0xc            ; rdi = FrontTokenKind value, not an sret slot
```

## Fix

Make the six emitters match the call-site convention by returning a heap-allocated pointer instead of a struct value:

1. Add `aggregateReturnIsHeapPtr(retT)` — true for every aggregate except `*ir.TupleType`. Tuple returns keep the in-register ABI because tuple-aware call sites bind the SSA register directly via `aggregateBinding{typeName, reg, fields}` and use `extractvalue`, not `getelementptr`.
2. Add `emitAggregateValueToPtrReturn(out, mctx, typeName, retval)` that allocates a slot via `osty_rt_stage0_alloc`, stores the in-register struct value with `store %T %retval, ptr %slot`, and emits `ret ptr %slot`. The existing `insertvalue` / phi chains that build `%retval` are left untouched — the new boxing lives only at the return seam.
3. Switch every named-aggregate emitter's signature from `define %T @fn(...)` to `define ptr @fn(...)` and call the helper at the return seam. Tuple returns continue to emit `define %tupleN @fn(...) ... ret %tupleN %x`.
4. Generalise `declareAggregateFunctionPrototype` to take the literal LLVM return token (`ptr` or `%T`) so forward declarations match the actual ABI. P21's wrapper now declares + calls the inner helper as `call ptr @inner(...)` when the callee returns a named aggregate.

The convention is now uniform across stage0:

| | Old (struct-by-value) | New (heap ptr) |
|---|---|---|
| `scalarFromTypeInternal(NamedType)` | `scalarOpaquePtr` | `scalarOpaquePtr` (unchanged) |
| Call site | `call ptr @fn(...)` | `call ptr @fn(...)` (unchanged) |
| Definition | `define %T @fn(...) ret %T %x` | `define ptr @fn(...) ... store %T %x, ptr %slot; ret ptr %slot` |
| Field read | `getelementptr inbounds %T, ptr %r, i32 0, i32 N` | unchanged |

## Audit progression (L4 fp-verify)

| Phase | Before | After |
|---|---|---|
| `--selfhost-doctor` | ✓ exit 0 (273B) | ✓ exit 0 (273B) — unchanged |
| `lir-proto-lower` | **SIGSEGV** in `frontScanResult+3` | clean `stage0 declined function: frontStringContentStart` banner |
| `compile` | **SIGSEGV** (same site) | clean decline banner |
| Deepest reached | `--selfhost-doctor` | decline-stub frontier inside the lex/parse pipeline |

Audit coverage unchanged: **7484 / 7555 stage0-covered (99.1%)**, 0 emit-broken, +0 stage0 declines beyond the existing 82.

## Test plan

- [x] `go test ./internal/backend/stage0/...` — pass
- [x] `go test ./internal/backend/...` — backend failure count 81 → 81 (no regression). Two flaky scheduler tests (`TestBundledRuntimeSchedulerConcurrentIncrementalMarkOverlapsMutators`, `TestBundledRuntimeSchedulerWorkerScaling`) flickered between runs but pass cleanly on `-count=3` rerun and are unrelated to stage0.
- [x] `go test ./internal/mir/... ./internal/ir/...` — pass
- [x] `go test -run TestParseFollowOnRecoveryB2MatchAssignHelperTail ./internal/parser` — pre-existing failure on `main`, untouched here.
- [x] `OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_FP_VERIFY=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — confirms `lir-proto-lower` + `compile` now reach the decline-stub frontier instead of segfaulting.
- [x] Manual gdb run on `osty lir-proto-lower fp_fixture.osty` — segfault gone; binary aborts cleanly via the structured `osty-self: stage0 declined function: ...` banner.

## Test assertion updates

Eight unit-test assertions pinned the old struct-by-value shape and were updated to the new `define ptr @fn ... store %T ... ret ptr` shape: `TestStage0AggregateResolvesOnbFnConstAndEmptyDefaults`, `TestStage0AggregateUsesErrTypedEnumPayloadCall`, `TestStage0AggregateReturnCanReadBaseFields`, `TestStage0P25AggregateReturnAfterCalls`, `TestStage0P17IfElseAggregateReturnStruct`, `TestStage0P17IfElseAggregateBranchUsesParam`, `TestStage0P18OrShortCircuitIfElseAggregate`, `TestStage0P19TwoArmElseIfChain`, `TestStage0P20OrPlusElseIfChain`, `TestStage0P21DirectAggregateCall{SingleParam,TwoParams,ThreeParams,ZeroParams}`, `TestStage0RealMIRBaseline/struct_constructor_{const,param}_fields`.

Tuple variants (`TestStage0P17IfElseAggregateReturnTuple`, `TestStage0P21DirectAggregateCallTupleReturn`, `TestStage0RealMIRBaseline/tuple_int_int_return`) keep their struct-by-value assertions and continue to pass — the fix is intentionally tuple-preserving.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_