### PR TITLE
[codex] selfhost box aggregate payloads

### DIFF
--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -18542,6 +18542,7 @@ pub fn mirEmitRuntimeDeclarationsSection() -> String {
     out = out + "declare void @osty_rt_io_write(ptr, i1, i1)\n"
     out = out + "declare void @osty_rt_abort(ptr)\n"
     out = out + "declare void @osty_rt_panic(ptr)\n"
+    out = out + "declare ptr @osty.gc.alloc_v1(i64, i64, ptr)\n"
     out = out + "declare ptr @osty_rt_int_to_string(i64)\n"
     out = out + "declare ptr @osty_rt_bool_to_string(i1)\n"
     out = out + "declare ptr @osty_rt_char_to_string(i32)\n"
@@ -19020,6 +19021,15 @@ fn mirEmitOptionalUnwrapCast(dest: String, rv: MirRValue, argText: String, fromL
 fn mirEmitWidenPayloadLine(widenedReg: String, payloadTy: String, payloadOp: String) -> String {
     if payloadTy == "ptr" {
         return "  " + widenedReg + " = ptrtoint ptr " + payloadOp + " to i64\n"
+    }
+    if mirStringStartsWith(payloadTy, "\{") {
+        let gep = widenedReg + ".box.gep"
+        let size = widenedReg + ".box.size"
+        let box = widenedReg + ".box"
+        let mut out = mirSizeOfLines(gep, size, payloadTy)
+        out = out + "  " + box + " = call ptr @osty.gc.alloc_v1(i64 0, i64 " + size + ", ptr null)\n"
+        out = out + "  store " + payloadTy + " " + payloadOp + ", ptr " + box + ", align 8\n"
+        return out + "  " + widenedReg + " = ptrtoint ptr " + box + " to i64\n"
     }
     if payloadTy == "double" {
         return "  " + widenedReg + " = bitcast double " + payloadOp + " to i64\n"


### PR DESCRIPTION
## Summary
- box aggregate Option/Result payloads before widening them into the i64 payload slot
- emit the matching `osty.gc.alloc_v1` declaration from the self-host runtime catalog
- pair with the aggregate unwrap unbox path so boxed aggregate payloads can round-trip

## Validation
- `git diff --check -- toolchain/mir_generator.osty`
- `.bin/osty check toolchain/mir_generator.osty`
- `.bin/osty check toolchain/mir.osty toolchain/mir_generator.osty`
- `go test -count=1 -vet=off ./internal/selfhost -run TestPhase0SelfHostWiringExists -v`