### PR TITLE
refactor: formatter use-sort + chain-break 정책 self-host

### DIFF
--- a/internal/format/printer.go
+++ b/internal/format/printer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -110,47 +111,33 @@ func (p *printer) printFile(f *ast.File) {
 	})
 }
 
-// useGroupOrder bins a use decl into the canonical group order:
-// 0 = stdlib (`std.*`), 1 = external (everything else that's not
-// FFI), 2 = FFI.
+// useGroupOrder bins a use decl into the canonical group order.
+// Policy lives in toolchain/format_policy.osty; this wrapper just
+// extracts the primitive inputs the policy needs.
 func useGroupOrder(u *ast.UseDecl) int {
-	if u.IsFFI() {
-		return 2
+	firstSeg := ""
+	if len(u.Path) > 0 {
+		firstSeg = u.Path[0]
 	}
-	if len(u.Path) > 0 && u.Path[0] == "std" {
-		return 0
-	}
-	return 1
+	return runner.UseGroupOrder(u.IsFFI(), firstSeg)
 }
 
-// useSortKey is the intra-group sort key — the RawPath when set
-// (preserves github.com/... style), otherwise the dotted path.
+// useSortKey is the intra-group sort key for `use` decls. Policy
+// lives in toolchain/format_policy.osty.
 func useSortKey(u *ast.UseDecl) string {
+	ffiPath := ""
 	if u.IsFFI() {
-		return u.FFIPath()
+		ffiPath = u.FFIPath()
 	}
-	if u.RawPath != "" {
-		return u.RawPath
-	}
-	return strings.Join(u.Path, ".")
+	return runner.UseSortKey(u.IsFFI(), ffiPath, u.RawPath, strings.Join(u.Path, "."))
 }
 
-// useCSurfaceLibName recognizes a runtime FFI path of the form
-// `runtime.cabi.<lib>` (single trailing segment) and returns the
-// library name so the printer can round-trip it as `use c "<lib>"`
-// rather than the canonical runtime form. Multi-segment cabi paths
-// (e.g. `runtime.cabi.libc.subgroup`) fall through to the runtime
-// printer because `use c` only carries one library name.
+// useCSurfaceLibName recognises the `runtime.cabi.<lib>` sugar so
+// the printer can round-trip it as `use c "<lib>"`. Policy lives
+// in toolchain/format_policy.osty.
 func useCSurfaceLibName(runtimePath string) (string, bool) {
-	const prefix = "runtime.cabi."
-	if !strings.HasPrefix(runtimePath, prefix) {
-		return "", false
-	}
-	lib := runtimePath[len(prefix):]
-	if lib == "" || strings.ContainsAny(lib, "./") {
-		return "", false
-	}
-	return lib, true
+	r := runner.UseCSurfaceLibName(runtimePath)
+	return r.Lib, r.Ok
 }
 
 // chainSeg is one link in a method chain, e.g. `.map(|x| x * 2)` in
@@ -245,31 +232,21 @@ func reverseSegs(s []*chainSeg) []*chainSeg {
 }
 
 // shouldBreakChain reports whether a chain should render in the
-// leading-dot multi-line form. Two triggers fire it:
-//   - 3 or more post-base segments (regardless of source layout) —
-//     §1.8 encourages the leading-dot style for long chains.
-//   - any post-base segment's `.name` that appears on a line below
-//     where the previous segment ended — the author already broke the
-//     chain in source; preserve that layout.
-//
-// nameEnd is the end position of the `.name` portion (before the `(`),
-// so a multi-line argument block in the segment's call doesn't push
-// the measurement onto a later line and feedback-loop fmt(fmt(x)).
+// leading-dot multi-line form. Policy lives in
+// toolchain/format_policy.osty; this wrapper extracts the line
+// numbers the policy needs from the AST positions.
 func shouldBreakChain(base ast.Expr, segs []*chainSeg) bool {
 	if len(segs) == 0 {
 		return false
 	}
-	if len(segs) >= 3 {
-		return true
-	}
-	prev := base.End().Line
-	for _, s := range segs {
-		if s.nameEnd.Line != prev {
-			return true
+	lines := make([]runner.ChainSegLines, len(segs))
+	for i, s := range segs {
+		lines[i] = runner.ChainSegLines{
+			NameEndLine: s.nameEnd.Line,
+			EndLine:     s.end.Line,
 		}
-		prev = s.end.Line
 	}
-	return false
+	return runner.ShouldBreakChain(base.End().Line, lines)
 }
 
 // printMethodChain emits a chain with the base on its own line and

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -40,6 +40,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"airepair_flags.osty",
 		"airepair_rewrite.osty",
 		"airepair_source.osty",
+		"format_policy.osty",
 		"profile_flags.osty",
 		"diag_policy.osty",
 		"test_runner.osty",

--- a/internal/runner/format_policy.go
+++ b/internal/runner/format_policy.go
@@ -1,0 +1,98 @@
+// format_policy.go is the Go snapshot of
+// toolchain/format_policy.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import "strings"
+
+// CSurfaceLib mirrors toolchain/format_policy.osty's CSurfaceLib.
+// Ok=false leaves Lib empty and signals the canonical runtime
+// printer should run.
+//
+// Osty: toolchain/format_policy.osty:22
+type CSurfaceLib struct {
+	Lib string
+	Ok  bool
+}
+
+// ChainSegLines mirrors toolchain/format_policy.osty's
+// ChainSegLines. Decoupling NameEndLine from EndLine matters
+// because a multi-line argument block in a chain segment must
+// not feedback-loop the break decision.
+//
+// Osty: toolchain/format_policy.osty:39
+type ChainSegLines struct {
+	NameEndLine int
+	EndLine     int
+}
+
+// UseGroupOrder bins a use decl into the canonical group order:
+// 0 = stdlib (`std.*`), 1 = external (everything else that's not
+// FFI), 2 = FFI.
+//
+// Osty: toolchain/format_policy.osty:50
+func UseGroupOrder(isFFI bool, firstPathSegment string) int {
+	if isFFI {
+		return 2
+	}
+	if firstPathSegment == "std" {
+		return 0
+	}
+	return 1
+}
+
+// UseSortKey is the intra-group sort key for `use` decls.
+// Precedence: FFI path -> raw path -> dotted path.
+//
+// Osty: toolchain/format_policy.osty:65
+func UseSortKey(isFFI bool, ffiPath, rawPath, dottedPath string) string {
+	if isFFI {
+		return ffiPath
+	}
+	if rawPath != "" {
+		return rawPath
+	}
+	return dottedPath
+}
+
+// UseCSurfaceLibName recognises a runtime FFI path of the form
+// `runtime.cabi.<lib>` (single trailing segment) and returns the
+// library name. Multi-segment cabi paths and ones that smuggle
+// a `/` through the segment fall through to the canonical
+// runtime printer.
+//
+// Osty: toolchain/format_policy.osty:80
+func UseCSurfaceLibName(runtimePath string) CSurfaceLib {
+	const prefix = "runtime.cabi."
+	if !strings.HasPrefix(runtimePath, prefix) {
+		return CSurfaceLib{}
+	}
+	lib := runtimePath[len(prefix):]
+	if lib == "" || strings.Contains(lib, ".") || strings.Contains(lib, "/") {
+		return CSurfaceLib{}
+	}
+	return CSurfaceLib{Lib: lib, Ok: true}
+}
+
+// ShouldBreakChain reports whether a method chain should render
+// in the leading-dot multi-line form. Triggers: 3+ segments, or
+// any segment whose `.name` sits on a line below the previous
+// segment's end.
+//
+// Osty: toolchain/format_policy.osty:101
+func ShouldBreakChain(baseEndLine int, segs []ChainSegLines) bool {
+	if len(segs) == 0 {
+		return false
+	}
+	if len(segs) >= 3 {
+		return true
+	}
+	prev := baseEndLine
+	for _, s := range segs {
+		if s.NameEndLine != prev {
+			return true
+		}
+		prev = s.EndLine
+	}
+	return false
+}

--- a/internal/runner/format_policy_test.go
+++ b/internal/runner/format_policy_test.go
@@ -1,0 +1,131 @@
+package runner
+
+import "testing"
+
+func TestUseGroupOrder(t *testing.T) {
+	cases := []struct {
+		name      string
+		isFFI     bool
+		firstSeg  string
+		want      int
+	}{
+		{"stdlib", false, "std", 0},
+		{"external-github", false, "github.com", 1},
+		{"external-other", false, "mypkg", 1},
+		{"external-empty", false, "", 1},
+		{"ffi", true, "go", 2},
+		{"ffi-with-std-segment", true, "std", 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := UseGroupOrder(c.isFFI, c.firstSeg); got != c.want {
+				t.Errorf("UseGroupOrder(%v, %q) = %d, want %d", c.isFFI, c.firstSeg, got, c.want)
+			}
+		})
+	}
+}
+
+func TestUseSortKey(t *testing.T) {
+	cases := []struct {
+		name      string
+		isFFI     bool
+		ffi       string
+		raw       string
+		dotted    string
+		want      string
+	}{
+		{"ffi-precedence", true, "net/http", "ignored", "ignored.too", "net/http"},
+		{"raw-path", false, "", "github.com/x/y", "x.y", "github.com/x/y"},
+		{"dotted-path", false, "", "", "std.io", "std.io"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := UseSortKey(c.isFFI, c.ffi, c.raw, c.dotted); got != c.want {
+				t.Errorf("UseSortKey = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestUseCSurfaceLibName(t *testing.T) {
+	cases := []struct {
+		name  string
+		path  string
+		ok    bool
+		lib   string
+	}{
+		{"simple", "runtime.cabi.libc", true, "libc"},
+		{"reject-no-prefix", "runtime.go.libc", false, ""},
+		{"reject-multi-segment", "runtime.cabi.libc.subgroup", false, ""},
+		{"reject-slash", "runtime.cabi.libc/extra", false, ""},
+		{"reject-empty-lib", "runtime.cabi.", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := UseCSurfaceLibName(c.path)
+			if got.Ok != c.ok {
+				t.Errorf("UseCSurfaceLibName(%q).Ok = %v, want %v", c.path, got.Ok, c.ok)
+			}
+			if got.Lib != c.lib {
+				t.Errorf("UseCSurfaceLibName(%q).Lib = %q, want %q", c.path, got.Lib, c.lib)
+			}
+		})
+	}
+}
+
+func TestShouldBreakChain(t *testing.T) {
+	cases := []struct {
+		name        string
+		baseEndLine int
+		segs        []ChainSegLines
+		want        bool
+	}{
+		{"empty", 1, nil, false},
+		{
+			"short-same-line", 1,
+			[]ChainSegLines{
+				{NameEndLine: 1, EndLine: 1},
+				{NameEndLine: 1, EndLine: 1},
+			},
+			false,
+		},
+		{
+			"three-or-more", 1,
+			[]ChainSegLines{
+				{NameEndLine: 1, EndLine: 1},
+				{NameEndLine: 1, EndLine: 1},
+				{NameEndLine: 1, EndLine: 1},
+			},
+			true,
+		},
+		{
+			"source-break", 1,
+			[]ChainSegLines{
+				{NameEndLine: 2, EndLine: 2},
+			},
+			true,
+		},
+		{
+			"preserves-prior-break", 1,
+			[]ChainSegLines{
+				{NameEndLine: 1, EndLine: 1},
+				{NameEndLine: 2, EndLine: 2},
+			},
+			true,
+		},
+		{
+			"multi-line-call-stays-flat", 1,
+			[]ChainSegLines{
+				{NameEndLine: 1, EndLine: 5},
+			},
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ShouldBreakChain(c.baseEndLine, c.segs); got != c.want {
+				t.Errorf("ShouldBreakChain = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/format_policy.osty
+++ b/toolchain/format_policy.osty
@@ -1,0 +1,115 @@
+/// Pure layout policy for the canonical-style formatter
+/// (internal/format). Host code in printer.go owns AST traversal,
+/// trivia attachment, and the actual `strings.Builder` output;
+/// this module decides:
+///
+///   - which group a `use` declaration falls into (stdlib vs
+///     external vs FFI) for the top-of-file ordering,
+///   - the intra-group sort key per `use` decl,
+///   - whether a FFI path is the `runtime.cabi.<lib>` sugar that
+///     should round-trip as `use c "<lib>"`,
+///   - whether a method chain should render in the leading-dot
+///     multi-line form.
+///
+/// Mirrored by `internal/runner/format_policy.go`. The drift test
+/// under internal/runner keeps the two in sync — the Osty file is
+/// the source of truth at review time.
+use std.strings as strings
+/// CSurfaceLib is the outcome of inspecting a FFI runtime path
+/// for the `runtime.cabi.<lib>` sugar. `ok == false` leaves `lib`
+/// empty and signals the canonical runtime printer should run.
+pub struct CSurfaceLib {
+    pub lib: String,
+    pub ok: Bool,
+}
+/// ChainSegLines captures the line-number information from one
+/// method-chain segment that `shouldBreakChain` consumes. Host
+/// code extracts these two numbers from the segment's AST `Pos`
+/// values:
+///
+///   - `nameEndLine`: line number where the `.name` portion ends
+///     (i.e. the position right before `(args)`). Decoupling the
+///     name-end from the call-end matters because a multi-line
+///     argument block must not feedback-loop the break decision.
+///   - `endLine`: line number where the entire segment ends
+///     (after `)` for call segments, after the `.name` for bare
+///     field segments).
+pub struct ChainSegLines {
+    pub nameEndLine: Int,
+    pub endLine: Int,
+}
+/// useGroupOrder bins a use decl into the canonical group order:
+/// `0 = stdlib (std.*)`, `1 = external (everything else that's
+/// not FFI)`, `2 = FFI`. Host passes the resolved `isFFI` flag
+/// (from `UseDecl.IsFFI()`) and the first dotted-path segment
+/// (`""` when the path is empty — those bin as external).
+pub fn useGroupOrder(isFFI: Bool, firstPathSegment: String) -> Int {
+    if isFFI {
+        return 2
+    }
+    if firstPathSegment == "std" {
+        return 0
+    }
+    1
+}
+/// useSortKey is the intra-group sort key for `use` decls.
+///
+///   - FFI: the raw `FFIPath()` round-trips uniquely.
+///   - Non-FFI with `RawPath` set: keep the as-written form so
+///     `github.com/x/y` style stays the sort dimension.
+///   - Otherwise: the dotted path (`use a.b.c` → `"a.b.c"`).
+pub fn useSortKey(isFFI: Bool, ffiPath: String, rawPath: String, dottedPath: String) -> String {
+    if isFFI {
+        return ffiPath
+    }
+    if rawPath != "" {
+        return rawPath
+    }
+    dottedPath
+}
+/// useCSurfaceLibName recognises a runtime FFI path of the form
+/// `runtime.cabi.<lib>` (single trailing segment) and returns the
+/// library name so the printer can round-trip it as
+/// `use c "<lib>"`. Multi-segment cabi paths (e.g.
+/// `runtime.cabi.libc.subgroup`) and ones that smuggle a `/`
+/// through the segment fall through to the canonical runtime
+/// printer — `use c` only carries one library name.
+pub fn useCSurfaceLibName(runtimePath: String) -> CSurfaceLib {
+    let prefix = "runtime.cabi."
+    if !strings.hasPrefix(runtimePath, prefix) {
+        return CSurfaceLib {lib: "", ok: false}
+    }
+    let lib = strings.trimPrefix(runtimePath, prefix)
+    if lib == "" || strings.contains(lib, ".") || strings.contains(lib, "/") {
+        return CSurfaceLib {lib: "", ok: false}
+    }
+    CSurfaceLib {lib: lib, ok: true}
+}
+/// shouldBreakChain reports whether a method chain should render
+/// in the leading-dot multi-line form (§1.8). Two triggers fire
+/// it:
+///
+///   - 3 or more post-base segments (regardless of source layout).
+///   - any post-base segment's `.name` that sits on a line below
+///     where the previous segment ended — the author already
+///     broke the chain in source, preserve that layout.
+///
+/// `baseEndLine` is the line where the chain's base expression
+/// ends (the receiver of the first `.method`). Empty `segs`
+/// returns `false` (nothing to chain).
+pub fn shouldBreakChain(baseEndLine: Int, segs: List<ChainSegLines>) -> Bool {
+    if segs.len() == 0 {
+        return false
+    }
+    if segs.len() >= 3 {
+        return true
+    }
+    let mut prev = baseEndLine
+    for s in segs {
+        if s.nameEndLine != prev {
+            return true
+        }
+        prev = s.endLine
+    }
+    false
+}

--- a/toolchain/format_policy_test.osty
+++ b/toolchain/format_policy_test.osty
@@ -1,0 +1,84 @@
+use std.testing
+fn testUseGroupOrderStdlib() {
+    testing.assertEq(useGroupOrder(false, "std"), 0)
+}
+fn testUseGroupOrderExternal() {
+    testing.assertEq(useGroupOrder(false, "github.com"), 1)
+    testing.assertEq(useGroupOrder(false, "mypkg"), 1)
+    testing.assertEq(useGroupOrder(false, ""), 1)
+}
+fn testUseGroupOrderFFI() {
+    testing.assertEq(useGroupOrder(true, "go"), 2)
+    testing.assertEq(useGroupOrder(true, "std"), 2)
+    testing.assertEq(useGroupOrder(true, ""), 2)
+}
+fn testUseSortKeyFFI() {
+    testing.assertEq(useSortKey(true, "net/http", "ignored", "ignored.too"), "net/http")
+}
+fn testUseSortKeyRawPath() {
+    testing.assertEq(useSortKey(false, "", "github.com/x/y", "x.y"), "github.com/x/y")
+}
+fn testUseSortKeyDottedPath() {
+    testing.assertEq(useSortKey(false, "", "", "std.io"), "std.io")
+}
+fn testUseCSurfaceLibNameSimple() {
+    let r = useCSurfaceLibName("runtime.cabi.libc")
+    testing.assert(r.ok)
+    testing.assertEq(r.lib, "libc")
+}
+fn testUseCSurfaceLibNameRejectsNoPrefix() {
+    let r = useCSurfaceLibName("runtime.go.libc")
+    testing.assert(!(r.ok))
+    testing.assertEq(r.lib, "")
+}
+fn testUseCSurfaceLibNameRejectsMultiSegment() {
+    let r = useCSurfaceLibName("runtime.cabi.libc.subgroup")
+    testing.assert(!(r.ok))
+    testing.assertEq(r.lib, "")
+}
+fn testUseCSurfaceLibNameRejectsSlash() {
+    let r = useCSurfaceLibName("runtime.cabi.libc/extra")
+    testing.assert(!(r.ok))
+}
+fn testUseCSurfaceLibNameRejectsEmptyLib() {
+    let r = useCSurfaceLibName("runtime.cabi.")
+    testing.assert(!(r.ok))
+}
+fn testShouldBreakChainEmpty() {
+    let segs: List<ChainSegLines> = []
+    testing.assert(!(shouldBreakChain(1, segs)))
+}
+fn testShouldBreakChainShortSameLine() {
+    let segs: List<ChainSegLines> = [
+        ChainSegLines {nameEndLine: 1, endLine: 1},
+        ChainSegLines {nameEndLine: 1, endLine: 1},
+    ]
+    testing.assert(!(shouldBreakChain(1, segs)))
+}
+fn testShouldBreakChainThreeOrMore() {
+    let segs: List<ChainSegLines> = [
+        ChainSegLines {nameEndLine: 1, endLine: 1},
+        ChainSegLines {nameEndLine: 1, endLine: 1},
+        ChainSegLines {nameEndLine: 1, endLine: 1},
+    ]
+    testing.assert(shouldBreakChain(1, segs))
+}
+fn testShouldBreakChainSourceBreak() {
+    let segs: List<ChainSegLines> = [
+        ChainSegLines {nameEndLine: 2, endLine: 2},
+    ]
+    testing.assert(shouldBreakChain(1, segs))
+}
+fn testShouldBreakChainPreservesPriorBreak() {
+    let segs: List<ChainSegLines> = [
+        ChainSegLines {nameEndLine: 1, endLine: 1},
+        ChainSegLines {nameEndLine: 2, endLine: 2},
+    ]
+    testing.assert(shouldBreakChain(1, segs))
+}
+fn testShouldBreakChainMultiLineCallStaysFlat() {
+    let segs: List<ChainSegLines> = [
+        ChainSegLines {nameEndLine: 1, endLine: 5},
+    ]
+    testing.assert(!(shouldBreakChain(1, segs)))
+}


### PR DESCRIPTION
## Summary

`internal/format/printer.go`의 4개 순수 layout 정책을 새
`toolchain/format_policy.osty`로 이전. internal/format 패키지의 첫
self-host 진입.

이전된 정책 (4 fn + 2 struct):

- `useGroupOrder(isFFI, firstPathSegment) -> Int` — stdlib(0) /
  external(1) / FFI(2) 분류
- `useSortKey(isFFI, ffiPath, rawPath, dottedPath) -> String` —
  intra-group 정렬 키 (FFI path → RawPath → dotted path 우선순위)
- `useCSurfaceLibName(runtimePath) -> CSurfaceLib` —
  `runtime.cabi.<lib>` sugar 인식 (single trailing segment 만, `.`/`/`
  smuggle 거부)
- `shouldBreakChain(baseEndLine, segs) -> Bool` — 메서드 체인을
  leading-dot multi-line으로 렌더링할지 결정 (3+ segment 또는
  source-level break 보존)

## API 설계

AST 노드를 직접 받는 대신 primitive (bool/string/line numbers)만
받도록 표면을 정리:

- `useGroupOrder`: `(isFFI, firstPathSegment)` — Go 측에서
  `u.IsFFI()` + `u.Path[0]`을 뽑아 넘김
- `useSortKey`: `(isFFI, ffiPath, rawPath, dottedPath)` —
  `strings.Join(u.Path, ".")` 한 번만 호출
- `shouldBreakChain`: AST가 아닌 `List<ChainSegLines>` 받음 (segment
  per name-end / end line numbers만 필요)

`ChainSegLines.nameEndLine`을 `endLine`과 분리한 건 multi-line argument
block이 break 결정을 feedback-loop하지 않게 하기 위한 기존 invariant
보존.

## Go wrapper 축소

`internal/format/printer.go`의 4개 함수는 모두 AST → primitive 추출
+ runner 호출 thin wrapper:

```go
func useGroupOrder(u *ast.UseDecl) int {
    firstSeg := ""
    if len(u.Path) > 0 { firstSeg = u.Path[0] }
    return runner.UseGroupOrder(u.IsFFI(), firstSeg)
}
```

호출 사이트는 변경 없음 — wrapper 시그니처 유지.

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/format/... ./internal/runner/...` —
      pass (drift test 포함, 10개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run 'TestFmt'` — pass (6.3s)

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_