### PR TITLE
fix(stage0): take struct param by pointer, not by value, in field-getter patterns

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -12205,10 +12205,14 @@ func matchStructFieldRead(fn *mir.Function, mctx *moduleCtx) (structFieldReadPat
 
 func emitStructFieldRead(out *strings.Builder, fn *mir.Function, pat structFieldReadPattern) error {
 	resultLLVM := pat.resultType.llvm()
-	fmt.Fprintf(out, "define %s @%s(%%%s %%%s) {\n", resultLLVM, fn.Name, pat.structName, pat.paramName)
+	// Take the struct by pointer to stay ABI-compatible with the
+	// generic call-site emission (see emitStructFieldListLen for the
+	// failure mode this prevents).
+	fmt.Fprintf(out, "define %s @%s(ptr %%%s) {\n", resultLLVM, fn.Name, pat.paramName)
 	out.WriteString("entry:\n")
-	fmt.Fprintf(out, "  %%0 = extractvalue %%%s %%%s, %d\n", pat.structName, pat.paramName, pat.fieldIndex)
-	fmt.Fprintf(out, "  ret %s %%0\n", resultLLVM)
+	fmt.Fprintf(out, "  %%0 = getelementptr inbounds %%%s, ptr %%%s, i32 0, i32 %d\n", pat.structName, pat.paramName, pat.fieldIndex)
+	fmt.Fprintf(out, "  %%1 = load %s, ptr %%0\n", resultLLVM)
+	fmt.Fprintf(out, "  ret %s %%1\n", resultLLVM)
 	out.WriteString("}\n\n")
 	return nil
 }
@@ -12379,20 +12383,28 @@ func classifyP15Operand(op mir.Operand, paramID mir.LocalID, fieldTypes []scalar
 func emitStructFieldBinaryOp(out *strings.Builder, fn *mir.Function, pat structFieldBinaryOpPattern) error {
 	resultLLVM := pat.resultType.llvm()
 	operandLLVM := pat.operandType.llvm()
-	fmt.Fprintf(out, "define %s @%s(%%%s %%%s) {\n", resultLLVM, fn.Name, pat.structName, pat.paramName)
+	// Take the struct by pointer (see emitStructFieldListLen for the
+	// ABI-mismatch failure mode this avoids).
+	fmt.Fprintf(out, "define %s @%s(ptr %%%s) {\n", resultLLVM, fn.Name, pat.paramName)
 	out.WriteString("entry:\n")
 	nextSSA := 0
 	leftExpr := pat.left.constText
 	if pat.left.isField {
-		leftExpr = fmt.Sprintf("%%%d", nextSSA)
-		fmt.Fprintf(out, "  %s = extractvalue %%%s %%%s, %d\n", leftExpr, pat.structName, pat.paramName, pat.left.fieldIndex)
+		slotReg := fmt.Sprintf("%%%d", nextSSA)
 		nextSSA++
+		leftExpr = fmt.Sprintf("%%%d", nextSSA)
+		nextSSA++
+		fmt.Fprintf(out, "  %s = getelementptr inbounds %%%s, ptr %%%s, i32 0, i32 %d\n", slotReg, pat.structName, pat.paramName, pat.left.fieldIndex)
+		fmt.Fprintf(out, "  %s = load %s, ptr %s\n", leftExpr, operandLLVM, slotReg)
 	}
 	rightExpr := pat.right.constText
 	if pat.right.isField {
-		rightExpr = fmt.Sprintf("%%%d", nextSSA)
-		fmt.Fprintf(out, "  %s = extractvalue %%%s %%%s, %d\n", rightExpr, pat.structName, pat.paramName, pat.right.fieldIndex)
+		slotReg := fmt.Sprintf("%%%d", nextSSA)
 		nextSSA++
+		rightExpr = fmt.Sprintf("%%%d", nextSSA)
+		nextSSA++
+		fmt.Fprintf(out, "  %s = getelementptr inbounds %%%s, ptr %%%s, i32 0, i32 %d\n", slotReg, pat.structName, pat.paramName, pat.right.fieldIndex)
+		fmt.Fprintf(out, "  %s = load %s, ptr %s\n", rightExpr, operandLLVM, slotReg)
 	}
 	resultReg := fmt.Sprintf("%%%d", nextSSA)
 	fmt.Fprintf(out, "  %s = %s %s %s, %s\n", resultReg, pat.llvmOp, operandLLVM, leftExpr, rightExpr)
@@ -12493,11 +12505,22 @@ func matchStructFieldListLen(fn *mir.Function, mctx *moduleCtx) (structFieldList
 }
 
 func emitStructFieldListLen(out *strings.Builder, fn *mir.Function, pat structFieldListLenPattern) error {
-	fmt.Fprintf(out, "define i64 @%s(%%%s %%%s) {\n", fn.Name, pat.structName, pat.paramName)
+	// Take the struct by pointer to stay ABI-compatible with the
+	// generic call-site emission, which passes user-named structs as
+	// `ptr` (see e.g. `emitCallChain`'s opaque-named handling). Earlier
+	// versions emitted `%StructName %p` (by value) here, which clang
+	// accepted but caused a silent ABI mismatch: callers pushed 8
+	// bytes (the pointer), callees read the first N×8 bytes of the
+	// struct from registers/stack and got garbage. The dropped low
+	// bytes meant the function returned the address itself instead of
+	// `arena.nodes.len()`, surfacing way upstream as a billion-element
+	// list_reserve in `checkAliasDeepCacheSet`.
+	fmt.Fprintf(out, "define i64 @%s(ptr %%%s) {\n", fn.Name, pat.paramName)
 	out.WriteString("entry:\n")
-	fmt.Fprintf(out, "  %%0 = extractvalue %%%s %%%s, %d\n", pat.structName, pat.paramName, pat.fieldIndex)
-	out.WriteString("  %1 = call i64 @osty_rt_list_len(ptr %0)\n")
-	out.WriteString("  ret i64 %1\n")
+	fmt.Fprintf(out, "  %%0 = getelementptr inbounds %%%s, ptr %%%s, i32 0, i32 %d\n", pat.structName, pat.paramName, pat.fieldIndex)
+	out.WriteString("  %1 = load ptr, ptr %0\n")
+	out.WriteString("  %2 = call i64 @osty_rt_list_len(ptr %1)\n")
+	out.WriteString("  ret i64 %2\n")
 	out.WriteString("}\n\n")
 	return nil
 }

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -2819,10 +2819,11 @@ func TestStage0P25StructFieldListLen(t *testing.T) {
 	for _, want := range []string{
 		"%FrontCheckResult = type { ptr }",
 		"declare i64 @osty_rt_list_len(ptr)",
-		"define i64 @frontCheckResultTypedNodeCount(%FrontCheckResult %result)",
-		"%0 = extractvalue %FrontCheckResult %result, 0",
-		"%1 = call i64 @osty_rt_list_len(ptr %0)",
-		"ret i64 %1",
+		"define i64 @frontCheckResultTypedNodeCount(ptr %result)",
+		"%0 = getelementptr inbounds %FrontCheckResult, ptr %result, i32 0, i32 0",
+		"%1 = load ptr, ptr %0",
+		"%2 = call i64 @osty_rt_list_len(ptr %1)",
+		"ret i64 %2",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("emitted IR missing %q:\n%s", want, got)

--- a/internal/backend/stage0_p15_test.go
+++ b/internal/backend/stage0_p15_test.go
@@ -21,11 +21,11 @@ fn main() {}`
 	}
 	wants := []string{
 		"%Point = type { i64, i64 }",
-		"define i64 @pointSum(%Point %p) {",
-		"%0 = extractvalue %Point %p, 0",
-		"%1 = extractvalue %Point %p, 1",
-		"%2 = add i64 %0, %1",
-		"ret i64 %2",
+		"define i64 @pointSum(ptr %p) {",
+		"getelementptr inbounds %Point, ptr %p, i32 0, i32 0",
+		"getelementptr inbounds %Point, ptr %p, i32 0, i32 1",
+		"load i64",
+		"add i64",
 	}
 	got := string(out)
 	for _, want := range wants {
@@ -45,9 +45,9 @@ fn main() {}`
 		t.Fatalf("stage0 declined: %v", err)
 	}
 	wants := []string{
-		"define i1 @boundsOk(%Bounds %b) {",
-		"extractvalue %Bounds %b, 0",
-		"extractvalue %Bounds %b, 1",
+		"define i1 @boundsOk(ptr %b) {",
+		"getelementptr inbounds %Bounds, ptr %b, i32 0, i32 0",
+		"getelementptr inbounds %Bounds, ptr %b, i32 0, i32 1",
 		"icmp slt i64",
 	}
 	got := string(out)
@@ -68,8 +68,8 @@ fn main() {}`
 		t.Fatalf("stage0 declined: %v", err)
 	}
 	wants := []string{
-		"define i64 @bump(%Counter %c) {",
-		"extractvalue %Counter %c, 0",
+		"define i64 @bump(ptr %c) {",
+		"getelementptr inbounds %Counter, ptr %c, i32 0, i32 0",
 		"add i64",
 		", 1",
 	}

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -273,9 +273,9 @@ fn first(p: Point) -> Int { p.x }
 fn main() {}`,
 			wantIR: []string{
 				"%Point = type { i64, i64 }",
-				"define i64 @first(%Point %p)",
-				"%0 = extractvalue %Point %p, 0",
-				"ret i64 %0",
+				"define i64 @first(ptr %p)",
+				"getelementptr inbounds %Point, ptr %p, i32 0, i32 0",
+				"load i64",
 			},
 		},
 		{
@@ -285,7 +285,8 @@ fn second(p: Pair) -> Int { p.b }
 fn main() {}`,
 			wantIR: []string{
 				"%Pair = type { i64, i64 }",
-				"%0 = extractvalue %Pair %p, 1",
+				"getelementptr inbounds %Pair, ptr %p, i32 0, i32 1",
+				"load i64",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Three single-field-getter pattern emitters — `emitStructFieldRead`, `emitStructFieldBinaryOp`, `emitStructFieldListLen` — lowered the input struct as `%StructName %p` (a by-value parameter) and used `extractvalue` to read the field. The generic call-site emission, on the other hand, passes user-named structs as `ptr`.

Clang accepted the mismatch silently (opaque-pointer SSA, no static type check on the call) but the x86-64 SysV ABI didn't agree: callers pushed 8 bytes of pointer where the callee expected the full struct (often hundreds of bytes for shapes like `%TyArena`). The callee read field 0 from registers/stack that were never initialised with struct bytes, so the getter returned garbage — typically a neighbouring stack address.

## The downstream blast radius

The first end-user-visible symptom is the bootstrap path's "out of memory" abort on a one-line smoke fixture (`fn main() -> Int { let x: Int = 42; x }`). The chain:

1. `tyNodeCount(arena)` returned a pointer instead of `arena.nodes.len()` (the by-value ABI bug).
2. That pointer flowed into `arena.idxInt` during `emptyTyArena` initialisation.
3. The bogus "Int type index" propagated through `tyPrim` → `tyFromString` → `astTypeToTy` → `elabBindPattern` → the `CheckBinding`'s `.ty` field.
4. The eventual `checkResolveAliasDeep(env, ty=1073741825)` call walked into `checkAliasDeepCacheSet`, whose `for n <= ty { push(-1) }` grow loop pushed a billion entries onto the alias-cache list.
5. The list grow doubling exhausted the host's 15 GB of RAM before `malloc()` finally returned `NULL` (the runtime's pre-existing bare `osty_rt_abort("out of memory")`, plus the 1 G ceiling added in #1712, both hit on this path).

## Fix

Switch each of the three emitters to take `ptr %p` and replace
`extractvalue %S %p, i` with the equivalent
`getelementptr inbounds %S, ptr %p, i32 0, i32 i` + `load`.

Update the four golden-IR fixtures that pinned the old by-value shape.

## Verification

- Smoke: `rm -rf toolchain/.osty/out/ .osty/cache/ && OSTY_STAGE0_FALLBACK=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 .bin/osty install-self && .osty/cache/self-host/*/osty-self lir-proto-lower /tmp/smoke.osty` succeeds with exit 0 (previously aborted with `list_reserve called with min_cap=1073741825`).
- Backend test runs no longer surface the runtime-OOM path on this code; the next visible failure on the previously-OOMing tests is a separate segfault somewhere in the same dispatch chain (sibling ABI bug in another emitter, separate ticket).

## Test plan

- [x] `go test ./internal/backend/stage0/...` clean (4 golden-IR fixtures updated to the new ptr-passing shape)
- [x] `go test -short ./internal/backend/...` clean
- [x] Smoke fixture path traced end-to-end via newly-cached `osty-self`

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_