### PR TITLE
[codex] runtime result unwrap err helper

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -188,6 +188,7 @@ func TestLLVMBackendEmitBinaryBuildsBundledRuntime(t *testing.T) {
 		"osty_rt_strings_Equal",
 		"osty_rt_crypto_sha256",
 		"osty_rt_crypto_random_bytes",
+		"osty_rt_result_unwrap_err",
 		"osty.gc.pre_write_v1",
 		"osty.gc.load_v1",
 		"osty.gc.root_bind_v1",

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1790,6 +1790,13 @@ void osty_rt_option_unwrap_none(void) {
     osty_rt_abort("called unwrap on None");
 }
 
+// Public abort helper called from LLVM IR when `Result.unwrap()` fires on
+// an Err value. Kept separate from the Option helper so diagnostics preserve
+// the source-level construct that failed.
+void osty_rt_result_unwrap_err(void) {
+    osty_rt_abort("called unwrap on Err");
+}
+
 // Public panic helper called from LLVM IR when source code invokes
 // the prelude `panic(message: String) -> Never`. The MIR `IntrinsicAbort`
 // lowerer emits `call void @osty_rt_panic(ptr msg) + unreachable`.


### PR DESCRIPTION
## Summary
- add the bundled C runtime helper for the `Result.unwrap()` Err panic path
- keep the Result diagnostic separate from the existing Option unwrap helper
- cover the new helper in the backend bundled-runtime source check

## Validation
- `git diff --check -- internal/backend/runtime/osty_runtime.c internal/backend/llvm_test.go`
- `clang -std=c11 -fsyntax-only internal/backend/runtime/osty_runtime.c`
- `go test -count=1 -vet=off ./internal/backend -run TestLLVMBackendEmitBinaryBuildsBundledRuntime -v`