### PR TITLE
fix(lir_proto): canonicalize `T?` Option sugar to `Option<T>` at type-lowering entry

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -1795,7 +1795,8 @@ fn lirEmitMirGlobals(out: LirModule, mir: MirModule, diags: List<LirDiagnostic>)
 // payload field can hold the full struct value (>8 bytes). The struct type
 // must be looked up in the same layout table so the named struct typedef
 // is emitted before the Option/Result typedef references it.
-fn lirLowerMirType_module(out: LirModule, mir: MirModule, name: String, path: String, diags: List<LirDiagnostic>) -> LirType {
+fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path: String, diags: List<LirDiagnostic>) -> LirType {
+    let name = lirCanonicalizeOptionalSugar(rawName)
     let primitive = lirLowerPrimitiveTypeName(name)
     if !(lirTypeIsZero(primitive)) {
         return primitive
@@ -5843,6 +5844,18 @@ fn lirParseResultPayloadAsI64(l: LirMirFunctionLowerer, valueReg: String, valueT
 fn lirIsOptionTypeName(name: String) -> Bool {
     strings.startsWith(name, "Option<") || strings.startsWith(name, "Maybe<")
 }
+// `lirCanonicalizeOptionalSugar` rewrites the trailing-`?` Option
+// sugar form (`T?`) into the explicit `Option<T>` spelling so the
+// rest of the LIR type-lowering machinery doesn't need a second
+// recognition path. Inner uses (`List<Int?>`, struct fields, etc.)
+// keep the sugar until their type strings are looked up directly.
+fn lirCanonicalizeOptionalSugar(name: String) -> String {
+    if name.len() > 1 && strings.hasSuffix(name, "?") {
+        let inner = strings.slice(name, 0, name.len() - 1)
+        return "Option<" + inner + ">"
+    }
+    name
+}
 // `lirAggTypeNameFromRV` resolves the target type name for an
 // aggregate / nullary rvalue: prefer `rv.typ` (set by the HIR→MIR
 // lowerer); fall back to `hintName` (passed down from the assign
@@ -6762,7 +6775,8 @@ fn lirInterfaceConcreteName(name: String) -> String {
     }
     name
 }
-fn lirLowerMirType(l: LirMirFunctionLowerer, name: String) -> LirType {
+fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
+    let name = lirCanonicalizeOptionalSugar(rawName)
     let primitive = lirLowerPrimitiveTypeName(name)
     if !(lirTypeIsZero(primitive)) {
         return primitive


### PR DESCRIPTION
## Summary

`lirIsOptionTypeName` only recognized `Option<...>` / `Maybe<...>` — not the trailing-`?` sugar form (`Int?`, `String?`). When that sugar showed up as a local's MIR type (which happens for the `??`-coalesce temporary, `_None` literal, `_scrut` of an Option match, etc.), `lirLowerMirType` fell through every recognition path and returned the zero `LirType`, surfacing as:

- `unsupported local._coalesce: unsupported local type 'Int?'`
- `unsupported local.None: unsupported local type 'Int?'`
- `unsupported assign destination type 'Int?'`

Combined **~70 occurrences** in the latest backend-test triage, mostly on Option<primitive> shapes that should have worked.

## Fix

Add `lirCanonicalizeOptionalSugar(name)` that maps `T?` → `Option<T>` for the outer type only, and call it at the entry of both `lirLowerMirType` (function context, line 6765) and `lirLowerMirType_module` (module context, line 1798). Inner uses (`List<Int?>`, struct fields) keep the sugar until their type strings are looked up directly — recursive canonicalization happens naturally on the next lookup.

Downstream consumers (`lirIsOptionTypeName`, `lirMangleAlgebraicTypeName`, `lirOptionResultPayloadInner`, `lirAlgebraicAggregateBody_module`) already work with the explicit `Option<T>` spelling, so no other files need to change.

## Test plan

- [ ] CI on full backend suite — tests using `??`, `_None`-literal, Option match on `T?`-typed locals are candidates to flip PASS.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_