### PR TITLE
fix: unblock bootstrap path — slice helper, -lm link, partial-IR opt-in

### DIFF
--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/osty/osty/internal/backend/stage0"
 	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/llvmabi"
 	"github.com/osty/osty/internal/nativellvmgen"
@@ -267,6 +268,26 @@ func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options
 		s0Out, s0Err := tryStage0Fallback(entry, opts)
 		if s0Err == nil {
 			nativeWarnings = append(nativeWarnings, errors.New("stage0 fallback: emitted MIR through bootstrap-only path"))
+			return s0Out, nativeWarnings, nil
+		}
+		// Bootstrap path: when both `OSTY_STAGE0_FALLBACK=1` and
+		// `OSTY_STAGE0_LIST_ALL_DECLINES=1` are set, stage0 emits
+		// partial IR + an aggregated declines error. Accept that
+		// partial IR so the chicken-and-egg `osty install-self` can
+		// produce an osty-self binary whose body covers the
+		// supported subset; declined functions land as abort-stubs
+		// (see `stage0.EmitMIR`'s aggregated path at emit.go:282).
+		// Without this branch, the very first build on a fresh
+		// clone fails hard the moment any toolchain function falls
+		// outside stage0's pattern set — even though the produced
+		// binary is good enough to run the smoke tests that
+		// exercise only the covered subset. Only fires when the
+		// caller has explicitly opted into both env vars, so
+		// production builds remain unaffected.
+		if len(s0Out) > 0 && stage0.IsListAllDeclines() {
+			nativeWarnings = append(nativeWarnings,
+				errors.New("stage0 fallback: partial IR with aggregated declines (OSTY_STAGE0_LIST_ALL_DECLINES=1)"),
+				fmt.Errorf("stage0 declines: %w", s0Err))
 			return s0Out, nativeWarnings, nil
 		}
 		traceLLVMDispatch("stage0 fallback declined: %v", s0Err)

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -3661,7 +3661,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -37,6 +37,14 @@ var ErrUnsupported = errors.New("stage0: MIR shape outside bootstrap subset")
 // first place — see internal/backend/bootstrap.go).
 const ListAllDeclinesEnv = "OSTY_STAGE0_LIST_ALL_DECLINES"
 
+// IsListAllDeclines reports whether `OSTY_STAGE0_LIST_ALL_DECLINES=1`
+// is set. The bootstrap dispatcher (`emitLLVMFallback`) consults this
+// to decide whether to accept partial IR with declines as a
+// best-effort emit for `osty install-self` on fresh clones.
+func IsListAllDeclines() bool {
+	return listAllDeclinesEnabled()
+}
+
 func listAllDeclinesEnabled() bool {
 	switch strings.TrimSpace(os.Getenv(ListAllDeclinesEnv)) {
 	case "1", "true", "TRUE", "True", "on", "ON", "On", "yes", "YES", "Yes":

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -705,7 +705,11 @@ fn collectFnDecl(cx: ElabCx, declIdx: Int, node: AstNode, owner: String, ownerGe
         let mut cleanNames: List<String> = []
         for pn in sig.paramNames {
             if pn.startsWith("?") {
-                cleanNames.push(pn.slice(1))
+                // String has no 1-arg `slice` intrinsic method; use the
+                // free-function form `strings.slice(s, start, end)`
+                // which the native checker recognises and the MIR
+                // emitter lowers to `MirIntrinsicStringSubstring`.
+                cleanNames.push(strings.slice(pn, 1, pn.len()))
             } else {
                 cleanNames.push(pn)
             }

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -355,11 +355,15 @@ fn elabVariantOwnerType(cx: ElabCx, variant: CheckVariantSig) -> Int {
 /// fnSigToTy builds an `fn(params) -> ret` type from a CheckFnSig.
 /// G20: propagates parameter names as type-equality-neutral metadata.
 fn fnSigToTy(env: CheckEnv, sig: CheckFnSig) -> Int {
-    // Strip the "?" prefix that arity-tracking uses.
+    // Strip the "?" prefix that arity-tracking uses. String has no
+    // 1-arg `slice` intrinsic method; use the free-function form
+    // `strings.slice(s, start, end)` which the native checker
+    // recognises and the MIR emitter lowers to
+    // `MirIntrinsicStringSubstring`.
     let mut cleanNames: List<String> = []
     for pn in sig.paramNames {
         if pn.startsWith("?") {
-            cleanNames.push(pn.slice(1))
+            cleanNames.push(strings.slice(pn, 1, pn.len()))
         } else {
             cleanNames.push(pn)
         }


### PR DESCRIPTION
## Summary

Three independent fixes that move the fresh-clone bootstrap forward. None of them alone unblocks `osty install-self` (toolchain LLVM lowering OOM-kills around 2.6 GB RSS), but together they remove the three concrete errors the audit was hitting before that ceiling.

- **`toolchain/{check,elab}.osty`** — replace `pn.slice(1)` with the v0.5 helper `strings.slice(pn, 1, pn.len())`. `String` exposes no `slice` method; the previous form was a leftover from an earlier spec draft and crashed the checker the moment any nested package path made it through resolve.
- **`internal/backend/llvm_runtime_gc_test.go`** — add `-lm` to the gc harness link line. The bundled runtime calls libm intrinsics (it pulls in `pow`/`log` through tracing helpers); without `-lm`, the bundled-runtime tests fail to link on a fresh clone where libm is not implicitly resolved by clang's default driver search.
- **`internal/backend/llvm.go` + `internal/backend/stage0/emit.go`** — the bootstrap dispatcher now accepts partial IR from stage0 when both `OSTY_STAGE0_FALLBACK=1` and `OSTY_STAGE0_LIST_ALL_DECLINES=1` are set. Without this branch, the very first build on a fresh clone fails hard the moment any toolchain function falls outside stage0's pattern set, even though the surviving IR is good enough to drive the smoke tests that only exercise the covered subset. Production builds (no env vars) keep the strict 100%-or-fail contract.

## Known limitation (left for follow-up)

The full `osty install-self → osty-self → backend tests` loop **still does not complete on a fresh clone in this branch**. The stage0 fallback path materialises the entire toolchain IR (~7500 functions) into a single in-memory buffer before returning; the kernel OOM-kills the build at ~2.6 GB RSS. Streaming stage0 output by function (rewrite `stage0.EmitMIR`'s aggregation contract) is the next ticket and was out of scope for this PR's blast radius. With that landed, the partial-IR opt-in added here is what would actually let the bootstrap complete.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/lexer/... ./internal/parser/... ./internal/resolve/... ./internal/check/... ./internal/backend/stage0/...` — no new failures (one pre-existing parser failure `TestParseFollowOnRecoveryB2MatchAssignHelperTail` already fails on parent commit f6a8b63; not addressed here)
- [ ] Full `OSTY_STAGE0_FALLBACK=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 osty install-self` end-to-end — blocked on the OOM described above
- [ ] `go test ./internal/backend/...` 81 backend failures — blocked on the same; will be resolvable once stage0 streams

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_