### PR TITLE
fix(ir): recognise nested IfExpr / MatchExpr as block-tail value (+26 stage0)

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1679,7 +1679,7 @@ func astBlockTailLooksLikeValueConstructor(b *ast.Block) bool {
 	// whether `(a, b)` / `x + y` / `obj.field` is the block's value, so
 	// classify by shape. Mirrors the additions in `expressionYieldsValue`
 	// — same rationale (always-yields-value syntactic shapes in Osty).
-	switch last.X.(type) {
+	switch x := last.X.(type) {
 	case *ast.TupleExpr, *ast.ListExpr, *ast.MapExpr, *ast.StructLit, *ast.RangeExpr,
 		*ast.IntLit, *ast.FloatLit, *ast.StringLit, *ast.CharLit, *ast.BoolLit,
 		*ast.BinaryExpr, *ast.UnaryExpr, *ast.FieldExpr, *ast.IndexExpr,
@@ -1689,6 +1689,22 @@ func astBlockTailLooksLikeValueConstructor(b *ast.Block) bool {
 		// almost always a value (function references are a theoretical
 		// false positive but harmless — they're FnType-valued).
 		return true
+	case *ast.IfExpr:
+		// Nested `if … { … } else { … }` at the block's tail — recurse
+		// so the enclosing block is still classified as value-yielding
+		// when every nested arm itself yields a value. Without this
+		// case, `if outer { if inner { a } else { b } } else { c }`
+		// drops the outer expression to an IfStmt and the function's
+		// return value never gets wired up. Audit-driven discovery:
+		// `frontStringContentStart` in toolchain/frontend.osty has
+		// exactly this shape (`if kind == FrontRawString { if triple
+		// { start + 4 } else { start + 2 } } else if … else …`).
+		return astIfLooksLikeValueExpr(x)
+	case *ast.MatchExpr:
+		// Same rationale as IfExpr: a trailing `match` at the block's
+		// tail yields a value when at least one arm does. Mirrors the
+		// post-#1645 syntactic-shape classification path for match.
+		return astMatchLooksLikeValueExpr(x)
 	}
 	return false
 }

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -1457,6 +1457,79 @@ fn main() {}`, "List<(Int, Int)>"},
 
 // `if let Some(x) = opt { x } else { default }` is a value expression
 // just like a regular `if ... else`. The pre-fix
+// TestLowerNestedIfElseTailYieldsValue covers the audit-discovered
+// `frontStringContentStart` shape: a function whose body is an
+// outer if-else chain where one of the arms' tail expression is
+// itself a nested if-else. Before #1705+1 (this commit),
+// `astBlockTailLooksLikeValueConstructor`'s syntactic switch
+// omitted `*ast.IfExpr` / `*ast.MatchExpr`, so the outer if
+// dropped to an IfStmt and the function's return local was never
+// assigned → MIR UnreachableTerm → stage0 decline at run time
+// (`osty-self: stage0 declined function: frontStringContentStart`).
+func TestLowerNestedIfElseTailYieldsValue(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			// Direct nested-if mirror of frontStringContentStart's
+			// then-branch shape.
+			"nested_if_in_then_arm",
+			`fn pick(kind: Int, triple: Bool, start: Int) -> Int {
+    if kind == 1 {
+        if triple { start + 4 } else { start + 2 }
+    } else if kind == 2 {
+        start + 2
+    } else if triple {
+        start + 3
+    } else {
+        start + 1
+    }
+}
+fn main() {}`,
+		},
+		{
+			// Nested match at the block tail.
+			"nested_match_in_then_arm",
+			`fn pick(tag: Int, x: Int) -> Int {
+    if tag > 0 {
+        match x {
+            0 -> 100,
+            _ -> 200,
+        }
+    } else {
+        -1
+    }
+}
+fn main() {}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, _ := parser.ParseDiagnostics([]byte(tt.src))
+			res := resolve.ResolveFileSourceDefault([]byte(tt.src), file, stdlib.LoadCached())
+			reg := stdlib.LoadCached()
+			chk := check.SelfhostFile(file, res, check.Opts{
+				Stdlib:        reg,
+				Primitives:    reg.Primitives,
+				ResultMethods: reg.ResultMethods,
+				Source:        []byte(tt.src),
+				Privileged:    true,
+			})
+			mod, _ := Lower("main", file, res, chk)
+			for _, decl := range mod.Decls {
+				fn, ok := decl.(*FnDecl)
+				if !ok || fn.Name == "main" {
+					continue
+				}
+				if fn.Body == nil || fn.Body.Result == nil {
+					t.Errorf("fn %s: body.Result = nil — outer if-else dropped to IfStmt (nested-if/match tail regression)", fn.Name)
+				}
+			}
+		})
+	}
+}
+
 // `astIfLooksLikeValueExpr` short-circuited on `IsIfLet → false`,
 // dropping the trailing if-let expression to ExprStmt → MIR
 // UnreachableTerm. Also covers the case where a then-branch's tail


### PR DESCRIPTION
## Summary

After #1705 fixed the aggregate-return ABI segfault, the next L4 fp-verify ceiling is a runtime decline at `frontStringContentStart` (`toolchain/frontend.osty:1194`). The audit shows the function reaches stage0 with a malformed MIR — 13 blocks but only 6 instructions, the final return block is `UnreachableTerm`, and the four unnamed `Int` locals that should hold the arithmetic results (`start + N`) never get assigned.

## Root cause

`astBlockTailLooksLikeValueConstructor` (`internal/ir/lower.go:1667`) decides whether a block's trailing expression makes the block yield a value. Its switch already accepts `*ast.BinaryExpr`, `*ast.Ident`, `*ast.IntLit`, and 13 other shapes — and `expressionYieldsValue` already accepts `*ast.IfExpr` / `*ast.MatchExpr` at the outer position via `astIfLooksLikeValueExpr` / `astMatchLooksLikeValueExpr`. But once we descend into a block's tail, the same recursion was missing.

```osty
fn frontStringContentStart(units, start, kind, triple) -> Int {
    if kind == FrontRawString {
        if triple { start + 4 } else { start + 2 }   // ← nested IfExpr at block tail
    } else if kind == FrontByte {
        start + 2
    } else if triple {
        start + 3
    } else {
        start + 1
    }
}
```

The outer if's then-block has a nested `IfExpr` as its trailing `ExprStmt`. Without a recursive case the recognizer returns false, the outer if falls through to `lowerIfStmt`, the function's return local is never assigned, and MIR lowers the entire CFG with empty arm bodies that all GotoTerm into an UnreachableTerm exit. The stage0-produced binary then aborts at the decline-stub for this function once dispatch reaches it.

## Fix

Add `*ast.IfExpr` and `*ast.MatchExpr` arms to the switch in `astBlockTailLooksLikeValueConstructor`, recursing through the existing `astIfLooksLikeValueExpr` / `astMatchLooksLikeValueExpr` helpers. Symmetric with how `expressionYieldsValue` and `astElseLooksLikeValueConstructor` already handle these shapes — no new helpers, just the missing recursive case.

## Validation

- **`frontStringContentStart` covered**: stage0 audit on this single function flips from `0 / 1 (0.0%)` → `1 / 1 (100%)`. Verified via `OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_FN=frontStringContentStart go test ./internal/backend/`.
- **Module-wide coverage**: stage0 audit on `toolchain/` advances from **7484 / 7555 → 7510 / 7580 (99.1%)** — **+26 newly covered**, +25 more functions reach stage0 (previously their front-end MIR was `UnreachableTerm`-only and the audit's `fnHasOnlyUnreachable` filter skipped them).
- Touched packages clean: `go test ./internal/ir ./internal/mir ./internal/check ./internal/resolve ./internal/format ./internal/backend/stage0` — all pass.
- Backend test failure count: **81 → 81** (no regression). Single flaky `TestBundledRuntimeSchedulerConcurrentIncrementalMarkOverlapsMutators` flickered once and passes on `-count=3` rerun. Pre-existing `TestParseFollowOnRecoveryB2MatchAssignHelperTail` parser flake unaffected.
- New focused regression test `TestLowerNestedIfElseTailYieldsValue` covers:
  - nested `if-else` at the block tail (the `frontStringContentStart` mirror)
  - nested `match { ... }` at the block tail
  
  Both assert `fn.Body.Result != nil` so future regressions trip the test rather than silently fall through to MIR `UnreachableTerm`.

## Follow-up

L4 fp-verify still reports a separate clang link error (`%idx.slot` defined with type `ptr` but expected `i64` in `losslessFormatTrivia`'s `osty_rt_strings_ConcatI64Left` call) that **pre-dates this change** — it occurs on `b5053d3` too. Stage0's i64-arg classifier needs to insert a load when the operand is a stack slot. Tracking separately.

## Test plan

- [x] `go test -run "TestLowerNestedIfElseTailYieldsValue|TestLowerTrailingIfLetYieldsValue|TestLowerTrailing" ./internal/ir/` — all pass.
- [x] `OSTY_STAGE0_AUDIT=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — 7510 / 7580 (was 7484 / 7555).
- [x] `OSTY_STAGE0_AUDIT_FN=frontStringContentStart` audit run shows 1/1 covered.
- [x] `go test ./internal/backend/` failure diff vs baseline: zero real regressions.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_