### PR TITLE
refactor: airepair semantic 리라이터 (append + enumerate) self-host

### DIFF
--- a/internal/airepair/semantic.go
+++ b/internal/airepair/semantic.go
@@ -20,8 +20,6 @@ import (
 	"github.com/osty/osty/internal/types"
 )
 
-const semanticIndentStep = "    "
-
 type semanticEdit struct {
 	start  int
 	end    int
@@ -118,78 +116,12 @@ func rewriteEnumerateLoopsForChecker(src []byte) ([]byte, []repair.Change, bool)
 }
 
 func rewriteEnumerateLoopHeader(line sourceLine, counter *int) (string, []repair.Change, bool) {
-	trimmed := line.trimmed
-	if !strings.HasPrefix(trimmed, "for ") || !strings.HasSuffix(trimmed, "{") {
+	r := runner.RewriteEnumerateLoopHeader(line.indent, line.trimmed, *counter)
+	if !r.Ok {
 		return "", nil, false
 	}
-	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "for "), "{"))
-	inIdx := strings.Index(body, " in ")
-	if inIdx <= 0 {
-		return "", nil, false
-	}
-
-	lhs := strings.TrimSpace(body[:inIdx])
-	rhs := strings.TrimSpace(body[inIdx+4:])
-	if !strings.HasSuffix(rhs, ".enumerate()") {
-		return "", nil, false
-	}
-	iterExpr := strings.TrimSpace(strings.TrimSuffix(rhs, ".enumerate()"))
-	if iterExpr == "" {
-		return "", nil, false
-	}
-
-	if strings.HasPrefix(lhs, "(") && strings.HasSuffix(lhs, ")") {
-		lhs = strings.TrimSpace(lhs[1 : len(lhs)-1])
-	}
-	parts := runner.SplitTopLevelComma(lhs)
-	if len(parts) != 2 {
-		return "", nil, false
-	}
-
-	indexBinding := strings.TrimSpace(parts[0])
-	valueBinding := strings.TrimSpace(parts[1])
-	if valueBinding == "" {
-		return "", nil, false
-	}
-
-	indexVar := indexBinding
-	switch {
-	case indexBinding == "_":
-		indexVar = fmt.Sprintf("_osty_index%d", *counter)
-	case runner.IsSimpleIdentifierBinding(indexBinding):
-		// use the original binding directly in the rewritten loop header.
-	default:
-		return "", nil, false
-	}
-
-	next := *counter
-	*counter = next + 1
-	iterTemp := fmt.Sprintf("_osty_enumerate%d", next)
-
-	bodyIndent := line.indent + semanticIndentStep
-	var out strings.Builder
-	out.WriteString(line.indent)
-	out.WriteString("let ")
-	out.WriteString(iterTemp)
-	out.WriteString(" = ")
-	out.WriteString(iterExpr)
-	out.WriteByte('\n')
-	out.WriteString(line.indent)
-	out.WriteString("for ")
-	out.WriteString(indexVar)
-	out.WriteString(" in 0..")
-	out.WriteString(iterTemp)
-	out.WriteString(".len() {\n")
-	out.WriteString(bodyIndent)
-	out.WriteString("let ")
-	out.WriteString(valueBinding)
-	out.WriteString(" = ")
-	out.WriteString(iterTemp)
-	out.WriteByte('[')
-	out.WriteString(indexVar)
-	out.WriteByte(']')
-
-	return out.String(), []repair.Change{
+	*counter = r.NextCounter
+	return r.Rewritten, []repair.Change{
 		{
 			Kind:    "enumerate_index_loop",
 			Message: "replace `.enumerate()` tuple loop with an indexed Osty loop the native checker can validate",
@@ -241,103 +173,19 @@ func rewriteSemanticAppendLines(src []byte) ([]byte, []repair.Change, bool) {
 }
 
 func rewriteAppendLine(line sourceLine) (string, []repair.Change, bool) {
-	trimmed := line.trimmed
-	if !strings.Contains(trimmed, "append(") {
+	r := runner.RewriteAppendLine(line.indent, line.trimmed)
+	if !r.Ok {
 		return "", nil, false
 	}
-
-	if rewritten, ok := rewriteLetAppendLine(line); ok {
-		return rewritten, []repair.Change{{
-			Kind:    "builtin_append_call",
-			Message: "replace foreign `append(...)` helper with Osty list mutation",
-			Pos: token.Pos{
-				Offset: line.start + len(line.indent),
-				Line:   line.lineNo,
-				Column: len([]rune(line.indent)) + 1,
-			},
-		}}, true
-	}
-	if rewritten, ok := rewriteSelfAssignAppendLine(line); ok {
-		return rewritten, []repair.Change{{
-			Kind:    "builtin_append_call",
-			Message: "replace foreign `append(...)` helper with Osty list mutation",
-			Pos: token.Pos{
-				Offset: line.start + len(line.indent),
-				Line:   line.lineNo,
-				Column: len([]rune(line.indent)) + 1,
-			},
-		}}, true
-	}
-	if rewritten, ok := rewriteStandaloneAppendLine(line); ok {
-		return rewritten, []repair.Change{{
-			Kind:    "builtin_append_call",
-			Message: "replace foreign `append(...)` helper with Osty list mutation",
-			Pos: token.Pos{
-				Offset: line.start + len(line.indent),
-				Line:   line.lineNo,
-				Column: len([]rune(line.indent)) + 1,
-			},
-		}}, true
-	}
-	return "", nil, false
-}
-
-func rewriteLetAppendLine(line sourceLine) (string, bool) {
-	trimmed := line.trimmed
-	if !strings.HasPrefix(trimmed, "let ") {
-		return "", false
-	}
-
-	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, "let "))
-	if strings.HasPrefix(rest, "mut ") {
-		rest = strings.TrimSpace(strings.TrimPrefix(rest, "mut "))
-	}
-	eqIdx := strings.Index(rest, " = ")
-	if eqIdx <= 0 {
-		return "", false
-	}
-
-	name := strings.TrimSpace(rest[:eqIdx])
-	rhs := strings.TrimSpace(rest[eqIdx+3:])
-	if !runner.IsSimpleIdentifierBinding(name) {
-		return "", false
-	}
-
-	parsed := runner.ParseAppendCall(rhs)
-	if !parsed.Ok || parsed.Base == name {
-		return "", false
-	}
-
-	return line.indent + "let mut " + name + " = " + parsed.Base + "\n" +
-		line.indent + name + ".push(" + parsed.Item + ")", true
-}
-
-func rewriteSelfAssignAppendLine(line sourceLine) (string, bool) {
-	trimmed := line.trimmed
-	eqIdx := strings.Index(trimmed, " = ")
-	if eqIdx <= 0 {
-		return "", false
-	}
-	lhs := strings.TrimSpace(trimmed[:eqIdx])
-	rhs := strings.TrimSpace(trimmed[eqIdx+3:])
-	if !runner.IsSimpleIdentifierBinding(lhs) {
-		return "", false
-	}
-
-	parsed := runner.ParseAppendCall(rhs)
-	if !parsed.Ok || parsed.Base != lhs {
-		return "", false
-	}
-
-	return line.indent + lhs + ".push(" + parsed.Item + ")", true
-}
-
-func rewriteStandaloneAppendLine(line sourceLine) (string, bool) {
-	parsed := runner.ParseAppendCall(line.trimmed)
-	if !parsed.Ok || !runner.IsSimpleIdentifierBinding(parsed.Base) {
-		return "", false
-	}
-	return line.indent + parsed.Base + ".push(" + parsed.Item + ")", true
+	return r.Rewritten, []repair.Change{{
+		Kind:    "builtin_append_call",
+		Message: "replace foreign `append(...)` helper with Osty list mutation",
+		Pos: token.Pos{
+			Offset: line.start + len(line.indent),
+			Line:   line.lineNo,
+			Column: len([]rune(line.indent)) + 1,
+		},
+	}}, true
 }
 
 func rewriteLengthProperties(src []byte) ([]byte, []repair.Change, bool) {

--- a/internal/runner/airepair_rewrite_policy.go
+++ b/internal/runner/airepair_rewrite_policy.go
@@ -3,7 +3,10 @@
 // the drift test in this package keeps the two in sync.
 package runner
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // AppendCallParse mirrors toolchain/airepair_rewrite.osty's
 // AppendCallParse. Empty Base/Item with Ok=false signals the
@@ -357,4 +360,191 @@ func RewriteForeignLoopHeader(trimmed string) ForeignLoopRewrite {
 		}
 	}
 	return ForeignLoopRewrite{}
+}
+
+// AppendLineRewrite mirrors toolchain/airepair_rewrite.osty's
+// AppendLineRewrite. Empty Rewritten with Ok=false means the line
+// is not a foreign `append(...)` shape this rewriter recognises.
+//
+// Osty: toolchain/airepair_rewrite.osty:411
+type AppendLineRewrite struct {
+	Rewritten string
+	Ok        bool
+}
+
+// RewriteLetAppendLine recognises `let xs = append(prev, x)` and
+// rewrites it to `let mut xs = prev` + `xs.push(x)`. Self-base
+// shapes (`let xs = append(xs, x)`) are rejected because the
+// shadowing `let mut` would break referential transparency.
+//
+// Osty: toolchain/airepair_rewrite.osty:421
+func RewriteLetAppendLine(indent, trimmed string) AppendLineRewrite {
+	if !strings.HasPrefix(trimmed, "let ") {
+		return AppendLineRewrite{}
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, "let "))
+	if strings.HasPrefix(rest, "mut ") {
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, "mut "))
+	}
+	eqIdx := strings.Index(rest, " = ")
+	if eqIdx <= 0 {
+		return AppendLineRewrite{}
+	}
+	name := strings.TrimSpace(rest[:eqIdx])
+	rhs := strings.TrimSpace(rest[eqIdx+3:])
+	if !IsSimpleIdentifierBinding(name) {
+		return AppendLineRewrite{}
+	}
+	parsed := ParseAppendCall(rhs)
+	if !parsed.Ok || parsed.Base == name {
+		return AppendLineRewrite{}
+	}
+	return AppendLineRewrite{
+		Rewritten: indent + "let mut " + name + " = " + parsed.Base + "\n" +
+			indent + name + ".push(" + parsed.Item + ")",
+		Ok: true,
+	}
+}
+
+// RewriteSelfAssignAppendLine recognises `xs = append(xs, item)`
+// and emits `xs.push(item)`. The `parsed.Base != lhs` check
+// rejects shapes like `xs = append(ys, item)` — those are a
+// binding swap, not a mutation.
+//
+// Osty: toolchain/airepair_rewrite.osty:451
+func RewriteSelfAssignAppendLine(indent, trimmed string) AppendLineRewrite {
+	eqIdx := strings.Index(trimmed, " = ")
+	if eqIdx <= 0 {
+		return AppendLineRewrite{}
+	}
+	lhs := strings.TrimSpace(trimmed[:eqIdx])
+	rhs := strings.TrimSpace(trimmed[eqIdx+3:])
+	if !IsSimpleIdentifierBinding(lhs) {
+		return AppendLineRewrite{}
+	}
+	parsed := ParseAppendCall(rhs)
+	if !parsed.Ok || parsed.Base != lhs {
+		return AppendLineRewrite{}
+	}
+	return AppendLineRewrite{
+		Rewritten: indent + lhs + ".push(" + parsed.Item + ")",
+		Ok:        true,
+	}
+}
+
+// RewriteStandaloneAppendLine recognises a bare expression
+// statement `append(xs, item)` and emits `xs.push(item)`. The
+// base must be a simple identifier so the rewrite stays a
+// side-effecting method call rather than a pure expression on a
+// temporary.
+//
+// Osty: toolchain/airepair_rewrite.osty:475
+func RewriteStandaloneAppendLine(indent, trimmed string) AppendLineRewrite {
+	parsed := ParseAppendCall(trimmed)
+	if !parsed.Ok || !IsSimpleIdentifierBinding(parsed.Base) {
+		return AppendLineRewrite{}
+	}
+	return AppendLineRewrite{
+		Rewritten: indent + parsed.Base + ".push(" + parsed.Item + ")",
+		Ok:        true,
+	}
+}
+
+// RewriteAppendLine is the dispatcher that asks each append-shape
+// rewriter in turn (let-binding -> self-assign -> bare statement).
+// Only fires on lines that mention `append(` to avoid running the
+// downstream parsers on plain Osty code.
+//
+// Osty: toolchain/airepair_rewrite.osty:491
+func RewriteAppendLine(indent, trimmed string) AppendLineRewrite {
+	if !strings.Contains(trimmed, "append(") {
+		return AppendLineRewrite{}
+	}
+	if r := RewriteLetAppendLine(indent, trimmed); r.Ok {
+		return r
+	}
+	if r := RewriteSelfAssignAppendLine(indent, trimmed); r.Ok {
+		return r
+	}
+	if r := RewriteStandaloneAppendLine(indent, trimmed); r.Ok {
+		return r
+	}
+	return AppendLineRewrite{}
+}
+
+// EnumerateLoopRewrite mirrors toolchain/airepair_rewrite.osty's
+// EnumerateLoopRewrite. NextCounter is the value the host should
+// thread into the next call (unchanged on reject so no name is
+// burned).
+//
+// Osty: toolchain/airepair_rewrite.osty:516
+type EnumerateLoopRewrite struct {
+	Rewritten   string
+	NextCounter int
+	Ok          bool
+}
+
+// airepairSemanticIndentStep mirrors the constant of the same name
+// in the Osty source — four spaces, the canonical body indent the
+// rewriter emits inside generated `for` blocks.
+//
+// Osty: toolchain/airepair_rewrite.osty:524
+const airepairSemanticIndentStep = "    "
+
+// RewriteEnumerateLoopHeader transforms a `for X.enumerate() {`
+// header into the indexed-loop shape the native checker can
+// validate end-to-end. Counter monotonically increments by one
+// per accepted rewrite; on reject the counter passes through
+// unchanged so the host can pass the same value to the next line.
+//
+// Osty: toolchain/airepair_rewrite.osty:540
+func RewriteEnumerateLoopHeader(indent, trimmed string, counter int) EnumerateLoopRewrite {
+	if !strings.HasPrefix(trimmed, "for ") || !strings.HasSuffix(trimmed, "{") {
+		return EnumerateLoopRewrite{NextCounter: counter}
+	}
+	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "for "), "{"))
+	inIdx := strings.Index(body, " in ")
+	if inIdx <= 0 {
+		return EnumerateLoopRewrite{NextCounter: counter}
+	}
+	lhs := strings.TrimSpace(body[:inIdx])
+	rhs := strings.TrimSpace(body[inIdx+4:])
+	if !strings.HasSuffix(rhs, ".enumerate()") {
+		return EnumerateLoopRewrite{NextCounter: counter}
+	}
+	iterExpr := strings.TrimSpace(strings.TrimSuffix(rhs, ".enumerate()"))
+	if iterExpr == "" {
+		return EnumerateLoopRewrite{NextCounter: counter}
+	}
+	if strings.HasPrefix(lhs, "(") && strings.HasSuffix(lhs, ")") {
+		lhs = strings.TrimSpace(lhs[1 : len(lhs)-1])
+	}
+	parts := SplitTopLevelComma(lhs)
+	if len(parts) != 2 {
+		return EnumerateLoopRewrite{NextCounter: counter}
+	}
+	indexBinding := strings.TrimSpace(parts[0])
+	valueBinding := strings.TrimSpace(parts[1])
+	if valueBinding == "" {
+		return EnumerateLoopRewrite{NextCounter: counter}
+	}
+	indexVar := indexBinding
+	switch {
+	case indexBinding == "_":
+		indexVar = fmt.Sprintf("_osty_index%d", counter)
+	case IsSimpleIdentifierBinding(indexBinding):
+		// keep the original binding
+	default:
+		return EnumerateLoopRewrite{NextCounter: counter}
+	}
+	iterTemp := fmt.Sprintf("_osty_enumerate%d", counter)
+	bodyIndent := indent + airepairSemanticIndentStep
+	rewritten := indent + "let " + iterTemp + " = " + iterExpr + "\n" +
+		indent + "for " + indexVar + " in 0.." + iterTemp + ".len() {\n" +
+		bodyIndent + "let " + valueBinding + " = " + iterTemp + "[" + indexVar + "]"
+	return EnumerateLoopRewrite{
+		Rewritten:   rewritten,
+		NextCounter: counter + 1,
+		Ok:          true,
+	}
 }

--- a/internal/runner/airepair_rewrite_policy_test.go
+++ b/internal/runner/airepair_rewrite_policy_test.go
@@ -214,6 +214,165 @@ func TestRewriteForeignLoopHeader(t *testing.T) {
 	}
 }
 
+func TestRewriteLetAppendLine(t *testing.T) {
+	cases := []struct {
+		name        string
+		indent      string
+		trimmed     string
+		ok          bool
+		want        string
+	}{
+		{"simple", "    ", "let xs = append(prev, x)", true, "    let mut xs = prev\n    xs.push(x)"},
+		{"mut-keyword", "", "let mut xs = append(prev, x)", true, "let mut xs = prev\nxs.push(x)"},
+		{"reject-self-base", "", "let xs = append(xs, x)", false, ""},
+		{"reject-non-append", "", "let xs = ys", false, ""},
+		{"reject-bad-name", "", "let 1xs = append(prev, x)", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewriteLetAppendLine(c.indent, c.trimmed)
+			if got.Ok != c.ok {
+				t.Errorf("RewriteLetAppendLine(%q).Ok = %v, want %v", c.trimmed, got.Ok, c.ok)
+			}
+			if got.Rewritten != c.want {
+				t.Errorf("RewriteLetAppendLine(%q).Rewritten = %q, want %q", c.trimmed, got.Rewritten, c.want)
+			}
+		})
+	}
+}
+
+func TestRewriteSelfAssignAppendLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		indent  string
+		trimmed string
+		ok      bool
+		want    string
+	}{
+		{"simple", "  ", "xs = append(xs, item)", true, "  xs.push(item)"},
+		{"reject-different-base", "", "xs = append(ys, item)", false, ""},
+		{"reject-non-append", "", "xs = something_else", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewriteSelfAssignAppendLine(c.indent, c.trimmed)
+			if got.Ok != c.ok {
+				t.Errorf("RewriteSelfAssignAppendLine(%q).Ok = %v, want %v", c.trimmed, got.Ok, c.ok)
+			}
+			if got.Rewritten != c.want {
+				t.Errorf("RewriteSelfAssignAppendLine(%q).Rewritten = %q, want %q", c.trimmed, got.Rewritten, c.want)
+			}
+		})
+	}
+}
+
+func TestRewriteStandaloneAppendLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		indent  string
+		trimmed string
+		ok      bool
+		want    string
+	}{
+		{"simple", "\t", "append(items, x)", true, "\titems.push(x)"},
+		{"reject-expression-base", "", "append(foo(), x)", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewriteStandaloneAppendLine(c.indent, c.trimmed)
+			if got.Ok != c.ok {
+				t.Errorf("RewriteStandaloneAppendLine(%q).Ok = %v, want %v", c.trimmed, got.Ok, c.ok)
+			}
+			if got.Rewritten != c.want {
+				t.Errorf("RewriteStandaloneAppendLine(%q).Rewritten = %q, want %q", c.trimmed, got.Rewritten, c.want)
+			}
+		})
+	}
+}
+
+func TestRewriteAppendLineDispatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		trimmed string
+		ok      bool
+		want    string
+	}{
+		{"let", "let xs = append(prev, x)", true, "let mut xs = prev\nxs.push(x)"},
+		{"self-assign", "xs = append(xs, x)", true, "xs.push(x)"},
+		{"standalone", "append(xs, x)", true, "xs.push(x)"},
+		{"skips-without-append", "let xs = ys", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewriteAppendLine("", c.trimmed)
+			if got.Ok != c.ok {
+				t.Errorf("RewriteAppendLine(%q).Ok = %v, want %v", c.trimmed, got.Ok, c.ok)
+			}
+			if got.Rewritten != c.want {
+				t.Errorf("RewriteAppendLine(%q).Rewritten = %q, want %q", c.trimmed, got.Rewritten, c.want)
+			}
+		})
+	}
+}
+
+func TestRewriteEnumerateLoopHeader(t *testing.T) {
+	cases := []struct {
+		name        string
+		indent      string
+		trimmed     string
+		counter     int
+		ok          bool
+		nextCounter int
+		want        string
+	}{
+		{
+			name: "bare-tuple", indent: "    ", trimmed: "for i, v in xs.enumerate() {",
+			counter: 0, ok: true, nextCounter: 1,
+			want: "    let _osty_enumerate0 = xs\n    for i in 0.._osty_enumerate0.len() {\n        let v = _osty_enumerate0[i]",
+		},
+		{
+			name: "paren-tuple", indent: "", trimmed: "for (i, v) in items.enumerate() {",
+			counter: 7, ok: true, nextCounter: 8,
+			want: "let _osty_enumerate7 = items\nfor i in 0.._osty_enumerate7.len() {\n    let v = _osty_enumerate7[i]",
+		},
+		{
+			name: "wildcard-index", indent: "", trimmed: "for _, v in xs.enumerate() {",
+			counter: 3, ok: true, nextCounter: 4,
+			want: "let _osty_enumerate3 = xs\nfor _osty_index3 in 0.._osty_enumerate3.len() {\n    let v = _osty_enumerate3[_osty_index3]",
+		},
+		{
+			name: "reject-bad-index-binding", indent: "", trimmed: "for foo(x), v in xs.enumerate() {",
+			counter: 0, ok: false, nextCounter: 0, want: "",
+		},
+		{
+			name: "reject-non-enumerate", indent: "", trimmed: "for i, v in xs {",
+			counter: 0, ok: false, nextCounter: 0, want: "",
+		},
+		{
+			name: "reject-empty-iterable", indent: "", trimmed: "for i, v in .enumerate() {",
+			counter: 0, ok: false, nextCounter: 0, want: "",
+		},
+		{
+			name: "reject-single-binding", indent: "", trimmed: "for i in xs.enumerate() {",
+			counter: 0, ok: false, nextCounter: 0, want: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewriteEnumerateLoopHeader(c.indent, c.trimmed, c.counter)
+			if got.Ok != c.ok {
+				t.Errorf("RewriteEnumerateLoopHeader(%q).Ok = %v, want %v", c.trimmed, got.Ok, c.ok)
+			}
+			if got.NextCounter != c.nextCounter {
+				t.Errorf("RewriteEnumerateLoopHeader(%q).NextCounter = %d, want %d", c.trimmed, got.NextCounter, c.nextCounter)
+			}
+			if got.Rewritten != c.want {
+				t.Errorf("RewriteEnumerateLoopHeader(%q).Rewritten =\n%q\nwant\n%q", c.trimmed, got.Rewritten, c.want)
+			}
+		})
+	}
+}
+
 func TestIsRewritableLengthTypeKind(t *testing.T) {
 	yes := []struct{ kind, name string }{
 		{"primitive", "String"},

--- a/toolchain/airepair_rewrite.osty
+++ b/toolchain/airepair_rewrite.osty
@@ -397,3 +397,178 @@ pub fn rewriteForeignLoopHeader(trimmed: String) -> ForeignLoopRewrite {
     }
     ForeignLoopRewrite {rewritten: "", kind: "", message: "", ok: false}
 }
+/// AppendLineRewrite is the outcome of any of the per-shape
+/// `append(base, item)` line rewriters. `ok == false` leaves
+/// `rewritten` empty and signals "this line is not a foreign
+/// `append` call I recognise — try a different shape or fall back
+/// to the original source".
+pub struct AppendLineRewrite {
+    pub rewritten: String,
+    pub ok: Bool,
+}
+/// rewriteLetAppendLine recognises a foreign-style binding like
+/// `let xs = append(prev, x)` and rewrites it to the Osty pair
+/// `let mut xs = prev` + `xs.push(x)`. The `let mut` shadowing is
+/// only emitted when `prev` differs from `xs` — otherwise it would
+/// shadow the binding being mutated and break referential
+/// transparency for callers that depend on the prior value.
+pub fn rewriteLetAppendLine(indent: String, trimmed: String) -> AppendLineRewrite {
+    if !strings.hasPrefix(trimmed, "let ") {
+        return AppendLineRewrite {rewritten: "", ok: false}
+    }
+    let mut rest = strings.trimSpace(strings.trimPrefix(trimmed, "let "))
+    if strings.hasPrefix(rest, "mut ") {
+        rest = strings.trimSpace(strings.trimPrefix(rest, "mut "))
+    }
+    let eqIdx = airepairByteIndexOf(rest, " = ")
+    if eqIdx <= 0 {
+        return AppendLineRewrite {rewritten: "", ok: false}
+    }
+    let name = strings.trimSpace(strings.slice(rest, 0, eqIdx))
+    let rhs = strings.trimSpace(strings.slice(rest, eqIdx + 3, rest.len()))
+    if !isSimpleIdentifierBinding(name) {
+        return AppendLineRewrite {rewritten: "", ok: false}
+    }
+    let parsed = parseAppendCall(rhs)
+    if !parsed.ok || parsed.base == name {
+        return AppendLineRewrite {rewritten: "", ok: false}
+    }
+    AppendLineRewrite {
+        rewritten: indent + "let mut " + name + " = " + parsed.base + "\n" + indent + name + ".push(" + parsed.item + ")",
+        ok: true,
+    }
+}
+/// rewriteSelfAssignAppendLine recognises `xs = append(xs, item)`
+/// (re-assignment of the same binding) and emits `xs.push(item)`.
+/// The `parsed.base != lhs` check rejects shapes like
+/// `xs = append(ys, item)` — those are a binding swap, not a
+/// mutation, and Osty's `.push` would silently discard `ys`.
+pub fn rewriteSelfAssignAppendLine(indent: String, trimmed: String) -> AppendLineRewrite {
+    let eqIdx = airepairByteIndexOf(trimmed, " = ")
+    if eqIdx <= 0 {
+        return AppendLineRewrite {rewritten: "", ok: false}
+    }
+    let lhs = strings.trimSpace(strings.slice(trimmed, 0, eqIdx))
+    let rhs = strings.trimSpace(strings.slice(trimmed, eqIdx + 3, trimmed.len()))
+    if !isSimpleIdentifierBinding(lhs) {
+        return AppendLineRewrite {rewritten: "", ok: false}
+    }
+    let parsed = parseAppendCall(rhs)
+    if !parsed.ok || parsed.base != lhs {
+        return AppendLineRewrite {rewritten: "", ok: false}
+    }
+    AppendLineRewrite {
+        rewritten: indent + lhs + ".push(" + parsed.item + ")",
+        ok: true,
+    }
+}
+/// rewriteStandaloneAppendLine recognises a bare expression
+/// statement `append(xs, item)` (no binding, no assignment) and
+/// emits `xs.push(item)`. The base must be a simple identifier so
+/// the rewrite stays a side-effecting method call rather than a
+/// pure expression on a temporary.
+pub fn rewriteStandaloneAppendLine(indent: String, trimmed: String) -> AppendLineRewrite {
+    let parsed = parseAppendCall(trimmed)
+    if !parsed.ok || !isSimpleIdentifierBinding(parsed.base) {
+        return AppendLineRewrite {rewritten: "", ok: false}
+    }
+    AppendLineRewrite {
+        rewritten: indent + parsed.base + ".push(" + parsed.item + ")",
+        ok: true,
+    }
+}
+/// rewriteAppendLine is the dispatcher that asks each append-shape
+/// rewriter in turn (let-binding -> self-assign -> bare statement).
+/// Only fires on lines that mention `append(` to avoid running the
+/// downstream parsers on plain Osty code.
+pub fn rewriteAppendLine(indent: String, trimmed: String) -> AppendLineRewrite {
+    if !strings.contains(trimmed, "append(") {
+        return AppendLineRewrite {rewritten: "", ok: false}
+    }
+    let letCase = rewriteLetAppendLine(indent, trimmed)
+    if letCase.ok {
+        return letCase
+    }
+    let selfCase = rewriteSelfAssignAppendLine(indent, trimmed)
+    if selfCase.ok {
+        return selfCase
+    }
+    let standalone = rewriteStandaloneAppendLine(indent, trimmed)
+    if standalone.ok {
+        return standalone
+    }
+    AppendLineRewrite {rewritten: "", ok: false}
+}
+/// EnumerateLoopRewrite is the outcome of the
+/// `for (i, v) in xs.enumerate() \{` -> indexed-loop rewriter. The
+/// rewriter mints fresh `_osty_enumerate\{N\}` and `_osty_index\{N\}`
+/// names from a counter the host threads through; `nextCounter` is
+/// the value the host should pass on the next call.
+pub struct EnumerateLoopRewrite {
+    pub rewritten: String,
+    pub nextCounter: Int,
+    pub ok: Bool,
+}
+/// airepairSemanticIndentStep is the canonical body indent the
+/// rewriter emits inside generated `for` blocks — four spaces, to
+/// match the existing Osty formatter style.
+let airepairSemanticIndentStep: String = "    "
+/// rewriteEnumerateLoopHeader transforms a `for X.enumerate() \{`
+/// header into the indexed-loop shape the native checker can
+/// validate end-to-end. The new shape pre-binds the iterable to
+/// `_osty_enumerate\{N\}`, walks `0..len()`, and projects the value
+/// out via `iter[i]` so the body's `valueBinding` reads from a
+/// concrete subscript instead of a tuple destructure the checker
+/// hasn't grown.
+///
+/// `_` index bindings are replaced with a fresh `_osty_index\{N\}`
+/// so the generated code can still reference the index inside the
+/// `let value = iter[index]` projection. Counter monotonically
+/// increments by one per accepted rewrite.
+///
+/// On reject, `nextCounter` is returned unchanged so the host can
+/// pass the same value to the next line without burning a name.
+pub fn rewriteEnumerateLoopHeader(indent: String, trimmed: String, counter: Int) -> EnumerateLoopRewrite {
+    if !strings.hasPrefix(trimmed, "for ") || !strings.hasSuffix(trimmed, "\{") {
+        return EnumerateLoopRewrite {rewritten: "", nextCounter: counter, ok: false}
+    }
+    let withoutFor = strings.trimPrefix(trimmed, "for ")
+    let body = strings.trimSpace(strings.trimSuffix(withoutFor, "\{"))
+    let inIdx = airepairByteIndexOf(body, " in ")
+    if inIdx <= 0 {
+        return EnumerateLoopRewrite {rewritten: "", nextCounter: counter, ok: false}
+    }
+    let mut lhs = strings.trimSpace(strings.slice(body, 0, inIdx))
+    let rhs = strings.trimSpace(strings.slice(body, inIdx + 4, body.len()))
+    if !strings.hasSuffix(rhs, ".enumerate()") {
+        return EnumerateLoopRewrite {rewritten: "", nextCounter: counter, ok: false}
+    }
+    let iterExpr = strings.trimSpace(strings.trimSuffix(rhs, ".enumerate()"))
+    if iterExpr == "" {
+        return EnumerateLoopRewrite {rewritten: "", nextCounter: counter, ok: false}
+    }
+    if strings.hasPrefix(lhs, "(") && strings.hasSuffix(lhs, ")") {
+        lhs = strings.trimSpace(strings.slice(lhs, 1, lhs.len() - 1))
+    }
+    let parts = splitTopLevelComma(lhs)
+    if parts.len() != 2 {
+        return EnumerateLoopRewrite {rewritten: "", nextCounter: counter, ok: false}
+    }
+    let indexBinding = strings.trimSpace(parts[0])
+    let valueBinding = strings.trimSpace(parts[1])
+    if valueBinding == "" {
+        return EnumerateLoopRewrite {rewritten: "", nextCounter: counter, ok: false}
+    }
+    let mut indexVar = indexBinding
+    if indexBinding == "_" {
+        indexVar = "_osty_index{counter}"
+    } else if !isSimpleIdentifierBinding(indexBinding) {
+        return EnumerateLoopRewrite {rewritten: "", nextCounter: counter, ok: false}
+    }
+    let iterTemp = "_osty_enumerate{counter}"
+    let bodyIndent = indent + airepairSemanticIndentStep
+    let rewritten = indent + "let " + iterTemp + " = " + iterExpr + "\n" +
+        indent + "for " + indexVar + " in 0.." + iterTemp + ".len() \{\n" +
+        bodyIndent + "let " + valueBinding + " = " + iterTemp + "[" + indexVar + "]"
+    EnumerateLoopRewrite {rewritten: rewritten, nextCounter: counter + 1, ok: true}
+}

--- a/toolchain/airepair_rewrite_test.osty
+++ b/toolchain/airepair_rewrite_test.osty
@@ -241,3 +241,104 @@ fn testRewriteForeignLoopHeaderUnknown() {
     testing.assert(!(r.ok))
     testing.assertEq(r.kind, "")
 }
+fn testRewriteLetAppendLineSimple() {
+    let r = rewriteLetAppendLine("    ", "let xs = append(prev, x)")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "    let mut xs = prev\n    xs.push(x)")
+}
+fn testRewriteLetAppendLineMutKeyword() {
+    let r = rewriteLetAppendLine("", "let mut xs = append(prev, x)")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "let mut xs = prev\nxs.push(x)")
+}
+fn testRewriteLetAppendLineRejectsSelfBase() {
+    let r = rewriteLetAppendLine("", "let xs = append(xs, x)")
+    testing.assert(!(r.ok))
+}
+fn testRewriteLetAppendLineRejectsNonAppend() {
+    let r = rewriteLetAppendLine("", "let xs = ys")
+    testing.assert(!(r.ok))
+}
+fn testRewriteLetAppendLineRejectsBadName() {
+    let r = rewriteLetAppendLine("", "let 1xs = append(prev, x)")
+    testing.assert(!(r.ok))
+}
+fn testRewriteSelfAssignAppendLineSimple() {
+    let r = rewriteSelfAssignAppendLine("  ", "xs = append(xs, item)")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "  xs.push(item)")
+}
+fn testRewriteSelfAssignAppendLineRejectsDifferentBase() {
+    let r = rewriteSelfAssignAppendLine("", "xs = append(ys, item)")
+    testing.assert(!(r.ok))
+}
+fn testRewriteSelfAssignAppendLineRejectsNonAppend() {
+    let r = rewriteSelfAssignAppendLine("", "xs = something_else")
+    testing.assert(!(r.ok))
+}
+fn testRewriteStandaloneAppendLineSimple() {
+    let r = rewriteStandaloneAppendLine("\t", "append(items, x)")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "\titems.push(x)")
+}
+fn testRewriteStandaloneAppendLineRejectsExpressionBase() {
+    let r = rewriteStandaloneAppendLine("", "append(foo(), x)")
+    testing.assert(!(r.ok))
+}
+fn testRewriteAppendLineDispatchesToLet() {
+    let r = rewriteAppendLine("", "let xs = append(prev, x)")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "let mut xs = prev\nxs.push(x)")
+}
+fn testRewriteAppendLineDispatchesToSelfAssign() {
+    let r = rewriteAppendLine("", "xs = append(xs, x)")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "xs.push(x)")
+}
+fn testRewriteAppendLineDispatchesToStandalone() {
+    let r = rewriteAppendLine("", "append(xs, x)")
+    testing.assert(r.ok)
+    testing.assertEq(r.rewritten, "xs.push(x)")
+}
+fn testRewriteAppendLineSkipsLinesWithoutAppendCall() {
+    let r = rewriteAppendLine("", "let xs = ys")
+    testing.assert(!(r.ok))
+}
+fn testRewriteEnumerateLoopHeaderBareTuple() {
+    let r = rewriteEnumerateLoopHeader("    ", "for i, v in xs.enumerate() \{", 0)
+    testing.assert(r.ok)
+    testing.assertEq(r.nextCounter, 1)
+    testing.assertEq(r.rewritten, "    let _osty_enumerate0 = xs\n    for i in 0.._osty_enumerate0.len() \{\n        let v = _osty_enumerate0[i]")
+}
+fn testRewriteEnumerateLoopHeaderParenTuple() {
+    let r = rewriteEnumerateLoopHeader("", "for (i, v) in items.enumerate() \{", 7)
+    testing.assert(r.ok)
+    testing.assertEq(r.nextCounter, 8)
+    testing.assertEq(r.rewritten, "let _osty_enumerate7 = items\nfor i in 0.._osty_enumerate7.len() \{\n    let v = _osty_enumerate7[i]")
+}
+fn testRewriteEnumerateLoopHeaderWildcardIndex() {
+    let r = rewriteEnumerateLoopHeader("", "for _, v in xs.enumerate() \{", 3)
+    testing.assert(r.ok)
+    testing.assertEq(r.nextCounter, 4)
+    testing.assertEq(r.rewritten, "let _osty_enumerate3 = xs\nfor _osty_index3 in 0.._osty_enumerate3.len() \{\n    let v = _osty_enumerate3[_osty_index3]")
+}
+fn testRewriteEnumerateLoopHeaderRejectsBadIndexBinding() {
+    let r = rewriteEnumerateLoopHeader("", "for foo(x), v in xs.enumerate() \{", 0)
+    testing.assert(!(r.ok))
+    testing.assertEq(r.nextCounter, 0)
+}
+fn testRewriteEnumerateLoopHeaderRejectsNonEnumerate() {
+    let r = rewriteEnumerateLoopHeader("", "for i, v in xs \{", 0)
+    testing.assert(!(r.ok))
+    testing.assertEq(r.nextCounter, 0)
+}
+fn testRewriteEnumerateLoopHeaderRejectsEmptyIterable() {
+    let r = rewriteEnumerateLoopHeader("", "for i, v in .enumerate() \{", 0)
+    testing.assert(!(r.ok))
+    testing.assertEq(r.nextCounter, 0)
+}
+fn testRewriteEnumerateLoopHeaderRejectsSingleBinding() {
+    let r = rewriteEnumerateLoopHeader("", "for i in xs.enumerate() \{", 0)
+    testing.assert(!(r.ok))
+    testing.assertEq(r.nextCounter, 0)
+}


### PR DESCRIPTION
## Summary

PR #1751 / #1752의 마무리. `internal/airepair/semantic.go`에 남아있던
마지막 순수-정책 리라이터 5개를 `toolchain/airepair_rewrite.osty`로
이전. Go 측 wrapper는 host-only한 일 (Change.Pos 계산, sourceLine
splitting, source-edit application)만 담당.

이전된 함수:

- `rewriteLetAppendLine(indent, trimmed)` — `let xs = append(prev, x)`
  → `let mut xs = prev` + `xs.push(x)` (단, `xs == prev`면 reject —
  shadowing이 referential transparency 깬다)
- `rewriteSelfAssignAppendLine(indent, trimmed)` —
  `xs = append(xs, item)` → `xs.push(item)` (base가 lhs와 다르면
  reject, binding swap 방지)
- `rewriteStandaloneAppendLine(indent, trimmed)` — bare expression
  statement `append(xs, item)` → `xs.push(item)`
- `rewriteAppendLine(indent, trimmed)` — 위 셋 디스패처. `append(`
  포함 안 한 라인은 빠르게 reject
- `rewriteEnumerateLoopHeader(indent, trimmed, counter)` —
  `for i, v in xs.enumerate() {` →
  `let _osty_enumerate{N} = xs` + `for i in 0..len()` +
  `let v = iter[i]` (네이티브 체커가 검증할 수 있는 인덱스-기반 루프)

## 설계 노트

- **mut counter → 값 전달**: Osty는 host의 `*int` 같은 mut 포인터가
  없으므로 `EnumerateLoopRewrite { rewritten, nextCounter, ok }`로
  명시. host가 nextCounter를 다음 호출에 넘긴다. reject 시 counter
  pass-through (이름 burn 방지)
- **`semanticIndentStep` 상수 이동**: Go의 `const semanticIndentStep
  = "    "`는 Osty `let airepairSemanticIndentStep: String = "    "`로
  옮기고 Go 쪽 상수는 삭제 (이제 Osty 리라이터 안에서만 쓰임)
- **Go wrapper 축소**: 원래 ~220줄짜리 함수 5개 → 17줄짜리 wrapper
  2개. host는 Pos 계산 + Kind/Message 상수만 채운다

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/airepair/... ./internal/runner/...` —
      pass (drift test 포함, 8개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run 'TestAIRepair*|TestFmtAIRepair*|TestFmtRunsSemantic*'` —
      pass (8.3s)
- [x] `go vet ./internal/airepair/... ./internal/runner/...` — clean

## 셀프호스팅 진척 (이 PR 시리즈 누적)

| | PR #1751 | PR #1752 | 본 PR |
|---|---|---|---|
| `toolchain/airepair_rewrite.osty` lines | 154 | 400 | 575 |
| pure helpers/structs self-hosted | 4+1 | 9+4 | 14+6 |
| `internal/airepair/` 정책 줄수 (cumulative net) | -115 | -150 | -180 |

`internal/airepair/`는 이제 정책-free. `splitSourceLines`,
`isIgnorablePythonLine`, source-edit application,
`validLengthFieldOffsets` (selfhost API 통합), pattern walker 같은
host-only 일만 남는다.

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_