### PR TITLE
fix(lir_proto): map Osty source-level &quot;()&quot; to LLVM void

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -1336,6 +1336,9 @@ pub fn lirLowerPrimitiveTypeName(name: String) -> LirType {
     if name == "Unit" {
         return lirVoidType()
     }
+    if name == "()" {
+        return lirVoidType()
+    }
     if name == "Never" {
         return lirVoidType()
     }


### PR DESCRIPTION
## Summary

`lirLowerPrimitiveTypeName` matched `"Unit"` and `"Never"` for the unit / never type names but missed the source-level spelling `"()"`. That Osty notation reaches `lirLowerMirType` via `fn.returnType` for any toolchain function declared without an explicit `-> T` (e.g. `fn main() {}`, every void-returning helper). Because `lirLowerMirType` then falls through to the `if strings.contains(name, "(")` arm — meant for function-type literals like `"fn(Int) -> Int"` — and constructs `LirType{llvm: "()", className: LirTypeFunction}`. That LirType flows through `lirRenderFunction`'s normalisation guard (`lirTypeIsZero` is false, so the void rewrite is skipped) and the emitter writes the literal token verbatim:

```
; Osty: fn main() {}
declare () @main()       ← invalid LLVM IR
define  () @main()       ← clang rejects with "expected type"
```

Surfaces on the LLVM backend test path whenever a fixture compiles through `osty-self lir-proto-lower` and the entry point is unit-returning (most `fn main()` fixtures). Backend tests fail at the clang-compile step with `error: expected type: define () @main()`.

## Fix

Treat `"()"` as void in `lirLowerPrimitiveTypeName`, sitting right next to the existing `"Unit"` case. The check runs before the falls-through to the function-type-literal arm, which the existing dispatch order already guarantees.

## Validation

After rebuilding `osty-self`:

```
$ osty-self lir-proto-lower /tmp/probe.osty   # fn main() {}
; Code generated by osty LIR Proto. DO NOT EDIT.
…
declare void @main()        ← was `declare () @main()`
```

The clang-compile step now accepts the IR.

## Out of scope

`println(<Int>)` still lowers as bare `call void @println(i64 N)` — the intrinsic-vs-regular-call classification at the HIR layer routes Int-arg `println` through the regular call path, skipping the `lirLowerMirPrintIntrinsic` runtime translation. That's a sibling bug at the elab/HIR boundary, unrelated to the type-name normalisation here.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_