### PR TITLE
feat(toolchain/main): gate MIR emission on mirValidateModule

### DIFF
--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -110,6 +110,14 @@ fn runCompile(args: List<String>) -> Int {
     }
     let hir = hirLowerSource("main", source)
     let mir = mirLowerModule(hir)
+    let mirErrs = mirValidateModule(mir)
+    if mirErrs.len() != 0 {
+        eprint("osty-self compile: MIR validation failed:\n")
+        for e in mirErrs {
+            eprint("  " + e + "\n")
+        }
+        return 1
+    }
     let opts = mirEmitOpts("main", path, "")
     let irText = mirEmitModule(mir, opts)
     print(irText)
@@ -157,6 +165,14 @@ fn runLirProtoLower(args: List<String>) -> Int {
     }
     let hir = hirLowerSource(packageName, source)
     let mir = mirLowerModule(hir)
+    let mirErrs = mirValidateModule(mir)
+    if mirErrs.len() != 0 {
+        eprint("osty-self lir-proto-lower: MIR validation failed:\n")
+        for e in mirErrs {
+            eprint("  " + e + "\n")
+        }
+        return 1
+    }
     let cfg = lirLowerConfig(packageName, path, target)
     let result = lirLowerMirModule(cfg, mir)
     if !lirLowerOK(result) {


### PR DESCRIPTION
## Summary

`mirValidateModule` (at `toolchain/mir_validator.osty:41`) implements a comprehensive structural check on MIR — verifies `isParam`/`isReturn` flags, block termination, local-slot integrity, etc. — but a repo-wide scan showed it was only called from its own unit tests. The two production MIR producers in `toolchain/main.osty` (`runCompile`, `runLirProtoLower`) handed the freshly-lowered module straight to the emitter/lower with no gate.

PR #1726 (just landed) fixed a missing-`isParam` bug at `mir_lower.osty:735`. The validator already detects exactly that shape (`"params[N]=_M is not marked isParam"`) and would have caught the bug at green-light time on the first build of any parametric function — but it never ran in production.

Wire it between `mirLowerModule` and the consumers, mirroring `internal/backend/entry.go:227` on the Go side. The validator is `O(blocks + locals)` per module with no quadratic checks; running unconditionally is the same posture as the Go pipeline.

## Test plan

- [x] Diff applies cleanly to both `runCompile` and `runLirProtoLower`
- [ ] CI: validator should produce zero errors on the current toolchain corpus (the recent `isParam` fix would have triggered it before #1726)
- [ ] If any function in the spec corpus produces a real validation error post-fix, that's a new bug worth landing as a separate fix — should appear in CI

## Notes

If a perf escape hatch is ever needed later, an env-gate like `if env.get("OSTY_SKIP_MIR_VALIDATE") == ""` can be added. Not gating now matches Go-side behavior and prevents the exact silent-wrong-codegen scenario the validator was designed to prevent.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_