### PR TITLE
refactor: airepair 리라이트 헬퍼 self-host (toolchain/airepair_rewrite.osty)

### DIFF
--- a/internal/airepair/foreign_loops.go
+++ b/internal/airepair/foreign_loops.go
@@ -3,10 +3,10 @@ package airepair
 import (
 	"bytes"
 	"strings"
-	"unicode"
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/repair"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -134,7 +134,7 @@ func rewriteJSForOfHeader(trimmed string) (string, bool) {
 		}
 		return "for (" + normalized + ") in " + rhs + " {", true
 	}
-	if !isSimpleIdentifierBinding(lhs) {
+	if !runner.IsSimpleIdentifierBinding(lhs) {
 		return "", false
 	}
 	return "for " + lhs + " in " + rhs + " {", true
@@ -151,11 +151,11 @@ func rewritePythonRangeLoopHeader(trimmed string) (string, bool) {
 	}
 	lhs := strings.TrimSpace(body[:inIdx])
 	rhs := strings.TrimSpace(body[inIdx+4:])
-	if !isSimpleIdentifierBinding(lhs) || !strings.HasPrefix(rhs, "range(") || !strings.HasSuffix(rhs, ")") {
+	if !runner.IsSimpleIdentifierBinding(lhs) || !strings.HasPrefix(rhs, "range(") || !strings.HasSuffix(rhs, ")") {
 		return "", false
 	}
 
-	args := splitTopLevelComma(strings.TrimSpace(rhs[len("range(") : len(rhs)-1]))
+	args := runner.SplitTopLevelComma(strings.TrimSpace(rhs[len("range(") : len(rhs)-1]))
 	var start, end string
 	switch len(args) {
 	case 1:
@@ -213,80 +213,18 @@ func rewritePythonEnumerateLoopHeader(trimmed string) (string, bool) {
 	return "for (" + normalized + ") in " + iterable + ".enumerate() {", true
 }
 
-func splitTopLevelComma(src string) []string {
-	if strings.TrimSpace(src) == "" {
-		return nil
-	}
-
-	var (
-		parts        []string
-		start        int
-		parenDepth   int
-		bracketDepth int
-		braceDepth   int
-	)
-
-	for i, r := range src {
-		switch r {
-		case '(':
-			parenDepth++
-		case ')':
-			if parenDepth > 0 {
-				parenDepth--
-			}
-		case '[':
-			bracketDepth++
-		case ']':
-			if bracketDepth > 0 {
-				bracketDepth--
-			}
-		case '{':
-			braceDepth++
-		case '}':
-			if braceDepth > 0 {
-				braceDepth--
-			}
-		case ',':
-			if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 {
-				parts = append(parts, src[start:i])
-				start = i + 1
-			}
-		}
-	}
-	parts = append(parts, src[start:])
-	return parts
-}
-
 func normalizeTupleLoopBindings(src string) (string, bool) {
-	parts := splitTopLevelComma(src)
+	parts := runner.SplitTopLevelComma(src)
 	if len(parts) < 2 {
 		return "", false
 	}
 	normalized := make([]string, 0, len(parts))
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
-		if !isSimpleIdentifierBinding(part) {
+		if !runner.IsSimpleIdentifierBinding(part) {
 			return "", false
 		}
 		normalized = append(normalized, part)
 	}
 	return strings.Join(normalized, ", "), true
-}
-
-func isSimpleIdentifierBinding(part string) bool {
-	if part == "_" {
-		return true
-	}
-	for i, r := range part {
-		if i == 0 {
-			if r != '_' && !unicode.IsLetter(r) {
-				return false
-			}
-			continue
-		}
-		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
-			return false
-		}
-	}
-	return part != ""
 }

--- a/internal/airepair/semantic.go
+++ b/internal/airepair/semantic.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osty/osty/internal/lexer"
 	"github.com/osty/osty/internal/repair"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/selfhost"
 	selfhostapi "github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/stdlib"
@@ -140,7 +141,7 @@ func rewriteEnumerateLoopHeader(line sourceLine, counter *int) (string, []repair
 	if strings.HasPrefix(lhs, "(") && strings.HasSuffix(lhs, ")") {
 		lhs = strings.TrimSpace(lhs[1 : len(lhs)-1])
 	}
-	parts := splitTopLevelComma(lhs)
+	parts := runner.SplitTopLevelComma(lhs)
 	if len(parts) != 2 {
 		return "", nil, false
 	}
@@ -155,7 +156,7 @@ func rewriteEnumerateLoopHeader(line sourceLine, counter *int) (string, []repair
 	switch {
 	case indexBinding == "_":
 		indexVar = fmt.Sprintf("_osty_index%d", *counter)
-	case isSimpleIdentifierBinding(indexBinding):
+	case runner.IsSimpleIdentifierBinding(indexBinding):
 		// use the original binding directly in the rewritten loop header.
 	default:
 		return "", nil, false
@@ -298,17 +299,17 @@ func rewriteLetAppendLine(line sourceLine) (string, bool) {
 
 	name := strings.TrimSpace(rest[:eqIdx])
 	rhs := strings.TrimSpace(rest[eqIdx+3:])
-	if !isSimpleIdentifierBinding(name) {
+	if !runner.IsSimpleIdentifierBinding(name) {
 		return "", false
 	}
 
-	base, item, ok := parseAppendCall(rhs)
-	if !ok || strings.TrimSpace(base) == name {
+	parsed := runner.ParseAppendCall(rhs)
+	if !parsed.Ok || parsed.Base == name {
 		return "", false
 	}
 
-	return line.indent + "let mut " + name + " = " + base + "\n" +
-		line.indent + name + ".push(" + item + ")", true
+	return line.indent + "let mut " + name + " = " + parsed.Base + "\n" +
+		line.indent + name + ".push(" + parsed.Item + ")", true
 }
 
 func rewriteSelfAssignAppendLine(line sourceLine) (string, bool) {
@@ -319,40 +320,24 @@ func rewriteSelfAssignAppendLine(line sourceLine) (string, bool) {
 	}
 	lhs := strings.TrimSpace(trimmed[:eqIdx])
 	rhs := strings.TrimSpace(trimmed[eqIdx+3:])
-	if !isSimpleIdentifierBinding(lhs) {
+	if !runner.IsSimpleIdentifierBinding(lhs) {
 		return "", false
 	}
 
-	base, item, ok := parseAppendCall(rhs)
-	if !ok || strings.TrimSpace(base) != lhs {
+	parsed := runner.ParseAppendCall(rhs)
+	if !parsed.Ok || parsed.Base != lhs {
 		return "", false
 	}
 
-	return line.indent + lhs + ".push(" + item + ")", true
+	return line.indent + lhs + ".push(" + parsed.Item + ")", true
 }
 
 func rewriteStandaloneAppendLine(line sourceLine) (string, bool) {
-	base, item, ok := parseAppendCall(line.trimmed)
-	if !ok || !isSimpleIdentifierBinding(strings.TrimSpace(base)) {
+	parsed := runner.ParseAppendCall(line.trimmed)
+	if !parsed.Ok || !runner.IsSimpleIdentifierBinding(parsed.Base) {
 		return "", false
 	}
-	return line.indent + strings.TrimSpace(base) + ".push(" + item + ")", true
-}
-
-func parseAppendCall(expr string) (string, string, bool) {
-	if !strings.HasPrefix(expr, "append(") || !strings.HasSuffix(expr, ")") {
-		return "", "", false
-	}
-	args := splitTopLevelComma(strings.TrimSpace(expr[len("append(") : len(expr)-1]))
-	if len(args) != 2 {
-		return "", "", false
-	}
-	base := strings.TrimSpace(args[0])
-	item := strings.TrimSpace(args[1])
-	if base == "" || item == "" {
-		return "", "", false
-	}
-	return base, item, true
+	return line.indent + parsed.Base + ".push(" + parsed.Item + ")", true
 }
 
 func rewriteLengthProperties(src []byte) ([]byte, []repair.Change, bool) {
@@ -437,27 +422,11 @@ func validLengthFieldOffsets(src []byte) map[int]bool {
 		// rewriting those to `.len()` replaces a valid field read with a
 		// missing-method call. Be conservative: protect anything that is
 		// not a known builtin.
-		if rec == nil || rec.Type == nil || !isRewritableLengthTypeRepr(rec.Type) {
+		if rec == nil || rec.Type == nil || !runner.IsRewritableLengthTypeKind(rec.Type.Kind, rec.Type.Name) {
 			skip[fe.EndV.Offset-len(fe.Name)] = true
 		}
 	})
 	return skip
-}
-
-func isRewritableLengthTypeRepr(tr *selfhostapi.TypeRepr) bool {
-	if tr == nil {
-		return false
-	}
-	switch tr.Kind {
-	case "primitive":
-		return tr.Name == "String" || tr.Name == "Bytes"
-	case "named":
-		switch tr.Name {
-		case "List", "Map", "Set", "OrderedMap":
-			return true
-		}
-	}
-	return false
 }
 
 func semanticPatternBindsNode(p ast.Pattern, target ast.Node) bool {

--- a/internal/runner/airepair_rewrite_policy.go
+++ b/internal/runner/airepair_rewrite_policy.go
@@ -1,0 +1,143 @@
+// airepair_rewrite_policy.go is the Go snapshot of
+// toolchain/airepair_rewrite.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import "strings"
+
+// AppendCallParse mirrors toolchain/airepair_rewrite.osty's
+// AppendCallParse. Empty Base/Item with Ok=false signals the
+// expression is not a recognisable `append(base, item)` shape.
+//
+// Osty: toolchain/airepair_rewrite.osty:23
+type AppendCallParse struct {
+	Base string
+	Item string
+	Ok   bool
+}
+
+// SplitTopLevelComma splits `src` on commas that sit at the
+// outermost paren/bracket/brace nesting level. Empty / whitespace
+// input returns nil. Returned segments are not trimmed — callers
+// that care apply their own whitespace strip.
+//
+// Osty: toolchain/airepair_rewrite.osty:36
+func SplitTopLevelComma(src string) []string {
+	if strings.TrimSpace(src) == "" {
+		return nil
+	}
+	var (
+		parts        []string
+		start        int
+		parenDepth   int
+		bracketDepth int
+		braceDepth   int
+	)
+	bs := []byte(src)
+	for i, b := range bs {
+		switch b {
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case '[':
+			bracketDepth++
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case '{':
+			braceDepth++
+		case '}':
+			if braceDepth > 0 {
+				braceDepth--
+			}
+		case ',':
+			if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 {
+				parts = append(parts, string(bs[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, string(bs[start:]))
+	return parts
+}
+
+// IsSimpleIdentifierBinding reports whether `part` is the wildcard
+// `_` or an ASCII identifier (`[A-Za-z_][A-Za-z0-9_]*`). Empty
+// input is rejected.
+//
+// Osty: toolchain/airepair_rewrite.osty:80
+func IsSimpleIdentifierBinding(part string) bool {
+	if part == "_" {
+		return true
+	}
+	if part == "" {
+		return false
+	}
+	for i := 0; i < len(part); i++ {
+		b := part[i]
+		isUnderscore := b == '_'
+		isUpper := b >= 'A' && b <= 'Z'
+		isLower := b >= 'a' && b <= 'z'
+		isDigit := b >= '0' && b <= '9'
+		if i == 0 {
+			if !isUnderscore && !isUpper && !isLower {
+				return false
+			}
+		} else if !isUnderscore && !isUpper && !isLower && !isDigit {
+			return false
+		}
+	}
+	return true
+}
+
+// ParseAppendCall recognises an `append(base, item)` expression
+// surface so the airepair rewriter can replace it with the
+// equivalent `base.push(item)` Osty form. Anything that doesn't
+// match the exact `append( ... )` envelope with two top-level
+// arguments returns Ok=false.
+//
+// Osty: toolchain/airepair_rewrite.osty:111
+func ParseAppendCall(expr string) AppendCallParse {
+	const prefix = "append("
+	if !strings.HasPrefix(expr, prefix) || !strings.HasSuffix(expr, ")") {
+		return AppendCallParse{}
+	}
+	inner := expr[len(prefix) : len(expr)-1]
+	args := SplitTopLevelComma(strings.TrimSpace(inner))
+	if len(args) != 2 {
+		return AppendCallParse{}
+	}
+	base := strings.TrimSpace(args[0])
+	item := strings.TrimSpace(args[1])
+	if base == "" || item == "" {
+		return AppendCallParse{}
+	}
+	return AppendCallParse{Base: base, Item: item, Ok: true}
+}
+
+// IsRewritableLengthTypeKind reports whether a `.length` field
+// access on a receiver typed `(kind, name)` is the JS/Python habit
+// we want to rewrite to `.len()`. The conservative whitelist matches
+// receivers whose Osty surface guarantees a `.len()` intrinsic:
+// `String`/`Bytes` primitives plus the `List`/`Map`/`Set`/
+// `OrderedMap` named container types. Anything else is left alone
+// so we don't replace a valid field read with a missing-method
+// call.
+//
+// Osty: toolchain/airepair_rewrite.osty:128
+func IsRewritableLengthTypeKind(kind, name string) bool {
+	switch kind {
+	case "primitive":
+		return name == "String" || name == "Bytes"
+	case "named":
+		switch name {
+		case "List", "Map", "Set", "OrderedMap":
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runner/airepair_rewrite_policy_test.go
+++ b/internal/runner/airepair_rewrite_policy_test.go
@@ -1,0 +1,114 @@
+package runner
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitTopLevelComma(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"whitespace-only", "   ", nil},
+		{"single", "just_one", []string{"just_one"}},
+		{"simple", "a, b, c", []string{"a", " b", " c"}},
+		{"ignores-parens", "a, (b, c), d", []string{"a", " (b, c)", " d"}},
+		{"ignores-brackets", "a, [b, c, d], e", []string{"a", " [b, c, d]", " e"}},
+		{"ignores-braces", "x, {a, b}, y", []string{"x", " {a, b}", " y"}},
+		{"nested", "foo(a, b), bar([1, 2])", []string{"foo(a, b)", " bar([1, 2])"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SplitTopLevelComma(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("SplitTopLevelComma(%q) = %#v, want %#v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsSimpleIdentifierBinding(t *testing.T) {
+	allowed := []string{"_", "name", "_leading", "snake_case", "camelCase", "x123"}
+	for _, in := range allowed {
+		if !IsSimpleIdentifierBinding(in) {
+			t.Errorf("IsSimpleIdentifierBinding(%q) = false, want true", in)
+		}
+	}
+	rejected := []string{"", "1abc", "with-hyphen", "a.b", "a,b", "a b"}
+	for _, in := range rejected {
+		if IsSimpleIdentifierBinding(in) {
+			t.Errorf("IsSimpleIdentifierBinding(%q) = true, want false", in)
+		}
+	}
+}
+
+func TestParseAppendCallSimple(t *testing.T) {
+	r := ParseAppendCall("append(items, x)")
+	if !r.Ok || r.Base != "items" || r.Item != "x" {
+		t.Errorf("ParseAppendCall(append(items, x)) = %#v, want {items x true}", r)
+	}
+}
+
+func TestParseAppendCallTrimsArgs(t *testing.T) {
+	r := ParseAppendCall("append( xs ,  value )")
+	if !r.Ok || r.Base != "xs" || r.Item != "value" {
+		t.Errorf("ParseAppendCall trims = %#v, want {xs value true}", r)
+	}
+}
+
+func TestParseAppendCallNestedItem(t *testing.T) {
+	r := ParseAppendCall("append(out, foo(a, b))")
+	if !r.Ok || r.Base != "out" || r.Item != "foo(a, b)" {
+		t.Errorf("ParseAppendCall nested = %#v, want {out foo(a, b) true}", r)
+	}
+}
+
+func TestParseAppendCallRejects(t *testing.T) {
+	cases := []string{
+		"append(only_one)",       // wrong arity
+		"push(xs, v)",            // not append
+		"append(a, b) + 1",       // trailing
+		"append(, x)",            // empty base
+		"append(xs, )",           // empty item
+		"",                       // empty
+		"append",                 // no parens
+	}
+	for _, in := range cases {
+		r := ParseAppendCall(in)
+		if r.Ok {
+			t.Errorf("ParseAppendCall(%q).Ok = true, want false", in)
+		}
+	}
+}
+
+func TestIsRewritableLengthTypeKind(t *testing.T) {
+	yes := []struct{ kind, name string }{
+		{"primitive", "String"},
+		{"primitive", "Bytes"},
+		{"named", "List"},
+		{"named", "Map"},
+		{"named", "Set"},
+		{"named", "OrderedMap"},
+	}
+	for _, c := range yes {
+		if !IsRewritableLengthTypeKind(c.kind, c.name) {
+			t.Errorf("IsRewritableLengthTypeKind(%q, %q) = false, want true", c.kind, c.name)
+		}
+	}
+	no := []struct{ kind, name string }{
+		{"primitive", "Int"},
+		{"primitive", "Float"},
+		{"primitive", ""},
+		{"named", "MyStruct"},
+		{"generic", "List"},
+		{"", ""},
+	}
+	for _, c := range no {
+		if IsRewritableLengthTypeKind(c.kind, c.name) {
+			t.Errorf("IsRewritableLengthTypeKind(%q, %q) = true, want false", c.kind, c.name)
+		}
+	}
+}

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -38,6 +38,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 	ostySources := []string{
 		"runner.osty",
 		"airepair_flags.osty",
+		"airepair_rewrite.osty",
 		"profile_flags.osty",
 		"diag_policy.osty",
 		"test_runner.osty",

--- a/toolchain/airepair_rewrite.osty
+++ b/toolchain/airepair_rewrite.osty
@@ -1,0 +1,153 @@
+/// Pure rewrite-helper policy for `osty airepair`'s semantic
+/// rewriters. Host code (internal/airepair) owns lex/parse, source
+/// edit application, and diagnostic shaping; this module decides:
+///
+///   - how to split a top-level argument list (paren/bracket/brace
+///     aware comma split),
+///   - whether a token is a simple identifier binding,
+///   - whether an `append(base, item)` expression matches the shape
+///     we know how to rewrite to `base.push(item)`,
+///   - whether a typed receiver's `.length` is a foreign habit we
+///     can rewrite to `.len()`.
+///
+/// Mirrored by `internal/runner/airepair_rewrite_policy.go`. The
+/// drift test under internal/runner keeps the two in sync — the
+/// Osty file is the source of truth at review time.
+use std.strings as strings
+/// AppendCallParse is the structured outcome of inspecting an
+/// expression that *might* be `append(base, item)`. `ok == false`
+/// signals the expression isn't recognisable; `base` and `item`
+/// are then empty.
+pub struct AppendCallParse {
+    pub base: String,
+    pub item: String,
+    pub ok: Bool,
+}
+/// splitTopLevelComma splits `src` on commas that sit at the
+/// outermost paren/bracket/brace nesting level. Empty / whitespace
+/// input returns an empty list. The returned segments are *not*
+/// trimmed — callers that care apply `strings.trimSpace` themselves
+/// so we don't lose information about where commas fell.
+///
+/// Example: `"a, (b, c), d"` -> `["a", " (b, c)", " d"]`.
+pub fn splitTopLevelComma(src: String) -> List<String> {
+    let mut parts: List<String> = []
+    if strings.trimSpace(src) == "" {
+        return parts
+    }
+    let bs = src.bytes()
+    let n = bs.len()
+    let mut start = 0
+    let mut parenDepth = 0
+    let mut bracketDepth = 0
+    let mut braceDepth = 0
+    let mut i = 0
+    for i < n {
+        let b = bs[i].toInt()
+        if b == 0x28 {
+            parenDepth = parenDepth + 1
+        } else if b == 0x29 {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if b == 0x5B {
+            bracketDepth = bracketDepth + 1
+        } else if b == 0x5D {
+            if bracketDepth > 0 {
+                bracketDepth = bracketDepth - 1
+            }
+        } else if b == 0x7B {
+            braceDepth = braceDepth + 1
+        } else if b == 0x7D {
+            if braceDepth > 0 {
+                braceDepth = braceDepth - 1
+            }
+        } else if b == 0x2C {
+            if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 {
+                parts.push(strings.slice(src, start, i))
+                start = i + 1
+            }
+        }
+        i = i + 1
+    }
+    parts.push(strings.slice(src, start, n))
+    parts
+}
+/// isSimpleIdentifierBinding reports whether `part` is either the
+/// wildcard `_` or an ASCII identifier (`[A-Za-z_][A-Za-z0-9_]*`).
+/// Empty input is rejected.
+///
+/// Practical scope: airepair rewriters inspect source written in
+/// foreign languages (JS / Python) and transform it toward Osty.
+/// All callers that consume this predicate go on to splice the
+/// binding into a generated `for` / `let` header, so they need a
+/// shape they can paste verbatim — ASCII identifiers cover the
+/// observed corpus and keep the rewriter conservative.
+pub fn isSimpleIdentifierBinding(part: String) -> Bool {
+    if part == "_" {
+        return true
+    }
+    if part == "" {
+        return false
+    }
+    let bs = part.bytes()
+    let n = bs.len()
+    let mut i = 0
+    for i < n {
+        let b = bs[i].toInt()
+        let isUnderscore = b == 0x5F
+        let isUpper = b >= 0x41 && b <= 0x5A
+        let isLower = b >= 0x61 && b <= 0x7A
+        let isDigit = b >= 0x30 && b <= 0x39
+        if i == 0 {
+            if !isUnderscore && !isUpper && !isLower {
+                return false
+            }
+        } else if !isUnderscore && !isUpper && !isLower && !isDigit {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+/// parseAppendCall recognises an `append(base, item)` expression
+/// surface so the airepair rewriter can replace it with the
+/// equivalent `base.push(item)` Osty form. Anything that doesn't
+/// match the exact `append( ... )` envelope with two top-level
+/// arguments returns `ok == false`.
+///
+/// `base` and `item` are returned trimmed so the rewriter can drop
+/// them straight into a new line.
+pub fn parseAppendCall(expr: String) -> AppendCallParse {
+    if !strings.hasPrefix(expr, "append(") || !strings.hasSuffix(expr, ")") {
+        return AppendCallParse {base: "", item: "", ok: false}
+    }
+    let inner = strings.slice(expr, 7, expr.len() - 1)
+    let args = splitTopLevelComma(strings.trimSpace(inner))
+    if args.len() != 2 {
+        return AppendCallParse {base: "", item: "", ok: false}
+    }
+    let base = strings.trimSpace(args[0])
+    let item = strings.trimSpace(args[1])
+    if base == "" || item == "" {
+        return AppendCallParse {base: "", item: "", ok: false}
+    }
+    AppendCallParse {base: base, item: item, ok: true}
+}
+/// isRewritableLengthTypeKind reports whether a `.length` field
+/// access on a receiver typed `(kind, name)` is the JS/Python habit
+/// we want to rewrite to `.len()`. The conservative whitelist
+/// matches the receivers whose Osty surface guarantees a `.len()`
+/// intrinsic: `String`/`Bytes` primitives, plus the `List`/`Map`/
+/// `Set`/`OrderedMap` named container types. Anything else (an
+/// unknown user struct, a generic parameter, etc.) is left alone so
+/// we don't replace a valid field read with a missing-method call.
+pub fn isRewritableLengthTypeKind(kind: String, name: String) -> Bool {
+    if kind == "primitive" {
+        return name == "String" || name == "Bytes"
+    }
+    if kind == "named" {
+        return name == "List" || name == "Map" || name == "Set" || name == "OrderedMap"
+    }
+    false
+}

--- a/toolchain/airepair_rewrite_test.osty
+++ b/toolchain/airepair_rewrite_test.osty
@@ -1,0 +1,126 @@
+use std.testing
+fn testSplitTopLevelCommaSimple() {
+    let parts = splitTopLevelComma("a, b, c")
+    testing.assertEq(parts.len(), 3)
+    testing.assertEq(parts[0], "a")
+    testing.assertEq(parts[1], " b")
+    testing.assertEq(parts[2], " c")
+}
+fn testSplitTopLevelCommaEmpty() {
+    let parts = splitTopLevelComma("")
+    testing.assertEq(parts.len(), 0)
+}
+fn testSplitTopLevelCommaWhitespaceOnly() {
+    let parts = splitTopLevelComma("   ")
+    testing.assertEq(parts.len(), 0)
+}
+fn testSplitTopLevelCommaSinglePart() {
+    let parts = splitTopLevelComma("just_one")
+    testing.assertEq(parts.len(), 1)
+    testing.assertEq(parts[0], "just_one")
+}
+fn testSplitTopLevelCommaIgnoresParens() {
+    let parts = splitTopLevelComma("a, (b, c), d")
+    testing.assertEq(parts.len(), 3)
+    testing.assertEq(parts[0], "a")
+    testing.assertEq(parts[1], " (b, c)")
+    testing.assertEq(parts[2], " d")
+}
+fn testSplitTopLevelCommaIgnoresBrackets() {
+    let parts = splitTopLevelComma("a, [b, c, d], e")
+    testing.assertEq(parts.len(), 3)
+    testing.assertEq(parts[0], "a")
+    testing.assertEq(parts[1], " [b, c, d]")
+    testing.assertEq(parts[2], " e")
+}
+fn testSplitTopLevelCommaIgnoresBraces() {
+    let parts = splitTopLevelComma("x, {a, b}, y")
+    testing.assertEq(parts.len(), 3)
+    testing.assertEq(parts[0], "x")
+    testing.assertEq(parts[1], " {a, b}")
+    testing.assertEq(parts[2], " y")
+}
+fn testSplitTopLevelCommaNested() {
+    let parts = splitTopLevelComma("foo(a, b), bar([1, 2])")
+    testing.assertEq(parts.len(), 2)
+    testing.assertEq(parts[0], "foo(a, b)")
+    testing.assertEq(parts[1], " bar([1, 2])")
+}
+fn testIsSimpleIdentifierBindingWildcard() {
+    testing.assert(isSimpleIdentifierBinding("_"))
+}
+fn testIsSimpleIdentifierBindingPlain() {
+    testing.assert(isSimpleIdentifierBinding("name"))
+    testing.assert(isSimpleIdentifierBinding("_leading"))
+    testing.assert(isSimpleIdentifierBinding("snake_case"))
+    testing.assert(isSimpleIdentifierBinding("camelCase"))
+    testing.assert(isSimpleIdentifierBinding("x123"))
+}
+fn testIsSimpleIdentifierBindingRejectsDigitFirst() {
+    testing.assert(!(isSimpleIdentifierBinding("1abc")))
+}
+fn testIsSimpleIdentifierBindingRejectsHyphen() {
+    testing.assert(!(isSimpleIdentifierBinding("with-hyphen")))
+}
+fn testIsSimpleIdentifierBindingRejectsEmpty() {
+    testing.assert(!(isSimpleIdentifierBinding("")))
+}
+fn testIsSimpleIdentifierBindingRejectsPunctuation() {
+    testing.assert(!(isSimpleIdentifierBinding("a.b")))
+    testing.assert(!(isSimpleIdentifierBinding("a,b")))
+    testing.assert(!(isSimpleIdentifierBinding("a b")))
+}
+fn testParseAppendCallSimple() {
+    let r = parseAppendCall("append(items, x)")
+    testing.assert(r.ok)
+    testing.assertEq(r.base, "items")
+    testing.assertEq(r.item, "x")
+}
+fn testParseAppendCallTrimsArgs() {
+    let r = parseAppendCall("append( xs ,  value )")
+    testing.assert(r.ok)
+    testing.assertEq(r.base, "xs")
+    testing.assertEq(r.item, "value")
+}
+fn testParseAppendCallNestedItem() {
+    let r = parseAppendCall("append(out, foo(a, b))")
+    testing.assert(r.ok)
+    testing.assertEq(r.base, "out")
+    testing.assertEq(r.item, "foo(a, b)")
+}
+fn testParseAppendCallRejectsWrongArity() {
+    let r = parseAppendCall("append(only_one)")
+    testing.assert(!(r.ok))
+}
+fn testParseAppendCallRejectsNotAppend() {
+    let r = parseAppendCall("push(xs, v)")
+    testing.assert(!(r.ok))
+}
+fn testParseAppendCallRejectsTrailingExpression() {
+    let r = parseAppendCall("append(a, b) + 1")
+    testing.assert(!(r.ok))
+}
+fn testParseAppendCallRejectsEmptyArg() {
+    let r = parseAppendCall("append(, x)")
+    testing.assert(!(r.ok))
+    let r2 = parseAppendCall("append(xs, )")
+    testing.assert(!(r2.ok))
+}
+fn testIsRewritableLengthTypeKindPrimitives() {
+    testing.assert(isRewritableLengthTypeKind("primitive", "String"))
+    testing.assert(isRewritableLengthTypeKind("primitive", "Bytes"))
+    testing.assert(!(isRewritableLengthTypeKind("primitive", "Int")))
+    testing.assert(!(isRewritableLengthTypeKind("primitive", "Float")))
+}
+fn testIsRewritableLengthTypeKindNamedContainers() {
+    testing.assert(isRewritableLengthTypeKind("named", "List"))
+    testing.assert(isRewritableLengthTypeKind("named", "Map"))
+    testing.assert(isRewritableLengthTypeKind("named", "Set"))
+    testing.assert(isRewritableLengthTypeKind("named", "OrderedMap"))
+}
+fn testIsRewritableLengthTypeKindRejectsUnknown() {
+    testing.assert(!(isRewritableLengthTypeKind("named", "MyStruct")))
+    testing.assert(!(isRewritableLengthTypeKind("generic", "List")))
+    testing.assert(!(isRewritableLengthTypeKind("", "")))
+    testing.assert(!(isRewritableLengthTypeKind("primitive", "")))
+}


### PR DESCRIPTION
## Summary

CLAUDE.md의 "Osty로 작성 가능한 것은 Go로 작성 금지" 원칙에 따라
`internal/airepair/`에서 순수 정책 헬퍼 4개를 `toolchain/airepair_rewrite.osty`로
이전. Go 측은 `internal/runner/airepair_rewrite_policy.go` 스냅샷을
유지하고, `internal/airepair`는 `runner.*` 브리지를 통해 호출하도록
재배선. `internal/runner/drift_test.go`가 `pub fn` 시그니처 일치를 강제.

이전된 헬퍼:

- `splitTopLevelComma(src) -> List<String>` — paren/bracket/brace 깊이 인지
  콤마 분리 (UTF-8 byte iteration)
- `isSimpleIdentifierBinding(part) -> Bool` — `_` 와일드카드 또는 ASCII
  identifier (`[A-Za-z_][A-Za-z0-9_]*`)
- `parseAppendCall(expr) -> AppendCallParse` — `append(base, item)` 표면을
  분해해 `base.push(item)` 변환에 사용
- `isRewritableLengthTypeKind(kind, name) -> Bool` — 어떤 수신자 타입이
  `.length` → `.len()` 재작성 대상인지 결정 (String/Bytes/List/Map/Set/
  OrderedMap whitelist)

부수 변경:

- `isSimpleIdentifierBinding`은 Go 원본의 `unicode.IsLetter`/`unicode.IsDigit`
  의존을 끊고 ASCII identifier로 좁혔다. (a) airepair 리라이터가 다루는
  소스 코퍼스는 ASCII identifier뿐이고 (b) Osty 측 `Char.isAlpha()`/
  `Char.isDigit()` 인트린식은 체커가 아직 lower하지 못해 ASCII 바이트
  비교가 self-host로 옮길 수 있는 가장 안전한 표현
- `parseAppendCall`은 `(string, string, bool)` 다중 반환 대신
  `AppendCallParse` 구조체 반환 — 호출자도 `parsed.Base` / `parsed.Item`
  로 정리

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/airepair/... ./internal/runner/...` —
      pass (drift test 포함)
- [x] `go test -count=1 -short ./cmd/osty/...` — pass
      (`TestAIRepair*`, `TestFmtAIRepair*`, `TestFmtRunsSemanticAIRepair*`
      포함, 8.6s)
- [x] 기존 frontend/spec 실패 (`TestParseFollowOnRecoveryB2MatchAssignHelperTail`,
      `TestSpecNegative` E0502/E0503/E0504)는 base commit `2e65a7a`에서도
      동일하게 발생 — 본 PR과 무관

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_