### PR TITLE
[codex] selfhost MIR generator task group payload

### DIFF
--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -452,6 +452,10 @@ func TestPhase0SelfHostWiringExists(t *testing.T) {
 				"mirEmitIntrinsicAuxLabel(blockId, instrIdx, \"algebraic.unwrap.absent\")",
 				"declare void @osty_rt_option_unwrap_none()",
 				"declare void @osty_rt_result_unwrap_err()",
+				// Phase 2e — taskGroup result payloads use the same
+				// i64 raw lane narrowing as handle.join.
+				"return out + mirEmitNarrowPayloadLine(dest, raw, destLLVM)",
+				"TODO taskGroup dest type",
 			},
 		},
 		{

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -20173,7 +20173,16 @@ fn mirEmitTaskGroupIntrinsic(func: MirFunction, instr: MirInstr) -> String {
     let body = mirEmitOperand(instr.args[0])
     if instr.hasDest {
         let dest = mirEmitLocalRegName(instr.dest.local)
-        return "  " + dest + " = call i64 @osty_rt_task_group(ptr " + body + ")\n"
+        let destLLVM = mirEmitParamType(func, instr.dest.local)
+        if destLLVM == "void" || mirStringStartsWith(destLLVM, "\{") {
+            return "  ; TODO taskGroup dest type \"" + destLLVM + "\"\n"
+        }
+        let raw = dest + ".raw"
+        let mut out = "  " + raw + " = call i64 @osty_rt_task_group(ptr " + body + ")\n"
+        if destLLVM == "i64" {
+            return out + "  " + dest + " = add i64 0, " + raw + "\n"
+        }
+        return out + mirEmitNarrowPayloadLine(dest, raw, destLLVM)
     }
     "  call i64 @osty_rt_task_group(ptr " + body + ")\n"
 }


### PR DESCRIPTION
## Summary
- make self-host taskGroup result emission read the raw i64 runtime payload into a temp
- narrow the taskGroup payload to Bool/Byte/Char/Float/pointer-shaped destinations like handle.join already does
- keep aggregate/void destinations guarded with an explicit TODO instead of emitting a type-mismatched SSA value

## Validation
- git diff --check -- toolchain/mir_generator.osty internal/selfhost/phase0_wiring_test.go
- .bin/osty check toolchain/mir_generator.osty
- .bin/osty check toolchain/mir.osty toolchain/mir_generator.osty
- go test -count=1 -vet=off ./internal/selfhost -run TestPhase0SelfHostWiringExists -v

## Known local failures
- broader selfhost/front sweeps still have the same pre-existing local blockers noted on #1741-#1743: TestParseSnapshot snapshot drift and missing osty-self/OSTY_SELF_BIN for mir-direct