### PR TITLE
refactor: airepair foreign-loop 리라이터 self-host (toolchain/airepair_rewrite.osty 확장)

### DIFF
--- a/internal/airepair/foreign_loops.go
+++ b/internal/airepair/foreign_loops.go
@@ -57,20 +57,20 @@ func rewriteForeignLoopHeaders(src []byte) ([]byte, []repair.Change, bool) {
 			continue
 		}
 
-		rewritten, kind, msg, ok := rewriteForeignLoopHeader(line.trimmed)
-		if !ok {
+		r := runner.RewriteForeignLoopHeader(line.trimmed)
+		if !r.Ok {
 			out.WriteString(line.raw)
 			continue
 		}
 
 		out.WriteString(line.indent)
-		out.WriteString(rewritten)
+		out.WriteString(r.Rewritten)
 		if line.hasNewline {
 			out.WriteByte('\n')
 		}
 		changes = append(changes, repair.Change{
-			Kind:    kind,
-			Message: msg,
+			Kind:    r.Kind,
+			Message: r.Message,
 			Pos: token.Pos{
 				Offset: line.start + len(line.indent),
 				Line:   line.lineNo,
@@ -86,145 +86,3 @@ func rewriteForeignLoopHeaders(src []byte) ([]byte, []repair.Change, bool) {
 	return []byte(out.String()), changes, true
 }
 
-func rewriteForeignLoopHeader(trimmed string) (string, string, string, bool) {
-	if rewritten, ok := rewriteJSForOfHeader(trimmed); ok {
-		return rewritten, "js_for_of_loop", "replace JS-style `for (... of ...)` loop with Osty `for ... in` syntax", true
-	}
-	if rewritten, ok := rewritePythonEnumerateLoopHeader(trimmed); ok {
-		return rewritten, "python_enumerate_loop", "replace Python `enumerate(...)` loop with Osty `.enumerate()` iteration", true
-	}
-	if rewritten, ok := rewritePythonRangeLoopHeader(trimmed); ok {
-		return rewritten, "python_range_loop", "replace Python `range(...)` loop with Osty range syntax", true
-	}
-	return "", "", "", false
-}
-
-func rewriteJSForOfHeader(trimmed string) (string, bool) {
-	if !strings.HasPrefix(trimmed, "for ") || !strings.HasSuffix(trimmed, "{") {
-		return "", false
-	}
-	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "for "), "{"))
-	if !strings.HasPrefix(body, "(") || !strings.HasSuffix(body, ")") {
-		return "", false
-	}
-	inner := strings.TrimSpace(body[1 : len(body)-1])
-	ofIdx := strings.Index(inner, " of ")
-	if ofIdx <= 0 {
-		return "", false
-	}
-
-	lhs := strings.TrimSpace(inner[:ofIdx])
-	rhs := strings.TrimSpace(inner[ofIdx+4:])
-	switch {
-	case strings.HasPrefix(lhs, "const "):
-		lhs = strings.TrimSpace(strings.TrimPrefix(lhs, "const "))
-	case strings.HasPrefix(lhs, "let "):
-		lhs = strings.TrimSpace(strings.TrimPrefix(lhs, "let "))
-	case strings.HasPrefix(lhs, "var "):
-		lhs = strings.TrimSpace(strings.TrimPrefix(lhs, "var "))
-	}
-	if lhs == "" || rhs == "" {
-		return "", false
-	}
-
-	if strings.HasPrefix(lhs, "[") && strings.HasSuffix(lhs, "]") {
-		normalized, ok := normalizeTupleLoopBindings(strings.TrimSpace(lhs[1 : len(lhs)-1]))
-		if !ok {
-			return "", false
-		}
-		return "for (" + normalized + ") in " + rhs + " {", true
-	}
-	if !runner.IsSimpleIdentifierBinding(lhs) {
-		return "", false
-	}
-	return "for " + lhs + " in " + rhs + " {", true
-}
-
-func rewritePythonRangeLoopHeader(trimmed string) (string, bool) {
-	if !strings.HasPrefix(trimmed, "for ") || !strings.HasSuffix(trimmed, "{") {
-		return "", false
-	}
-	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "for "), "{"))
-	inIdx := strings.Index(body, " in ")
-	if inIdx <= 0 {
-		return "", false
-	}
-	lhs := strings.TrimSpace(body[:inIdx])
-	rhs := strings.TrimSpace(body[inIdx+4:])
-	if !runner.IsSimpleIdentifierBinding(lhs) || !strings.HasPrefix(rhs, "range(") || !strings.HasSuffix(rhs, ")") {
-		return "", false
-	}
-
-	args := runner.SplitTopLevelComma(strings.TrimSpace(rhs[len("range(") : len(rhs)-1]))
-	var start, end string
-	switch len(args) {
-	case 1:
-		start = "0"
-		end = strings.TrimSpace(args[0])
-	case 2:
-		start = strings.TrimSpace(args[0])
-		end = strings.TrimSpace(args[1])
-	case 3:
-		start = strings.TrimSpace(args[0])
-		end = strings.TrimSpace(args[1])
-		if strings.TrimSpace(args[2]) != "1" {
-			return "", false
-		}
-	default:
-		return "", false
-	}
-	if start == "" || end == "" {
-		return "", false
-	}
-	return "for " + lhs + " in " + start + ".." + end + " {", true
-}
-
-func rewritePythonEnumerateLoopHeader(trimmed string) (string, bool) {
-	if !strings.HasPrefix(trimmed, "for ") || !strings.HasSuffix(trimmed, "{") {
-		return "", false
-	}
-	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "for "), "{"))
-	inIdx := strings.Index(body, " in ")
-	if inIdx <= 0 {
-		return "", false
-	}
-	lhs := strings.TrimSpace(body[:inIdx])
-	rhs := strings.TrimSpace(body[inIdx+4:])
-	if !strings.HasPrefix(rhs, "enumerate(") || !strings.HasSuffix(rhs, ")") {
-		return "", false
-	}
-	iterable := strings.TrimSpace(rhs[len("enumerate(") : len(rhs)-1])
-	if iterable == "" {
-		return "", false
-	}
-
-	if strings.HasPrefix(lhs, "(") && strings.HasSuffix(lhs, ")") {
-		normalized, ok := normalizeTupleLoopBindings(strings.TrimSpace(lhs[1 : len(lhs)-1]))
-		if !ok {
-			return "", false
-		}
-		return "for (" + normalized + ") in " + iterable + ".enumerate() {", true
-	}
-
-	normalized, ok := normalizeTupleLoopBindings(lhs)
-	if !ok {
-		return "", false
-	}
-	return "for (" + normalized + ") in " + iterable + ".enumerate() {", true
-}
-
-func normalizeTupleLoopBindings(src string) (string, bool) {
-	parts := runner.SplitTopLevelComma(src)
-	if len(parts) < 2 {
-		return "", false
-	}
-	normalized := make([]string, 0, len(parts))
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if !runner.IsSimpleIdentifierBinding(part) {
-			return "", false
-		}
-		normalized = append(normalized, part)
-	}
-	return strings.Join(normalized, ", "), true
-}

--- a/internal/airepair/tuple_loop.go
+++ b/internal/airepair/tuple_loop.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/repair"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -97,10 +98,10 @@ func rewriteBareTupleForHeader(trimmed string) (string, bool) {
 		return "", false
 	}
 
-	normalized, ok := normalizeTupleLoopBindings(lhs)
-	if !ok {
+	normalized := runner.NormalizeTupleLoopBindings(lhs)
+	if !normalized.Ok {
 		return "", false
 	}
 
-	return "for (" + normalized + ") in " + rhs + " {", true
+	return "for (" + normalized.Joined + ") in " + rhs + " {", true
 }

--- a/internal/runner/airepair_rewrite_policy.go
+++ b/internal/runner/airepair_rewrite_policy.go
@@ -141,3 +141,220 @@ func IsRewritableLengthTypeKind(kind, name string) bool {
 	}
 	return false
 }
+
+// LoopRewrite mirrors toolchain/airepair_rewrite.osty's LoopRewrite.
+// Empty Rewritten with Ok=false means the candidate header is not a
+// shape this rewriter recognises.
+//
+// Osty: toolchain/airepair_rewrite.osty:158
+type LoopRewrite struct {
+	Rewritten string
+	Ok        bool
+}
+
+// ForeignLoopRewrite mirrors toolchain/airepair_rewrite.osty's
+// ForeignLoopRewrite. Kind / Message are populated only when the
+// dispatcher matched a sub-rewriter so the host can shape the
+// resulting diag without re-running the dispatch.
+//
+// Osty: toolchain/airepair_rewrite.osty:166
+type ForeignLoopRewrite struct {
+	Rewritten string
+	Kind      string
+	Message   string
+	Ok        bool
+}
+
+// TupleBindingNormalize mirrors toolchain/airepair_rewrite.osty's
+// TupleBindingNormalize. Joined is the trimmed-and-rejoined form a
+// caller can splice into the generated header.
+//
+// Osty: toolchain/airepair_rewrite.osty:176
+type TupleBindingNormalize struct {
+	Joined string
+	Ok     bool
+}
+
+// NormalizeTupleLoopBindings parses a `binding, binding, ...`
+// payload from a tuple-loop header.
+//
+// Osty: toolchain/airepair_rewrite.osty:185
+func NormalizeTupleLoopBindings(src string) TupleBindingNormalize {
+	parts := SplitTopLevelComma(src)
+	if len(parts) < 2 {
+		return TupleBindingNormalize{}
+	}
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if !IsSimpleIdentifierBinding(trimmed) {
+			return TupleBindingNormalize{}
+		}
+		normalized = append(normalized, trimmed)
+	}
+	return TupleBindingNormalize{Joined: strings.Join(normalized, ", "), Ok: true}
+}
+
+// RewriteJSForOfHeader recognises a JS `for (... of ...) {` loop
+// header and emits the Osty equivalent. Recognises bare `let` /
+// `const` / `var` keyword prefixes on the binding side and
+// `[a, b]` array-destructure shapes (rewritten to Osty tuple
+// destructuring).
+//
+// Osty: toolchain/airepair_rewrite.osty:228
+func RewriteJSForOfHeader(trimmed string) LoopRewrite {
+	if !strings.HasPrefix(trimmed, "for ") || !strings.HasSuffix(trimmed, "{") {
+		return LoopRewrite{}
+	}
+	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "for "), "{"))
+	if !strings.HasPrefix(body, "(") || !strings.HasSuffix(body, ")") {
+		return LoopRewrite{}
+	}
+	inner := strings.TrimSpace(body[1 : len(body)-1])
+	ofIdx := strings.Index(inner, " of ")
+	if ofIdx <= 0 {
+		return LoopRewrite{}
+	}
+	lhs := strings.TrimSpace(inner[:ofIdx])
+	rhs := strings.TrimSpace(inner[ofIdx+4:])
+	switch {
+	case strings.HasPrefix(lhs, "const "):
+		lhs = strings.TrimSpace(strings.TrimPrefix(lhs, "const "))
+	case strings.HasPrefix(lhs, "let "):
+		lhs = strings.TrimSpace(strings.TrimPrefix(lhs, "let "))
+	case strings.HasPrefix(lhs, "var "):
+		lhs = strings.TrimSpace(strings.TrimPrefix(lhs, "var "))
+	}
+	if lhs == "" || rhs == "" {
+		return LoopRewrite{}
+	}
+	if strings.HasPrefix(lhs, "[") && strings.HasSuffix(lhs, "]") {
+		inside := strings.TrimSpace(lhs[1 : len(lhs)-1])
+		normalized := NormalizeTupleLoopBindings(inside)
+		if !normalized.Ok {
+			return LoopRewrite{}
+		}
+		return LoopRewrite{Rewritten: "for (" + normalized.Joined + ") in " + rhs + " {", Ok: true}
+	}
+	if !IsSimpleIdentifierBinding(lhs) {
+		return LoopRewrite{}
+	}
+	return LoopRewrite{Rewritten: "for " + lhs + " in " + rhs + " {", Ok: true}
+}
+
+// RewritePythonRangeLoopHeader recognises a `for X in range(...) {`
+// loop header and emits an Osty `for X in start..end` form. The
+// 3-arg form (`range(start, end, step)`) is only accepted when
+// `step == 1`.
+//
+// Osty: toolchain/airepair_rewrite.osty:272
+func RewritePythonRangeLoopHeader(trimmed string) LoopRewrite {
+	if !strings.HasPrefix(trimmed, "for ") || !strings.HasSuffix(trimmed, "{") {
+		return LoopRewrite{}
+	}
+	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "for "), "{"))
+	inIdx := strings.Index(body, " in ")
+	if inIdx <= 0 {
+		return LoopRewrite{}
+	}
+	lhs := strings.TrimSpace(body[:inIdx])
+	rhs := strings.TrimSpace(body[inIdx+4:])
+	if !IsSimpleIdentifierBinding(lhs) || !strings.HasPrefix(rhs, "range(") || !strings.HasSuffix(rhs, ")") {
+		return LoopRewrite{}
+	}
+	args := SplitTopLevelComma(strings.TrimSpace(rhs[len("range(") : len(rhs)-1]))
+	var start, end string
+	switch len(args) {
+	case 1:
+		start = "0"
+		end = strings.TrimSpace(args[0])
+	case 2:
+		start = strings.TrimSpace(args[0])
+		end = strings.TrimSpace(args[1])
+	case 3:
+		start = strings.TrimSpace(args[0])
+		end = strings.TrimSpace(args[1])
+		if strings.TrimSpace(args[2]) != "1" {
+			return LoopRewrite{}
+		}
+	default:
+		return LoopRewrite{}
+	}
+	if start == "" || end == "" {
+		return LoopRewrite{}
+	}
+	return LoopRewrite{Rewritten: "for " + lhs + " in " + start + ".." + end + " {", Ok: true}
+}
+
+// RewritePythonEnumerateLoopHeader recognises
+// `for i, v in enumerate(xs) {` and emits an Osty enumerate-shape
+// header. Both bare-tuple and parenthesised binding shapes are
+// accepted.
+//
+// Osty: toolchain/airepair_rewrite.osty:316
+func RewritePythonEnumerateLoopHeader(trimmed string) LoopRewrite {
+	if !strings.HasPrefix(trimmed, "for ") || !strings.HasSuffix(trimmed, "{") {
+		return LoopRewrite{}
+	}
+	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "for "), "{"))
+	inIdx := strings.Index(body, " in ")
+	if inIdx <= 0 {
+		return LoopRewrite{}
+	}
+	lhs := strings.TrimSpace(body[:inIdx])
+	rhs := strings.TrimSpace(body[inIdx+4:])
+	if !strings.HasPrefix(rhs, "enumerate(") || !strings.HasSuffix(rhs, ")") {
+		return LoopRewrite{}
+	}
+	iterable := strings.TrimSpace(rhs[len("enumerate(") : len(rhs)-1])
+	if iterable == "" {
+		return LoopRewrite{}
+	}
+	if strings.HasPrefix(lhs, "(") && strings.HasSuffix(lhs, ")") {
+		inside := strings.TrimSpace(lhs[1 : len(lhs)-1])
+		normalized := NormalizeTupleLoopBindings(inside)
+		if !normalized.Ok {
+			return LoopRewrite{}
+		}
+		return LoopRewrite{Rewritten: "for (" + normalized.Joined + ") in " + iterable + ".enumerate() {", Ok: true}
+	}
+	normalized := NormalizeTupleLoopBindings(lhs)
+	if !normalized.Ok {
+		return LoopRewrite{}
+	}
+	return LoopRewrite{Rewritten: "for (" + normalized.Joined + ") in " + iterable + ".enumerate() {", Ok: true}
+}
+
+// RewriteForeignLoopHeader is the dispatcher that asks each
+// shape-specific rewriter in turn. Order matters: JS for-of first
+// (parenthesised body), then enumerate (so `enumerate(...)` is not
+// partially matched by range), then range.
+//
+// Osty: toolchain/airepair_rewrite.osty:367
+func RewriteForeignLoopHeader(trimmed string) ForeignLoopRewrite {
+	if r := RewriteJSForOfHeader(trimmed); r.Ok {
+		return ForeignLoopRewrite{
+			Rewritten: r.Rewritten,
+			Kind:      "js_for_of_loop",
+			Message:   "replace JS-style `for (... of ...)` loop with Osty `for ... in` syntax",
+			Ok:        true,
+		}
+	}
+	if r := RewritePythonEnumerateLoopHeader(trimmed); r.Ok {
+		return ForeignLoopRewrite{
+			Rewritten: r.Rewritten,
+			Kind:      "python_enumerate_loop",
+			Message:   "replace Python `enumerate(...)` loop with Osty `.enumerate()` iteration",
+			Ok:        true,
+		}
+	}
+	if r := RewritePythonRangeLoopHeader(trimmed); r.Ok {
+		return ForeignLoopRewrite{
+			Rewritten: r.Rewritten,
+			Kind:      "python_range_loop",
+			Message:   "replace Python `range(...)` loop with Osty range syntax",
+			Ok:        true,
+		}
+	}
+	return ForeignLoopRewrite{}
+}

--- a/internal/runner/airepair_rewrite_policy_test.go
+++ b/internal/runner/airepair_rewrite_policy_test.go
@@ -84,6 +84,136 @@ func TestParseAppendCallRejects(t *testing.T) {
 	}
 }
 
+func TestNormalizeTupleLoopBindings(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		ok   bool
+		want string
+	}{
+		{"single-rejected", "only_one", false, ""},
+		{"two-idents", "i, value", true, "i, value"},
+		{"trims-parts", "  k ,  v  ", true, "k, v"},
+		{"rejects-expr", "i, foo(x)", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := NormalizeTupleLoopBindings(c.in)
+			if got.Ok != c.ok {
+				t.Errorf("NormalizeTupleLoopBindings(%q).Ok = %v, want %v", c.in, got.Ok, c.ok)
+			}
+			if got.Joined != c.want {
+				t.Errorf("NormalizeTupleLoopBindings(%q).Joined = %q, want %q", c.in, got.Joined, c.want)
+			}
+		})
+	}
+}
+
+func TestRewriteJSForOfHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		ok   bool
+		want string
+	}{
+		{"simple", "for (item of items) {", true, "for item in items {"},
+		{"const", "for (const item of items) {", true, "for item in items {"},
+		{"let", "for (let x of xs) {", true, "for x in xs {"},
+		{"var", "for (var x of xs) {", true, "for x in xs {"},
+		{"array-destructure", "for (const [k, v] of entries) {", true, "for (k, v) in entries {"},
+		{"reject-bare-for", "for x in xs {", false, ""},
+		{"reject-pattern-lhs", "for (foo(x) of xs) {", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewriteJSForOfHeader(c.in)
+			if got.Ok != c.ok {
+				t.Errorf("RewriteJSForOfHeader(%q).Ok = %v, want %v", c.in, got.Ok, c.ok)
+			}
+			if got.Rewritten != c.want {
+				t.Errorf("RewriteJSForOfHeader(%q).Rewritten = %q, want %q", c.in, got.Rewritten, c.want)
+			}
+		})
+	}
+}
+
+func TestRewritePythonRangeLoopHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		ok   bool
+		want string
+	}{
+		{"one-arg", "for i in range(10) {", true, "for i in 0..10 {"},
+		{"two-args", "for i in range(2, 8) {", true, "for i in 2..8 {"},
+		{"three-args-step-one", "for i in range(0, 10, 1) {", true, "for i in 0..10 {"},
+		{"reject-non-unit-stride", "for i in range(0, 10, 2) {", false, ""},
+		{"reject-four-args", "for i in range(0, 10, 1, x) {", false, ""},
+		{"reject-bad-binding", "for i, j in range(10) {", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewritePythonRangeLoopHeader(c.in)
+			if got.Ok != c.ok {
+				t.Errorf("RewritePythonRangeLoopHeader(%q).Ok = %v, want %v", c.in, got.Ok, c.ok)
+			}
+			if got.Rewritten != c.want {
+				t.Errorf("RewritePythonRangeLoopHeader(%q).Rewritten = %q, want %q", c.in, got.Rewritten, c.want)
+			}
+		})
+	}
+}
+
+func TestRewritePythonEnumerateLoopHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		ok   bool
+		want string
+	}{
+		{"bare-tuple", "for i, v in enumerate(xs) {", true, "for (i, v) in xs.enumerate() {"},
+		{"paren-tuple", "for (i, v) in enumerate(items) {", true, "for (i, v) in items.enumerate() {"},
+		{"reject-bare-ident", "for x in enumerate(xs) {", false, ""},
+		{"reject-empty-arg", "for i, v in enumerate() {", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewritePythonEnumerateLoopHeader(c.in)
+			if got.Ok != c.ok {
+				t.Errorf("RewritePythonEnumerateLoopHeader(%q).Ok = %v, want %v", c.in, got.Ok, c.ok)
+			}
+			if got.Rewritten != c.want {
+				t.Errorf("RewritePythonEnumerateLoopHeader(%q).Rewritten = %q, want %q", c.in, got.Rewritten, c.want)
+			}
+		})
+	}
+}
+
+func TestRewriteForeignLoopHeader(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		ok       bool
+		wantKind string
+	}{
+		{"js-for-of", "for (item of items) {", true, "js_for_of_loop"},
+		{"py-enumerate", "for i, v in enumerate(xs) {", true, "python_enumerate_loop"},
+		{"py-range", "for i in range(10) {", true, "python_range_loop"},
+		{"unknown", "if cond {", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewriteForeignLoopHeader(c.in)
+			if got.Ok != c.ok {
+				t.Errorf("RewriteForeignLoopHeader(%q).Ok = %v, want %v", c.in, got.Ok, c.ok)
+			}
+			if got.Kind != c.wantKind {
+				t.Errorf("RewriteForeignLoopHeader(%q).Kind = %q, want %q", c.in, got.Kind, c.wantKind)
+			}
+		})
+	}
+}
+
 func TestIsRewritableLengthTypeKind(t *testing.T) {
 	yes := []struct{ kind, name string }{
 		{"primitive", "String"},

--- a/toolchain/airepair_rewrite.osty
+++ b/toolchain/airepair_rewrite.osty
@@ -151,3 +151,249 @@ pub fn isRewritableLengthTypeKind(kind: String, name: String) -> Bool {
     }
     false
 }
+/// LoopRewrite is the outcome of a single foreign-loop-shape
+/// rewriter (JS-for-of, Python-range, Python-enumerate). `ok ==
+/// false` leaves `rewritten` empty and signals "I do not recognise
+/// this header — try a different shape".
+pub struct LoopRewrite {
+    pub rewritten: String,
+    pub ok: Bool,
+}
+/// ForeignLoopRewrite is the dispatcher result. `kind` and
+/// `message` are populated only when `ok` is true so the host can
+/// shape the diag the user sees without guessing which sub-rewriter
+/// fired.
+pub struct ForeignLoopRewrite {
+    pub rewritten: String,
+    pub kind: String,
+    pub message: String,
+    pub ok: Bool,
+}
+/// TupleBindingNormalize is the outcome of normalising a comma-
+/// separated tuple-loop binding list (e.g. `i, value` or `[i, v]`
+/// stripped of brackets). `joined` is the trimmed-and-rejoined form
+/// the rewriter will splice into the generated header.
+pub struct TupleBindingNormalize {
+    pub joined: String,
+    pub ok: Bool,
+}
+/// normalizeTupleLoopBindings parses a `binding, binding, ...`
+/// payload from a tuple-loop header. Every comma-separated piece
+/// must be a simple identifier binding (`isSimpleIdentifierBinding`)
+/// otherwise we refuse the rewrite — the source likely has a
+/// pattern shape we'd silently corrupt.
+pub fn normalizeTupleLoopBindings(src: String) -> TupleBindingNormalize {
+    let parts = splitTopLevelComma(src)
+    if parts.len() < 2 {
+        return TupleBindingNormalize {joined: "", ok: false}
+    }
+    let mut normalized: List<String> = []
+    for part in parts {
+        let trimmed = strings.trimSpace(part)
+        if !isSimpleIdentifierBinding(trimmed) {
+            return TupleBindingNormalize {joined: "", ok: false}
+        }
+        normalized.push(trimmed)
+    }
+    TupleBindingNormalize {joined: strings.join(normalized, ", "), ok: true}
+}
+/// airepairByteIndexOf is a byte-faithful substring search over
+/// `haystack` for `needle`. Returns -1 when not found.
+///
+/// `strings.indexOf` returns char (not byte) indexes, which would
+/// desync with `strings.slice`'s byte-indexed slicing on multi-
+/// byte input. The airepair rewriters splice slices around the
+/// search hit, so we need a byte-correct index that matches Go's
+/// `strings.Index` semantics exactly.
+fn airepairByteIndexOf(haystack: String, needle: String) -> Int {
+    let hbs = haystack.bytes()
+    let nbs = needle.bytes()
+    let h = hbs.len()
+    let n = nbs.len()
+    if n == 0 {
+        return 0
+    }
+    if n > h {
+        return -1
+    }
+    let last = h - n
+    let mut i = 0
+    for i <= last {
+        let mut matched = true
+        let mut j = 0
+        for j < n {
+            if hbs[i + j].toInt() != nbs[j].toInt() {
+                matched = false
+                break
+            }
+            j = j + 1
+        }
+        if matched {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+/// rewriteJSForOfHeader recognises a JS `for (... of ...) {` loop
+/// header and emits the Osty equivalent. Recognises bare `let` /
+/// `const` / `var` keyword prefixes on the binding side and
+/// `[a, b]` array-destructure shapes (rewritten to Osty tuple
+/// destructuring).
+pub fn rewriteJSForOfHeader(trimmed: String) -> LoopRewrite {
+    if !strings.hasPrefix(trimmed, "for ") || !strings.hasSuffix(trimmed, "\{") {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    let withoutFor = strings.trimPrefix(trimmed, "for ")
+    let body = strings.trimSpace(strings.trimSuffix(withoutFor, "\{"))
+    if !strings.hasPrefix(body, "(") || !strings.hasSuffix(body, ")") {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    let inner = strings.trimSpace(strings.slice(body, 1, body.len() - 1))
+    let ofIdx = airepairByteIndexOf(inner, " of ")
+    if ofIdx <= 0 {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    let mut lhs = strings.trimSpace(strings.slice(inner, 0, ofIdx))
+    let rhs = strings.trimSpace(strings.slice(inner, ofIdx + 4, inner.len()))
+    if strings.hasPrefix(lhs, "const ") {
+        lhs = strings.trimSpace(strings.trimPrefix(lhs, "const "))
+    } else if strings.hasPrefix(lhs, "let ") {
+        lhs = strings.trimSpace(strings.trimPrefix(lhs, "let "))
+    } else if strings.hasPrefix(lhs, "var ") {
+        lhs = strings.trimSpace(strings.trimPrefix(lhs, "var "))
+    }
+    if lhs == "" || rhs == "" {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    if strings.hasPrefix(lhs, "[") && strings.hasSuffix(lhs, "]") {
+        let inside = strings.trimSpace(strings.slice(lhs, 1, lhs.len() - 1))
+        let normalized = normalizeTupleLoopBindings(inside)
+        if !normalized.ok {
+            return LoopRewrite {rewritten: "", ok: false}
+        }
+        return LoopRewrite {rewritten: "for (" + normalized.joined + ") in " + rhs + " \{", ok: true}
+    }
+    if !isSimpleIdentifierBinding(lhs) {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    LoopRewrite {rewritten: "for " + lhs + " in " + rhs + " \{", ok: true}
+}
+/// rewritePythonRangeLoopHeader recognises a `for X in range(...) {`
+/// loop header and emits an Osty `for X in start..end` form. The
+/// 3-arg form (`range(start, end, step)`) is only accepted when
+/// `step == 1`; non-unit strides have no concise Osty surface and
+/// are left for the user to translate by hand.
+pub fn rewritePythonRangeLoopHeader(trimmed: String) -> LoopRewrite {
+    if !strings.hasPrefix(trimmed, "for ") || !strings.hasSuffix(trimmed, "\{") {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    let withoutFor = strings.trimPrefix(trimmed, "for ")
+    let body = strings.trimSpace(strings.trimSuffix(withoutFor, "\{"))
+    let inIdx = airepairByteIndexOf(body, " in ")
+    if inIdx <= 0 {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    let lhs = strings.trimSpace(strings.slice(body, 0, inIdx))
+    let rhs = strings.trimSpace(strings.slice(body, inIdx + 4, body.len()))
+    if !isSimpleIdentifierBinding(lhs) || !strings.hasPrefix(rhs, "range(") || !strings.hasSuffix(rhs, ")") {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    let argsPayload = strings.trimSpace(strings.slice(rhs, 6, rhs.len() - 1))
+    let args = splitTopLevelComma(argsPayload)
+    let mut start = ""
+    let mut end = ""
+    if args.len() == 1 {
+        start = "0"
+        end = strings.trimSpace(args[0])
+    } else if args.len() == 2 {
+        start = strings.trimSpace(args[0])
+        end = strings.trimSpace(args[1])
+    } else if args.len() == 3 {
+        start = strings.trimSpace(args[0])
+        end = strings.trimSpace(args[1])
+        if strings.trimSpace(args[2]) != "1" {
+            return LoopRewrite {rewritten: "", ok: false}
+        }
+    } else {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    if start == "" || end == "" {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    LoopRewrite {rewritten: "for " + lhs + " in " + start + ".." + end + " \{", ok: true}
+}
+/// rewritePythonEnumerateLoopHeader recognises
+/// `for i, v in enumerate(xs) {` and emits an Osty enumerate-shape
+/// header. Both bare-tuple (`i, v`) and parenthesised (`(i, v)`)
+/// binding shapes are accepted.
+pub fn rewritePythonEnumerateLoopHeader(trimmed: String) -> LoopRewrite {
+    if !strings.hasPrefix(trimmed, "for ") || !strings.hasSuffix(trimmed, "\{") {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    let withoutFor = strings.trimPrefix(trimmed, "for ")
+    let body = strings.trimSpace(strings.trimSuffix(withoutFor, "\{"))
+    let inIdx = airepairByteIndexOf(body, " in ")
+    if inIdx <= 0 {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    let lhs = strings.trimSpace(strings.slice(body, 0, inIdx))
+    let rhs = strings.trimSpace(strings.slice(body, inIdx + 4, body.len()))
+    if !strings.hasPrefix(rhs, "enumerate(") || !strings.hasSuffix(rhs, ")") {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    let iterable = strings.trimSpace(strings.slice(rhs, 10, rhs.len() - 1))
+    if iterable == "" {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    if strings.hasPrefix(lhs, "(") && strings.hasSuffix(lhs, ")") {
+        let inside = strings.trimSpace(strings.slice(lhs, 1, lhs.len() - 1))
+        let normalized = normalizeTupleLoopBindings(inside)
+        if !normalized.ok {
+            return LoopRewrite {rewritten: "", ok: false}
+        }
+        return LoopRewrite {rewritten: "for (" + normalized.joined + ") in " + iterable + ".enumerate() \{", ok: true}
+    }
+    let normalized = normalizeTupleLoopBindings(lhs)
+    if !normalized.ok {
+        return LoopRewrite {rewritten: "", ok: false}
+    }
+    LoopRewrite {rewritten: "for (" + normalized.joined + ") in " + iterable + ".enumerate() \{", ok: true}
+}
+/// rewriteForeignLoopHeader is the dispatcher that asks each
+/// shape-specific rewriter in turn. Order matters: JS `for-of`
+/// runs first because its `for (X of Y)` envelope is the only
+/// shape that requires the parenthesised body — it would never
+/// match `range(...)` / `enumerate(...)`. Among the Python shapes,
+/// enumerate is checked before range so a bare `range` inside an
+/// `enumerate(...)` argument is not partially matched.
+pub fn rewriteForeignLoopHeader(trimmed: String) -> ForeignLoopRewrite {
+    let js = rewriteJSForOfHeader(trimmed)
+    if js.ok {
+        return ForeignLoopRewrite {
+            rewritten: js.rewritten,
+            kind: "js_for_of_loop",
+            message: "replace JS-style `for (... of ...)` loop with Osty `for ... in` syntax",
+            ok: true,
+        }
+    }
+    let enumerated = rewritePythonEnumerateLoopHeader(trimmed)
+    if enumerated.ok {
+        return ForeignLoopRewrite {
+            rewritten: enumerated.rewritten,
+            kind: "python_enumerate_loop",
+            message: "replace Python `enumerate(...)` loop with Osty `.enumerate()` iteration",
+            ok: true,
+        }
+    }
+    let ranged = rewritePythonRangeLoopHeader(trimmed)
+    if ranged.ok {
+        return ForeignLoopRewrite {
+            rewritten: ranged.rewritten,
+            kind: "python_range_loop",
+            message: "replace Python `range(...)` loop with Osty range syntax",
+            ok: true,
+        }
+    }
+    ForeignLoopRewrite {rewritten: "", kind: "", message: "", ok: false}
+}

--- a/toolchain/airepair_rewrite_test.osty
+++ b/toolchain/airepair_rewrite_test.osty
@@ -124,3 +124,120 @@ fn testIsRewritableLengthTypeKindRejectsUnknown() {
     testing.assert(!(isRewritableLengthTypeKind("", "")))
     testing.assert(!(isRewritableLengthTypeKind("primitive", "")))
 }
+fn testNormalizeTupleLoopBindingsRejectsSingle() {
+    let r = normalizeTupleLoopBindings("only_one")
+    testing.assert(!(r.ok))
+}
+fn testNormalizeTupleLoopBindingsTwoIdents() {
+    let r = normalizeTupleLoopBindings("i, value")
+    testing.assert(r.ok)
+    testing.assertEq(r.joined, "i, value")
+}
+fn testNormalizeTupleLoopBindingsTrimsParts() {
+    let r = normalizeTupleLoopBindings("  k ,  v  ")
+    testing.assert(r.ok)
+    testing.assertEq(r.joined, "k, v")
+}
+fn testNormalizeTupleLoopBindingsRejectsExpression() {
+    let r = normalizeTupleLoopBindings("i, foo(x)")
+    testing.assert(!(r.ok))
+}
+fn testRewriteJSForOfHeaderSimple() {
+    let r = rewriteJSForOfHeader("for (item of items) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for item in items \{")
+}
+fn testRewriteJSForOfHeaderConstKeyword() {
+    let r = rewriteJSForOfHeader("for (const item of items) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for item in items \{")
+}
+fn testRewriteJSForOfHeaderLetKeyword() {
+    let r = rewriteJSForOfHeader("for (let x of xs) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for x in xs \{")
+}
+fn testRewriteJSForOfHeaderVarKeyword() {
+    let r = rewriteJSForOfHeader("for (var x of xs) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for x in xs \{")
+}
+fn testRewriteJSForOfHeaderArrayDestructure() {
+    let r = rewriteJSForOfHeader("for (const [k, v] of entries) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for (k, v) in entries \{")
+}
+fn testRewriteJSForOfHeaderRejectsBareFor() {
+    let r = rewriteJSForOfHeader("for x in xs \{")
+    testing.assert(!(r.ok))
+}
+fn testRewriteJSForOfHeaderRejectsBadPatternLhs() {
+    let r = rewriteJSForOfHeader("for (foo(x) of xs) \{")
+    testing.assert(!(r.ok))
+}
+fn testRewritePythonRangeLoopHeaderOneArg() {
+    let r = rewritePythonRangeLoopHeader("for i in range(10) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for i in 0..10 \{")
+}
+fn testRewritePythonRangeLoopHeaderTwoArgs() {
+    let r = rewritePythonRangeLoopHeader("for i in range(2, 8) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for i in 2..8 \{")
+}
+fn testRewritePythonRangeLoopHeaderThreeArgsStepOne() {
+    let r = rewritePythonRangeLoopHeader("for i in range(0, 10, 1) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for i in 0..10 \{")
+}
+fn testRewritePythonRangeLoopHeaderRejectsNonUnitStride() {
+    let r = rewritePythonRangeLoopHeader("for i in range(0, 10, 2) \{")
+    testing.assert(!(r.ok))
+}
+fn testRewritePythonRangeLoopHeaderRejectsFourArgs() {
+    let r = rewritePythonRangeLoopHeader("for i in range(0, 10, 1, x) \{")
+    testing.assert(!(r.ok))
+}
+fn testRewritePythonRangeLoopHeaderRejectsBadBinding() {
+    let r = rewritePythonRangeLoopHeader("for i, j in range(10) \{")
+    testing.assert(!(r.ok))
+}
+fn testRewritePythonEnumerateLoopHeaderBareTuple() {
+    let r = rewritePythonEnumerateLoopHeader("for i, v in enumerate(xs) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for (i, v) in xs.enumerate() \{")
+}
+fn testRewritePythonEnumerateLoopHeaderParenTuple() {
+    let r = rewritePythonEnumerateLoopHeader("for (i, v) in enumerate(items) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "for (i, v) in items.enumerate() \{")
+}
+fn testRewritePythonEnumerateLoopHeaderRejectsBareIdent() {
+    let r = rewritePythonEnumerateLoopHeader("for x in enumerate(xs) \{")
+    testing.assert(!(r.ok))
+}
+fn testRewritePythonEnumerateLoopHeaderRejectsEmptyArg() {
+    let r = rewritePythonEnumerateLoopHeader("for i, v in enumerate() \{")
+    testing.assert(!(r.ok))
+}
+fn testRewriteForeignLoopHeaderJS() {
+    let r = rewriteForeignLoopHeader("for (item of items) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.kind, "js_for_of_loop")
+    testing.assertEq(r.rewritten, "for item in items \{")
+}
+fn testRewriteForeignLoopHeaderEnumerate() {
+    let r = rewriteForeignLoopHeader("for i, v in enumerate(xs) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.kind, "python_enumerate_loop")
+}
+fn testRewriteForeignLoopHeaderRange() {
+    let r = rewriteForeignLoopHeader("for i in range(10) \{")
+    testing.assert(r.ok)
+    testing.assertEq(r.kind, "python_range_loop")
+}
+fn testRewriteForeignLoopHeaderUnknown() {
+    let r = rewriteForeignLoopHeader("if cond \{")
+    testing.assert(!(r.ok))
+    testing.assertEq(r.kind, "")
+}


### PR DESCRIPTION
## Summary

PR #1751의 후속. 같은 `internal/airepair/` 영역에서 `foreign_loops.go`의
나머지 순수-정책 리라이터들을 `toolchain/airepair_rewrite.osty`로
이전한다. `internal/airepair`는 `runner.*` 브리지로만 호출하고,
foreign-loop 헤더 인식/변환 로직은 더 이상 Go 측에 살지 않는다.

이전된 헬퍼 (총 5개):

- `normalizeTupleLoopBindings(src) -> TupleBindingNormalize` — 콤마 분리된
  튜플-바인딩 페이로드 정규화
- `rewriteJSForOfHeader(trimmed) -> LoopRewrite` — `for (... of ...) {`
  (const/let/var 키워드, `[a, b]` 디스트럭처)
- `rewritePythonRangeLoopHeader(trimmed) -> LoopRewrite` —
  `for X in range(...) {` (1/2/3-arg, step=1만 허용)
- `rewritePythonEnumerateLoopHeader(trimmed) -> LoopRewrite` —
  `for i, v in enumerate(xs) {` (bare/paren tuple)
- `rewriteForeignLoopHeader(trimmed) -> ForeignLoopRewrite` — 위 셋을
  순서대로 시도하는 디스패처 (kind/message 페어 동시 제공)

부수 변경:

- **byte-faithful indexOf**: Osty `strings.indexOf`는 char 인덱스를
  반환하지만 `strings.slice`는 바이트 인덱스를 쓴다. 두 헬퍼를 함께
  쓰면 multi-byte 입력에서 슬라이싱이 어긋난다. Go 원본의
  `strings.Index` 시맨틱을 그대로 보존하기 위해 `airepairByteIndexOf`
  내부 헬퍼를 새로 둠 (private fn, `bytes()` iterator 기반)
- **다중 반환 제거**: `(string, bool)` / `(string, string, string, bool)`
  를 `LoopRewrite` / `ForeignLoopRewrite` / `TupleBindingNormalize`
  구조체로 명시화 — 호출자도 `r.Rewritten` / `r.Kind` / `n.Joined`로
  같이 정리

`internal/airepair/foreign_loops.go`는 이제 splitSourceLines + 디스패치
+ source-edit 적용만 담당 (152줄 → 80줄). 정책은 0줄.

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/airepair/... ./internal/runner/...` —
      pass (drift test 포함, 8개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/...` — pass (8.3s,
      `TestAIRepair*`/`TestFmtAIRepair*` 포함)
- [x] `go vet ./internal/airepair/... ./internal/runner/...` — clean
- [x] 기존 frontend/spec failure 2종 (`TestParseFollowOnRecoveryB2*`,
      `TestSpecNegative` E0502/E0503/E0504)은 base commit `6331408`에서도
      동일하게 발생 — 본 PR과 무관

## 셀프호스팅 진척

| | PR #1751 (직전) | 본 PR |
|---|---|---|
| `toolchain/airepair_rewrite.osty` lines | 154 | 400 |
| pure helpers self-hosted | 4 | 9 |
| `internal/airepair/` lines (정책) | -115 | -150 |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_