### PR TITLE
fix(stage0): load stack-slot before passing as i64 to ConcatI64* concat

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -4260,6 +4260,27 @@ func resolveOperandWithPrelude(fn *mir.Function, op mir.Operand, bindings map[mi
 		}
 		return resolveProjectedFieldOperand(fn, cp.Place, bindings, mctx)
 	}
+	// Stack-allocated locals carry the alloca pointer (e.g. `%idx.slot`)
+	// in `b.expr` and the scalar type in `b.ty`. The while-context
+	// reader (`resolveOperandWithLoad` + `loadFromStack`) materialises
+	// the load before use; the sequential reader (`resolveOperand`)
+	// returns `b.expr` directly, which silently produces calls like
+	// `call ptr @osty_rt_strings_ConcatI64Left(i64 %idx.slot, …)` —
+	// passing the slot pointer where an `i64` value is expected and
+	// failing clang's `defined with type 'ptr' but expected 'i64'`
+	// verifier. Insert the load into the prelude so any caller
+	// (including the sequential classifiers reached from
+	// `forInListIntrinsic` → `classifyStringConcatIntrinsic`) sees a
+	// proper SSA value. The projection / index paths above already
+	// load through their own helpers, so this only fires for the
+	// bare-local case.
+	if cp, ok := op.(*mir.CopyOp); ok && !cp.Place.HasProjections() && mctx != nil {
+		if b, found := bindings[cp.Place.Local]; found && b.defined && b.isStack {
+			reg := mctx.freshTempName("local.load")
+			prelude := fmt.Sprintf("  %s = load %s, ptr %s\n", reg, b.ty.llvm(), b.expr)
+			return prelude, reg, b.ty, true
+		}
+	}
 	expr, ty, ok := resolveOperand(op, bindings, mctx)
 	return "", expr, ty, ok
 }

--- a/internal/backend/stage0_stack_load_test.go
+++ b/internal/backend/stage0_stack_load_test.go
@@ -1,0 +1,75 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStage0LoadsStackSlotBeforeStringConcatI64 regression-tests the
+// audit-discovered clang link error
+//
+//	error: '%idx.slot' defined with type 'ptr' but expected 'i64'
+//
+// surfaced by `losslessFormatTrivia` (toolchain/lossless_lex.osty).
+// The sequential intrinsic classifier `classifyStringConcatIntrinsic`
+// was reaching `resolveOperandWithPrelude` → `resolveOperand` for a
+// `CopyOp` of a stack-allocated mutable Int local, which returned
+// the alloca pointer (e.g. `%idx.slot`) as the operand expression
+// while the call signature demanded `i64`. Without an intervening
+// `load`, clang's IR verifier rejected the module and the
+// stage0-produced binary couldn't even link.
+//
+// The fix in `resolveOperandWithPrelude` materialises a `load` into
+// the returned prelude when the binding is stack-allocated. This
+// test reproduces the shape (mutable `Int` local + trailing string
+// interpolation prefixed by the local) and asserts:
+//
+//   - clang-friendly output: the SSA register passed to the
+//     `osty_rt_strings_ConcatI64Left` family is the LOADED i64
+//     value, never the slot pointer; the slot is only ever the
+//     target of a `load` / `store` instruction.
+//   - the load is emitted ahead of the call site, not omitted.
+func TestStage0LoadsStackSlotBeforeStringConcatI64(t *testing.T) {
+	// Mirror the `losslessFormatTrivia` shape that surfaced the bug:
+	// a function with a mutable `Int` local that flows into a string
+	// interpolation built inside a for-in loop body. The for-in path
+	// routes the trailing `IntrinsicStringConcat` through
+	// `forInListIntrinsic` → `classifyStringConcatIntrinsic` →
+	// `stringConcatSequentialArg` → `resolveOperandWithPrelude`,
+	// which was the broken seam.
+	// Note: idx is the LEADING operand below. That binds the first
+	// concat to ConcatI64Left(i64, ptr) — the i64-as-first-arg
+	// shape that surfaces the slot-pointer bug. Reversing the order
+	// would route through ConcatI64Right and miss the seam.
+	src := "pub fn formatLines(xs: List<String>) -> String {\n" +
+		"    let mut lines: List<String> = []\n" +
+		"    let mut idx = 0\n" +
+		"    for x in xs {\n" +
+		"        lines.push(\"{idx} {x}\")\n" +
+		"        idx = idx + 1\n" +
+		"    }\n" +
+		"    \"\"\n" +
+		"}\n" +
+		"\nfn main() {}\n"
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	got := string(out)
+
+	// Negative: the IR must never feed the slot pointer to the i64
+	// parameter of `osty_rt_strings_ConcatI64Left`. Regressing here
+	// resurrects the clang diagnostic
+	// `defined with type 'ptr' but expected 'i64'`.
+	if strings.Contains(got, "ConcatI64Left(i64 %idx.slot") {
+		t.Fatalf("ConcatI64Left passes the slot pointer where an i64 value is expected:\n%s", got)
+	}
+
+	// Positive: at least one `load i64, ptr %idx.slot` precedes the
+	// concat call that consumes the value. We don't pin the exact
+	// SSA register because freshTempName / freshReg id-space can
+	// shift between emit-path versions.
+	if !strings.Contains(got, "load i64, ptr %idx.slot") {
+		t.Fatalf("expected `load i64, ptr %%idx.slot` before the concat call:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1706. The L4 fp-verify audit reported a clang link failure independent of the nested-if/match recovery:

```
module.ll:329115:53: error: '%idx.slot' defined with type 'ptr' but expected 'i64'
 %11 = call ptr @osty_rt_strings_ConcatI64Left(i64 %idx.slot, ptr @.str.355)
```

`%idx.slot` is an alloca holding a stack-allocated mutable `Int` local — `let mut idx = 0` in `losslessFormatTrivia` (`toolchain/lossless_lex.osty:963`). The call needs the loaded i64 value, but stage0 was feeding the alloca pointer instead.

## Root cause

`resolveOperand` (`internal/backend/stage0/emit.go:4202`) returns the binding expression directly for a plain `CopyOp` of a local — including when the binding is stack-allocated. For stack bindings `b.expr` is the alloca pointer (e.g. `%idx.slot`) while `b.ty` is the scalar type (e.g. `scalarInt`). The while-loop reader has its own helper `resolveOperandWithLoad` that calls `loadFromStack` before returning, but `resolveOperandWithPrelude` — used by the sequential intrinsic / call classifiers — defers to bare `resolveOperand` and silently returns the pointer.

That worked accidentally for most paths because callers were already used inside `load` / `store` instructions or compound expressions that themselves emitted a load. The string-concat path was special: when the **leading** operand of `IntrinsicStringConcat` is the i64 local, `classifyStringConcatIntrinsic` routes through `stringConcatSequentialArg` → `resolveOperandWithPrelude` → `resolveOperand` and the resulting `callArg{expr: "%idx.slot", ty: "i64"}` flows directly into `emitCallChain`, producing `call ptr @osty_rt_strings_ConcatI64Left(i64 %idx.slot, …)`. Reversing the order — `"prefix {idx}"` instead of `"{idx} prefix"` — routes through `ConcatI64Right` whose i64 arg comes from a path that already loads, so the bug only manifests with **i64-as-first-arg**.

## Fix

Materialise the missing load inside `resolveOperandWithPrelude` when the binding is stack-allocated:

```go
if cp, ok := op.(*mir.CopyOp); ok && !cp.Place.HasProjections() && mctx != nil {
    if b, found := bindings[cp.Place.Local]; found && b.defined && b.isStack {
        reg := mctx.freshTempName("local.load")
        prelude := fmt.Sprintf("  %s = load %s, ptr %s\n", reg, b.ty.llvm(), b.expr)
        return prelude, reg, b.ty, true
    }
}
```

Projection / index operands already feed through their own helpers (`resolveIndexedOperand`, `resolveProjectedFieldOperand`) that load via `field.slot` GEPs, so this branch only fires for the bare `CopyOp{Local: id}` shape. Symmetric with how `resolveOperandWithLoad` handles the same case for the while-loop context.

## Validation

- **Clang verify**: the produced fp-verify binary now links cleanly on the audit fixture (was `error: '%idx.slot' defined with type 'ptr' but expected 'i64'`). The fp-verify path now proceeds past the link step to actual binary execution.
- **Stage0 audit coverage**: `toolchain/` advances from **7510 / 7580 (99.1%) → 7512 / 7580 (99.1%)** (+2 covered, declines 76 → 74). Both `losslessFormatTrivia` and a sibling formatter newly pass stage0 emit.
- `osty --selfhost-doctor` ✓ exit 0 unchanged.
- `osty lir-proto-lower` now actually reaches binary execution instead of failing at the link step; bottoms out at a deeper ceiling (hang past the audit's timeout — separate follow-up).
- New focused regression test `TestStage0LoadsStackSlotBeforeStringConcatI64` reproduces the exact `losslessFormatTrivia` shape (`let mut idx = 0; for x in xs { lines.push("{idx} {x}"); idx = idx + 1 }`) and asserts:
  - the IR contains `load i64, ptr %idx.slot` before the concat,
  - and never `ConcatI64Left(i64 %idx.slot, …)`.
  Confirmed to FAIL on `main` (HEAD), PASS with this commit.
- `go test ./internal/ir ./internal/mir ./internal/check ./internal/backend/stage0` — all green, no assertion changes.

## Test plan

- [x] `go test -run TestStage0LoadsStackSlotBeforeStringConcatI64 ./internal/backend/` — passes with fix, FAILS on baseline.
- [x] `OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_FP_VERIFY=1 go test -run TestStage0ToolchainAudit ./internal/backend/` — coverage advances + clang link succeeds.
- [x] `go test ./internal/backend/stage0/` — passes.
- [x] `go test ./internal/ir ./internal/mir ./internal/check` — passes.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_