### PR TITLE
fix(elab): route prelude formatters (print/println/...) through coreIntrinsic

### DIFF
--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1394,6 +1394,23 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
         if !(tyIsBad(cx.env.tys, expected)) {
             let _ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
         }
+        // §A.8 / §17 prelude formatters (`print` / `println` / `eprint`
+        // / `eprintln`) accept `T: ToString` rather than a concrete
+        // `String`. The check side skips the param-type comparison
+        // (see `elabCallArgsMonomorphicWithNames`'s `skipParamCheck`
+        // branch), but historically the call still lowered as a
+        // regular `CoreCall(println, …)` → `MIR CallInstr(println, …)`
+        // → `call void @println(i64 …)` at the LIR Proto layer. That
+        // bare `@println` symbol does not exist in the runtime, so
+        // the link fails with `undefined symbol: println`. Route the
+        // formatter calls through `coreIntrinsic` so the downstream
+        // HIR / MIR / LIR pipeline picks up the intrinsic dispatch
+        // table (`lirLowerMirPrintIntrinsic` → `@osty_rt_io_write`
+        // with the ToString-coercing prelude in front).
+        if elabIsToStringFormatter(baseCallee.text) {
+            let coreIntr = coreIntrinsic(cx.core, baseCallee.text, coreArgs, retTy, node.start, node.end)
+            return ElabResult {node: coreIntr, ty: retTy}
+        }
         let coreCallNode = coreCall(cx.core, coreFn, coreArgs, [], retTy, node.start, node.end)
         return ElabResult {node: coreCallNode, ty: retTy}
     }


### PR DESCRIPTION
## Summary

`elabInferCall` looks up the callee in the registered-fn table and emits `CoreCall(coreIdent(println), …)` for any name registered as a regular fn. That includes `print` / `println` / `eprint` / `eprintln`, which the check side already special-cases via `elabIsToStringFormatter` to skip the param-type comparison (those formatters accept any `T: ToString`, not the concrete `String` the prelude signature advertises for fn-value interop).

Skipping the check is necessary but not sufficient: the call still lowered as a regular call through HIR / MIR, so the LIR Proto emitter wrote `call void @println(i64 …)` for `println(42)`. There is no `@println` symbol in the runtime — the link step fails with `undefined symbol: println` once the unit-type fix (#1722) lets clang accept the IR.

## Fix

Route the four formatters through `coreIntrinsic(baseCallee.text, coreArgs, retTy, …)` instead. The downstream `hirLowerIntrinsicFromIdent → HirIntrinsicPrint{ln,} / Eprint{ln,} → MirIntrinsicPrint{ln,} / Eprint{ln,}` dispatch is already wired up. The intrinsic lowering in `lir_proto.osty::lirLowerMirPrintIntrinsic` then calls into the runtime's existing `osty_rt_int_to_string` / `osty_rt_float_to_string` / `osty_rt_bool_to_string` ToString helpers and forwards the resulting `ptr` to `osty_rt_io_write` — the runtime symbol that already exists.

## Validation

After rebuilding `osty-self`:

```
$ osty-self lir-proto-lower /tmp/println-int.osty
…
  %t0 = call ptr @osty_rt_int_to_string(i64 42)
  call void @osty_rt_io_write(ptr %t0, i1 1, i1 0)
```

was

```
  call void @println(i64 42)
```

- `go test -run TestLLVMBackendBinaryRunsBitwiseIntOps` now passes (was failing at link with `undefined symbol: println` after #1722).

## Compounding effect

Combined with #1721 (`@len` alias + `checkIsWideningConversion` param fix) and #1722 (`define ()` → `define void`), this should unblock the largest remaining cluster of backend tests — the println-int / println-bool / println-bytewise smoke fixtures that bottomed-out at the link step.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_