### PR TITLE
fix(lir_proto): route source-level widened enum constructors through struct-typed insertvalue

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -6648,6 +6648,28 @@ fn lirLowerMirEnumVariantAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hint
     let discText = lirIntToString(rv.aggVariantIdx)
     let step1 = lirFresh(l)
     l.instrs.push(lirInsertValue(step1, aggType, "undef", lirOperand(lirIntType(64), discText), [0]))
+    // Widened payload: lower the field operand directly and insert with
+    // its native struct type. Mirrors the stdlib container path
+    // (`lirEmitOptionSomeStruct` / `lirEmitResultOkStruct` in #1738) but
+    // routes user-source `Some(s)` / `Ok(o)` / `Err(e)` / `MyEnum.V(s)`
+    // literals through the struct-typed insertvalue instead of the
+    // i64-coercion path which would have truncated the payload.
+    if rv.aggFields.len() == 1 && lirAggregateHasWidenedPayload(l.out, aggType) {
+        let arg = rv.aggFields[0]
+        let argHint = lirLowerMirType(l, arg.typ)
+        let payload = lirLowerMirOperand(l, arg, arg.typ, argHint)
+        if payload.value == "" {
+            return lirOperandInvalid()
+        }
+        let structRef = lirOptionResultPayloadStructRef(l.out, aggType.llvm)
+        if structRef == "" {
+            lirLowerError(l, LirDiagUnsupported, "widened enum variant `" + typeName + "` could not extract payload typedef from `" + aggType.llvm + "`", "aggregate.enum.widened")
+            return lirOperandInvalid()
+        }
+        let value = lirFresh(l)
+        l.instrs.push(lirInsertValue(value, aggType, step1, lirOperand(lirAggregateType(structRef), payload.value), [1]))
+        return lirOperand(aggType, value)
+    }
     let payloadI64 = if rv.aggFields.len() == 0 {
         "0"
     } else if rv.aggFields.len() == 1 {


### PR DESCRIPTION
## Summary

Follow-up to #1738. `lirLowerMirEnumVariantAggregate` is the construction site for source-level enum literals (`Some(s)`, `Ok(o)`, `Err(e)`, `MyEnum.Variant(s)`, etc.) — distinct from the stdlib container helpers `lirEmitOption{Some,None}` / `lirEmitResult{Ok,Err}` that #1737/#1738 covered. It always coerced the single-payload field to i64 via `lirParseResultPayloadAsI64`, which silently truncated struct payloads to 8 bytes when the aggregate's typedef body was the widened `{ i64, %Struct }` shape (#1731-side).

## Fix

Detect `lirAggregateHasWidenedPayload(l.out, aggType)` for single-field variants. When widened, lower the field operand directly and emit `insertvalue {i64, %Struct} %step1, %Struct %payload, 1` with the actual struct type extracted via `lirOptionResultPayloadStructRef` (introduced in #1737). Falls back to the i64-coercion path for narrow `{ i64, i64 }` aggregates and for 0-arity / multi-field variants.

## Combined effect

With #1737 (None/zeroinit) + #1738 (stdlib container helpers) + this PR (source-level constructors):
- `Option<MyStruct>` and `Result<MyStruct, _>` round-trip end-to-end through both source-level construction and stdlib container returns
- User enums with single struct payload (`enum Cell { Filled(BigStruct), Empty }`) also benefit since they share the widened typedef shape

## Limitations

- Multi-field variants (`Variant(a, b)` with 2+ payload fields) still return the existing "only scalar / 0-arity supported" diagnostic — separate aggregate-payload layout question.

## Test plan

- [ ] CI on full backend — programs constructing `Some(myStruct)` / `Ok(myStruct)` / user-enum variants with struct payload should now lower correctly.

https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBhXpostcBmjt5UbXjGQrn)_