### PR TITLE
fix(llvmabi): detect LLD before adding -mllvm link flag

### DIFF
--- a/internal/llvmabi/api.go
+++ b/internal/llvmabi/api.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -154,16 +155,34 @@ func ClangCompileObjectArgs(target, irPath, objectPath string) []string {
 
 func ClangLinkBinaryArgs(target string, objectPaths []string, binaryPath string) []string {
 	target = CanonicalLLVMTarget(target)
-	args := make([]string, 0, len(objectPaths)+8)
+	args := make([]string, 0, len(objectPaths)+10)
 	if target != "" {
 		args = append(args, "-target", target)
 	}
-	args = append(args, "-O3", "-flto=thin", "-Wl,-mllvm,-import-instr-limit=500")
+	args = append(args, "-O3", "-flto=thin")
+	// The `-mllvm` flag below is LLD-only — BFD ld parses it as `-m llvm`
+	// and bails with "unrecognised emulation mode: llvm". We force LLD
+	// when it's reachable and drop the import-instr-limit tuning when
+	// it isn't, so fresh-clone hosts that only have BFD ld can still
+	// produce a (slightly less aggressively-inlined) binary instead of
+	// failing the bootstrap link outright.
+	if hasLLD() {
+		args = append(args, "-fuse-ld=lld", "-Wl,-mllvm,-import-instr-limit=500")
+	}
 	args = append(args, objectPaths...)
 	if !strings.Contains(target, "windows") {
 		args = append(args, "-pthread", "-lz")
 	}
 	return append(args, "-o", binaryPath)
+}
+
+func hasLLD() bool {
+	for _, name := range []string{"ld.lld", "lld"} {
+		if _, err := exec.LookPath(name); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func MissingClangMessage() string {


### PR DESCRIPTION
## Summary

The bootstrap link line hardcoded `-Wl,-mllvm,-import-instr-limit=500` to tune ThinLTO's per-callsite import budget. That flag is only understood by LLD — BFD ld parses `-mllvm` as the emulation-mode option and bails with:

```
/usr/bin/ld: unrecognised emulation mode: llvm
Supported emulations: elf_x86_64 elf32_x86_64 elf_i386 elf_iamcu i386pep i386pe
clang: error: linker command failed with exit code 1
```

…which kills the very first `osty install-self` on fresh-clone hosts where clang's default driver search lands on BFD ld instead of LLD.

`ClangLinkBinaryArgs` now probes for `ld.lld` / `lld` on `PATH` and only appends `-fuse-ld=lld` + the `-mllvm` tuning when one of them is reachable. Hosts that only have BFD ld still link successfully, just without the cross-module-inlining budget bump.

## Scope notes

The matching `.osty` copy in `toolchain/llvmgen.osty:1991-2010` still carries the unconditional flag — that path runs inside `osty-self` and needs a host bridge for `exec.LookPath`, so it's left as a follow-up. The Go-side fix here is what actually unblocks the Go-driver-driven `osty install-self → osty-self` step on a fresh clone.

This is a follow-up to #1708, which removed the upstream stage0-declines hard-fail. Together they let `osty install-self` complete end-to-end on a fresh clone:

```
$ OSTY_STAGE0_FALLBACK=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 osty install-self
Profile: debug  Target: host  Features: none
Built /home/user/osty/toolchain/.osty/out/debug/llvm/osty-self (debug)
installed: /home/user/osty/.osty/cache/self-host/9ef7ebfe...-linux-amd64/osty-self
```

## Test plan

- [x] `go build ./...` clean
- [x] `osty install-self` on a fresh-clone host with BFD ld + LLD installed produces a working `osty-self` binary (~6 min, ~2.6 GB peak RSS)
- [x] Reproduces the original `unrecognised emulation mode: llvm` failure before the patch on the same host
- [ ] The 81 backend test failures are **not** fully cleared by this PR — they hit a separate runtime OOM inside the produced `osty-self` (decline-stubs leave its GC in an inconsistent state), and on top of that the `selfhostcache.LocateProjectRoot` lookup fails when `osty.toml` is missing at the repo root. Both of those need their own follow-ups; this PR only fixes the link-line.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_