### PR TITLE
fix: skip osty-tests without osty-self; follow-on parser test

### DIFF
--- a/internal/parser/frontend_authority_test.go
+++ b/internal/parser/frontend_authority_test.go
@@ -198,6 +198,9 @@ func requireRecoveryForStmtWithTrailingLet(t *testing.T, result Result, declIdx 
 
 func requireFollowOnFnWithHelper(t *testing.T, result Result, fnDeclIdx int, fnBodyStmts int, helperDeclIdx int, helperBodyStmts int, helperName string, wantCodes ...string) (*ast.FnDecl, *ast.FnDecl) {
 	t.Helper()
+	if len(wantCodes) == 0 {
+		t.Fatal("requireFollowOnFnWithHelper: pass every diagnostic Code as wantCodes — empty wrongly implies zero diagnostics")
+	}
 	requireParseDiagnosticCodes(t, result, wantCodes...)
 	fn := requireFnDeclAt(t, result.File, fnDeclIdx, fnBodyStmts, "primary fn plus preserved helper fn")
 	helper := requireFnDeclAt(t, result.File, helperDeclIdx, helperBodyStmts, "preserved helper fn "+helperName)
@@ -419,10 +422,9 @@ func TestParseFollowOnRecoveryB2MatchAssignHelperTail(t *testing.T) {
 	src := fixtureFollowOnBMatchAssignHelperTail("rfB2MatchAssignHelperTail", "rfB2Tail")
 
 	result := ParseDetailed(src)
-	requireParseDiagnosticCount(t, result, 5, "follow-on diagnostics")
-	requireParseDiagnosticCodePresent(t, result, "E0100")
 	requireParseDiagnosticWithCodeAndMessage(t, result, "E0204", "expected match arm body before `->`")
-	fn, helper := requireFollowOnFnWithHelper(t, result, 0, 1, 1, 0, "rfB2Tail")
+	// E0204×4 + E0100 — match ParseDetailed multiset for this shape.
+	fn, helper := requireFollowOnFnWithHelper(t, result, 0, 1, 1, 0, "rfB2Tail", "E0204", "E0204", "E0204", "E0204", "E0100")
 	stmt := requireExprStmtAt(t, fn.Body.Stmts, 0, "expression statement")
 	match, ok := stmt.X.(*ast.MatchExpr)
 	if !ok || len(match.Arms) != 2 {

--- a/justfile
+++ b/justfile
@@ -160,8 +160,17 @@ osty: build verify-selfhost
     just osty-tests
 
 osty-tests:
+    #!/usr/bin/env bash
     set -euo pipefail
     test -x {{bin}} || just build
+    # Example packages compile through the LLVM + mir-direct path, which
+    # requires a cached `osty-self` (see `just bootstrap` / `osty install-self`).
+    # Fresh checkouts should still pass `just front` / `just short` without a
+    # multi-minute toolchain build.
+    if ! {{bin}} cache-self --check >/dev/null 2>&1; then
+        echo "skip osty-tests: no selfhostcache osty-self (run \`just bootstrap\` to enable)" >&2
+        exit 0
+    fi
     for dir in {{osty_test_dirs}}; do {{bin}} test --seed 0x1 "$dir"; done
 
 test pkg="./...":


### PR DESCRIPTION
## Summary
- **`osty-tests` (just)**: If `osty cache-self --check` fails (no cached `osty-self`), skip LLVM example package runs so `just front` and fresh clones succeed without `just bootstrap`.
- **`internal/parser`**: Fix `TestParseFollowOnRecoveryB2MatchAssignHelperTail` — pass the real diagnostic multiset (E0204×4 + E0100) into `requireFollowOnFnWithHelper`. Add a guard so empty `wantCodes` cannot silently imply “zero diagnostics” again.

## Verification
- `just front`

Full example LLVM E2E still requires `just bootstrap` or an existing selfhostcache hit.