### PR TITLE
fix(toolchain/mir_lower): mark return + parameter locals with isReturn/isParam

### DIFF
--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -722,6 +722,7 @@ fn mirLowerCopyFnAnnotations(out: MirFunction, decl: HirFnDecl) {
 /// `newFunction`. Must run before any body lowering.
 pub fn mirLowerSeedFunction(out: MirFunction, params: List<HirParam>, retT: HirType, span: MirSpan) {
     let retLocal = mirFunctionNewLocal(out, "_return", hirTypeString(retT), true, span)
+    out.locals[retLocal].isReturn = true
     out.returnLocal = retLocal
     let mut idx = 0
     for p in params {
@@ -733,6 +734,7 @@ pub fn mirLowerSeedFunction(out: MirFunction, params: List<HirParam>, retT: HirT
         let paramTypeText = hirTypeString(p.typ)
         let paramSpan = mirSpanFromHir(p.span)
         let id = mirFunctionNewLocal(out, paramName, paramTypeText, true, paramSpan)
+        out.locals[id].isParam = true
         out.params.push(id)
         idx = idx + 1
     }
@@ -5972,9 +5974,11 @@ pub fn mirLowerClosureRValue(bs: MirLowerBodyState, e: HirExpr, hint: HirType) -
     let span = mirSpanFromHir(e.span)
     let mut lifted = mirFunction(symbol, hirTypeString(retT), span)
     let retLocal = mirFunctionNewLocal(lifted, "_return", hirTypeString(retT), true, span)
+    lifted.locals[retLocal].isReturn = true
     lifted.returnLocal = retLocal
     let envType = mirLowerClosureEnvType()
     let envLocal = mirFunctionNewLocal(lifted, "_env", hirTypeString(envType), false, span)
+    lifted.locals[envLocal].isParam = true
     lifted.params.push(envLocal)
     let mut userIdx = 0
     for p in e.closureParams {
@@ -5989,6 +5993,7 @@ pub fn mirLowerClosureRValue(bs: MirLowerBodyState, e: HirExpr, hint: HirType) -
             hirTypeErr()
         }
         let id = mirFunctionNewLocal(lifted, paramName, hirTypeString(pt), false, mirSpanFromHir(p.span))
+        lifted.locals[id].isParam = true
         lifted.params.push(id)
         userIdx = userIdx + 1
     }


### PR DESCRIPTION
## Summary

Two MIR-seed sites in `toolchain/mir_lower.osty` created fresh locals via `mirFunctionNewLocal` (which defaults `isReturn: false, isParam: false`) and never set the flags back to true:

1. `mirLowerSeedFunction` (line 723-741) — the production seed for every user-defined fn/method.
2. `mirLowerClosureRValue` (line 5975-5996) — the closure-lift seed; open-coded a duplicate of the same logic and inherited the same omission for the env-ptr param and every user closure-param.

Without the flag, `lirLowerMirLocals` at `toolchain/lir_proto.osty:2323-2325` skipped the `store %argN -> slot` prologue, so every function with parameters silently loaded uninitialised stack instead of its arguments.

Net effect:
- `id::<Int>(42)` (`TestLLVMBackendBinaryRunsGenericIdentity`) returned `0` instead of `42`.
- Every closure body saw a garbage env-ptr and garbage user args, with downstream GC root issues for managed captures.

Fix is 5 lines total: set the flag after each `mirFunctionNewLocal` call on the seed paths. Mirrors `internal/mir/lower.go:583-602` exactly.

## Test plan

- [ ] `osty install-self` succeeds (build in progress in parallel)
- [ ] `/tmp/test_isparam.osty` (`id::<Int>(42)` + `double(21)`) prints `42\n42\n`
- [ ] CI on full backend test suite — `TestLLVMBackendBinaryRunsGenericIdentity` + closure tests likely to flip FAIL -> PASS

## Notes

- The MIR validator at `mir_validator.osty:110` already detects this exact shape (`"params[N]=_M is not marked isParam"`) — but a repo-wide scan shows zero production call sites. Wiring `mirValidateModule` into the lowering pipeline is a follow-up that would have caught this bug at green-light time.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_