### PR TITLE
feat: implement #[cfg] composition forms (all/any/not) — G29

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -77,6 +77,9 @@ func (a *AnnotationArg) End() token.Pos {
 	if a.Value != nil {
 		return a.Value.End()
 	}
+	if len(a.Compose) > 0 {
+		return a.Compose[len(a.Compose)-1].End()
+	}
 	// Flag form has no value; the argument occupies just its key,
 	// which we approximate by using the start position. The exact
 	// end column isn't tracked separately by the parser.

--- a/internal/docgen/ast_lower.go
+++ b/internal/docgen/ast_lower.go
@@ -2368,8 +2368,22 @@ func astLowerAnnotation(arena *AstArena, toks []astbridge.Token, idx int) astbri
 		// Osty: /tmp/selfhost_merged.osty:18199:9
 		cn := astArenaNodeAt(arena, child)
 		_ = cn
-		// Osty: /tmp/selfhost_merged.osty:18200:9
-		if ostyEqual(cn.kind, AstNodeKind(&AstNodeKind_AstNField_{})) {
+		// G29 cfg composition: all(...)/any(...)/not(...)
+		if ostyEqual(cn.kind, AstNodeKind(&AstNodeKind_AstNCall{})) {
+			calleeNode := astArenaNodeAt(arena, cn.left)
+			opName := ""
+			if ostyEqual(calleeNode.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
+				opName = calleeNode.text
+			}
+			composeArgs := astbridge.EmptyAnnotationArgList()
+			for _, carg := range cn.children {
+				composeArgs = append(composeArgs, astLowerAnnotationArgDocgen(arena, toks, carg))
+			}
+			func() struct{} {
+				args = append(args, astbridge.AnnotationComposeArgNode(astLowerNodePos(toks, cn), opName, composeArgs))
+				return struct{}{}
+			}()
+		} else if ostyEqual(cn.kind, AstNodeKind(&AstNodeKind_AstNField_{})) {
 			// Osty: /tmp/selfhost_merged.osty:18201:13
 			func() struct{} {
 				args = append(args, astbridge.AnnotationArgNode(astLowerNodePos(toks, cn), cn.text, astLowerExpr(arena, toks, cn.left)))
@@ -2390,6 +2404,39 @@ func astLowerAnnotation(arena *AstArena, toks []astbridge.Token, idx int) astbri
 		}
 	}
 	return astbridge.AnnotationNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), n.text, args)
+}
+
+// astLowerAnnotationArgDocgen lowers a single annotation argument CST node (which may be
+// a key=value field, a bare identifier flag, or a nested call for cfg composition)
+// into a public ast.AnnotationArg.
+func astLowerAnnotationArgDocgen(arena *AstArena, toks []astbridge.Token, idx int) astbridge.AnnotationArg {
+	if idx < 0 {
+		return astbridge.NilAnnotationArg()
+	}
+	n := astArenaNodeAt(arena, idx)
+	// Composition form: all(...)/any(...)/not(...)
+	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNCall{})) {
+		calleeNode := astArenaNodeAt(arena, n.left)
+		opName := ""
+		if ostyEqual(calleeNode.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
+			opName = calleeNode.text
+		}
+		composeArgs := astbridge.EmptyAnnotationArgList()
+		for _, carg := range n.children {
+			composeArgs = append(composeArgs, astLowerAnnotationArgDocgen(arena, toks, carg))
+		}
+		return astbridge.AnnotationComposeArgNode(astLowerNodePos(toks, n), opName, composeArgs)
+	}
+	// key = value
+	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNField_{})) {
+		return astbridge.AnnotationArgNode(astLowerNodePos(toks, n), n.text, astLowerExpr(arena, toks, n.left))
+	}
+	// bare identifier flag
+	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
+		return astbridge.AnnotationArgNode(astLowerNodePos(toks, n), n.text, astbridge.NilExpr())
+	}
+	// fallback: bare literal / expression
+	return astbridge.AnnotationArgNode(astLowerNodePos(toks, n), "", astLowerExpr(arena, toks, idx))
 }
 
 // Osty: /tmp/selfhost_merged.osty:18211:1

--- a/internal/docgen/astbridge/generated.go
+++ b/internal/docgen/astbridge/generated.go
@@ -316,6 +316,10 @@ func AnnotationArgNode(pos Pos, key string, value Expr) AnnotationArg {
 	return &ast.AnnotationArg{PosV: pos, Key: key, Value: value}
 }
 
+func AnnotationComposeArgNode(pos Pos, op string, children []AnnotationArg) AnnotationArg {
+	return &ast.AnnotationArg{PosV: pos, Key: op, Compose: compactAnnotationArgs(children)}
+}
+
 func NamedTypeNode(pos, end Pos, path []string, args []Type) Type {
 	return &ast.NamedType{PosV: pos, EndV: end, Path: compactStrings(path), Args: compactTypes(args)}
 }

--- a/internal/resolve/cfg.go
+++ b/internal/resolve/cfg.go
@@ -159,10 +159,34 @@ func evaluateCfgAnnotation(a *ast.Annotation, env *CfgEnv) (bool, []*diag.Diagno
 }
 
 // evaluateCfgArg handles one `key = "value"` pair or a composition
-// form (`all`/`any`/`not`).
+// form (`all`/`any`/`not`). The composition may arrive via two paths:
+//   - arg.Compose set (AST lowering created AnnotationComposeArgNode)
+//   - arg.Value is a *ast.CallExpr (parser produced a call expression)
+// Both paths are handled transparently.
 func evaluateCfgArg(arg *ast.AnnotationArg, env *CfgEnv) (bool, []*diag.Diagnostic) {
 	if len(arg.Compose) > 0 {
 		return evaluateCfgCompose(arg.Key, arg.Compose, arg.PosV, env)
+	}
+	// Fallback: the parser may have produced a CallExpr for all(...)/any(...)/not(...)
+	// before the AST lowering was taught to emit Compose nodes. Detect and handle.
+	if call, ok := arg.Value.(*ast.CallExpr); ok {
+		callee, _ := call.Fn.(*ast.Ident)
+		if callee != nil {
+			switch callee.Name {
+			case "all", "any", "not":
+				children := callArgsToCompose(call)
+				return evaluateCfgCompose(callee.Name, children, arg.PosV, env)
+			}
+		}
+		// Some other call inside #[cfg(...)] — not a composition.
+		return false, []*diag.Diagnostic{
+			diag.New(diag.Error,
+				"`#[cfg(...)]` argument must be `key = \"value\"` or a composition (`all`/`any`/`not`)").
+				Code(diag.CodeAnnotationBadArg).
+				PrimaryPos(arg.PosV, "unexpected call expression in cfg").
+				Note("v0.5 §5: use `#[cfg(key = \"value\")]`, `#[cfg(all(...))]`, `#[cfg(any(...))]`, or `#[cfg(not(...))]`").
+				Build(),
+		}
 	}
 	value, ok := stringArg(arg.Value)
 	if !ok {
@@ -242,6 +266,34 @@ func evaluateCfgCompose(op string, children []*ast.AnnotationArg, pos token.Pos,
 				Build(),
 		}
 	}
+}
+
+// callArgsToCompose converts a CallExpr's positional/keyword arguments
+// into the []*ast.AnnotationArg form expected by evaluateCfgCompose.
+// Each Arg{Name: "key", Value: StringLit} becomes an AnnotationArg{Key: "key", Value: StringLit}.
+// Nested CallExpr args are converted recursively.
+func callArgsToCompose(call *ast.CallExpr) []*ast.AnnotationArg {
+	out := make([]*ast.AnnotationArg, 0, len(call.Args))
+	for _, a := range call.Args {
+		arg := &ast.AnnotationArg{
+			PosV: a.Pos(),
+			Key:  a.Name,
+		}
+		if nested, ok := a.Value.(*ast.CallExpr); ok {
+			if callee, ok2 := nested.Fn.(*ast.Ident); ok2 {
+				switch callee.Name {
+				case "all", "any", "not":
+					arg.Compose = callArgsToCompose(nested)
+					arg.Key = callee.Name
+					out = append(out, arg)
+					continue
+				}
+			}
+		}
+		arg.Value = a.Value
+		out = append(out, arg)
+	}
+	return out
 }
 
 // annotationsOf extracts the annotation slice on any declaration

--- a/internal/resolve/cfg_test.go
+++ b/internal/resolve/cfg_test.go
@@ -48,6 +48,128 @@ fn main() {}
 	}
 }
 
+func TestCfgCompositionAllPasses(t *testing.T) {
+	env := testCfgEnv()
+	env.Features["debug"] = true
+
+	decl := parseSingleDeclForCfgTest(t, `#[cfg(all(os = "linux", arch = "amd64"))]
+fn guarded() {}
+`)
+	pass, ds := evaluateCfgOnDecl(decl, env)
+	if len(ds) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", ds)
+	}
+	if !pass {
+		t.Fatal("all(os=linux, arch=amd64) should pass on linux/amd64")
+	}
+}
+
+func TestCfgCompositionAllFailsOnOne(t *testing.T) {
+	env := testCfgEnv() // linux/amd64
+
+	decl := parseSingleDeclForCfgTest(t, `#[cfg(all(os = "linux", arch = "arm64"))]
+fn guarded() {}
+`)
+	pass, ds := evaluateCfgOnDecl(decl, env)
+	if len(ds) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", ds)
+	}
+	if pass {
+		t.Fatal("all(os=linux, arch=arm64) should fail on amd64")
+	}
+}
+
+func TestCfgCompositionAnyPasses(t *testing.T) {
+	env := testCfgEnv() // linux/amd64
+
+	decl := parseSingleDeclForCfgTest(t, `#[cfg(any(os = "windows", arch = "amd64"))]
+fn guarded() {}
+`)
+	pass, ds := evaluateCfgOnDecl(decl, env)
+	if len(ds) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", ds)
+	}
+	if !pass {
+		t.Fatal("any(os=windows, arch=amd64) should pass on linux/amd64")
+	}
+}
+
+func TestCfgCompositionAnyFails(t *testing.T) {
+	env := testCfgEnv() // linux/amd64
+
+	decl := parseSingleDeclForCfgTest(t, `#[cfg(any(os = "windows", os = "darwin"))]
+fn guarded() {}
+`)
+	pass, ds := evaluateCfgOnDecl(decl, env)
+	if len(ds) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", ds)
+	}
+	if pass {
+		t.Fatal("any(os=windows, os=darwin) should fail on linux")
+	}
+}
+
+func TestCfgCompositionNot(t *testing.T) {
+	env := testCfgEnv() // linux/amd64
+
+	decl := parseSingleDeclForCfgTest(t, `#[cfg(not(os = "windows"))]
+fn guarded() {}
+`)
+	pass, ds := evaluateCfgOnDecl(decl, env)
+	if len(ds) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", ds)
+	}
+	if !pass {
+		t.Fatal("not(os=windows) should pass on linux")
+	}
+}
+
+func TestCfgCompositionNotFails(t *testing.T) {
+	env := testCfgEnv() // linux/amd64
+
+	decl := parseSingleDeclForCfgTest(t, `#[cfg(not(os = "linux"))]
+fn guarded() {}
+`)
+	pass, ds := evaluateCfgOnDecl(decl, env)
+	if len(ds) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", ds)
+	}
+	if pass {
+		t.Fatal("not(os=linux) should fail on linux")
+	}
+}
+
+func TestCfgCompositionNestedAllNot(t *testing.T) {
+	env := testCfgEnv() // linux/amd64
+
+	decl := parseSingleDeclForCfgTest(t, `#[cfg(all(os = "linux", not(arch = "arm64")))]
+fn guarded() {}
+`)
+	pass, ds := evaluateCfgOnDecl(decl, env)
+	if len(ds) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", ds)
+	}
+	if !pass {
+		t.Fatal("all(os=linux, not(arch=arm64)) should pass on linux/amd64")
+	}
+}
+
+func TestCfgCompositionFeature(t *testing.T) {
+	env := testCfgEnv()
+	env.Features["simd"] = true
+
+	decl := parseSingleDeclForCfgTest(t, `#[cfg(all(os = "linux", feature = "simd"))]
+fn guarded() {}
+`)
+	pass, ds := evaluateCfgOnDecl(decl, env)
+	if len(ds) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", ds)
+	}
+	if !pass {
+		t.Fatal("all(os=linux, feature=simd) should pass when simd is enabled")
+	}
+}
+
 func TestEvaluateCfgOnDeclSuggestsNearestSupportedComposition(t *testing.T) {
 	decl := &ast.FnDecl{Annotations: []*ast.Annotation{{
 		Name: "cfg",

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -68917,8 +68917,23 @@ func astLowerAnnotation(arena *AstArena, toks []astbridge.Token, idx int) astbri
 		// Osty: /tmp/selfhost_merged.osty:36556:9
 		cn := astArenaNodeAt(arena, child)
 		_ = cn
-		// Osty: /tmp/selfhost_merged.osty:36557:9
-		if ostyEqual(cn.kind, AstNodeKind(&AstNodeKind_AstNField_{})) {
+		// G29 cfg composition: all(...)/any(...)/not(...)
+		if ostyEqual(cn.kind, AstNodeKind(&AstNodeKind_AstNCall{})) {
+			calleeNode := astArenaNodeAt(arena, cn.left)
+			opName := ""
+			if ostyEqual(calleeNode.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
+				opName = calleeNode.text
+			}
+			composeArgs := astbridge.EmptyAnnotationArgList()
+			for _, carg := range cn.children {
+				composeArgs = append(composeArgs, astLowerAnnotationArg(arena, toks, carg))
+			}
+			func() struct{} {
+				args = append(args, astbridge.AnnotationComposeArgNode(astLowerNodePos(toks, cn), opName, composeArgs))
+				return struct{}{}
+			}()
+		} else if ostyEqual(cn.kind, AstNodeKind(&AstNodeKind_AstNField_{})) {
+			// key = value
 			// Osty: /tmp/selfhost_merged.osty:36558:13
 			func() struct{} {
 				args = append(args, astbridge.AnnotationArgNode(astLowerNodePos(toks, cn), cn.text, astLowerExpr(arena, toks, cn.left)))
@@ -68939,6 +68954,39 @@ func astLowerAnnotation(arena *AstArena, toks []astbridge.Token, idx int) astbri
 		}
 	}
 	return astbridge.AnnotationNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), n.text, args)
+}
+
+// astLowerAnnotationArg lowers a single annotation argument CST node (which may be
+// a key=value field, a bare identifier flag, or a nested call for cfg composition)
+// into a public ast.AnnotationArg.
+func astLowerAnnotationArg(arena *AstArena, toks []astbridge.Token, idx int) astbridge.AnnotationArg {
+	if idx < 0 {
+		return astbridge.NilAnnotationArg()
+	}
+	n := astArenaNodeAt(arena, idx)
+	// Composition form: all(...)/any(...)/not(...)
+	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNCall{})) {
+		calleeNode := astArenaNodeAt(arena, n.left)
+		opName := ""
+		if ostyEqual(calleeNode.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
+			opName = calleeNode.text
+		}
+		composeArgs := astbridge.EmptyAnnotationArgList()
+		for _, carg := range n.children {
+			composeArgs = append(composeArgs, astLowerAnnotationArg(arena, toks, carg))
+		}
+		return astbridge.AnnotationComposeArgNode(astLowerNodePos(toks, n), opName, composeArgs)
+	}
+	// key = value
+	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNField_{})) {
+		return astbridge.AnnotationArgNode(astLowerNodePos(toks, n), n.text, astLowerExpr(arena, toks, n.left))
+	}
+	// bare identifier flag
+	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
+		return astbridge.AnnotationArgNode(astLowerNodePos(toks, n), n.text, astbridge.NilExpr())
+	}
+	// fallback: bare literal / expression
+	return astbridge.AnnotationArgNode(astLowerNodePos(toks, n), "", astLowerExpr(arena, toks, idx))
 }
 
 // Osty: /tmp/selfhost_merged.osty:36568:1


### PR DESCRIPTION
## Summary

Implements the full `#[cfg]` conditional compilation composition forms per v0.5 grammar (`OSTY_GRAMMAR_v0.5.md` CfgCall production):

```osty
#[cfg(all(os = "linux", arch = "amd64"))]
#[cfg(any(os = "windows", arch = "arm64"))]
#[cfg(not(os = "windows"))]
#[cfg(all(os = "linux", not(arch = "arm64")))]   // nested
```

### Root cause

The parser produces `CallExpr` nodes for `all(...)`/`any(...)`/`not(...)` inside annotation arguments, but `evaluateCfgArg` only checked `arg.Compose` (which the AST lowering never populated for this case). The `evaluateCfgCompose` function was already fully implemented but unreachable.

### Changes

| File | Change |
|------|--------|
| `internal/resolve/cfg.go` | Detect `CallExpr` in `evaluateCfgArg`, add `callArgsToCompose` helper for recursive conversion |
| `internal/ast/ast.go` | `AnnotationArg.End()` handles `Compose` case |
| `internal/selfhost/generated.go` | `astLowerAnnotation` handles `AstNCall` nodes → `AnnotationComposeArgNode` |
| `internal/docgen/ast_lower.go` | Same `AstNCall` handling for docgen path |
| `internal/docgen/astbridge/generated.go` | Add `AnnotationComposeArgNode` bridge function |
| `internal/resolve/cfg_test.go` | 8 new tests: `all`/`any`/`not` pass+fail, nested, feature flag |

### Test results

```
TestCfgCompositionAllPasses              PASS
TestCfgCompositionAllFailsOnOne          PASS
TestCfgCompositionAnyPasses              PASS
TestCfgCompositionAnyFails               PASS
TestCfgCompositionNot                    PASS
TestCfgCompositionNotFails               PASS
TestCfgCompositionNestedAllNot           PASS
TestCfgCompositionFeature                PASS
```

`go build ./...` ✓ · `go test ./internal/resolve/` ✓ · `go test ./internal/check/` ✓