### PR TITLE
fix(selfhostcache): fall back to toolchain/osty.toml when locating root

### DIFF
--- a/internal/toolchain/selfhostcache/cache.go
+++ b/internal/toolchain/selfhostcache/cache.go
@@ -220,11 +220,43 @@ func LocateProjectRoot(start string) (string, error) {
 	if root, err := manifest.FindRoot(start); err == nil {
 		return root, nil
 	}
+	// Fallback path: this repo lays out `toolchain/osty.toml` as the
+	// only manifest, with no top-level `osty.toml`. `manifest.FindRoot`
+	// therefore fails when callers (tests, in particular) invoke from
+	// a subdir like `internal/backend/` — walking up never finds a
+	// manifest in any ancestor. Without this branch, the fallback
+	// `abs(start)` becomes a garbage "project root" and downstream
+	// `ComputeKey` chokes on the missing `toolchain/` directory.
+	//
+	// Walk up looking for a directory that contains `toolchain/osty.toml`
+	// (or, equivalently, a `toolchain/` subdir on the bootstrap path)
+	// and treat that as the project root.
+	if root, ok := findToolchainRoot(start); ok {
+		return root, nil
+	}
 	abs, err := filepath.Abs(start)
 	if err != nil {
 		return "", fmt.Errorf("selfhostcache: locate project root: %w", err)
 	}
 	return abs, nil
+}
+
+func findToolchainRoot(start string) (string, bool) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", false
+	}
+	for {
+		candidate := filepath.Join(dir, "toolchain", "osty.toml")
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
 }
 
 // Install copies `binPath` into the cache for `key`. It is


### PR DESCRIPTION
## Summary

`LocateProjectRoot` walks up looking for `osty.toml`. This repo lays out `toolchain/osty.toml` as the only manifest — there is **no top-level `osty.toml`** at the repo root — so `manifest.FindRoot` returns "could not find osty.toml" for every caller that doesn't start from inside `toolchain/` itself.

Tests under `internal/backend/` are the most affected: when `go test ./internal/backend/...` runs, the CWD is the package directory and `LocateProjectRoot(".")` falls through to `filepath.Abs(".") = .../internal/backend`. Downstream `ComputeKey(root)` then chokes on the missing `toolchain/` subdirectory and `ResolveBinary` returns `ErrNotCached`, surfacing as the canonical "osty-self not found" diagnostic — **even when `osty install-self` had already cached a working `osty-self` at `<repo>/.osty/cache/self-host/<key>/`**.

## Fix

After `manifest.FindRoot` fails, walk up looking for any ancestor that contains `toolchain/osty.toml`, and return that ancestor as the project root. Only fires on the post-manifest fallback path, so layouts that DO have a top-level `osty.toml` keep their original resolution.

## Verification

Reproduced the failure mode in a fresh shell on this checkout:

```
$ unset OSTY_SELF_BIN
$ go test -run TestLLVMBackendBinaryRunsBitwiseIntOps ./internal/backend/ -timeout=3m
```

**Before:** `Emit returned error: ... reasons: osty-self not found; run osty build toolchain/ or set OSTY_SELF_BIN; ...`

**After:** the cached `osty-self` is found; the test now reaches the next failure — `osty llvm runtime: out of memory` inside the compiled `osty-self`, which is a separate runtime ticket.

## Follow-up

The 81 backend test failures on this branch share two underlying causes; this PR removes the first. The remaining cause is the osty-self GC runtime OOM, which is being investigated separately.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/toolchain/selfhostcache/...` passes (existing `TestResolveBinary*` family unchanged)
- [x] `unset OSTY_SELF_BIN; go test -run TestLLVMBackendBinaryRunsBitwiseIntOps ./internal/backend/` no longer surfaces the "osty-self not found" diagnostic on this layout

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_