### PR TITLE
runtime: guard list_reserve against &gt;1G-element requests

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -37,6 +37,7 @@
 
 #if !defined(_WIN32)
 #include <zlib.h>
+#include <execinfo.h>
 #endif
 
 #if !defined(_WIN32)
@@ -7691,6 +7692,32 @@ static OSTY_HOT_INLINE void osty_rt_list_reserve(osty_rt_list *list, int64_t min
     }
     if (list->elem_size == 0) {
         osty_rt_abort("list element size is zero");
+    }
+    /* Bootstrap-debug guard: when stage0-emitted IR funnels a bogus
+     * (garbage / sign-extended / off-by-many) capacity argument into
+     * `osty_rt_list_reserve`, the doubling loop below silently chews
+     * its way to 16 GB before `malloc()` finally returns NULL — making
+     * the failure look like a real OOM instead of a stage0 emit bug.
+     * The 1 GB / 1B-element ceiling here trips on any plausibly-real
+     * workload that's actually buggy long before the host runs out of
+     * memory, and prints the offending capacity + element size so the
+     * IR site is identifiable. Toggle off by setting
+     * `OSTY_RT_LIST_RESERVE_NO_GUARD=1` for workloads that legitimately
+     * need >1 G elements. */
+    if (min_cap > (int64_t)1 << 30 && getenv("OSTY_RT_LIST_RESERVE_NO_GUARD") == NULL) {
+        fprintf(stderr,
+                "osty llvm runtime: list_reserve called with min_cap=%lld "
+                "elem_size=%lld list=%p len=%lld cap=%lld "
+                "(>1G elements)\n",
+                (long long)min_cap, (long long)list->elem_size,
+                (void *)list, (long long)list->len, (long long)list->cap);
+        void *bt[32];
+        int n = backtrace(bt, 32);
+        if (n > 0) {
+            fprintf(stderr, "osty llvm runtime: backtrace (%d frames):\n", n);
+            backtrace_symbols_fd(bt, n, 2);
+        }
+        osty_rt_abort("list allocation request exceeds 1G elements");
     }
     /* Inline-storage fast path. While the requested element count
      * fits in OSTY_RT_LIST_INLINE_BYTES, just bump `cap` to the


### PR DESCRIPTION
## Summary

When stage0-emitted IR (or any caller, including future hand-written intrinsics) funnels a bogus capacity argument into `osty_rt_list_reserve`, the existing doubling loop silently chews its way from a few MB up to ~16 GB before `malloc()` finally returns `NULL` and the bare `osty_rt_abort("out of memory")` fires. The host then spends ~30 seconds doing useless `mmap`+`munmap` cycles, and the resulting diagnostic blames "out of memory" — making the failure look like a real resource exhaustion instead of a caller-side bug.

Add an early ceiling at `min_cap > 1 << 30` (≈1 G elements) that aborts with the offending capacity, element size, and a `backtrace(3)` dump of up to 32 frames. Trip threshold is well above any plausibly-real workload — a list with one billion `i64` elements would be 8 GB on its own — and tractably below the 17 GB `ENOMEM` ceiling where the bare abort fires. `OSTY_RT_LIST_RESERVE_NO_GUARD=1` disables for the unusual case where >1 G elements is intentional.

## Empirical motivation

While bringing `osty install-self` end-to-end on a fresh clone, a trivial smoke fixture (`fn main() -> Int { 42 }`) aborted with "out of memory" after 30 s of mmap churn. With this guard in place, the same run aborts in <1 s with:

```
osty llvm runtime: list_reserve called with min_cap=1073741825
elem_size=8 list=0x… len=1073741824 cap=1073741824 (>1G elements)
osty llvm runtime: backtrace (16 frames):
  …osty-self(+0xf7db4)[…]
  …osty-self(+0x30aa2e)[…]    ← elabInferBinary
  …
```

which `addr2line` resolves to the `checkAliasDeepCacheSet` grow loop (`for n <= ty { cache.push(-1) }` in `toolchain/check_env.osty`) being asked to enlarge the alias-resolution cache to a billion-entry list. The underlying root cause — some caller passing a ~1 G `ty` value to `checkResolveAliasDeep` — is a separate front-end ticket that the diagnostic surfaces.

## Test plan

- [x] `go build ./...` clean (new `<execinfo.h>` include compiles on Linux)
- [x] Reproduced the original 30-s OOM failure on the bootstrap path, confirmed the guard fires <1 s with the expected diagnostic + addr2line-resolvable backtrace
- [x] The matching `osty_rt_list_reserve` callers (push, insert, copy_initialized) keep working on normal workloads — the guard only fires on the explicit `min_cap > 1 << 30` ceiling

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_