### PR TITLE
[codex] selfhost unwrap aggregate payloads

### DIFF
--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -19040,6 +19040,11 @@ fn mirEmitNarrowPayloadLine(dest: String, rawReg: String, toLLVM: String) -> Str
     if toLLVM == "ptr" {
         return "  " + dest + " = inttoptr i64 " + rawReg + " to ptr\n"
     }
+    if mirStringStartsWith(toLLVM, "\{") {
+        let box = dest + ".box"
+        let mut out = "  " + box + " = inttoptr i64 " + rawReg + " to ptr\n"
+        return out + "  " + dest + " = load " + toLLVM + ", ptr " + box + ", align 8\n"
+    }
     if toLLVM == "double" {
         return "  " + dest + " = bitcast i64 " + rawReg + " to double\n"
     }
@@ -20535,7 +20540,7 @@ fn mirEmitAlgebraicUnwrapIntrinsic(func: MirFunction, blockId: Int, instrIdx: In
     let value = mirEmitOperand(instr.args[0])
     let aggTy = mirEmitOperandLLVMType(instr.args[0])
     let destLLVM = mirEmitParamType(func, instr.dest.local)
-    if destLLVM == "void" || mirStringStartsWith(destLLVM, "\{") {
+    if destLLVM == "void" {
         return "  ; TODO algebraic unwrap for dest type \"" + destLLVM + "\"\n"
     }
     let base = mirEmitFreshTempName(blockId, instrIdx)


### PR DESCRIPTION
## Summary
- teach the self-host payload-narrow helper to recover aggregate payloads from boxed i64 pointers
- allow checked Option/Result unwrap to emit aggregate destinations instead of stopping at TODO
- complements the channel bytes-v1 aggregate receive path by adding the matching unbox step

## Validation
- `git diff --check -- toolchain/mir_generator.osty`
- `.bin/osty check toolchain/mir_generator.osty`
- `.bin/osty check toolchain/mir.osty toolchain/mir_generator.osty`
- `go test -count=1 -vet=off ./internal/selfhost -run TestPhase0SelfHostWiringExists -v`