### PR TITLE
fix(toolchain/solve): rewrite zonkAt wildcard match arm as if-chain

### DIFF
--- a/toolchain/solve.osty
+++ b/toolchain/solve.osty
@@ -261,13 +261,19 @@ fn zonkAt(env: CheckEnv, solver: Solver, ty: Int, depth: Int) -> Int {
     }
     let walked = solverWalk(env.tys, solver, ty)
     let kind = tyKindAt(env.tys, walked)
-    match kind {
-        TkNamed -> zonkAtNamed(env, solver, walked, depth),
-        TkTuple -> zonkAtTuple(env, solver, walked, depth),
-        TkFn -> zonkAtFn(env, solver, walked, depth),
-        TkOptional -> tyOptional(env.tys, zonkAt(env, solver, tyInnerAt(env.tys, walked), depth + 1)),
-        _ -> walked,
+    if kind == TkNamed {
+        return zonkAtNamed(env, solver, walked, depth)
     }
+    if kind == TkTuple {
+        return zonkAtTuple(env, solver, walked, depth)
+    }
+    if kind == TkFn {
+        return zonkAtFn(env, solver, walked, depth)
+    }
+    if kind == TkOptional {
+        return tyOptional(env.tys, zonkAt(env, solver, tyInnerAt(env.tys, walked), depth + 1))
+    }
+    walked
 }
 fn zonkAtNamed(env: CheckEnv, solver: Solver, walked: Int, depth: Int) -> Int {
     let args = tyArgsAt(env.tys, walked)


### PR DESCRIPTION
## Summary

Works around a stage0/MIR lowering bug where `match { ..., _ -> <local_var> }` drops the wildcard arm body, producing IR that emits `unreachable` in the default block. This caused `zonkAt` to crash the process via SIGSEGV during generic call elaboration — hitting 38 backend tests in the `TestLLVMBackendBinaryRunsGeneric*` family.

Rewriting `zonkAt` from `match kind { ... _ -> walked }` to an if-chain ending in a bare `walked` keeps the same semantics but avoids the default-arm-drop path entirely.

## Investigation

- IR for `zonkAt` showed the default `switch` label landing on `bb.7: unreachable` rather than a `ret i64 walked`.
- `mirLowerSwitchVariant` and `pmTryCompileVariantSwitch` both pass `defaultArm` / `defaultBody` correctly — the drop happens during stage0's lowering of the wildcard arm whose body is a plain local.
- Confirmed fix at the entry point: `osty-self lir-proto-lower /tmp/g_min.osty` now exits 0 (was SIGSEGV).
- `TestLLVMBackendBinaryRunsGenericIdentity` now reaches end-to-end execution. The binary still prints the wrong value (separate codegen-semantic bug in generic identity), but the crash class is gone.

## Test plan

- [x] `osty-self lir-proto-lower /tmp/g_min.osty` returns 0
- [x] `osty install-self` succeeds
- [ ] Backend test count after fix (running in background)
- [ ] Long-term: stage0/MIR should round-trip wildcard arms whose body is a simple local — tracked separately

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_