### PR TITLE
fix(toolchain): propagate `pub` on top-level `let` declarations

### DIFF
--- a/toolchain/docgen.osty
+++ b/toolchain/docgen.osty
@@ -994,6 +994,18 @@ fn selfDocLetType(file: AstFile, node: AstNode) -> String {
     ""
 }
 fn selfDocNodeIsPub(lexed: OstyLexResult, node: AstNode) -> Bool {
+    // AstNLet packs mut at bit 0 and pub at bit 1, unlike other decl
+    // kinds whose flag is the bare pub bit. Treat let separately so
+    // `let mut foo` (private mutable) is not mistaken for `pub let`.
+    if node.kind == AstNLet {
+        if (node.flags & 2) == 2 {
+            return true
+        }
+        if node.start > 0 {
+            return ostyLexResultTokenAt(lexed, node.start - 1).kind == FrontPub
+        }
+        return false
+    }
     if node.flags == 1 {
         return true
     }

--- a/toolchain/formatter_ast.osty
+++ b/toolchain/formatter_ast.osty
@@ -314,9 +314,12 @@ fn ostyAstStmt(f: OstyAstFormatter, idx: Int) -> String {
     }
 }
 fn ostyAstLetStmt(f: OstyAstFormatter, node: AstNode) -> String {
-    let mut text = "let "
-    if node.flags == 1 {
-        text = "let mut "
+    let isMut = (node.flags & 1) == 1
+    let isPub = (node.flags & 2) == 2
+    let mut text = if isPub {
+        if isMut { "pub let mut " } else { "pub let " }
+    } else {
+        if isMut { "let mut " } else { "let " }
     }
     text = strings.join([text, ostyAstPattern(f, node.left)], "")
     let typeIdx = ostyAstChildAt(node, 0)

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -2256,7 +2256,9 @@ fn hirLowerTopLevelLetDecl(cx: HirLowerContext, idx: Int, typeScope: HirLowerTyp
     } else {
         hirExprInvalid()
     }
-    hirLowerAssembleLetDecl(name, typ, hasValue, value, node.flags == 1, false, span)
+    let isMut = (node.flags & 1) == 1
+    let isPub = (node.flags & 2) == 2
+    hirLowerAssembleLetDecl(name, typ, hasValue, value, isMut, isPub, span)
 }
 fn hirLowerUseDecl(cx: HirLowerContext, idx: Int) -> HirUseDecl {
     let node = astArenaNodeAt(cx.ast.arena, idx)

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -1916,7 +1916,7 @@ fn opParseStmt(p: OstyParser) -> Int {
         return opParseForStmt(p, labelIdx)
     }
     if tok.kind == FrontLet {
-        return opParseLetStmt(p, [])
+        return opParseLetStmt(p, [], false)
     }
     if tok.kind == FrontReturn {
         return opParseReturnStmt(p)
@@ -2010,7 +2010,7 @@ fn opParseStmt(p: OstyParser) -> Int {
 // value. Plain `break` inside `for`/`while` continues without a
 // value. We parse greedily — if an expression starts on the
 // same line, capture it as the break value.
-fn opParseLetStmt(p: OstyParser, anns: List<Int>) -> Int {
+fn opParseLetStmt(p: OstyParser, anns: List<Int>, isPub: Bool) -> Int {
     let start = p.pos
     let _ = opAdvance(p)
     let mut isMut = false
@@ -2032,9 +2032,14 @@ fn opParseLetStmt(p: OstyParser, anns: List<Int>) -> Int {
     n.children = [typeIdx]
     n.start = start
     n.end = p.pos
+    let mut flags = 0
     if isMut {
-        n.flags = 1
+        flags = flags | 1
     }
+    if isPub {
+        flags = flags | 2
+    }
+    n.flags = flags
     n.extra = opPackAnnotations(p, anns)
     opAddNode(p, n)
 }
@@ -2706,7 +2711,7 @@ fn opParseDecl(p: OstyParser) -> Int {
         return opParseUseDecl(p, isPub)
     }
     if tok.kind == FrontLet {
-        return opParseLetStmt(p, anns)
+        return opParseLetStmt(p, anns, isPub)
     }
     if tok.kind == FrontDefer {
         opErrorFull(p, "`defer` is not allowed at the top level of a script", "move this `defer` inside a function body — it binds to the enclosing function's return", "", "E0608")


### PR DESCRIPTION
## Summary

`pub let` was silently dropped throughout the Osty toolchain — same parity-gap pattern as the recently-fixed `isParam = true` bug. Go side records the flag (`internal/ir/lower.go:618`, `Exported: ld.Pub`); Osty side did not.

Two dropping points:
1. `parser.osty:2709` — when delegating from the top-level decl router to `opParseLetStmt`, the `isPub` flag was discarded.
2. `hir_lower.osty:2259` — `hirLowerTopLevelLetDecl` hardcoded `exported = false` in the call to `hirLowerAssembleLetDecl`.

Result: `pub let X = ...` was treated identically to `let X = ...` across visibility checks, docgen output, and cross-package use.

## Fix

Extend `AstNLet`'s `flags` to a 2-bit packing:
- bit 0 = mut (unchanged)
- bit 1 = pub (new)

Parser threads `isPub` through `opParseLetStmt` and ORs into the right bit. HIR lowerer reads both with `(node.flags & 1) == 1` / `(node.flags & 2) == 2`.

Two consumers updated to the new layout:
- `selfDocNodeIsPub` (docgen): had a pre-existing bug — treated `let mut foo` (private mut) as pub because `flags == 1` matched both shapes. Now branches on `AstNLet` and reads bit 1 explicitly.
- `ostyAstLetStmt` (formatter): never emitted `pub` for AstNLet — it only knew the mut bit. Now decodes both and renders the right prefix combination so `osty fmt` preserves `pub let X` instead of stripping the keyword.

Local lets inside fn bodies (`opParseLetStmt` invoked from line 1919 with `isPub = false`) never have bit 1 set, so existing readers at `hir_lower.osty:2359` keep working with `flags == 1` — no regression.

## Test plan

- [ ] Parse `pub let X = 1` and confirm HirLetDecl gets `exported: true`
- [ ] Parse `let mut X = 1` and confirm HirLetDecl gets `mutable: true, exported: false`
- [ ] Parse `pub let mut X = 1` and confirm both flags set
- [ ] `osty fmt` round-trips `pub let X = 1` (was stripping `pub` before)
- [ ] CI on full backend test suite

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_