### PR TITLE
[codex] keep MIR cache helpers in stage0 subset

### DIFF
--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -2166,7 +2166,7 @@ pub struct MirLayoutCache {
         true
     }
     pub fn isEmpty(self) -> Bool {
-        self.enumLayoutOrder.isEmpty() && self.tupleOrder.isEmpty()
+        self.enumLayoutOrder.len() == 0 && self.tupleOrder.len() == 0
     }
 }
 /// enumLayoutOrder records enum-shaped type names in first-use
@@ -2293,7 +2293,7 @@ pub struct MirRuntimeDecls {
     pub names: List<String>,
     pub signatures: Map<String, String>,
     pub fn declare(mut self, name: String, signature: String) -> Bool {
-        if self.signatures.containsKey(name) {
+        if listContainsString(self.names, name) {
             return false
         }
         self.signatures.insert(name, signature)
@@ -2311,7 +2311,7 @@ pub struct MirRuntimeDecls {
         out
     }
     pub fn isEmpty(self) -> Bool {
-        self.names.isEmpty()
+        self.names.len() == 0
     }
 }
 /// names is the insertion-ordered list of declared runtime
@@ -2378,7 +2378,7 @@ pub struct MirStringPool {
         self.order
     }
     pub fn isEmpty(self) -> Bool {
-        self.order.isEmpty()
+        self.order.len() == 0
     }
 }
 /// byContent maps the literal content (the raw bytes between the
@@ -2425,10 +2425,10 @@ pub struct MirThunkDefs {
     pub bodies: Map<String, String>,
     pub order: List<String>,
     pub fn contains(self, symbol: String) -> Bool {
-        self.bodies.containsKey(symbol)
+        listContainsString(self.order, symbol)
     }
     pub fn register(mut self, symbol: String, body: String) -> Bool {
-        if self.bodies.containsKey(symbol) {
+        if self.contains(symbol) {
             return false
         }
         self.bodies.insert(symbol, body)
@@ -2446,7 +2446,7 @@ pub struct MirThunkDefs {
         out
     }
     pub fn isEmpty(self) -> Bool {
-        self.order.isEmpty()
+        self.order.len() == 0
     }
 }
 /// bodies maps the user-fn symbol (e.g. `main_renderReport`)
@@ -2501,7 +2501,7 @@ pub struct MirVtableRefs {
     pub seen: Map<String, Bool>,
     pub order: List<String>,
     pub fn register(mut self, symbol: String) -> Bool {
-        if self.seen.containsKey(symbol) {
+        if self.contains(symbol) {
             return false
         }
         self.seen.insert(symbol, true)
@@ -2509,13 +2509,13 @@ pub struct MirVtableRefs {
         true
     }
     pub fn contains(self, symbol: String) -> Bool {
-        self.seen.containsKey(symbol)
+        listContainsString(self.order, symbol)
     }
     pub fn orderedSymbols(self) -> List<String> {
         self.order
     }
     pub fn isEmpty(self) -> Bool {
-        self.order.isEmpty()
+        self.order.len() == 0
     }
 }
 /// seen tracks distinct `@osty.vtable.<impl>__<iface>` symbols


### PR DESCRIPTION
## Summary
- keep MIR generator cache helpers inside the stage0-friendly subset
- replace field Map.containsKey/List.isEmpty helper bodies with insertion-order list membership and len() checks
- moves no-list-all stage0 fallback from MirRuntimeDecls/MirThunkDefs decline to linked stage1 doctor

## Verification
- OSTY_STAGE0_FALLBACK=1 bash scripts/verify-self-rebuild --skip-gates --stage1-only .bin/osty (builds osty-self, then expected doctor failure at phase 0 body emission)
- just verify-self-rebuild-gates
- git diff --check

## Notes
- just fmt-check currently fails on pre-existing gofmt drift in internal/airepair/foreign_loops.go, internal/resolve/cfg.go, and internal/runner/airepair_rewrite_policy_test.go; this PR edits only toolchain/mir_generator.osty.
