### PR TITLE
fix(lir_proto): link generic enum instantiations to their bare declaration layout

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -6944,7 +6944,11 @@ fn lirMirStructLayoutMatches(layout: MirStructLayout, name: String) -> Bool {
     false
 }
 // Mirrors `lirMirStructLayoutMatches` for `MirEnumLayout` so the
-// type-lowering path can recognize user-defined enums.
+// type-lowering path can recognize user-defined enums. Generic
+// instantiations (`Maybe<Int>` against the bare `Maybe` declaration)
+// are linked by prefix — the layout-lookup site uses the
+// `{ i64 disc, i64 payload }` narrow shape so per-instantiation
+// field-type recursion isn't needed here.
 fn lirMirEnumLayoutMatches(layout: MirEnumLayout, name: String) -> Bool {
     if layout.name == name || layout.mangled == name {
         return true
@@ -6953,6 +6957,12 @@ fn lirMirEnumLayoutMatches(layout: MirEnumLayout, name: String) -> Bool {
         return true
     }
     if layout.mangled != "" && "%" + layout.mangled == name {
+        return true
+    }
+    if layout.name != "" && strings.startsWith(name, layout.name + "<") {
+        return true
+    }
+    if layout.mangled != "" && strings.startsWith(name, layout.mangled + "<") {
         return true
     }
     false


### PR DESCRIPTION
## Summary

`lirMirEnumLayoutMatches` only accepted exact name matches, so `Maybe<Int>` / `Gen<Bool>` / `Result<Int, String>` — generic enum instantiations whose source-level type name carries the concrete type argument — never matched the bare `Maybe` / `Gen` / `Result` declaration layouts the MIR pass produces (`mir_lower.osty:361` stamps `name = mangled = e.name` from the bare HIR enum decl).

Net effect: every monomorphized enum local hit `unsupported local type` because neither the function- nor the module-context type lowerer could find a layout. ~40 occurrences in the latest backend triage (Gen<Int>, Gen<Bool>, Gen<Float64>, Gen<Char>, Gen<Byte>, Gen<String>, Gen<Int?>, Gen<List<*>>, Gen<Result<*>>, _ZTSN4main5MaybeIlEE).

## Fix

Extend the matcher with two prefix probes — `name` matches `layout.name + "<"` or `layout.mangled + "<"`. Specifically scoped to the `<` separator so unrelated layouts whose name happens to share a prefix (`Pair` vs `PairOf`) stay distinct.

Why safe for payload-bearing enums even without per-T field lowering: the layout-lookup site (#1735) emits the narrow `{ i64 disc, i64 payload }` shape and does not recurse into variant payloads.

## Limitations

- Composite-payload generic enums still get the narrow slot (same caveat as #1735).
- Struct instantiations (`Pair<Int>`) are NOT extended because their lookup recursively lowers each field's type — the field types would resolve as the bare generic param `T` / `U` and fail. Separate (deeper) monomorphization fix.

## Test plan

- [ ] CI on full backend — `TestLLVMBackendBinaryTestingPropertyGeneratorSubset`, `TestLLVMBackendBinaryGenericEnumPayloadFreeVariantFromLetContext`, and similar tests using generic enums are candidates to flip PASS.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_