### PR TITLE
fix(stage0): rewrite match-arm tail calls into rets when sink is unreachable

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -13685,6 +13685,44 @@ func matchGenericScalarCFG(fn *mir.Function, mctx *moduleCtx) (genericCFGPattern
 			}
 		}
 	}
+	// Mixed-tail inference: even when the function has at least one
+	// explicit `ReturnTerm` block (e.g. an early-`return` guard before
+	// the body), other match arms can still funnel into a single
+	// storage-only-unreachable sink via `goto exit`. Without this pass,
+	// `classifyVoidCallLine` lowers each arm's last call as a void call
+	// and the join block stays `unreachable`, producing the classic
+	// "call elabInferIntLit; int3" crash chain — see the elabInferImpl
+	// match-on-AstNodeKind shape that surfaced as `Trace/breakpoint
+	// trap` across ~56 backend tests once the by-value ABI fix (#1713)
+	// stopped masking it with OOM. Populate `syntheticCallReturns` /
+	// `syntheticIntrinsicReturns` for the arms whose final discarded
+	// call/intrinsic can be re-emitted as `ret <retType> %call_result`,
+	// leaving the explicit-return blocks alone.
+	// Mixed-tail inference: even when the function has at least one
+	// explicit `ReturnTerm` block (e.g. an early-`return` guard before
+	// the body), other match arms can still funnel into a
+	// storage-only-unreachable sink via `goto exit`. Without this pass,
+	// `classifyVoidCallLine` lowers each arm's last call as a void
+	// call and the join block stays `unreachable`, producing the
+	// classic "call elabInferIntLit; int3" crash chain — see the
+	// elabInferImpl match-on-AstNodeKind shape that surfaced as
+	// `Trace/breakpoint trap` across ~56 backend tests once the
+	// by-value ABI fix (#1713) stopped masking it with OOM.
+	//
+	// We tolerate >1 storage-only-unreachable sink (e.g. elabInferImpl
+	// has two: the match-join and an end-of-function `unreachable`)
+	// because the per-arm rewrite only needs *some* such exit to
+	// target — the second sink stays as bare `unreachable`, which is
+	// already correct.
+	if !pat.returnsVoid && pat.syntheticCallReturns == nil && pat.syntheticIntrinsicReturns == nil && pat.syntheticReturns == nil {
+		callMap, intrMap := genericInferMixedTailDiscardedReturns(fn, mctx, pat.retType)
+		if len(callMap) > 0 {
+			pat.syntheticCallReturns = callMap
+		}
+		if len(intrMap) > 0 {
+			pat.syntheticIntrinsicReturns = intrMap
+		}
+	}
 	pat.blockOrder = make([]mir.BlockID, 0, len(blocks))
 	for _, bb := range blocks {
 		if bb == nil {
@@ -14139,6 +14177,58 @@ func genericInferDiscardedCallSyntheticReturn(fn *mir.Function, mctx *moduleCtx,
 		return 0, nil, false
 	}
 	return exitID, exitCall, true
+}
+
+// genericInferMixedTailDiscardedReturns rewrites match-arm-style
+// blocks that funnel a discarded `call <ret-type-matching-fn>(...)`
+// (or runtime intrinsic) into a storage-only-`unreachable` sink. The
+// pre-existing `…PreExitDiscarded*SyntheticReturns` helpers require
+// exactly one storage-only-unreachable exit AND no explicit
+// `ReturnTerm` elsewhere; this variant accepts any number of such
+// exits and leaves other blocks alone, which is the shape produced
+// by Osty source that mixes an early-`return` guard with a match
+// whose arms are tail calls (e.g. `elabInferImpl`,
+// `elabPatternMode`, `hirLowerStmt`).
+func genericInferMixedTailDiscardedReturns(fn *mir.Function, mctx *moduleCtx, retType scalarType) (map[mir.BlockID]*mir.CallInstr, map[mir.BlockID]*mir.IntrinsicInstr) {
+	if fn == nil || mctx == nil || retType == scalarUnknown {
+		return nil, nil
+	}
+	exits := map[mir.BlockID]bool{}
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		if _, unreachable := bb.Term.(*mir.UnreachableTerm); !unreachable {
+			continue
+		}
+		if !blockHasOnlyStorageMarkers(bb) {
+			continue
+		}
+		exits[bb.ID] = true
+	}
+	if len(exits) == 0 {
+		return nil, nil
+	}
+	calls := map[mir.BlockID]*mir.CallInstr{}
+	intrs := map[mir.BlockID]*mir.IntrinsicInstr{}
+	for _, bb := range fn.Blocks {
+		if bb == nil || exits[bb.ID] {
+			continue
+		}
+		gt, ok := bb.Term.(*mir.GotoTerm)
+		if !ok || !exits[gt.Target] {
+			continue
+		}
+		if call, ok := finalDiscardedCallInstr(bb); ok && discardedCallCanReturnScalar(fn, call, retType, mctx) {
+			calls[bb.ID] = call
+			continue
+		}
+		if ii, ok := finalDiscardedIntrinsicInstr(bb); ok && discardedIntrinsicCanReturnScalar(ii, retType) {
+			intrs[bb.ID] = ii
+			continue
+		}
+	}
+	return calls, intrs
 }
 
 func genericInferPreExitDiscardedCallSyntheticReturns(fn *mir.Function, mctx *moduleCtx, retType scalarType) (map[mir.BlockID]*mir.CallInstr, bool) {


### PR DESCRIPTION
## Summary

Functions like `elabInferImpl` mix two flow shapes that the existing synthetic-return inferrers couldn't both handle in one pass:

```osty
fn elabInferImpl(cx, idx) -> ElabResult {
    if idx < 0 {
        return elabErrResult(cx, 0, 0)   // explicit ReturnTerm
    }
    let node = astArenaNodeAt(cx.ast.arena, idx)
    match node.kind {
        AstNIntLit  -> elabInferIntLit(cx, idx, node),  // tail call
        AstNFloatLit -> elabInferFloatLit(cx, node),    // tail call
        ...                                              // tail calls
        _ -> elabErrResult(cx, node.start, node.end),
    }
}
```

The early `return` makes `genericHasReturnTerm(blocks)` true, which gates off the pre-existing `genericInfer{PreExit,}Discarded{Call,Intrinsic}SyntheticReturn` helpers — and the helpers themselves require **exactly one** storage-only-unreachable exit block, which `elabInferImpl` violates (the match-join and the fall-through after the discriminant switch both lower to bare `unreachable`).

## The blast radius

After the by-value ABI fix (#1713) stopped masking the rest of the pipeline with OOM, every match-arm bb ended as:

```llvm
bb.5:
  call void @elabInferIntLit(ptr %cx, i64 %idx, ptr %10)
  br label %bb.4
bb.4:
  unreachable
```

clang lowered `br + unreachable` to nothing and laid the next function's prologue out as the int3 padding right after the call — so the call would return cleanly into a sea of int3s and SIGTRAP. `addr2line` on the ~56 SIGTRAP-style backend test failures resolved to "elabInferImpl + small offset", which is exactly the match-arm body.

## Fix

Add a `genericInferMixedTailDiscardedReturns` helper that

1. enumerates **every** storage-only-`unreachable` block as a sink (tolerating >1, instead of the original "exactly one"),
2. rewrites each predecessor whose `goto sink` is preceded by a discarded call/intrinsic returning the function's scalar return type into `ret <retType> %call_result`,
3. leaves other blocks (explicit returns, sinks that nothing useful gotos) alone.

The new pass runs after the existing inference dispatch and only fires when none of the older inferrers populated a return map, so patterns that already had complete coverage are unaffected.

## Verification

- Smoke fixtures previously SIGTRAPping (`fn id<T>(x: T) -> T { x }; fn main() { println(id::<Int>(42)) }`) now reach a different failure mode (decline-stub for an upstream front-end function), i.e. the match-arm crash chain is gone.
- The `call void @elabInferIntLit(...)` pattern is no longer emitted in `toolchain/.osty/out/debug/llvm/main.ll`.
- `go test -short ./internal/backend/stage0/` passes unchanged.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/backend/stage0/...` clean
- [x] Smoke: SIGTRAP→exit-134 transition verified on `gid.osty` and `bitw.osty`
- [ ] Full `go test ./internal/backend/...` (running)

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_