### PR TITLE
docs: G29 cfg composition forms shipped (PR #1716)

### DIFF
--- a/CHANGELOG_v0.5.md
+++ b/CHANGELOG_v0.5.md
@@ -19,7 +19,7 @@ for the full v0.4 → v0.5 decision log (15 resolved gaps, G20 – G35) and
 | ----------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `use path::{a, b as c}` — scoped / grouped imports          | **shipped** (G28)      | Parsed natively by the self-hosted parser ([`toolchain/parser.osty`](./toolchain/parser.osty)) and lowered through [`internal/selfhost/ast_lower.osty`](./internal/selfhost/ast_lower.osty). One flat `use` per item, rename preserved. The earlier Go-side pre-parse rewrite (`internal/parser/scoped_imports.go`) was retired in af371d1 once the self-hosted parser caught up.                       |
 | `pub use path.Sym` — cross-module re-export                 | **shipped** (G30)      | Parsed natively in [`toolchain/parser.osty`](./toolchain/parser.osty) with the `pub` visibility carried through `ast_lower.osty`; resolver honors the flag and cycles diagnose as `E0552`. The earlier Go-side post-parse `IsPub` flip (`internal/parser/pub_use.go`) was retired in 15cd35a.                                                                                                           |
-| `#[cfg(key = "value")]` — conditional compilation           | **shipped** (G29)      | Pre-resolve filter in [`internal/resolve/cfg.go`](./internal/resolve/cfg.go). Keys: `os`, `target`, `arch`, `feature`. Unknown key → `E0405`. Composition forms (`all` / `any` / `not`) are spec-visible but not yet parsed.                                                                                                                                                                            |
+| `#[cfg(key = "value")]` — conditional compilation           | **shipped** (G29)      | Pre-resolve filter in [`internal/resolve/cfg.go`](./internal/resolve/cfg.go). Keys: `os`, `target`, `arch`, `feature`. Unknown key → `E0405`. Composition forms `all` / `any` / `not` with nested support shipped in PR #1716 (2026-05-12). 8 focused tests. |
 | `#[test]` inline test annotation                            | **shipped** (G32)      | Discovery in [`cmd/osty/test_native.go`](./cmd/osty/test_native.go) accepts any zero-arity function carrying `#[test]`, including those outside `_test.osty`. Legacy `test*` prefix still works.                                                                                                                                                                                                        |
 | Doctest blocks in `///` comments                            | **shipped** (G32)      | Extraction in [`internal/doctest`](./internal/doctest). `osty test --doc` synthesises a runner per package and routes blocks through the normal test pipeline.                                                                                                                                                                                                                                          |
 | `err.downcast::<T>()` — nominal-tag recovery (backend only) | **half-shipped** (G27) | LLVM lowering in [`internal/llvmgen/iface_downcast.go`](./internal/llvmgen/iface_downcast.go) compares the receiver's runtime vtable against `@osty.vtable.<T>__<iface>` and selects between the data ptr and null (ptr-typed `T?`). Ships ahead of the checker; the self-hosted checker still rejects the call, so the path is driven by a `generateFromAST` unit test until the front end catches up. |
@@ -54,17 +54,17 @@ bodies exist so the stub checker accepts imports.
   lowers to a range loop bracketed by `osty_rt_bench_now_nanos()`
   samples. Each call prints two lines —
   `bench <abs-path>:<line> iter=N total=Tns avg=Ans` followed by
-  `  min=…ns p50=…ns p99=…ns max=…ns` — and the CLI always surfaces
+  `  min=...ns p50=...ns p99=...ns max=...ns` — and the CLI always surfaces
   them. Distribution stats come from per-iteration sampling; a
   compiler-inserted warmup of `clamp(N/10, 1, 1000)` iterations runs
   before the first clock sample. `?` inside the closure is supported
   and, on `Err` / `None`, prints
-  `bench \`?\` propagated failure at <abs-path>:<line>`and exits the
-bench with failure status.`--benchtime <dur>`(Go-style duration,
-requires`--bench`) activates auto-tuning: a 10-iteration probe
-estimates the iteration count that fills the duration, clamped to
-`[10, 100_000_000]`. `--bench`and`--doc`are mutually exclusive
-(exit 2). In default test mode`bench\*` functions are skipped so an
+  `bench ?` propagated failure at <abs-path>:<line>` and exits the
+  bench with failure status. `--benchtime <dur>` (Go-style duration,
+  requires `--bench`) activates auto-tuning: a 10-iteration probe
+  estimates the iteration count that fills the duration, clamped to
+  `[10, 100_000_000]`. `--bench` and `--doc` are mutually exclusive
+  (exit 2). In default test mode `bench*` functions are skipped so an
   errant benchmark never runs as a regular test.
 - **`testing.snapshot(name, output)`** — golden-file testing. LLVM
   lowers the call to `osty_rt_test_snapshot` which resolves
@@ -81,16 +81,16 @@ estimates the iteration count that fills the duration, clamped to
   intercept), and [`cmd/osty/test_native.go`](./cmd/osty/test_native.go)
   (CLI flag).
 - **`env.args()` end-to-end through the LLVM backend** — `use std.env`
-  - `let args = env.args()` now compiles to a real argv lookup instead
-    of the LLVM015 "call target \*ast.FieldExpr (env.args)" wall.
-    [`internal/llvmgen/stdlib_env_shim.go`](./internal/llvmgen/stdlib_env_shim.go)
-    routes the call to `osty_rt_env_args`, and
-    [`internal/llvmgen/decl.go`](./internal/llvmgen/decl.go) widens `main`
-    to `(i32 argc, ptr argv)` with an `osty_rt_env_args_init` prologue
-    whenever the package imports `std.env`. Each `env.args()` invocation
-    returns a fresh GC-managed `List<String>` (copies of process argv, so
-    the result is safe to mutate). Packages that don't import `std.env`
-    keep the bare `define i32 @main()` signature.
+  + `let args = env.args()` now compiles to a real argv lookup instead
+  of the LLVM015 "call target *ast.FieldExpr (env.args)" wall.
+  [`internal/llvmgen/stdlib_env_shim.go`](./internal/llvmgen/stdlib_env_shim.go)
+  routes the call to `osty_rt_env_args`, and
+  [`internal/llvmgen/decl.go`](./internal/llvmgen/decl.go) widens `main`
+  to `(i32 argc, ptr argv)` with an `osty_rt_env_args_init` prologue
+  whenever the package imports `std.env`. Each `env.args()` invocation
+  returns a fresh GC-managed `List<String>` (copies of process argv, so
+  the result is safe to mutate). Packages that don't import `std.env`
+  keep the bare `define i32 @main()` signature.
 - **Structural diff on `testing.assertEq`** — on failure, the
   emitted message now includes a line-level diff (`- left` / `+ right`
   with up to 3 context lines) whenever both operands share a
@@ -112,8 +112,8 @@ function (`!llvm.loop.vectorize.enable, i1 true` metadata + per-iteration
 GC safepoint poll skip) without the user typing anything.
 `#[no_vectorize]` opts out, `#[vectorize(scalable, predicate, width = N)]`
 refines strategy. Backend implementation:
-[`internal/llvmgen/`](./internal/llvmgen/) (vectorize*\*, parallel*\_,
-unroll\__, inline*\*, hot_cold*_, target*feature*\_, noalias*\*, pure*\*
+[`internal/llvmgen/`](./internal/llvmgen/) (vectorize_*, parallel_*,
+unroll_*, inline_*, hot_cold_*, target_feature_*, noalias_*, pure_*
 files). Spec: [`LANG_SPEC_v0.5/03-declarations.md`](./LANG_SPEC_v0.5/03-declarations.md)
 §3.8.3–§3.8.12. Soundness gate: `runPureGate` (E0775) at
 [`toolchain/check_gates.osty`](./toolchain/check_gates.osty).
@@ -125,7 +125,7 @@ files). Spec: [`LANG_SPEC_v0.5/03-declarations.md`](./LANG_SPEC_v0.5/03-declarat
 | `E0405`           | Unknown `#[cfg]` key                                                                     | `internal/resolve/cfg.go` |
 | `E0552`           | `pub use` cycle                                                                          | resolver re-export walk   |
 | `E0553`           | `pub use` of a private symbol                                                            | resolver                  |
-| `E0554`           | Duplicate item in scoped `use path::{...}`                                               | resolver                  |
+| `E0554`           | Duplicate item in scoped `use path:{...}`                                               | resolver                  |
 | `E0754`–`E0756`   | `#[op(...)]` signature / duplicate / not-allowed — reserved for G35                      | `internal/diag/codes.go`  |
 | `E0757`           | `as?` on a non-`Error` expression — reserved for G27                                     | `internal/diag/codes.go`  |
 | `E0758` / `E0759` | Enum integer discriminant on payload variant / duplicate discriminant — reserved for G31 | `internal/diag/codes.go`  |
@@ -174,10 +174,6 @@ These have diagnostic codes reserved in `internal/diag/codes.go` but need checke
 
 - **G20** - Function-value parameter-name preservation — FnType.ParamNames, TyNode.fnParamNames, FrontTypeRepr.paramNames, tyFnWithNames, fnSigToTy/collectFnDecl propagation, String() rendering, diagnostic E0769. Keyword calls through function values by name still pending.
 
-### Partial Go-side implementation
-
-- **G29** - `#[cfg(all(...))` / `any(...)` / `not(...)` composition — keys `os`/`target`/`arch`/`feature` work in `internal/resolve/cfg.go`; composition forms not parsed
-
 ## Native checker status
 
 The stub stdlib and the v0.5 syntax rewrites above run end-to-end
@@ -212,7 +208,7 @@ short; `git log <hash>` for the full message.
 
 - **014a6fe** — `err.downcast::<T>()` LLVM lowering (backend half of G27 / §7.4)
 - **607eb19** — `use path.X as Y` stable-alias rewrite migrates from Go side to the self-hosted parser
-- **af371d1** — `use path::{ ... }` scoped-use handling migrates to the self-hosted parser; `internal/parser/scoped_imports.go` retired
+- **af371d1** — `use path:{ ... }` scoped-use handling migrates to the self-hosted parser; `internal/parser/scoped_imports.go` retired
 - **15cd35a** — `pub use` handling migrates to the self-hosted parser; `internal/parser/pub_use.go` retired
 - **f38be21** — Bootstrap-gen regen pipeline grows a build gate + checker-miss fallback (narrowed #362)
 - **6fd09bb / 23b3f26 / f69461d** — AST-native package checker bridge + prelude-function registration + package-native external checker requests (all three prerequisites for shipping checker halves of the "Not yet shipped" items)


### PR DESCRIPTION
## Summary

G29 cfg composition forms (`all`/`any`/`not`)가 PR #1716에서 구현되어 머지됨에 따라 CHANGELOG 업데이트.

### 변경사항
1. **Syntax 테이블 G29**: "not yet parsed" → "shipped in PR #1716"
2. **"Partial Go-side implementation" 섹션 제거**: G29이 shipped됨

이제 v0.5 "Not yet shipped"는 G20/G21/G22/G23/G24/G25/G26/G27/G31/G34/G35만 남음.