### PR TITLE
docs: v0.5 "Not yet shipped"를 parser/checker/ELAB 레벨로 세분화

### DIFF
--- a/CHANGELOG_v0.5.md
+++ b/CHANGELOG_v0.5.md
@@ -2,10 +2,10 @@
 
 - **Scope**: v0.5 edition changes — new surface, wired features, regen status
 - **Type**: Changelog
-Tracks the user-visible slice of the v0.5 spec (`LANG_SPEC_v0.5/`) that
-has landed in the compiler today, separate from the spec itself. The
-spec is the authority on what v0.5 *will* be; this file is the
-authority on what v0.5 *is* right now.
+  Tracks the user-visible slice of the v0.5 spec (`LANG_SPEC_v0.5/`) that
+  has landed in the compiler today, separate from the spec itself. The
+  spec is the authority on what v0.5 _will_ be; this file is the
+  authority on what v0.5 _is_ right now.
 
 See [`LANG_SPEC_v0.5/18-change-history.md`](./LANG_SPEC_v0.5/18-change-history.md)
 for the full v0.4 → v0.5 decision log (15 resolved gaps, G20 – G35) and
@@ -15,13 +15,13 @@ for the full v0.4 → v0.5 decision log (15 resolved gaps, G20 – G35) and
 
 ### Syntax
 
-| Form | Status | Notes |
-|---|---|---|
-| `use path::{a, b as c}` — scoped / grouped imports | **shipped** (G28) | Parsed natively by the self-hosted parser ([`toolchain/parser.osty`](./toolchain/parser.osty)) and lowered through [`internal/selfhost/ast_lower.osty`](./internal/selfhost/ast_lower.osty). One flat `use` per item, rename preserved. The earlier Go-side pre-parse rewrite (`internal/parser/scoped_imports.go`) was retired in af371d1 once the self-hosted parser caught up. |
-| `pub use path.Sym` — cross-module re-export | **shipped** (G30) | Parsed natively in [`toolchain/parser.osty`](./toolchain/parser.osty) with the `pub` visibility carried through `ast_lower.osty`; resolver honors the flag and cycles diagnose as `E0552`. The earlier Go-side post-parse `IsPub` flip (`internal/parser/pub_use.go`) was retired in 15cd35a. |
-| `#[cfg(key = "value")]` — conditional compilation | **shipped** (G29) | Pre-resolve filter in [`internal/resolve/cfg.go`](./internal/resolve/cfg.go). Keys: `os`, `target`, `arch`, `feature`. Unknown key → `E0405`. Composition forms (`all` / `any` / `not`) are spec-visible but not yet parsed. |
-| `#[test]` inline test annotation | **shipped** (G32) | Discovery in [`cmd/osty/test_native.go`](./cmd/osty/test_native.go) accepts any zero-arity function carrying `#[test]`, including those outside `_test.osty`. Legacy `test*` prefix still works. |
-| Doctest blocks in `///` comments | **shipped** (G32) | Extraction in [`internal/doctest`](./internal/doctest). `osty test --doc` synthesises a runner per package and routes blocks through the normal test pipeline. |
+| Form                                                        | Status                 | Notes                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ----------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `use path::{a, b as c}` — scoped / grouped imports          | **shipped** (G28)      | Parsed natively by the self-hosted parser ([`toolchain/parser.osty`](./toolchain/parser.osty)) and lowered through [`internal/selfhost/ast_lower.osty`](./internal/selfhost/ast_lower.osty). One flat `use` per item, rename preserved. The earlier Go-side pre-parse rewrite (`internal/parser/scoped_imports.go`) was retired in af371d1 once the self-hosted parser caught up.                       |
+| `pub use path.Sym` — cross-module re-export                 | **shipped** (G30)      | Parsed natively in [`toolchain/parser.osty`](./toolchain/parser.osty) with the `pub` visibility carried through `ast_lower.osty`; resolver honors the flag and cycles diagnose as `E0552`. The earlier Go-side post-parse `IsPub` flip (`internal/parser/pub_use.go`) was retired in 15cd35a.                                                                                                           |
+| `#[cfg(key = "value")]` — conditional compilation           | **shipped** (G29)      | Pre-resolve filter in [`internal/resolve/cfg.go`](./internal/resolve/cfg.go). Keys: `os`, `target`, `arch`, `feature`. Unknown key → `E0405`. Composition forms (`all` / `any` / `not`) are spec-visible but not yet parsed.                                                                                                                                                                            |
+| `#[test]` inline test annotation                            | **shipped** (G32)      | Discovery in [`cmd/osty/test_native.go`](./cmd/osty/test_native.go) accepts any zero-arity function carrying `#[test]`, including those outside `_test.osty`. Legacy `test*` prefix still works.                                                                                                                                                                                                        |
+| Doctest blocks in `///` comments                            | **shipped** (G32)      | Extraction in [`internal/doctest`](./internal/doctest). `osty test --doc` synthesises a runner per package and routes blocks through the normal test pipeline.                                                                                                                                                                                                                                          |
 | `err.downcast::<T>()` — nominal-tag recovery (backend only) | **half-shipped** (G27) | LLVM lowering in [`internal/llvmgen/iface_downcast.go`](./internal/llvmgen/iface_downcast.go) compares the receiver's runtime vtable against `@osty.vtable.<T>__<iface>` and selects between the data ptr and null (ptr-typed `T?`). Ships ahead of the checker; the self-hosted checker still rejects the call, so the path is driven by a `generateFromAST` unit test until the front end catches up. |
 
 ### Stdlib — signatures
@@ -59,7 +59,7 @@ bodies exist so the stub checker accepts imports.
   compiler-inserted warmup of `clamp(N/10, 1, 1000)` iterations runs
   before the first clock sample. `?` inside the closure is supported
   and, on `Err` / `None`, prints
-  `bench \`?\` propagated failure at <abs-path>:<line>` and exits the
+  `bench ?` propagated failure at <abs-path>:<line>` and exits the
   bench with failure status. `--benchtime <dur>` (Go-style duration,
   requires `--bench`) activates auto-tuning: a 10-iteration probe
   estimates the iteration count that fills the duration, clamped to
@@ -120,26 +120,28 @@ files). Spec: [`LANG_SPEC_v0.5/03-declarations.md`](./LANG_SPEC_v0.5/03-declarat
 
 ### Diagnostic codes
 
-| Code | Meaning | Where |
-|---|---|---|
-| `E0405` | Unknown `#[cfg]` key | `internal/resolve/cfg.go` |
-| `E0552` | `pub use` cycle | resolver re-export walk |
-| `E0553` | `pub use` of a private symbol | resolver |
-| `E0554` | Duplicate item in scoped `use path::{...}` | resolver |
-| `E0754`–`E0756` | `#[op(...)]` signature / duplicate / not-allowed — reserved for G35 | `internal/diag/codes.go` |
-| `E0757` | `as?` on a non-`Error` expression — reserved for G27 | `internal/diag/codes.go` |
-| `E0758` / `E0759` | Enum integer discriminant on payload variant / duplicate discriminant — reserved for G31 | `internal/diag/codes.go` |
-| `E0763` | Unknown loop label in `break 'lbl` | reserved for G24 |
-| `E0764` | Label shadowing | reserved for G24 |
-| `E0765` | Implicit narrowing conversion (numeric) | reserved for G34 |
+| Code              | Meaning                                                                                  | Where                     |
+| ----------------- | ---------------------------------------------------------------------------------------- | ------------------------- |
+| `E0405`           | Unknown `#[cfg]` key                                                                     | `internal/resolve/cfg.go` |
+| `E0552`           | `pub use` cycle                                                                          | resolver re-export walk   |
+| `E0553`           | `pub use` of a private symbol                                                            | resolver                  |
+| `E0554`           | Duplicate item in scoped `use path:{...}`                                               | resolver                  |
+| `E0754`–`E0756`   | `#[op(...)]` signature / duplicate / not-allowed — reserved for G35                      | `internal/diag/codes.go`  |
+| `E0757`           | `as?` on a non-`Error` expression — reserved for G27                                     | `internal/diag/codes.go`  |
+| `E0758` / `E0759` | Enum integer discriminant on payload variant / duplicate discriminant — reserved for G31 | `internal/diag/codes.go`  |
+| `E0763`           | Unknown loop label in `break 'lbl`                                                       | reserved for G24          |
+| `E0764`           | Label shadowing                                                                          | reserved for G24          |
+| `E0765`           | Implicit narrowing conversion (numeric)                                                  | reserved for G34          |
 
 All codes appear in [`ERROR_CODES.md`](./ERROR_CODES.md) (generated) and
 have focused tests under `internal/diag/testdata`.
 
 ## Not yet shipped
 
-The following v0.5 forms are spec-frozen but still need edits to
-`toolchain/parser.osty` / `toolchain/elab.osty`, which route through
+The following v0.5 forms are spec-frozen. Most have full parser AST
+building in `toolchain/parser.osty`; the remaining gap is the
+checker/ELAB layer in `toolchain/elab.osty` / `toolchain/check.osty`,
+which routes through
 the bootstrap-gen regen pipeline
 (see [issue #362](https://github.com/choiceoh/osty/issues/362) —
 `go generate ./internal/selfhost`). The upstream fallback landed in
@@ -148,18 +150,33 @@ self-hosted surface (af371d1, 15cd35a), so the blocker is now
 narrower than the original #362 framing, but editing the checker
 half of these forms still round-trips through the regen path.
 
-- `loop { break value }` — value-returning unbounded loop (G22)
-- `'label: for / loop …` + labeled `break 'label` / `continue 'label` (G24)
-- Range step `0..100 by 2` (G25)
-- Struct update shorthand `receiver { field: value }` (G26)
-- Trailing closure `f(x) |y| { body }` (G23)
-- `err as? T` downcast syntax (G27) — LLVM lowering shipped (see table above); checker recognition pending so full `osty build` still rejects
-- `pub? const fn` — compile-time evaluable functions (G21 extension)
-- Enum integer discriminants `pub enum X: Int { A = 1, ... }` (G31)
-- `#[op(+)]` operator overload (G35) — six-operator allow-list
-- Lossless numeric widening (G34)
-- Function-value parameter-name preservation (G20) — infrastructure shipped: FnType.ParamNames, TyNode.fnParamNames, FrontTypeRepr.paramNames, tyFnWithNames, fnSigToTy/collectFnDecl propagation, String() rendering, diagnostic E0769
-- `#[cfg]` composition forms `all(...)` / `any(...)` / `not(...)` (G29 partial)
+### Parser-level shipped (checker/ELAB pending)
+
+These forms are fully parsed by `toolchain/parser.osty`. The AST nodes carry the right shape; only the checker semantics remain.
+
+- **G22** - `loop { break value }` — value-returning unbounded loop (`AstNBreak.left` on value, loop return type unification pending)
+- **G23** - Trailing closure `f(x) |y| { body }` — `opAttachTrailingClosure` appends closure to CallExpr args
+- **G24** - `'label: ...` + labeled `break 'label` / `continue 'label` — `FrontLabel` token, `opParseLabelNode`, resolver scope validation pending
+- **G25** - Range step `0..100 by 2` — `rangeFlags | 2` + step in `AstNRange.children`
+- **G26** - Struct update shorthand `receiver { field: value }` — `opParseStructUpdateShorthand` + `opLooksLikeStructLitBody`
+- **G27** - `err as? T` downcast — `FrontAsQuestion` token (parser); LLVM lowering shipped; checker still rejects
+
+### Checker/ELAB infra shipped (body pending)
+
+These have diagnostic codes reserved in `internal/diag/codes.go` but need checker logic.
+
+- **G21** - `pub? const fn` — `E0762/E0766/E0767/E0768` codes defined; ELAB capability matrix pending
+- **G31** - Enum integer discriminants — `E0758/E0759` codes defined; ELAB auto-derive `.discriminant()` pending
+- **G34** - Lossless numeric widening — `E0765` code defined; widening lattice in checker pending
+- **G35** - `#[op(+)]` operator overload — `E0754/E0755/E0756` codes defined; dispatch lowering pending
+
+### Infrastructure shipped, metadata propagation only
+
+- **G20** - Function-value parameter-name preservation — FnType.ParamNames, TyNode.fnParamNames, FrontTypeRepr.paramNames, tyFnWithNames, fnSigToTy/collectFnDecl propagation, String() rendering, diagnostic E0769. Keyword calls through function values by name still pending.
+
+### Partial Go-side implementation
+
+- **G29** - `#[cfg(all(...))` / `any(...)` / `not(...)` composition — keys `os`/`target`/`arch`/`feature` work in `internal/resolve/cfg.go`; composition forms not parsed
 
 ## Native checker status
 
@@ -195,7 +212,7 @@ short; `git log <hash>` for the full message.
 
 - **014a6fe** — `err.downcast::<T>()` LLVM lowering (backend half of G27 / §7.4)
 - **607eb19** — `use path.X as Y` stable-alias rewrite migrates from Go side to the self-hosted parser
-- **af371d1** — `use path::{ ... }` scoped-use handling migrates to the self-hosted parser; `internal/parser/scoped_imports.go` retired
+- **af371d1** — `use path:{ ... }` scoped-use handling migrates to the self-hosted parser; `internal/parser/scoped_imports.go` retired
 - **15cd35a** — `pub use` handling migrates to the self-hosted parser; `internal/parser/pub_use.go` retired
 - **f38be21** — Bootstrap-gen regen pipeline grows a build gate + checker-miss fallback (narrowed #362)
 - **6fd09bb / 23b3f26 / f69461d** — AST-native package checker bridge + prelude-function registration + package-native external checker requests (all three prerequisites for shipping checker halves of the "Not yet shipped" items)


### PR DESCRIPTION
## Summary

`CHANGELOG_v0.5.md`의 "Not yet shipped" 섹션을 코드 분석 결과에 맞게 수정.

## Changes

### 이전 상태
모든 v0.5 기능이 동일한 flat bullet list로 "not yet shipped" 취급됨

### 새로운 상태
Parser/Checker/ELAB 레벨로 세분화:

- **Parser-level shipped** (G22-G27): 이미 `toolchain/parser.osty`에 AST building 완료
- **Checker/ELAB infra shipped** (G21/G31/G34/G35): Diagnostic codes 정의됨, checker logic 작성 필요
- **Infrastructure shipped** (G20): Metadata propagation 인프라 완료
- **Partial Go-side** (G29): cfg composition forms 미구현

## 분석 근거

코드 내 실제 구현 확인:
- G23 trailing closure: `opAttachTrailingClosure` (parser L1516-1673)
- G24 labeled break: `FrontLabel` token + `opParseLabelNode`
- G25 range step by: `rangeFlags | 2` in `AstNRange.children`
- G26 struct update shorthand: `opParseStructUpdateShorthand`
- G27 as? downcast: `FrontAsQuestion` token
- G22 loop break value: `AstNBreak.left` on value