### PR TITLE
fix(stage0): refuse partial coverage in mixed-tail synthetic-return inference

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -15543,6 +15543,7 @@ func genericInferMixedTailDiscardedReturns(fn *mir.Function, mctx *moduleCtx, re
 	}
 	calls := map[mir.BlockID]*mir.CallInstr{}
 	intrs := map[mir.BlockID]*mir.IntrinsicInstr{}
+	hasUncoveredReturnAssign := false
 	for _, bb := range fn.Blocks {
 		if bb == nil || exits[bb.ID] {
 			continue
@@ -15559,6 +15560,22 @@ func genericInferMixedTailDiscardedReturns(fn *mir.Function, mctx *moduleCtx, re
 			intrs[bb.ID] = ii
 			continue
 		}
+		if genericPreExitBlockHasReturnTypeAssign(fn, bb) {
+			hasUncoveredReturnAssign = true
+		}
+	}
+	// Same wildcard-arm bare-local guard as the primary inference
+	// helpers (PR #1725). If an uncovered pre-exit block carries an
+	// assignment to a return-typed local, refuse the rewrite so the
+	// outer cascade falls through to a path that emits `ret %local`
+	// at the merge instead of leaving it as `unreachable`. Without
+	// this gate, mixed-tail functions with an early-return guard and a
+	// wildcard-arm bare-local body silently produced `unreachable` in
+	// the wildcard branch (the comment block above claimed multi-sink
+	// tolerance was safe — it's only safe when uncovered blocks carry
+	// no return-typed assignment).
+	if hasUncoveredReturnAssign {
+		return nil, nil
 	}
 	return calls, intrs
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #1725. `genericInferMixedTailDiscardedReturns` at `emit.go:15524` is the second-pass synthetic-return inference variant (runs for functions with at least one explicit `ReturnTerm` block, e.g. early-return guard followed by a match). It had the same partial-coverage shape as the primary inference helpers fixed in #1725 — silently leaving uncovered pre-exit blocks as `unreachable`.

The function's comment block at lines 15016-15020 claimed multi-sink tolerance was always safe ("the second sink stays as bare `unreachable`, which is already correct"). That holds only when uncovered sinks have no return-typed assignment feeding them. Mixed-tail functions where one arm is `early-return` + another arm is `assign result_slot = local; goto exit` (the wildcard bare-local shape) silently lowered the wildcard branch to `unreachable` — the same crash class #1725 closed on the primary path.

## Fix

Reuse the `genericPreExitBlockHasReturnTypeAssign` helper from #1725 as a gate: if any uncovered pre-exit block carries a return-typed assignment, return `(nil, nil)` so the cascade doesn't populate `syntheticCallReturns`/`syntheticIntrinsicReturns` for this function. Empty `goto exit` redirect blocks remain accepted, same as the primary-pass gate.

## Test plan

- [x] `go test -count=1 ./internal/backend/stage0/...` — passes (no existing test exercised the bug shape)
- [ ] CI on full backend test suite

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_