### PR TITLE
refactor: airepair source-parsing + 4개 src-trigger predicate self-host

### DIFF
--- a/internal/airepair/diagnostic.go
+++ b/internal/airepair/diagnostic.go
@@ -1,23 +1,18 @@
 package airepair
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/repair"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/token"
 )
 
-type sourceLine struct {
-	start      int
-	text       string
-	raw        string
-	indent     string
-	trimmed    string
-	hasNewline bool
-	lineNo     int
-}
+// sourceLine aliases runner.SourceLine so the internal call sites
+// can keep using a short, package-local name. The struct shape and
+// field meanings are owned by toolchain/airepair_source.osty.
+type sourceLine = runner.SourceLine
 
 type pythonScopeKind int
 
@@ -57,19 +52,11 @@ func diagnosticGuidedSource(src []byte, diags []*diag.Diagnostic) repair.Result 
 }
 
 func wantsPythonColonBlockRepair(src []byte, diags []*diag.Diagnostic) bool {
-	if !bytes.Contains(src, []byte(":\n")) {
-		return false
-	}
-	for _, d := range diags {
-		if d != nil && d.Severity == diag.Error {
-			return true
-		}
-	}
-	return false
+	return runner.SrcWantsPythonColonBlockRepair(src) && diagsHaveError(diags)
 }
 
 func rewritePythonColonBlocks(src []byte) ([]byte, []repair.Change, bool) {
-	lines := splitSourceLines(src)
+	lines := runner.SplitSourceLines(src)
 	if len(lines) == 0 {
 		return src, nil, false
 	}
@@ -82,8 +69,8 @@ func rewritePythonColonBlocks(src []byte) ([]byte, []repair.Change, bool) {
 	)
 
 	for _, line := range lines {
-		if line.trimmed == "" || isIgnorablePythonLine(line.trimmed) {
-			out.WriteString(line.raw)
+		if line.Trimmed == "" || runner.IsIgnorablePythonLine(line.Trimmed) {
+			out.WriteString(line.Raw)
 			continue
 		}
 
@@ -91,12 +78,12 @@ func rewritePythonColonBlocks(src []byte) ([]byte, []repair.Change, bool) {
 			closings []pythonBlockScope
 			ok       bool
 		)
-		stack, closings, ok = preparePythonBlockClosings(stack, line.indent)
+		stack, closings, ok = preparePythonBlockClosings(stack, line.Indent)
 		if !ok {
 			return src, nil, false
 		}
 
-		header, headerOK := rewritePythonColonHeader(line.trimmed)
+		header, headerOK := rewritePythonColonHeader(line.Trimmed)
 		if headerOK && header.elseish {
 			headerOK = len(closings) > 0 && closings[len(closings)-1].kind == pythonScopeBlock
 		}
@@ -106,27 +93,27 @@ func rewritePythonColonBlocks(src []byte) ([]byte, []repair.Change, bool) {
 		if headerOK {
 			writePythonClosings(&out, closings, !header.elseish)
 			if header.elseish && len(closings) > 0 {
-				out.WriteString(line.indent)
+				out.WriteString(line.Indent)
 				out.WriteString("} ")
 				out.WriteString(header.rewritten)
 			} else {
-				out.WriteString(line.indent)
+				out.WriteString(line.Indent)
 				out.WriteString(header.rewritten)
 			}
-			if line.hasNewline {
+			if line.HasNewline {
 				out.WriteByte('\n')
 			}
 			stack = append(stack, pythonBlockScope{
 				kind:         header.scopeKind,
-				headerIndent: line.indent,
+				headerIndent: line.Indent,
 			})
 			changes = append(changes, repair.Change{
 				Kind:    header.changeKind,
 				Message: header.message,
 				Pos: token.Pos{
-					Offset: line.start + len(line.indent),
-					Line:   line.lineNo,
-					Column: len([]rune(line.indent)) + 1,
+					Offset: line.Start + len(line.Indent),
+					Line:   line.LineNo,
+					Column: len([]rune(line.Indent)) + 1,
 				},
 			})
 			changed = true
@@ -134,7 +121,7 @@ func rewritePythonColonBlocks(src []byte) ([]byte, []repair.Change, bool) {
 		}
 
 		writePythonClosings(&out, closings, true)
-		out.WriteString(line.raw)
+		out.WriteString(line.Raw)
 	}
 
 	for i := len(stack) - 1; i >= 0; i-- {
@@ -157,49 +144,17 @@ func rewritePythonColonBlocks(src []byte) ([]byte, []repair.Change, bool) {
 	return []byte(out.String()), changes, true
 }
 
-func splitSourceLines(src []byte) []sourceLine {
-	if len(src) == 0 {
-		return nil
+// diagsHaveError reports whether `diags` carries at least one
+// error-severity entry. Shared by every `wantsXxxRepair` host
+// wrapper around the corresponding `runner.SrcWantsXxxRepair`
+// pure-source predicate.
+func diagsHaveError(diags []*diag.Diagnostic) bool {
+	for _, d := range diags {
+		if d != nil && d.Severity == diag.Error {
+			return true
+		}
 	}
-	var lines []sourceLine
-	start := 0
-	lineNo := 1
-	for start < len(src) {
-		end := start
-		for end < len(src) && src[end] != '\n' {
-			end++
-		}
-		rawEnd := end
-		hasNewline := false
-		if end < len(src) && src[end] == '\n' {
-			rawEnd = end + 1
-			hasNewline = true
-		}
-		text := string(src[start:end])
-		indentEnd := 0
-		for indentEnd < len(text) {
-			if text[indentEnd] != ' ' && text[indentEnd] != '\t' {
-				break
-			}
-			indentEnd++
-		}
-		lines = append(lines, sourceLine{
-			start:      start,
-			text:       text,
-			raw:        string(src[start:rawEnd]),
-			indent:     text[:indentEnd],
-			trimmed:    strings.TrimSpace(text),
-			hasNewline: hasNewline,
-			lineNo:     lineNo,
-		})
-		start = rawEnd
-		lineNo++
-	}
-	return lines
-}
-
-func isIgnorablePythonLine(trimmed string) bool {
-	return strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#")
+	return false
 }
 
 func preparePythonBlockClosings(stack []pythonBlockScope, indent string) ([]pythonBlockScope, []pythonBlockScope, bool) {

--- a/internal/airepair/foreign_loops.go
+++ b/internal/airepair/foreign_loops.go
@@ -1,7 +1,6 @@
 package airepair
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/osty/osty/internal/diag"
@@ -25,22 +24,11 @@ func diagnosticForeignLoopSource(src []byte, diags []*diag.Diagnostic) repair.Re
 }
 
 func wantsForeignLoopRepair(src []byte, diags []*diag.Diagnostic) bool {
-	if !bytes.Contains(src, []byte("for ")) {
-		return false
-	}
-	if !bytes.Contains(src, []byte(" of ")) && !bytes.Contains(src, []byte("range(")) && !bytes.Contains(src, []byte("enumerate(")) {
-		return false
-	}
-	for _, d := range diags {
-		if d != nil && d.Severity == diag.Error {
-			return true
-		}
-	}
-	return false
+	return runner.SrcWantsForeignLoopRepair(src) && diagsHaveError(diags)
 }
 
 func rewriteForeignLoopHeaders(src []byte) ([]byte, []repair.Change, bool) {
-	lines := splitSourceLines(src)
+	lines := runner.SplitSourceLines(src)
 	if len(lines) == 0 {
 		return src, nil, false
 	}
@@ -52,29 +40,29 @@ func rewriteForeignLoopHeaders(src []byte) ([]byte, []repair.Change, bool) {
 	)
 
 	for _, line := range lines {
-		if line.trimmed == "" || isIgnorablePythonLine(line.trimmed) {
-			out.WriteString(line.raw)
+		if line.Trimmed == "" || runner.IsIgnorablePythonLine(line.Trimmed) {
+			out.WriteString(line.Raw)
 			continue
 		}
 
-		r := runner.RewriteForeignLoopHeader(line.trimmed)
+		r := runner.RewriteForeignLoopHeader(line.Trimmed)
 		if !r.Ok {
-			out.WriteString(line.raw)
+			out.WriteString(line.Raw)
 			continue
 		}
 
-		out.WriteString(line.indent)
+		out.WriteString(line.Indent)
 		out.WriteString(r.Rewritten)
-		if line.hasNewline {
+		if line.HasNewline {
 			out.WriteByte('\n')
 		}
 		changes = append(changes, repair.Change{
 			Kind:    r.Kind,
 			Message: r.Message,
 			Pos: token.Pos{
-				Offset: line.start + len(line.indent),
-				Line:   line.lineNo,
-				Column: len([]rune(line.indent)) + 1,
+				Offset: line.Start + len(line.Indent),
+				Line:   line.LineNo,
+				Column: len([]rune(line.Indent)) + 1,
 			},
 		})
 		changed = true

--- a/internal/airepair/semantic.go
+++ b/internal/airepair/semantic.go
@@ -62,22 +62,11 @@ func diagnosticSemanticSource(src []byte, diags []*diag.Diagnostic) repair.Resul
 }
 
 func wantsSemanticRepair(src []byte, diags []*diag.Diagnostic) bool {
-	if !bytes.Contains(src, []byte(".enumerate()")) &&
-		!bytes.Contains(src, []byte("append(")) &&
-		!bytes.Contains(src, []byte("len(")) &&
-		!bytes.Contains(src, []byte(".length")) {
-		return false
-	}
-	for _, d := range diags {
-		if d != nil && d.Severity == diag.Error {
-			return true
-		}
-	}
-	return false
+	return runner.SrcWantsSemanticRepair(src) && diagsHaveError(diags)
 }
 
 func rewriteEnumerateLoopsForChecker(src []byte) ([]byte, []repair.Change, bool) {
-	lines := splitSourceLines(src)
+	lines := runner.SplitSourceLines(src)
 	if len(lines) == 0 {
 		return src, nil, false
 	}
@@ -90,19 +79,19 @@ func rewriteEnumerateLoopsForChecker(src []byte) ([]byte, []repair.Change, bool)
 	)
 
 	for _, line := range lines {
-		if line.trimmed == "" || isIgnorablePythonLine(line.trimmed) {
-			out.WriteString(line.raw)
+		if line.Trimmed == "" || runner.IsIgnorablePythonLine(line.Trimmed) {
+			out.WriteString(line.Raw)
 			continue
 		}
 
 		rewritten, changeSet, ok := rewriteEnumerateLoopHeader(line, &counter)
 		if !ok {
-			out.WriteString(line.raw)
+			out.WriteString(line.Raw)
 			continue
 		}
 
 		out.WriteString(rewritten)
-		if line.hasNewline && !strings.HasSuffix(rewritten, "\n") {
+		if line.HasNewline && !strings.HasSuffix(rewritten, "\n") {
 			out.WriteByte('\n')
 		}
 		changes = append(changes, changeSet...)
@@ -116,7 +105,7 @@ func rewriteEnumerateLoopsForChecker(src []byte) ([]byte, []repair.Change, bool)
 }
 
 func rewriteEnumerateLoopHeader(line sourceLine, counter *int) (string, []repair.Change, bool) {
-	r := runner.RewriteEnumerateLoopHeader(line.indent, line.trimmed, *counter)
+	r := runner.RewriteEnumerateLoopHeader(line.Indent, line.Trimmed, *counter)
 	if !r.Ok {
 		return "", nil, false
 	}
@@ -126,16 +115,16 @@ func rewriteEnumerateLoopHeader(line sourceLine, counter *int) (string, []repair
 			Kind:    "enumerate_index_loop",
 			Message: "replace `.enumerate()` tuple loop with an indexed Osty loop the native checker can validate",
 			Pos: token.Pos{
-				Offset: line.start + len(line.indent),
-				Line:   line.lineNo,
-				Column: len([]rune(line.indent)) + 1,
+				Offset: line.Start + len(line.Indent),
+				Line:   line.LineNo,
+				Column: len([]rune(line.Indent)) + 1,
 			},
 		},
 	}, true
 }
 
 func rewriteSemanticAppendLines(src []byte) ([]byte, []repair.Change, bool) {
-	lines := splitSourceLines(src)
+	lines := runner.SplitSourceLines(src)
 	if len(lines) == 0 {
 		return src, nil, false
 	}
@@ -147,19 +136,19 @@ func rewriteSemanticAppendLines(src []byte) ([]byte, []repair.Change, bool) {
 	)
 
 	for _, line := range lines {
-		if line.trimmed == "" || isIgnorablePythonLine(line.trimmed) {
-			out.WriteString(line.raw)
+		if line.Trimmed == "" || runner.IsIgnorablePythonLine(line.Trimmed) {
+			out.WriteString(line.Raw)
 			continue
 		}
 
 		rewritten, changeSet, ok := rewriteAppendLine(line)
 		if !ok {
-			out.WriteString(line.raw)
+			out.WriteString(line.Raw)
 			continue
 		}
 
 		out.WriteString(rewritten)
-		if line.hasNewline && !strings.HasSuffix(rewritten, "\n") {
+		if line.HasNewline && !strings.HasSuffix(rewritten, "\n") {
 			out.WriteByte('\n')
 		}
 		changes = append(changes, changeSet...)
@@ -173,7 +162,7 @@ func rewriteSemanticAppendLines(src []byte) ([]byte, []repair.Change, bool) {
 }
 
 func rewriteAppendLine(line sourceLine) (string, []repair.Change, bool) {
-	r := runner.RewriteAppendLine(line.indent, line.trimmed)
+	r := runner.RewriteAppendLine(line.Indent, line.Trimmed)
 	if !r.Ok {
 		return "", nil, false
 	}
@@ -181,9 +170,9 @@ func rewriteAppendLine(line sourceLine) (string, []repair.Change, bool) {
 		Kind:    "builtin_append_call",
 		Message: "replace foreign `append(...)` helper with Osty list mutation",
 		Pos: token.Pos{
-			Offset: line.start + len(line.indent),
-			Line:   line.lineNo,
-			Column: len([]rune(line.indent)) + 1,
+			Offset: line.Start + len(line.Indent),
+			Line:   line.LineNo,
+			Column: len([]rune(line.Indent)) + 1,
 		},
 	}}, true
 }

--- a/internal/airepair/tuple_loop.go
+++ b/internal/airepair/tuple_loop.go
@@ -1,7 +1,6 @@
 package airepair
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/osty/osty/internal/diag"
@@ -25,19 +24,11 @@ func diagnosticTupleLoopSource(src []byte, diags []*diag.Diagnostic) repair.Resu
 }
 
 func wantsTupleLoopRepair(src []byte, diags []*diag.Diagnostic) bool {
-	if !bytes.Contains(src, []byte("for ")) || !bytes.Contains(src, []byte(",")) || !bytes.Contains(src, []byte(" in ")) {
-		return false
-	}
-	for _, d := range diags {
-		if d != nil && d.Severity == diag.Error {
-			return true
-		}
-	}
-	return false
+	return runner.SrcWantsTupleLoopRepair(src) && diagsHaveError(diags)
 }
 
 func rewriteBareTupleForHeaders(src []byte) ([]byte, []repair.Change, bool) {
-	lines := splitSourceLines(src)
+	lines := runner.SplitSourceLines(src)
 	if len(lines) == 0 {
 		return src, nil, false
 	}
@@ -49,29 +40,29 @@ func rewriteBareTupleForHeaders(src []byte) ([]byte, []repair.Change, bool) {
 	)
 
 	for _, line := range lines {
-		if line.trimmed == "" || isIgnorablePythonLine(line.trimmed) {
-			out.WriteString(line.raw)
+		if line.Trimmed == "" || runner.IsIgnorablePythonLine(line.Trimmed) {
+			out.WriteString(line.Raw)
 			continue
 		}
 
-		rewritten, ok := rewriteBareTupleForHeader(line.trimmed)
+		rewritten, ok := rewriteBareTupleForHeader(line.Trimmed)
 		if !ok {
-			out.WriteString(line.raw)
+			out.WriteString(line.Raw)
 			continue
 		}
 
-		out.WriteString(line.indent)
+		out.WriteString(line.Indent)
 		out.WriteString(rewritten)
-		if line.hasNewline {
+		if line.HasNewline {
 			out.WriteByte('\n')
 		}
 		changes = append(changes, repair.Change{
 			Kind:    "tuple_loop_pattern",
 			Message: "wrap a bare tuple loop binding in Osty tuple-pattern syntax",
 			Pos: token.Pos{
-				Offset: line.start + len(line.indent),
-				Line:   line.lineNo,
-				Column: len([]rune(line.indent)) + 1,
+				Offset: line.Start + len(line.Indent),
+				Line:   line.LineNo,
+				Column: len([]rune(line.Indent)) + 1,
 			},
 		})
 		changed = true

--- a/internal/runner/airepair_source_policy.go
+++ b/internal/runner/airepair_source_policy.go
@@ -1,0 +1,129 @@
+// airepair_source_policy.go is the Go snapshot of
+// toolchain/airepair_source.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import (
+	"bytes"
+	"strings"
+)
+
+// SourceLine mirrors toolchain/airepair_source.osty's SourceLine.
+// Field order matches the Osty struct so the drift test can
+// confirm parity.
+//
+// Osty: toolchain/airepair_source.osty:34
+type SourceLine struct {
+	Start      int
+	Text       string
+	Raw        string
+	Indent     string
+	Trimmed    string
+	HasNewline bool
+	LineNo     int
+}
+
+// SplitSourceLines walks `src` byte-by-byte and produces one
+// SourceLine per line, splitting on `\n`. Empty input returns
+// nil. The last line is reported even when it has no trailing
+// newline (with HasNewline=false).
+//
+// Indent extraction only counts ASCII space (0x20) and tab
+// (0x09); other whitespace bytes are left in the body.
+//
+// Osty: toolchain/airepair_source.osty:50
+func SplitSourceLines(src []byte) []SourceLine {
+	if len(src) == 0 {
+		return nil
+	}
+	var lines []SourceLine
+	start := 0
+	lineNo := 1
+	for start < len(src) {
+		end := start
+		for end < len(src) && src[end] != '\n' {
+			end++
+		}
+		rawEnd := end
+		hasNewline := false
+		if end < len(src) && src[end] == '\n' {
+			rawEnd = end + 1
+			hasNewline = true
+		}
+		text := string(src[start:end])
+		indentEnd := 0
+		for indentEnd < len(text) {
+			if text[indentEnd] != ' ' && text[indentEnd] != '\t' {
+				break
+			}
+			indentEnd++
+		}
+		lines = append(lines, SourceLine{
+			Start:      start,
+			Text:       text,
+			Raw:        string(src[start:rawEnd]),
+			Indent:     text[:indentEnd],
+			Trimmed:    strings.TrimSpace(text),
+			HasNewline: hasNewline,
+			LineNo:     lineNo,
+		})
+		start = rawEnd
+		lineNo++
+	}
+	return lines
+}
+
+// IsIgnorablePythonLine reports whether a `trimmed` source line
+// is "noise" the dispatchers should skip with a verbatim copy.
+// The two recognised noise prefixes are line comments (`//`) and
+// Python-style `#` lines.
+//
+// Osty: toolchain/airepair_source.osty:97
+func IsIgnorablePythonLine(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#")
+}
+
+// SrcWantsForeignLoopRepair reports whether `src` contains any
+// of the byte markers the foreign-loop rewriter knows how to
+// transform.
+//
+// Osty: toolchain/airepair_source.osty:103
+func SrcWantsForeignLoopRepair(src []byte) bool {
+	if !bytes.Contains(src, []byte("for ")) {
+		return false
+	}
+	return bytes.Contains(src, []byte(" of ")) ||
+		bytes.Contains(src, []byte("range(")) ||
+		bytes.Contains(src, []byte("enumerate("))
+}
+
+// SrcWantsSemanticRepair reports whether `src` contains any of
+// the byte markers the semantic rewriter family needs.
+//
+// Osty: toolchain/airepair_source.osty:114
+func SrcWantsSemanticRepair(src []byte) bool {
+	return bytes.Contains(src, []byte(".enumerate()")) ||
+		bytes.Contains(src, []byte("append(")) ||
+		bytes.Contains(src, []byte("len(")) ||
+		bytes.Contains(src, []byte(".length"))
+}
+
+// SrcWantsTupleLoopRepair reports whether `src` looks like it
+// might contain a bare-tuple `for` header. Requires all three of
+// `for `, `,`, and ` in `.
+//
+// Osty: toolchain/airepair_source.osty:124
+func SrcWantsTupleLoopRepair(src []byte) bool {
+	return bytes.Contains(src, []byte("for ")) &&
+		bytes.Contains(src, []byte(",")) &&
+		bytes.Contains(src, []byte(" in "))
+}
+
+// SrcWantsPythonColonBlockRepair reports whether `src` contains
+// the `:\n` byte sequence — the universal marker for
+// Python-style colon-terminated block headers.
+//
+// Osty: toolchain/airepair_source.osty:134
+func SrcWantsPythonColonBlockRepair(src []byte) bool {
+	return bytes.Contains(src, []byte(":\n"))
+}

--- a/internal/runner/airepair_source_policy_test.go
+++ b/internal/runner/airepair_source_policy_test.go
@@ -1,0 +1,153 @@
+package runner
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitSourceLinesEmpty(t *testing.T) {
+	if got := SplitSourceLines(nil); got != nil {
+		t.Errorf("SplitSourceLines(nil) = %#v, want nil", got)
+	}
+	if got := SplitSourceLines([]byte("")); got != nil {
+		t.Errorf("SplitSourceLines(empty) = %#v, want nil", got)
+	}
+}
+
+func TestSplitSourceLinesSingleNoNewline(t *testing.T) {
+	got := SplitSourceLines([]byte("hello"))
+	want := []SourceLine{
+		{Start: 0, Text: "hello", Raw: "hello", Indent: "", Trimmed: "hello", HasNewline: false, LineNo: 1},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SplitSourceLines(\"hello\") = %#v, want %#v", got, want)
+	}
+}
+
+func TestSplitSourceLinesTwoLines(t *testing.T) {
+	got := SplitSourceLines([]byte("first\nsecond\n"))
+	want := []SourceLine{
+		{Start: 0, Text: "first", Raw: "first\n", Indent: "", Trimmed: "first", HasNewline: true, LineNo: 1},
+		{Start: 6, Text: "second", Raw: "second\n", Indent: "", Trimmed: "second", HasNewline: true, LineNo: 2},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SplitSourceLines mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestSplitSourceLinesNoTrailingNewline(t *testing.T) {
+	got := SplitSourceLines([]byte("a\nb"))
+	if len(got) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(got))
+	}
+	if !got[0].HasNewline {
+		t.Errorf("line 0 should have newline")
+	}
+	if got[1].HasNewline {
+		t.Errorf("line 1 should not have newline")
+	}
+	if got[1].Raw != "b" {
+		t.Errorf("line 1 raw = %q, want %q", got[1].Raw, "b")
+	}
+}
+
+func TestSplitSourceLinesPreservesIndent(t *testing.T) {
+	got := SplitSourceLines([]byte("    indented\n\tboth\n  no_tab"))
+	if got[0].Indent != "    " {
+		t.Errorf("line 0 indent = %q, want 4 spaces", got[0].Indent)
+	}
+	if got[0].Trimmed != "indented" {
+		t.Errorf("line 0 trimmed = %q", got[0].Trimmed)
+	}
+	if got[1].Indent != "\t" {
+		t.Errorf("line 1 indent = %q, want tab", got[1].Indent)
+	}
+	if got[2].Indent != "  " {
+		t.Errorf("line 2 indent = %q, want 2 spaces", got[2].Indent)
+	}
+}
+
+func TestSplitSourceLinesBlankLine(t *testing.T) {
+	got := SplitSourceLines([]byte("a\n\nb\n"))
+	if len(got) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(got))
+	}
+	if got[1].Text != "" || got[1].Trimmed != "" {
+		t.Errorf("middle blank line not blank: %#v", got[1])
+	}
+	if !got[1].HasNewline {
+		t.Errorf("middle blank line should still have newline")
+	}
+}
+
+func TestIsIgnorablePythonLine(t *testing.T) {
+	yes := []string{"// just a comment", "//", "#!/usr/bin/env python", "# coding: utf-8"}
+	for _, in := range yes {
+		if !IsIgnorablePythonLine(in) {
+			t.Errorf("IsIgnorablePythonLine(%q) = false, want true", in)
+		}
+	}
+	no := []string{"let x = 1", "for i in xs:", "", "x // y"}
+	for _, in := range no {
+		if IsIgnorablePythonLine(in) {
+			t.Errorf("IsIgnorablePythonLine(%q) = true, want false", in)
+		}
+	}
+}
+
+func TestSrcWantsForeignLoopRepair(t *testing.T) {
+	yes := []string{"for (item of items) {", "for i in range(10) {", "for i, v in enumerate(xs) {"}
+	for _, in := range yes {
+		if !SrcWantsForeignLoopRepair([]byte(in)) {
+			t.Errorf("SrcWantsForeignLoopRepair(%q) = false, want true", in)
+		}
+	}
+	no := []string{"for i in xs {", "range(10)", ""}
+	for _, in := range no {
+		if SrcWantsForeignLoopRepair([]byte(in)) {
+			t.Errorf("SrcWantsForeignLoopRepair(%q) = true, want false", in)
+		}
+	}
+}
+
+func TestSrcWantsSemanticRepair(t *testing.T) {
+	yes := []string{"xs.enumerate()", "append(xs, 1)", "len(xs)", "xs.length"}
+	for _, in := range yes {
+		if !SrcWantsSemanticRepair([]byte(in)) {
+			t.Errorf("SrcWantsSemanticRepair(%q) = false, want true", in)
+		}
+	}
+	no := []string{"let x = 1", "xs.push(1)"}
+	for _, in := range no {
+		if SrcWantsSemanticRepair([]byte(in)) {
+			t.Errorf("SrcWantsSemanticRepair(%q) = true, want false", in)
+		}
+	}
+}
+
+func TestSrcWantsTupleLoopRepair(t *testing.T) {
+	if !SrcWantsTupleLoopRepair([]byte("for k, v in m {")) {
+		t.Errorf("SrcWantsTupleLoopRepair on bare tuple = false")
+	}
+	no := []string{"for x in xs {", "for k, v", "k, v in m", ""}
+	for _, in := range no {
+		if SrcWantsTupleLoopRepair([]byte(in)) {
+			t.Errorf("SrcWantsTupleLoopRepair(%q) = true, want false", in)
+		}
+	}
+}
+
+func TestSrcWantsPythonColonBlockRepair(t *testing.T) {
+	yes := []string{"if x:\n    y", "for i in xs:\n    pass"}
+	for _, in := range yes {
+		if !SrcWantsPythonColonBlockRepair([]byte(in)) {
+			t.Errorf("SrcWantsPythonColonBlockRepair(%q) = false, want true", in)
+		}
+	}
+	no := []string{"if x: y", "type T: Int", ""}
+	for _, in := range no {
+		if SrcWantsPythonColonBlockRepair([]byte(in)) {
+			t.Errorf("SrcWantsPythonColonBlockRepair(%q) = true, want false", in)
+		}
+	}
+}

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -39,6 +39,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"runner.osty",
 		"airepair_flags.osty",
 		"airepair_rewrite.osty",
+		"airepair_source.osty",
 		"profile_flags.osty",
 		"diag_policy.osty",
 		"test_runner.osty",

--- a/toolchain/airepair_source.osty
+++ b/toolchain/airepair_source.osty
@@ -1,0 +1,146 @@
+/// Source-parsing utilities + per-rewriter src-trigger predicates
+/// shared by every airepair dispatcher (foreign-loop, semantic,
+/// tuple-loop, python-colon-block).
+///
+/// Host code (internal/airepair/*.go) owns the diag.Severity check
+/// and the per-line orchestration loop; this module decides:
+///
+///   - how to split a source byte stream into `SourceLine` records
+///     with byte offsets, indent prefixes, trimmed bodies, and
+///     trailing-newline flags;
+///   - which trimmed lines are "noise" the rewriters should skip
+///     verbatim (line comments and Python `#` shebangs / shebang
+///     blocks);
+///   - which byte markers in the source are necessary for each
+///     rewriter family to even bother running (the cheap
+///     pre-flight that lets us avoid the diag scan when there's
+///     nothing to repair).
+///
+/// Mirrored by `internal/runner/airepair_source_policy.go`. The
+/// drift test under internal/runner keeps the two in sync — the
+/// Osty file is the source of truth at review time.
+use std.strings as strings
+/// SourceLine is one line in the source byte stream. Field shapes
+/// match what the rewriter dispatchers consume:
+///
+///   - `start`: byte offset of the first byte in this line
+///     (relative to the original source). Carried so the host can
+///     compute the diag `Pos.Offset` for any `repair.Change`.
+///   - `text`: line body without the trailing newline.
+///   - `raw`: line body **with** any trailing newline still
+///     attached. Rewriters that bail on this line `out.write(raw)`
+///     to preserve byte-perfect round-tripping.
+///   - `indent`: leading whitespace prefix (tabs + spaces only).
+///   - `trimmed`: `text` with leading/trailing whitespace removed.
+///   - `hasNewline`: whether `raw` ends with `\n`.
+///   - `lineNo`: 1-based line number for diag positions.
+pub struct SourceLine {
+    pub start: Int,
+    pub text: String,
+    pub raw: String,
+    pub indent: String,
+    pub trimmed: String,
+    pub hasNewline: Bool,
+    pub lineNo: Int,
+}
+/// splitSourceLines walks `src` byte-by-byte and produces one
+/// `SourceLine` per line, splitting on `\n`. Empty input returns
+/// an empty list. The last line is reported even when it has no
+/// trailing newline (with `hasNewline = false`).
+///
+/// Byte semantics matter: the rewriters reach back into `src` via
+/// `start` offsets, so this function preserves byte boundaries
+/// exactly. Indent extraction only counts ASCII space (0x20) and
+/// tab (0x09); other whitespace bytes are left in the body so the
+/// caller's classifier (e.g. `isIgnorablePythonLine`) sees them.
+pub fn splitSourceLines(src: String) -> List<SourceLine> {
+    let mut lines: List<SourceLine> = []
+    let bs = src.bytes()
+    let n = bs.len()
+    if n == 0 {
+        return lines
+    }
+    let mut start = 0
+    let mut lineNo = 1
+    for start < n {
+        let mut end = start
+        for end < n && bs[end].toInt() != 0x0A {
+            end = end + 1
+        }
+        let mut rawEnd = end
+        let mut hasNewline = false
+        if end < n && bs[end].toInt() == 0x0A {
+            rawEnd = end + 1
+            hasNewline = true
+        }
+        let text = strings.slice(src, start, end)
+        let textBs = text.bytes()
+        let textN = textBs.len()
+        let mut indentEnd = 0
+        for indentEnd < textN {
+            let b = textBs[indentEnd].toInt()
+            if b != 0x20 && b != 0x09 {
+                break
+            }
+            indentEnd = indentEnd + 1
+        }
+        lines.push(SourceLine {
+            start: start,
+            text: text,
+            raw: strings.slice(src, start, rawEnd),
+            indent: strings.slice(text, 0, indentEnd),
+            trimmed: strings.trimSpace(text),
+            hasNewline: hasNewline,
+            lineNo: lineNo,
+        })
+        start = rawEnd
+        lineNo = lineNo + 1
+    }
+    lines
+}
+/// isIgnorablePythonLine reports whether a `trimmed` source line
+/// is "noise" the dispatchers should skip with a verbatim copy.
+/// The two recognised noise prefixes are line comments (`//`) and
+/// Python-style `#` lines (shebangs, `# -*- coding -*-`, etc.).
+pub fn isIgnorablePythonLine(trimmed: String) -> Bool {
+    strings.hasPrefix(trimmed, "//") || strings.hasPrefix(trimmed, "#")
+}
+/// srcWantsForeignLoopRepair reports whether `src` contains any
+/// of the byte markers the foreign-loop rewriter knows how to
+/// transform. Cheap pre-flight — the dispatcher uses this to
+/// decide whether to scan the diag list at all.
+pub fn srcWantsForeignLoopRepair(src: String) -> Bool {
+    if !strings.contains(src, "for ") {
+        return false
+    }
+    strings.contains(src, " of ") ||
+        strings.contains(src, "range(") ||
+        strings.contains(src, "enumerate(")
+}
+/// srcWantsSemanticRepair reports whether `src` contains any of
+/// the byte markers the semantic rewriter family needs (foreign
+/// `append(...)`, `.enumerate()` tuple loops, builtin `len(...)`
+/// calls, foreign `.length` field accesses).
+pub fn srcWantsSemanticRepair(src: String) -> Bool {
+    strings.contains(src, ".enumerate()") ||
+        strings.contains(src, "append(") ||
+        strings.contains(src, "len(") ||
+        strings.contains(src, ".length")
+}
+/// srcWantsTupleLoopRepair reports whether `src` looks like it
+/// might contain a bare-tuple `for` header (e.g. `for k, v in m
+/// {`). Requires all three of `for `, `,`, and ` in ` — without
+/// any one of those the bare-tuple shape is impossible.
+pub fn srcWantsTupleLoopRepair(src: String) -> Bool {
+    strings.contains(src, "for ") &&
+        strings.contains(src, ",") &&
+        strings.contains(src, " in ")
+}
+/// srcWantsPythonColonBlockRepair reports whether `src` contains
+/// the `:\n` byte sequence — the only universal marker for
+/// Python-style colon-terminated block headers. Does not need to
+/// distinguish `if:`/`for:`/`def:`/etc; the per-header rewriter
+/// rejects shapes it cannot translate.
+pub fn srcWantsPythonColonBlockRepair(src: String) -> Bool {
+    strings.contains(src, ":\n")
+}

--- a/toolchain/airepair_source_test.osty
+++ b/toolchain/airepair_source_test.osty
@@ -1,0 +1,104 @@
+use std.testing
+fn testSplitSourceLinesEmpty() {
+    let lines = splitSourceLines("")
+    testing.assertEq(lines.len(), 0)
+}
+fn testSplitSourceLinesSingleNoNewline() {
+    let lines = splitSourceLines("hello")
+    testing.assertEq(lines.len(), 1)
+    let line = lines[0]
+    testing.assertEq(line.start, 0)
+    testing.assertEq(line.text, "hello")
+    testing.assertEq(line.raw, "hello")
+    testing.assertEq(line.indent, "")
+    testing.assertEq(line.trimmed, "hello")
+    testing.assert(!(line.hasNewline))
+    testing.assertEq(line.lineNo, 1)
+}
+fn testSplitSourceLinesTwoLines() {
+    let lines = splitSourceLines("first\nsecond\n")
+    testing.assertEq(lines.len(), 2)
+    testing.assertEq(lines[0].text, "first")
+    testing.assertEq(lines[0].raw, "first\n")
+    testing.assertEq(lines[0].lineNo, 1)
+    testing.assert(lines[0].hasNewline)
+    testing.assertEq(lines[1].text, "second")
+    testing.assertEq(lines[1].raw, "second\n")
+    testing.assertEq(lines[1].lineNo, 2)
+    testing.assert(lines[1].hasNewline)
+    testing.assertEq(lines[1].start, 6)
+}
+fn testSplitSourceLinesNoTrailingNewline() {
+    let lines = splitSourceLines("a\nb")
+    testing.assertEq(lines.len(), 2)
+    testing.assert(lines[0].hasNewline)
+    testing.assert(!(lines[1].hasNewline))
+    testing.assertEq(lines[1].raw, "b")
+}
+fn testSplitSourceLinesPreservesIndent() {
+    let lines = splitSourceLines("    indented\n\tboth\n  no_tab")
+    testing.assertEq(lines[0].indent, "    ")
+    testing.assertEq(lines[0].trimmed, "indented")
+    testing.assertEq(lines[1].indent, "\t")
+    testing.assertEq(lines[1].trimmed, "both")
+    testing.assertEq(lines[2].indent, "  ")
+    testing.assertEq(lines[2].trimmed, "no_tab")
+}
+fn testSplitSourceLinesBlankLine() {
+    let lines = splitSourceLines("a\n\nb\n")
+    testing.assertEq(lines.len(), 3)
+    testing.assertEq(lines[1].text, "")
+    testing.assertEq(lines[1].trimmed, "")
+    testing.assert(lines[1].hasNewline)
+}
+fn testIsIgnorablePythonLineComment() {
+    testing.assert(isIgnorablePythonLine("// just a comment"))
+    testing.assert(isIgnorablePythonLine("//"))
+}
+fn testIsIgnorablePythonLineHash() {
+    testing.assert(isIgnorablePythonLine("#!/usr/bin/env python"))
+    testing.assert(isIgnorablePythonLine("# coding: utf-8"))
+}
+fn testIsIgnorablePythonLineRejectsCode() {
+    testing.assert(!(isIgnorablePythonLine("let x = 1")))
+    testing.assert(!(isIgnorablePythonLine("for i in xs:")))
+    testing.assert(!(isIgnorablePythonLine("")))
+    testing.assert(!(isIgnorablePythonLine("x // y")))
+}
+fn testSrcWantsForeignLoopRepairAccepts() {
+    testing.assert(srcWantsForeignLoopRepair("for (item of items) \{"))
+    testing.assert(srcWantsForeignLoopRepair("for i in range(10) \{"))
+    testing.assert(srcWantsForeignLoopRepair("for i, v in enumerate(xs) \{"))
+}
+fn testSrcWantsForeignLoopRepairRejectsMissingMarkers() {
+    testing.assert(!(srcWantsForeignLoopRepair("for i in xs \{")))
+    testing.assert(!(srcWantsForeignLoopRepair("range(10)")))
+    testing.assert(!(srcWantsForeignLoopRepair("")))
+}
+fn testSrcWantsSemanticRepairEachMarker() {
+    testing.assert(srcWantsSemanticRepair("xs.enumerate()"))
+    testing.assert(srcWantsSemanticRepair("append(xs, 1)"))
+    testing.assert(srcWantsSemanticRepair("len(xs)"))
+    testing.assert(srcWantsSemanticRepair("xs.length"))
+}
+fn testSrcWantsSemanticRepairRejectsClean() {
+    testing.assert(!(srcWantsSemanticRepair("let x = 1")))
+    testing.assert(!(srcWantsSemanticRepair("xs.push(1)")))
+}
+fn testSrcWantsTupleLoopRepairAccepts() {
+    testing.assert(srcWantsTupleLoopRepair("for k, v in m \{"))
+}
+fn testSrcWantsTupleLoopRepairRejectsMissingMarker() {
+    testing.assert(!(srcWantsTupleLoopRepair("for x in xs \{")))
+    testing.assert(!(srcWantsTupleLoopRepair("for k, v")))
+    testing.assert(!(srcWantsTupleLoopRepair("k, v in m")))
+}
+fn testSrcWantsPythonColonBlockRepairAccepts() {
+    testing.assert(srcWantsPythonColonBlockRepair("if x:\n    y"))
+    testing.assert(srcWantsPythonColonBlockRepair("for i in xs:\n    pass"))
+}
+fn testSrcWantsPythonColonBlockRepairRejectsMissingNewline() {
+    testing.assert(!(srcWantsPythonColonBlockRepair("if x: y")))
+    testing.assert(!(srcWantsPythonColonBlockRepair("type T: Int")))
+    testing.assert(!(srcWantsPythonColonBlockRepair("")))
+}


### PR DESCRIPTION
## Summary

PR #1751 / #1752 / #1755의 마무리. `internal/airepair/` 4개 파일이
공유하던 source parsing utility와 4개 src-trigger predicate를
새 `toolchain/airepair_source.osty`로 이전. Go는 1줄짜리 wrapper와
host-only한 일 (diag severity 검사, source-edit 적용, AST walker 등)만
담당.

이전된 정책 (총 6개 함수 + 1개 struct):

- `SourceLine { start, text, raw, indent, trimmed, hasNewline, lineNo }`
  — 4개 dispatcher가 공유하던 per-line 레코드. byte 오프셋 + indent +
  trailing-newline 플래그까지 정확히 보존
- `splitSourceLines(src) -> List<SourceLine>` — byte-stream을 `\n`
  기준으로 분해. trailing newline 없는 마지막 라인도 지원. indent는
  ASCII space (0x20) / tab (0x09)만 카운트
- `isIgnorablePythonLine(trimmed) -> Bool` — `//` / `#` prefix 노이즈
  필터
- `srcWantsForeignLoopRepair(src) -> Bool` — `for ` + (` of ` |
  `range(` | `enumerate(`) byte-marker 검사
- `srcWantsSemanticRepair(src) -> Bool` — `.enumerate()` | `append(`
  | `len(` | `.length` 검사
- `srcWantsTupleLoopRepair(src) -> Bool` — `for ` + `,` + ` in `
  3중 마커 검사
- `srcWantsPythonColonBlockRepair(src) -> Bool` — `:\n` 단일 마커

## Go 측 변화

- 4개 `wantsXxxRepair` 함수가 모두 1줄짜리 wrapper로 축소:
  ```go
  func wantsXxxRepair(src []byte, diags []*diag.Diagnostic) bool {
      return runner.SrcWantsXxxRepair(src) && diagsHaveError(diags)
  }
  ```
- 새 `diagsHaveError(diags) bool` host helper로 4개 wrapper의
  diag.Severity 검사 중복 제거
- `internal/airepair/sourceLine` private struct는 `type sourceLine =
  runner.SourceLine` alias로 유지 (4개 파일이 짧은 이름 그대로 쓸 수
  있게). 모든 필드 access는 PascalCase로 일괄 rename
- `splitSourceLines` / `isIgnorablePythonLine` Go 정의 삭제,
  `runner.SplitSourceLines` / `runner.IsIgnorablePythonLine` 호출로
  교체
- `bytes` import 3개 파일에서 제거 (`bytes.Contains` 호출이 모두
  runner 측으로 옮겨감)

## `internal/airepair/`는 정책-free 상태 도달

이 PR로 airepair 전체 self-host 마이그레이션이 마무리됨:

| 영역 | Osty 파일 | self-hosted |
|---|---|---|
| CLI 플래그 정책 | airepair_flags.osty | 4개 fn + 2개 struct |
| 라인-레벨 리라이터 | airepair_rewrite.osty | 14개 fn + 6개 struct |
| Source 파싱 + trigger | airepair_source.osty | 6개 fn + 1개 struct |

Go 측에 남는 것은 모두 host-boundary 일:
- source-edit application (`applySemanticEdits`)
- AST walker (`walkFieldExprs`)
- `repair.Change` Pos 계산
- selfhost lex/check 파이프라인 wiring (`validLengthFieldOffsets`)
- file I/O / CLI dispatch glue

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/airepair/... ./internal/runner/...` —
      pass (drift test 포함, 9개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run 'TestAIRepair*|TestFmtAIRepair*|TestFmtRunsSemantic*'` —
      pass (8.2s)
- [x] `go vet ./internal/airepair/... ./internal/runner/...` — clean

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_