### PR TITLE
fix(toolchain+runtime): align checkIsWideningConversion param types + add @len alias

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -8022,6 +8022,18 @@ OSTY_HOT_INLINE int64_t osty_rt_list_len(void *raw_list) {
     return list->len;
 }
 
+/* Bare `len` alias: stage0 emit lowers some `.len()` method-call sites
+ * (specifically those targeting List<T> reached through a match-arm /
+ * Option-unwrap binding — see e.g. `mir_lower::mirLowerMultiAssign`
+ * and `onb_aggregate::onbLowerStructLiteralAssign`) as a direct
+ * `call i64 @len(ptr)` rather than translating the symbol to
+ * `osty_rt_list_len`. Until stage0 grows that translation, declare a
+ * thin alias here so the link step resolves cleanly. Direct-parameter
+ * `.len()` already lowers as `@osty_rt_list_len` and is unaffected. */
+int64_t len(void *raw_list) {
+    return osty_rt_list_len(raw_list);
+}
+
 void osty_rt_list_pop_discard(void *raw_list) {
     osty_rt_list *list = osty_rt_list_cast(raw_list);
     if (list == NULL || list->len <= 0) {

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -928,7 +928,7 @@ fn checkIsNumericNarrowing(env: CheckEnv, expected: Int, got: Int) -> Bool {
 ///   Int8 -> Int16 -> Int32 -> Int -> Float64
 ///   Int  -> Float64
 ///   Float32 -> Float64
-fn checkIsWideningConversion(from: Int, to: Int) -> Bool {
+fn checkIsWideningConversion(from: PrimKind, to: PrimKind) -> Bool {
     // Int widening chain: Int8 -> Int16 -> Int32 -> Int
     if from == PkInt8 && (to == PkInt16 || to == PkInt32 || to == PkInt || to == PkFloat64) {
         return true


### PR DESCRIPTION
## Summary

Two narrowly-scoped fixes that together unblock `osty install-self` on the post-#1720 main snapshot.

### 1. `toolchain/check_env.osty`: PrimKind parameter type

`checkIsWideningConversion(from: Int, to: Int)` was declared with `Int` parameters but its body compares the arguments to `PrimKind` variants (`from == PkInt8`, `to == PkInt16`, …). The native checker now flags **21 instances** of "expected `Int`, found `PrimKind`" — both at the call site (`checkIsAssignableDepth` passes `sPrim: PrimKind, dPrim: PrimKind`) and inside the body. Switching the signature to `(from: PrimKind, to: PrimKind)` clears every one of those diagnostics; the body and callers already speak `PrimKind`. The parameter types were left as `Int` in 2d8bae5's G34 widening-lattice addition.

### 2. `internal/backend/runtime/osty_runtime.c`: `@len` forwarder

Stage0 emit lowers `.len()` method calls reached through a match-arm or Option-unwrap binding (e.g. `mir_lower::mirLowerMultiAssign`'s `elemTs.len()` and `onb_aggregate::onbLowerStructLiteralAssign`'s `layout.fields.len()`) as a direct `call i64 @len(ptr)` instead of translating the symbol to `@osty_rt_list_len`. Direct-parameter `.len()` already lowers correctly. Until stage0 grows that translation, declare a thin `len` forwarder so the link step resolves the bare symbol cleanly.

## Validation

- `osty check toolchain/check_env.osty`: **21 errors → 0**
- `OSTY_STAGE0_FALLBACK=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 osty install-self` now produces a fresh `osty-self` binary end-to-end (was failing at the link step with `undefined symbol: len`)
- Smoke fixture `osty-self lir-proto-lower /tmp/bitw.osty` exits 0

## Out of scope

These remain for sibling tickets:
- `define () @main()` literal `()` in LLVM IR for unit-returning toolchain `main` (regression from #1720's emit work, blocks backend tests at the clang compile step).
- Continued decline coverage for the 65 unique-shape long tail.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_