### PR TITLE
[codex] harden selfhost stage0 gate refresh

### DIFF
--- a/internal/backend/llvm_runtime_stage0_audit_symbols_test.go
+++ b/internal/backend/llvm_runtime_stage0_audit_symbols_test.go
@@ -1,0 +1,104 @@
+package backend
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/llvmabi"
+)
+
+func TestBundledRuntimeStage0AuditAliasesLinkWithThinLTO(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	runtimeObjectPath := filepath.Join(dir, bundledRuntimeObjectName)
+	irPath := filepath.Join(dir, "stage0_audit_aliases.ll")
+	irObjectPath := filepath.Join(dir, "stage0_audit_aliases.o")
+	binaryPath := filepath.Join(dir, "stage0_audit_aliases")
+
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+
+	ir := `@.path = private unnamed_addr constant [2 x i8] c".\00"
+@.fmt = private unnamed_addr constant [6 x i8] c"%lld\0A\00"
+@stderr = external global ptr
+@llvm.used = appending global [14 x ptr] [
+  ptr @Char__toString,
+  ptr @Char__len,
+  ptr @std.strings.fromChar,
+  ptr @std.strings.compare,
+  ptr @std.env.args,
+  ptr @std.env.get,
+  ptr @std.fs.readToString,
+  ptr @std.os.exit,
+  ptr @std.process.abort,
+  ptr @runtime.path.filepath.Base,
+  ptr @runtime.path.filepath.Ext,
+  ptr @__interp,
+  ptr @i64,
+  ptr @stderr
+], section "llvm.metadata"
+
+declare ptr @Char__toString(i32)
+declare i64 @Char__len(ptr)
+declare ptr @std.strings.fromChar(i32)
+declare i64 @std.strings.compare(ptr, ptr)
+declare ptr @std.env.args()
+declare ptr @std.env.get(ptr)
+declare ptr @std.fs.readToString(ptr)
+declare void @std.os.exit(i64)
+declare void @std.process.abort(ptr)
+declare ptr @runtime.path.filepath.Base(ptr)
+declare ptr @runtime.path.filepath.Ext(ptr)
+declare ptr @__interp()
+declare ptr @i64()
+declare i32 @fprintf(ptr, ptr, ...)
+
+define i32 @main() {
+entry:
+  %from_char = call ptr @std.strings.fromChar(i32 65)
+  %to_string = call ptr @Char__toString(i32 66)
+  %len = call i64 @Char__len(ptr %from_char)
+  %cmp = call i64 @std.strings.compare(ptr %from_char, ptr %to_string)
+  %args = call ptr @std.env.args()
+  %env = call ptr @std.env.get(ptr %from_char)
+  %file = call ptr @std.fs.readToString(ptr @.path)
+  %base = call ptr @runtime.path.filepath.Base(ptr @.path)
+  %ext = call ptr @runtime.path.filepath.Ext(ptr @.path)
+  %interp = call ptr @__interp()
+  %type_name = call ptr @i64()
+  %stderr = load ptr, ptr @stderr
+  %printed = call i32 (ptr, ptr, ...) @fprintf(ptr %stderr, ptr @.fmt, i64 %len)
+  ret i32 0
+}
+`
+	if err := os.WriteFile(irPath, []byte(ir), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", irPath, err)
+	}
+
+	runClang := func(label string, args []string) {
+		t.Helper()
+		out, err := exec.Command("clang", args...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("clang %s failed: %v\n%s", label, err, out)
+		}
+	}
+
+	runClang("compile runtime", clangCompileCObjectArgs("", runtimePath, runtimeObjectPath))
+	runClang("compile stage0 alias IR", llvmabi.ClangCompileObjectArgs("", irPath, irObjectPath))
+	linkArgs := llvmabi.ClangLinkBinaryArgs("", []string{irObjectPath, runtimeObjectPath}, binaryPath)
+	linkArgs = append(linkArgs, clangPlatformRuntimeLinkArgs("")...)
+	runClang("link stage0 alias binary", linkArgs)
+
+	out, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, out)
+	}
+	if got, want := string(out), "1\n"; got != want {
+		t.Fatalf("stage0 alias harness output = %q, want %q", got, want)
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -29483,6 +29483,9 @@ const char *osty_rt_result_unwrap_or_string(void *result, const char *fallback) 
 
 #if defined(__GNUC__) || defined(__clang__)
 
+#define OSTY_RT_AUDIT_SYMBOL(name) OSTY_GC_SYMBOL(name)
+#define OSTY_RT_AUDIT_USED __attribute__((used))
+
 /* UTF-8 encode a single Unicode codepoint into a freshly allocated
  * managed string. Invalid codepoints (>= 0x110000, surrogates) yield
  * the U+FFFD replacement character. Used by `Char.toString` and
@@ -29525,13 +29528,20 @@ static char *osty_rt_audit_char_to_string(int32_t codepoint) {
 }
 
 /* Char.toString(self) — stage0 emits the method mangle directly. */
-void *osty_rt_audit_Char_toString(int32_t codepoint) __asm__("Char__toString");
+void *osty_rt_audit_Char_toString(int32_t codepoint) __asm__(OSTY_RT_AUDIT_SYMBOL("Char__toString")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_Char_toString(int32_t codepoint) {
     return (void *)osty_rt_audit_char_to_string(codepoint);
 }
 
+/* Char.len(self) — stage0 may preserve the method mangle for string-like
+ * char helpers that have already been normalized to a String pointer. */
+int64_t osty_rt_audit_Char_len(const char *value) __asm__(OSTY_RT_AUDIT_SYMBOL("Char__len")) OSTY_RT_AUDIT_USED;
+int64_t osty_rt_audit_Char_len(const char *value) {
+    return osty_rt_strings_ByteLen(value);
+}
+
 /* std.strings.fromChar(c) — same semantics as Char.toString. */
-void *osty_rt_audit_strings_fromChar(int32_t codepoint) __asm__("std.strings.fromChar");
+void *osty_rt_audit_strings_fromChar(int32_t codepoint) __asm__(OSTY_RT_AUDIT_SYMBOL("std.strings.fromChar")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_strings_fromChar(int32_t codepoint) {
     return (void *)osty_rt_audit_char_to_string(codepoint);
 }
@@ -29539,10 +29549,18 @@ void *osty_rt_audit_strings_fromChar(int32_t codepoint) {
 /* std.strings.compare(a, b) — lexicographic byte compare matching
  * `osty_rt_strings_Compare`'s semantics (the LIR Proto path routes
  * here under a different mangle). */
-int64_t osty_rt_audit_strings_compare(const char *left, const char *right) __asm__("std.strings.compare");
+int64_t osty_rt_audit_strings_compare(const char *left, const char *right) __asm__(OSTY_RT_AUDIT_SYMBOL("std.strings.compare")) OSTY_RT_AUDIT_USED;
 int64_t osty_rt_audit_strings_compare(const char *left, const char *right) {
     return osty_rt_strings_Compare(left, right);
 }
+
+#if defined(__APPLE__)
+FILE *osty_rt_stage0_stderr_global __asm__(OSTY_RT_AUDIT_SYMBOL("stderr")) OSTY_RT_AUDIT_USED;
+__attribute__((constructor))
+static void osty_rt_stage0_init_stderr_global(void) {
+    osty_rt_stage0_stderr_global = stderr;
+}
+#endif
 
 /* Captured process argv. Populated once before main() runs via a
  * platform-specific initialiser (`.init_array` on glibc/musl,
@@ -29598,7 +29616,7 @@ static void (*osty_rt_audit_capture_argv_init_ptr)(int, char **, char **) =
  * `toolchain/main.osty:forwardedArgs` slices from index 1. Falls
  * back to an empty list if argv capture failed (unsupported host
  * or constructor skipped). */
-void *osty_rt_audit_env_args(void) __asm__("std.env.args");
+void *osty_rt_audit_env_args(void) __asm__(OSTY_RT_AUDIT_SYMBOL("std.env.args")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_env_args(void) {
     void *list = osty_rt_list_new();
     if (list == NULL || osty_rt_saved_argv == NULL) {
@@ -29620,7 +29638,7 @@ void *osty_rt_audit_env_args(void) {
  * the source/Go convention `Some=0, None=1` (see
  * `internal/mir/lower.go:7757`): tag=0 (Some) when set, tag=1
  * (None) when unset or on NULL input. */
-void *osty_rt_audit_env_get(const char *name) __asm__("std.env.get");
+void *osty_rt_audit_env_get(const char *name) __asm__(OSTY_RT_AUDIT_SYMBOL("std.env.get")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_env_get(const char *name) {
     int64_t *box = (int64_t *)osty_rt_stage0_alloc((int64_t)(sizeof(int64_t) * 2));
     if (box == NULL) {
@@ -29646,14 +29664,14 @@ void *osty_rt_audit_env_get(const char *name) {
 
 /* std.os.exit(code) — terminate the process with `code`. Declared
  * `Never` on the Osty side; matches libc `exit` semantics. */
-void osty_rt_audit_os_exit(int64_t code) __asm__("std.os.exit");
+void osty_rt_audit_os_exit(int64_t code) __asm__(OSTY_RT_AUDIT_SYMBOL("std.os.exit")) OSTY_RT_AUDIT_USED;
 void osty_rt_audit_os_exit(int64_t code) {
     exit((int)code);
 }
 
 /* std.process.abort(msg) — emit `msg` to stderr and abort. Declared
  * `Never` on the Osty side. */
-void osty_rt_audit_process_abort(const char *msg) __asm__("std.process.abort");
+void osty_rt_audit_process_abort(const char *msg) __asm__(OSTY_RT_AUDIT_SYMBOL("std.process.abort")) OSTY_RT_AUDIT_USED;
 void osty_rt_audit_process_abort(const char *msg) {
     if (msg != NULL) {
         char msg_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
@@ -29667,14 +29685,14 @@ void osty_rt_audit_process_abort(const char *msg) {
 
 /* runtime.path.filepath.Base(path) — forward to the existing
  * underscore-named helper. */
-void *osty_rt_audit_filepath_Base(const char *path) __asm__("runtime.path.filepath.Base");
+void *osty_rt_audit_filepath_Base(const char *path) __asm__(OSTY_RT_AUDIT_SYMBOL("runtime.path.filepath.Base")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_filepath_Base(const char *path) {
     return (void *)osty_rt_path_filepath_Base(path);
 }
 
 /* runtime.path.filepath.Ext(path) — forward to the existing
  * underscore-named helper. */
-void *osty_rt_audit_filepath_Ext(const char *path) __asm__("runtime.path.filepath.Ext");
+void *osty_rt_audit_filepath_Ext(const char *path) __asm__(OSTY_RT_AUDIT_SYMBOL("runtime.path.filepath.Ext")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_filepath_Ext(const char *path) {
     return (void *)osty_rt_path_filepath_Ext(path);
 }
@@ -29683,14 +29701,14 @@ void *osty_rt_audit_filepath_Ext(const char *path) {
  * lowerings outside the bootstrap subset. Reached only from declined
  * paths; safe empty string keeps the binary from segfaulting if it
  * does dispatch here. */
-void *osty_rt_audit_interp_placeholder(void) __asm__("__interp");
+void *osty_rt_audit_interp_placeholder(void) __asm__(OSTY_RT_AUDIT_SYMBOL("__interp")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_interp_placeholder(void) {
     return osty_rt_string_dup_site("", 0, "stage0.audit.interp_placeholder");
 }
 
 /* i64() — same placeholder category as `__interp`; surfaces when a
  * type-name leaks into the call site via stage0 fallback. */
-void *osty_rt_audit_i64_placeholder(void) __asm__("i64");
+void *osty_rt_audit_i64_placeholder(void) __asm__(OSTY_RT_AUDIT_SYMBOL("i64")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_i64_placeholder(void) {
     return osty_rt_string_dup_site("", 0, "stage0.audit.i64_placeholder");
 }
@@ -29708,7 +29726,7 @@ void *osty_rt_audit_i64_placeholder(void) {
  * with `undefined reference to std.fs.readToString` and the
  * stage0 dispatch ceiling moves back from "binary handled
  * --selfhost-doctor" to "binary fails to link". */
-void *osty_rt_audit_fs_readToString(const char *path) __asm__("std.fs.readToString");
+void *osty_rt_audit_fs_readToString(const char *path) __asm__(OSTY_RT_AUDIT_SYMBOL("std.fs.readToString")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_fs_readToString(const char *path) {
     int64_t *box = (int64_t *)osty_rt_stage0_alloc((int64_t)(sizeof(int64_t) * 2));
     if (box == NULL) {
@@ -29755,6 +29773,9 @@ void *osty_rt_audit_fs_readToString(const char *path) {
     memcpy(&box[1], &content, sizeof(content));
     return box;
 }
+
+#undef OSTY_RT_AUDIT_USED
+#undef OSTY_RT_AUDIT_SYMBOL
 
 #endif /* defined(__GNUC__) || defined(__clang__) */
 

--- a/justfile
+++ b/justfile
@@ -3,12 +3,16 @@ set shell := ["bash", "-cu"]
 bin := ".bin/osty"
 checker_bin := ".osty/bin/osty-native-checker"
 front_packages := "./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline"
-backend_packages := "./internal/ir ./internal/mir ./internal/backend ./internal/llvmgen"
+backend_packages := "./internal/ir ./internal/mir ./internal/backend ./internal/nativellvmgen ./internal/llvmabi ./internal/toolchain ./cmd/osty-native-llvmgen"
 osty_test_dirs := "examples/int_control_e2e examples/int_methods_e2e examples/int_struct_e2e"
 test_flags := "-count=1 -vet=off"
 stdlib_matrix_fast_tests := "TestStdlibSupportMatrix"
 stdlib_matrix_backend_tests := "Test(Stdlib(CheckResult|Symbol|Method)|InjectReachableStdlib|ReachableStdlib|Phase2|LLVMBackendBinaryRunsStd(Zip|Xlsx|Image|Smtp|Crypto|Random|Term|Os)|PrepareEntryRewritesStdEncoding)"
-stdlib_matrix_llvmgen_tests := "Test(Std(Env|Io|Term|Strings|Bytes|Crypto)|UnsupportedDiagnostic)"
+native_llvm_backend_tests := "Test(LLVMBackendBinaryStd(Io|Env)|LLVMBackendBinaryRunsStd(Term|Crypto)|LLVMBackendBinaryStdCrypto|EmitLLVMIRTextPrefersNativeOwned|LLVMBackendEmitBinaryPrefersNativeOwned|UseNativeOwnedLLVMIR|LLVMBackendDispatchTraceReportsSelectedRoute|LLVMBackendMissingMIRDoesNotRetryLegacyIRBridge)"
+native_llvmgen_cmd_tests := "TestRun(EmitsLLVMIRForMIRPayload|MIRPayloadPrefersLIRProtoWhenSelected|MIRPayloadDeclinesWhenLIRProtoDeclines|RejectsInvalidJSON)"
+native_llvmgen_exec_tests := "Test(TrySourceUsesEnvBinaryAndDecodesResponse|TryPackageUsesManagedBinaryWhenEnvUnset|RequestFromMIREncodesPayload)"
+native_llvmabi_tests := "TestUnsupported"
+toolchain_native_llvmgen_tests := "Test(EnsureNativeLLVMGen|ManagedNativeLLVMGenPath)"
 selfhost_matrix_fast_tests := "Test(CheckCLIDefaultPathExitsZero|RunCheckFileDefaultPathIsAstbridgeFree|ProductionFrontendPathsDoNotCallFrontendRunFile)"
 selfhost_matrix_cmd_tests := "Test(Run(Check|Typecheck|Resolve)(File|Package|Workspace).*AstbridgeFree|CheckCLI(DefaultPathExitsZero|Native.*)|TypecheckCLI.*|ResolveCLI.*)"
 selfhost_matrix_core_tests := "Test(ParseSnapshot|CheckSnapshot|CheckStructuredFromRunIsAstbridgeFree|CheckPackageStructuredIsAstbridgeFree|CheckDiagnosticsAsDiagIsAstbridgeFree|ProductionFrontendPathsDoNotCallFrontendRunFile)"
@@ -141,7 +145,11 @@ support-stdlib-medium:
     just support-stdlib-fast
     go test {{test_flags}} ./internal/stdlib
     go test {{test_flags}} ./internal/backend -run '{{stdlib_matrix_backend_tests}}' -v
-    go test {{test_flags}} ./internal/llvmgen -run '{{stdlib_matrix_llvmgen_tests}}' -v
+    go test {{test_flags}} ./internal/llvmabi -run '{{native_llvmabi_tests}}' -v
+    go test {{test_flags}} ./cmd/osty-native-llvmgen -run '{{native_llvmgen_cmd_tests}}' -v
+    go test {{test_flags}} ./internal/nativellvmgen -run '{{native_llvmgen_exec_tests}}' -v
+    go test {{test_flags}} ./internal/toolchain -run '{{toolchain_native_llvmgen_tests}}' -v
+    go test {{test_flags}} ./internal/backend -run '{{native_llvm_backend_tests}}' -v
 
 support-selfhost-fast:
     go test {{test_flags}} ./cmd/osty ./internal/selfhost -run '{{selfhost_matrix_fast_tests}}' -v

--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -326,8 +326,15 @@ run_gates() {
 	log "selfhost snapshot parity"
 	go test -count=1 -vet=off ./internal/ci ./internal/runner -run 'SnapshotParity|CoreSnapshotParity'
 
-	log "merged native toolchain MIR pipeline"
-	go test -count=1 -vet=off ./internal/llvmgen -run 'TestNativeToolchainMergedMIRPipelineIsClean|TestNativeToolchainMergedMIRErrTypeFloor'
+	log "stage0 toolchain audit"
+	OSTY_STAGE0_AUDIT=1 go test -count=1 -vet=off ./internal/backend -run 'TestStage0ToolchainAudit' -v
+
+	log "native llvmgen route probes"
+	go test -count=1 -vet=off ./internal/llvmabi -run 'TestUnsupported'
+	go test -count=1 -vet=off ./cmd/osty-native-llvmgen -run 'TestRun(EmitsLLVMIRForMIRPayload|MIRPayloadPrefersLIRProtoWhenSelected|MIRPayloadDeclinesWhenLIRProtoDeclines|RejectsInvalidJSON)' -v
+	go test -count=1 -vet=off ./internal/nativellvmgen -run 'Test(TrySourceUsesEnvBinaryAndDecodesResponse|TryPackageUsesManagedBinaryWhenEnvUnset|RequestFromMIREncodesPayload)' -v
+	go test -count=1 -vet=off ./internal/toolchain -run 'Test(EnsureNativeLLVMGen|ManagedNativeLLVMGenPath)' -v
+	go test -count=1 -vet=off ./internal/backend -run 'Test(EmitLLVMIRTextPrefersNativeOwned|LLVMBackendEmitBinaryPrefersNativeOwned|UseNativeOwnedLLVMIR|LLVMBackendDispatchTraceReportsSelectedRoute|LLVMBackendMissingMIRDoesNotRetryLegacyIRBridge)' -v
 }
 
 require_exec "$host_bin" "host osty"
@@ -365,6 +372,8 @@ fi
 # (older host osty binaries). On a fresh build we promote the result
 # into both caches so the next ratchet hits the fast path.
 selfhostcache_hit=""
+cache_stage1_after_smoke=0
+install_selfhostcache_after_smoke=0
 if [[ "$reuse_stage1" == "1" ]]; then
 	if selfhostcache_hit="$(selfhostcache_check)" && [[ -n "$selfhostcache_hit" ]]; then
 		log "stage1: reuse selfhostcache $selfhostcache_hit"
@@ -372,18 +381,26 @@ if [[ "$reuse_stage1" == "1" ]]; then
 	elif [[ -x "$stage1_cache" ]] && stage1_cache_fresh; then
 		log "stage1: reuse cache $stage1_cache"
 		copy_override_binary "$stage1_cache" "$stage1" "osty-self-1 cache"
+		install_selfhostcache_after_smoke=1
 	else
 		[[ -x "$stage1_cache" ]] && log "stage1: cache stale; rebuild $stage1_cache"
 		build_self_binary "$host_bin" "stage1" "$stage1"
-		cache_stage1_binary "$stage1"
-		install_into_selfhostcache "$stage1"
+		cache_stage1_after_smoke=1
+		install_selfhostcache_after_smoke=1
 	fi
 else
 	build_self_binary "$host_bin" "stage1" "$stage1"
-	install_into_selfhostcache "$stage1"
+	install_selfhostcache_after_smoke=1
 fi
 
 smoke_self_driver "$stage1" "stage1"
+
+if [[ "$cache_stage1_after_smoke" == "1" ]]; then
+	cache_stage1_binary "$stage1"
+fi
+if [[ "$install_selfhostcache_after_smoke" == "1" ]]; then
+	install_into_selfhostcache "$stage1"
+fi
 
 if [[ "$mode" == "stage1" ]]; then
 	log "stage1-only complete: $stage1"


### PR DESCRIPTION
## Summary
- keep Stage0 audit runtime aliases linkable under ThinLTO and Darwin symbol prefixes
- add a direct ThinLTO link regression for Stage0 dotted runtime aliases, Char__len, and stderr
- refresh self-rebuild gate packages after the native llvmgen move and delay stage1 cache promotion until smoke passes

## Verification
- go test -count=1 -vet=off ./internal/backend -run 'Test(BundledRuntimeStage0AuditAliasesLinkWithThinLTO|Stage0ToolchainAudit)$' -v
- just verify-self-rebuild-gates
- shellcheck scripts/verify-self-rebuild
- git diff --check
