### PR TITLE
fix(toolchain): treat AstNLet.flags as bitmask in elab/check/HIR consumers

### DIFF
--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -945,7 +945,7 @@ fn collectLetDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
     if declared >= 0 && tyEscapingCapabilityHead(cx.env.tys, ty) != "" {
         cx.env.local.diagnostics.push(diagNonEscapingEscape(tyToString(cx.env.tys, ty), "module-level binding", node.start, node.end))
     }
-    checkBindSpan(cx.env, name, ty, node.flags == 1, node.start, node.end)
+    checkBindSpan(cx.env, name, ty, (node.flags & 1) == 1, node.start, node.end)
     checkRecordSymbol(cx.env, declIdx, "let", name, "", ty, node.start, node.end)
 }
 // §8.1 G13 / E0743: a module-scope `let` outlives any individual

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -726,7 +726,7 @@ fn elabLetStmt(cx: ElabCx, node: AstNode) -> Int {
         node.extra
     }
     let valueIdx = node.right
-    let mutable = node.flags == 1
+    let mutable = (node.flags & 1) == 1
     let declared = astTypeToTy(cx, typeAnnotIdx)
     let value = if declared >= 0 {
         elabCheck(cx, valueIdx, declared)

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -2358,7 +2358,7 @@ fn hirLowerStmt(cx: HirLowerContext, idx: Int, stmtScope: HirLowerStmtScope, typ
         } else {
             hirExprInvalid()
         }
-        return hirLowerAssembleLetStmt(pattern, typ, hasValue, value, node.flags == 1, span)
+        return hirLowerAssembleLetStmt(pattern, typ, hasValue, value, (node.flags & 1) == 1, span)
     }
     if node.kind == AstNAssign {
         let target = hirLowerExpr(cx, node.left, typeScope)
@@ -3592,7 +3592,7 @@ fn hirLowerCoreIdentCaptureKind(cx: HirLowerContext, coreIdx: Int, name: String)
 // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
 fn hirLowerBindingMutable(node: AstNode) -> Bool {
     if node.kind == AstNLet {
-        return node.flags == 1
+        return (node.flags & 1) == 1
     }
     if node.kind == AstNParam {
         return node.flags == 1


### PR DESCRIPTION
## Summary

Follow-up to #1728. That PR extended `AstNLet.flags` to a 2-bit packing (bit 0 = mut, bit 1 = pub) but only updated 4 consumers (hir_lower top-level let, docgen, formatter, parser). **Three more sites still used `node.flags == 1` to test the mut bit**, which is `false` for any top-level let that also carries pub — i.e. `pub let mut counter` is silently bound as IMMUTABLE in the elab/check/capture path.

This is a regression #1728 introduced: pre-#1728 `pub let mut` couldn't exist (parser dropped pub), so `flags == 1` always meant "mut". Post-#1728 `pub let mut` → flags=3 → `flags == 1` is FALSE → mut=false. Spurious E0746/immutable-binding diagnostics on legal code, plus wrong codegen for captured `pub let mut`.

## Fix

Change `node.flags == 1` → `(node.flags & 1) == 1` at:
- `elab.osty:729` — HIGH (elab core records wrong mutability)
- `check.osty:948` — HIGH (env registers wrong mut, breaks later assignability lookups)
- `hir_lower.osty:3595` — HIGH (`hirLowerBindingMutable` for captures propagates to MIR)
- `hir_lower.osty:2361` — LOW (inner-block lets never have bit 1 set today, but bitmask is consistent)

The receiver-`mut self` flag on AstNParam at `hir_lower.osty:3598` is left as `== 1` — that node kind doesn't reuse bit 1.

## Test plan

- [ ] Compile `pub let mut counter = 0; fn main() { counter = counter + 1; ... }` — should not emit E0746
- [ ] Closure capturing `pub let mut counter` should still bind mutably
- [ ] CI on full suite

## Follow-up

`resolve.osty:528` hardcodes `public: false` for top-level let symbols (same shape, resolver side). Go has a compensating workaround at `resolve_bridge.go:818-827`. Worth patching but the resolver self-host bridge needs more care than this hot-fix.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_