### PR TITLE
fix(lir_proto): lower println(List/Map/Set) via existing runtime to_string helpers

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3275,6 +3275,40 @@ fn lirLowerMirPrintTextOperand(l: LirMirFunctionLowerer, op: MirOperand) -> LirO
     if op.typ == "String" {
         return lirOperand(lirPtrType(), value.value)
     }
+    // Composite-container fast paths: route `println(List<T>)` /
+    // `println(Map<K,V>)` / `println(Set<T>)` through the existing
+    // runtime to_string helpers instead of bailing out as
+    // "print argument type ... is not implemented". Mirrors the
+    // explicit `xs.toString()` intrinsic path (`lirLowerMirListToString`
+    // and the map/set siblings) without requiring an MIR-level toString
+    // call wrapping the operand.
+    if strings.startsWith(op.typ, "List<") {
+        let elemName = lirListElemTypeName(op.typ)
+        let elemLir = lirContainerElemLaneType(elemName)
+        if !(lirTypeIsZero(elemLir)) && !(lirTypeIsVoid(elemLir)) {
+            let listSym = lirListToStringSymbolForLane(elemLir.llvm, lirContainerElemIsString(elemName))
+            if listSym != "" {
+                lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeToStringDecl(listSym, lirPtrType()))
+                let dest = lirFresh(l)
+                l.instrs.push(lirCall(dest, lirPtrType(), "@" + listSym, [lirOperand(lirPtrType(), value.value)]))
+                return lirOperand(lirPtrType(), dest)
+            }
+        }
+    }
+    if strings.startsWith(op.typ, "Map<") {
+        let mapSym = "osty_rt_map_to_string"
+        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeToStringDecl(mapSym, lirPtrType()))
+        let dest = lirFresh(l)
+        l.instrs.push(lirCall(dest, lirPtrType(), "@" + mapSym, [lirOperand(lirPtrType(), value.value)]))
+        return lirOperand(lirPtrType(), dest)
+    }
+    if strings.startsWith(op.typ, "Set<") {
+        let setSym = "osty_rt_set_to_string"
+        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeToStringDecl(setSym, lirPtrType()))
+        let dest = lirFresh(l)
+        l.instrs.push(lirCall(dest, lirPtrType(), "@" + setSym, [lirOperand(lirPtrType(), value.value)]))
+        return lirOperand(lirPtrType(), dest)
+    }
     let symbol = lirRuntimeToStringSymbolForType(argType)
     if symbol == "" {
         lirLowerError(l, LirDiagUnsupported, "print argument type `" + op.typ + "` is not implemented", "intrinsic.print")


### PR DESCRIPTION
## Summary

`lirLowerMirPrintTextOperand` (`toolchain/lir_proto.osty:3272`) bailed with "print argument type `T` is not implemented" for anything that wasn't one of five primitive ToString lanes (i64/double/i1/i32/i8). But the runtime already ships `osty_rt_list_to_string_<lane>` (used by `lirLowerMirListToString` at line 4750), `osty_rt_map_to_string` (line 3036), and `osty_rt_set_to_string` (line 3039) — the explicit `xs.toString()` intrinsic path wires them up just fine. The print path was simply not routing through them.

Net effect: `println(myList)`, `println(myMap)`, `println(mySet)` all declined, surfacing the LLVM stage0 declined-coverage diagnostic.

Identified by the LIR-proto gap audit; bug #1 of 8 reported.

## Fix

Before falling through to the primitive symbol lookup, detect `List<T>` / `Map<K,V>` / `Set<T>` by source-level type-name prefix and synthesise the corresponding runtime call directly. The list path reuses `lirListElemTypeName` + `lirContainerElemLaneType` + `lirListToStringSymbolForLane` (the same trio `xs.toString()` uses); map and set route through their fixed runtime entry points since those formatters are not lane-specialised.

Composite element types (struct / enum / nested List) still surface as `unsupported` from `lirListToStringSymbolForLane` returning "" — runtime gap, not a lowering gap, matches the documented limitation at line 4747-4749.

## Test plan

- [ ] CI on full backend suite — tests doing `println(xs)` where `xs: List<Int|String|Float|Bool|Char|Byte>` are candidates to flip PASS.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_