### PR TITLE
fix(lir_proto): widen Option/Result typedef in fn-context to match module path

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -6778,7 +6778,14 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, name: String) -> LirType {
     }
     if lirIsOptionTypeName(name) || lirIsResultTypeName(name) {
         let typeName = "%" + lirMangleAlgebraicTypeName(name)
-        lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, "\{ i64, i64 \}"))
+        // Match the module-context widening (`lirAlgebraicAggregateBody_module`
+        // at line 1868): when the payload type is a user struct, the typedef
+        // body widens to `{ i64, %StructMangled }`. The function-context path
+        // previously hardcoded `{ i64, i64 }`, truncating the payload to 8
+        // bytes — Option<BigStruct> first introduced inside a function body
+        // would mint the wrong typedef for the whole module.
+        let body = lirAlgebraicAggregateBody_module(l.out, l.mirModule, name)
+        lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, body))
         return lirAggregateType(typeName)
     }
     for layout in l.mirModule.layouts.structs {


### PR DESCRIPTION
## Summary

`lirLowerMirType` at line 6779-6782 (function-context type lookup) hardcoded the Option/Result aggregate body to `{ i64, i64 }`, while the module-context helper `lirAlgebraicAggregateBody_module` at line 1868 widens to `{ i64, %StructMangled }` when the payload is a user struct. When `Option<BigStruct>` was first introduced inside a function body, the function path won the typedef race and minted the truncated form for the whole module — every subsequent use loaded only the first 8 bytes of the payload.

Identified by the LIR-proto gap audit; bug #2 of 8 reported.

## Fix

Call `lirAlgebraicAggregateBody_module(l.out, l.mirModule, name)` in the function-context branch, identical to module-context emission. For primitive payloads (Int?, String?) the helper still returns the narrow `{ i64, i64 }`, so non-struct shapes are unaffected.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_