### PR TITLE
debug(lirproto): env-gated keep-staged + staged-source trace

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -83,11 +83,14 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 		return nativelirproto.Response{Declined: true, Error: err.Error()}, nil
 	}
 	sourcePath, cleanup, err := stageInput(req)
-	if cleanup != nil {
+	if cleanup != nil && os.Getenv("OSTY_LIRPROTO_KEEP_STAGED") == "" {
 		defer cleanup()
 	}
 	if err != nil {
 		return nativelirproto.Response{}, err
+	}
+	if dbg := os.Getenv("OSTY_LIRPROTO_DEBUG"); dbg != "" {
+		fmt.Fprintf(os.Stderr, "[lirproto-debug] staged source=%s\n", sourcePath)
 	}
 
 	pkgName := req.PackageName


### PR DESCRIPTION
## Summary

The native LIR Proto subprocess deletes the staged source temp directory on return, so when a backend test fails with "signal: segmentation fault" surfaced through `nativelirproto.Run`, there is no on-disk source left to feed back into the cached osty-self binary for a manual repro. Each repro round means re-running the failing test, attaching to the random temp dir before it goes away, and rebuilding the bridge.

Add two debug env vars to make in-place repros easy:

- `OSTY_LIRPROTO_KEEP_STAGED=1` skips the temp-dir cleanup so the exact `main.osty` the test sent to osty-self stays on disk (and can be re-run with `osty-self lir-proto-lower …` outside the test harness).
- `OSTY_LIRPROTO_DEBUG=1` prints `[lirproto-debug] staged source=<path>` to stderr before exec. The path is otherwise unobservable when the test runner captures stderr.

Both are inert (default-off) and gated on env var presence — no behaviour change for any existing caller.

## Why now

Useful for the next investigation pass after #1713: a residual stage0 emit bug surfaces as osty-self segfaulting in `checkBindingStackIndexTop` during backend tests, but the exact staged input the test sent is gone by the time the test framework reports the failure. With these vars in place, a repro is one `cat $latest_temp/main.osty` away.

## Test plan

- [x] `go build ./...` clean
- [x] With both vars set, the staged source survives the bridge invocation and the same osty-self invocation can be replayed manually

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_