### PR TITLE
test(stage0): env-var-tunable decline-list cap in toolchain audit

### DIFF
--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -250,10 +250,15 @@ func TestStage0ToolchainAudit(t *testing.T) {
 		}
 		return buckets[i].key < buckets[j].key
 	})
-	t.Logf("decline reasons (top 30):")
-	max := 30
+	maxDeclines := 30
+	if v := os.Getenv("OSTY_STAGE0_AUDIT_DECLINE_LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxDeclines = n
+		}
+	}
+	t.Logf("decline reasons (top %d):", maxDeclines)
 	for i, b := range buckets {
-		if i >= max {
+		if i >= maxDeclines {
 			break
 		}
 		t.Logf("  %4d  %s", b.count, b.key)


### PR DESCRIPTION
## Summary

The audit harness in `TestStage0ToolchainAudit` was hard-coding the top-30 cap on the "decline reasons" log. With 65+ unique declined shapes in the current toolchain MIR snapshot, the bottom of the long tail was silently dropped from the report, so anyone working through "which functions still decline" had to either edit the test or read through `OSTY_STAGE0_AUDIT_SAMPLES` per-bucket dumps to enumerate them.

`OSTY_STAGE0_AUDIT_DECLINE_LIMIT=<N>` now overrides the cap (default `30` preserved). Useful for full-picture surveys when triaging which declines are real stage0 gaps vs. front-end MIR-lowering bugs surfacing as stage0 declines.

## Context (why this matters)

While investigating the remaining 7512 / 7580 (99.1%) audit coverage gap, the simplest candidate decline shape (`selfPkgPathDependency`: 1 block, 3 instrs) turned out to **not** be a stage0 surface gap — the MIR for that function records `anySemReq()`'s callee type as `ErrType` and its dest local as `Bool`, even though the source declares the function to return `SemReq`. That's a front-end resolution / MIR-lowerer bug surfacing through the audit as a stage0 decline.

The wider implication is that the long tail of 65 unique shapes is likely a **mix** of genuine stage0 pattern gaps and upstream MIR-lowering bugs, and the audit's truncated-30 view was obscuring that. Bumping the cap on demand lets reviewers see the full list at once.

## Test plan

- [x] `go build ./...` clean
- [x] `OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_DECLINE_LIMIT=200 go test -run TestStage0ToolchainAudit` prints all 65 declines instead of truncating at 30
- [x] Without the env var, behaviour is unchanged (default 30)

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_