### PR TITLE
refactor: scaffold expectedPaths Kind-layout 정책 self-host

### DIFF
--- a/internal/runner/scaffold_policy.go
+++ b/internal/runner/scaffold_policy.go
@@ -62,6 +62,60 @@ func ResolveFixtureCases(requested int) FixtureCaseCount {
 	return FixtureCaseCount{Count: requested, OverCap: false}
 }
 
+// ScaffoldDefaultWorkspaceMember is the directory name used for
+// the default member of a `--workspace` scaffold when the caller
+// did not supply one.
+//
+// Osty: toolchain/scaffold_policy.osty:74
+func ScaffoldDefaultWorkspaceMember() string {
+	return "core"
+}
+
+// ScaffoldRelativePaths returns the source-order list of relative
+// file paths the scaffolder will write for a project of `kind`.
+// Path separators are forward slashes (`/`); the host joins each
+// entry with the project root and converts to the platform-native
+// separator. Unknown kinds fall through to the binary layout.
+//
+// Osty: toolchain/scaffold_policy.osty:89
+func ScaffoldRelativePaths(kind, workspaceMember string) []string {
+	switch kind {
+	case "lib":
+		return []string{"osty.toml", "lib.osty", "lib_test.osty", ".gitignore"}
+	case "workspace":
+		member := workspaceMember
+		if member == "" {
+			member = ScaffoldDefaultWorkspaceMember()
+		}
+		return []string{
+			"osty.toml",
+			".gitignore",
+			member + "/osty.toml",
+			member + "/main.osty",
+			member + "/main_test.osty",
+			member + "/.gitignore",
+		}
+	case "cli":
+		return []string{"osty.toml", "main.osty", "args.osty", "app.osty", "app_test.osty", ".gitignore"}
+	case "service":
+		return []string{"osty.toml", "main.osty", "routes.osty", "routes_test.osty", ".gitignore"}
+	case "gui-qtquick":
+		return []string{"osty.toml", "main.osty", "ui/main.qml", "README.md", ".gitignore"}
+	case "gui-webview2":
+		return []string{
+			"osty.toml",
+			"src/main.osty",
+			"src/main_test.osty",
+			"ui/index.html",
+			"ui/app.css",
+			"ui/app.js",
+			"assets/.gitkeep",
+			".gitignore",
+		}
+	}
+	return []string{"osty.toml", "main.osty", "main_test.osty", ".gitignore"}
+}
+
 func isScaffoldLetter(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
 }

--- a/internal/runner/scaffold_policy_test.go
+++ b/internal/runner/scaffold_policy_test.go
@@ -53,3 +53,80 @@ func TestScaffoldFixtureCapsMatchOstyConstants(t *testing.T) {
 		t.Errorf("ScaffoldFixtureCasesMax = %d, want 64", ScaffoldFixtureCasesMax)
 	}
 }
+
+func TestScaffoldDefaultWorkspaceMember(t *testing.T) {
+	if got := ScaffoldDefaultWorkspaceMember(); got != "core" {
+		t.Errorf("ScaffoldDefaultWorkspaceMember() = %q, want %q", got, "core")
+	}
+}
+
+func TestScaffoldRelativePaths(t *testing.T) {
+	cases := []struct {
+		name    string
+		kind    string
+		member  string
+		want    []string
+	}{
+		{
+			"bin", "bin", "",
+			[]string{"osty.toml", "main.osty", "main_test.osty", ".gitignore"},
+		},
+		{
+			"lib", "lib", "",
+			[]string{"osty.toml", "lib.osty", "lib_test.osty", ".gitignore"},
+		},
+		{
+			"workspace-default-member", "workspace", "",
+			[]string{
+				"osty.toml", ".gitignore",
+				"core/osty.toml", "core/main.osty", "core/main_test.osty", "core/.gitignore",
+			},
+		},
+		{
+			"workspace-custom-member", "workspace", "alpha",
+			[]string{
+				"osty.toml", ".gitignore",
+				"alpha/osty.toml", "alpha/main.osty", "alpha/main_test.osty", "alpha/.gitignore",
+			},
+		},
+		{
+			"cli", "cli", "",
+			[]string{"osty.toml", "main.osty", "args.osty", "app.osty", "app_test.osty", ".gitignore"},
+		},
+		{
+			"service", "service", "",
+			[]string{"osty.toml", "main.osty", "routes.osty", "routes_test.osty", ".gitignore"},
+		},
+		{
+			"gui-qtquick", "gui-qtquick", "",
+			[]string{"osty.toml", "main.osty", "ui/main.qml", "README.md", ".gitignore"},
+		},
+		{
+			"gui-webview2", "gui-webview2", "",
+			[]string{
+				"osty.toml",
+				"src/main.osty", "src/main_test.osty",
+				"ui/index.html", "ui/app.css", "ui/app.js",
+				"assets/.gitkeep", ".gitignore",
+			},
+		},
+		{
+			"unknown-falls-back-to-bin", "nonsense", "",
+			[]string{"osty.toml", "main.osty", "main_test.osty", ".gitignore"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ScaffoldRelativePaths(c.kind, c.member)
+			if len(got) != len(c.want) {
+				t.Fatalf("ScaffoldRelativePaths(%q, %q) length = %d, want %d\n got: %v\nwant: %v",
+					c.kind, c.member, len(got), len(c.want), got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("path[%d] = %q, want %q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -99,6 +99,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/runner"
@@ -324,78 +325,41 @@ func checkNoConflicts(dir string, opts Options) *diag.Diagnostic {
 
 // expectedPaths lists every file the scaffolder will write for the
 // given options, in source order. Used by Init to pre-flight the
-// target directory for conflicts.
+// target directory for conflicts. Layout policy lives in
+// toolchain/scaffold_policy.osty; this wrapper resolves Kind → name
+// and joins each relative path with `dir`, converting any forward
+// slashes to the platform-native separator.
 func expectedPaths(dir string, opts Options) []string {
-	switch opts.Kind {
+	rels := runner.ScaffoldRelativePaths(kindName(opts.Kind), opts.WorkspaceMember)
+	out := make([]string, len(rels))
+	for i, rel := range rels {
+		// Osty emits forward slashes; split + filepath.Join produces
+		// the right separator on Windows without needing two cases.
+		segments := strings.Split(rel, "/")
+		out[i] = filepath.Join(append([]string{dir}, segments...)...)
+	}
+	return out
+}
+
+// kindName maps the Kind enum to the string the toolchain policy
+// matches on. Keep this in lock-step with
+// `toolchain/scaffold_policy.osty:scaffoldRelativePaths`.
+func kindName(k Kind) string {
+	switch k {
 	case KindLib:
-		return []string{
-			filepath.Join(dir, "osty.toml"),
-			filepath.Join(dir, "lib.osty"),
-			filepath.Join(dir, "lib_test.osty"),
-			filepath.Join(dir, ".gitignore"),
-		}
+		return "lib"
 	case KindWorkspace:
-		member := opts.WorkspaceMember
-		if member == "" {
-			member = "core"
-		}
-		return []string{
-			filepath.Join(dir, "osty.toml"),
-			filepath.Join(dir, ".gitignore"),
-			filepath.Join(dir, member, "osty.toml"),
-			filepath.Join(dir, member, "main.osty"),
-			filepath.Join(dir, member, "main_test.osty"),
-			filepath.Join(dir, member, ".gitignore"),
-		}
+		return "workspace"
 	case KindCli:
-		// CLI layout splits responsibilities across three source
-		// files so the testable surface (parseArgs, run) lives apart
-		// from the process-binding `main`. The single `_test.osty`
-		// covers both halves.
-		return []string{
-			filepath.Join(dir, "osty.toml"),
-			filepath.Join(dir, "main.osty"),
-			filepath.Join(dir, "args.osty"),
-			filepath.Join(dir, "app.osty"),
-			filepath.Join(dir, "app_test.osty"),
-			filepath.Join(dir, ".gitignore"),
-		}
+		return "cli"
 	case KindService:
-		// Service layout splits the entry point from the routing
-		// table so handlers can be added without touching `main`.
-		return []string{
-			filepath.Join(dir, "osty.toml"),
-			filepath.Join(dir, "main.osty"),
-			filepath.Join(dir, "routes.osty"),
-			filepath.Join(dir, "routes_test.osty"),
-			filepath.Join(dir, ".gitignore"),
-		}
+		return "service"
 	case KindGUIQtQuick:
-		return []string{
-			filepath.Join(dir, "osty.toml"),
-			filepath.Join(dir, "main.osty"),
-			filepath.Join(dir, "ui", "main.qml"),
-			filepath.Join(dir, "README.md"),
-			filepath.Join(dir, ".gitignore"),
-		}
+		return "gui-qtquick"
 	case KindGUIWebView2:
-		return []string{
-			filepath.Join(dir, "osty.toml"),
-			filepath.Join(dir, "src", "main.osty"),
-			filepath.Join(dir, "src", "main_test.osty"),
-			filepath.Join(dir, "ui", "index.html"),
-			filepath.Join(dir, "ui", "app.css"),
-			filepath.Join(dir, "ui", "app.js"),
-			filepath.Join(dir, "assets", ".gitkeep"),
-			filepath.Join(dir, ".gitignore"),
-		}
-	default: // KindBin
-		return []string{
-			filepath.Join(dir, "osty.toml"),
-			filepath.Join(dir, "main.osty"),
-			filepath.Join(dir, "main_test.osty"),
-			filepath.Join(dir, ".gitignore"),
-		}
+		return "gui-webview2"
+	default:
+		return "bin"
 	}
 }
 

--- a/toolchain/scaffold_policy.osty
+++ b/toolchain/scaffold_policy.osty
@@ -62,3 +62,67 @@ fn scaffoldIsLetter(unit: String) -> Bool {
 fn scaffoldIsDigit(unit: String) -> Bool {
     unit >= "0" && unit <= "9"
 }
+/// scaffoldDefaultWorkspaceMember is the directory name used for
+/// the default member of a `--workspace` scaffold when the caller
+/// did not supply one. Exported as policy so cmd/osty's flag default
+/// and the scaffolder agree.
+pub fn scaffoldDefaultWorkspaceMember() -> String {
+    "core"
+}
+/// scaffoldRelativePaths returns the source-order list of relative
+/// file paths the scaffolder will write for a project of `kind`.
+/// Path separators are forward slashes (`/`); the host joins each
+/// entry with the project root and converts to the platform-native
+/// separator. Used by `Init` to pre-flight the target directory
+/// for conflicts.
+///
+/// `kind` matches the host's `Kind` enum stringified
+/// (`bin`/`lib`/`workspace`/`cli`/`service`/`gui-qtquick`/
+/// `gui-webview2`). Unknown kinds fall through to the binary layout
+/// so a typo can't crash the scaffolder.
+///
+/// `workspaceMember` is the sub-directory name for the default
+/// workspace member; empty string resolves to
+/// `scaffoldDefaultWorkspaceMember()`. Ignored for non-workspace
+/// kinds.
+pub fn scaffoldRelativePaths(kind: String, workspaceMember: String) -> List<String> {
+    if kind == "lib" {
+        return ["osty.toml", "lib.osty", "lib_test.osty", ".gitignore"]
+    }
+    if kind == "workspace" {
+        let mut member = workspaceMember
+        if member == "" {
+            member = scaffoldDefaultWorkspaceMember()
+        }
+        return [
+            "osty.toml",
+            ".gitignore",
+            member + "/osty.toml",
+            member + "/main.osty",
+            member + "/main_test.osty",
+            member + "/.gitignore",
+        ]
+    }
+    if kind == "cli" {
+        return ["osty.toml", "main.osty", "args.osty", "app.osty", "app_test.osty", ".gitignore"]
+    }
+    if kind == "service" {
+        return ["osty.toml", "main.osty", "routes.osty", "routes_test.osty", ".gitignore"]
+    }
+    if kind == "gui-qtquick" {
+        return ["osty.toml", "main.osty", "ui/main.qml", "README.md", ".gitignore"]
+    }
+    if kind == "gui-webview2" {
+        return [
+            "osty.toml",
+            "src/main.osty",
+            "src/main_test.osty",
+            "ui/index.html",
+            "ui/app.css",
+            "ui/app.js",
+            "assets/.gitkeep",
+            ".gitignore",
+        ]
+    }
+    ["osty.toml", "main.osty", "main_test.osty", ".gitignore"]
+}

--- a/toolchain/scaffold_policy_test.osty
+++ b/toolchain/scaffold_policy_test.osty
@@ -56,3 +56,84 @@ fn testResolveFixtureCasesClampsOverCap() {
     testing.assertEq(big.count, 64)
     testing.assert(big.overCap)
 }
+fn testScaffoldDefaultWorkspaceMember() {
+    testing.assertEq(scaffoldDefaultWorkspaceMember(), "core")
+}
+fn testScaffoldRelativePathsBin() {
+    let paths = scaffoldRelativePaths("bin", "")
+    testing.assertEq(paths.len(), 4)
+    testing.assertEq(paths[0], "osty.toml")
+    testing.assertEq(paths[1], "main.osty")
+    testing.assertEq(paths[2], "main_test.osty")
+    testing.assertEq(paths[3], ".gitignore")
+}
+fn testScaffoldRelativePathsLib() {
+    let paths = scaffoldRelativePaths("lib", "")
+    testing.assertEq(paths.len(), 4)
+    testing.assertEq(paths[0], "osty.toml")
+    testing.assertEq(paths[1], "lib.osty")
+    testing.assertEq(paths[2], "lib_test.osty")
+    testing.assertEq(paths[3], ".gitignore")
+}
+fn testScaffoldRelativePathsWorkspaceDefaultsMember() {
+    let paths = scaffoldRelativePaths("workspace", "")
+    testing.assertEq(paths.len(), 6)
+    testing.assertEq(paths[0], "osty.toml")
+    testing.assertEq(paths[1], ".gitignore")
+    testing.assertEq(paths[2], "core/osty.toml")
+    testing.assertEq(paths[3], "core/main.osty")
+    testing.assertEq(paths[4], "core/main_test.osty")
+    testing.assertEq(paths[5], "core/.gitignore")
+}
+fn testScaffoldRelativePathsWorkspaceCustomMember() {
+    let paths = scaffoldRelativePaths("workspace", "alpha")
+    testing.assertEq(paths.len(), 6)
+    testing.assertEq(paths[2], "alpha/osty.toml")
+    testing.assertEq(paths[3], "alpha/main.osty")
+}
+fn testScaffoldRelativePathsCli() {
+    let paths = scaffoldRelativePaths("cli", "")
+    testing.assertEq(paths.len(), 6)
+    testing.assertEq(paths[0], "osty.toml")
+    testing.assertEq(paths[1], "main.osty")
+    testing.assertEq(paths[2], "args.osty")
+    testing.assertEq(paths[3], "app.osty")
+    testing.assertEq(paths[4], "app_test.osty")
+    testing.assertEq(paths[5], ".gitignore")
+}
+fn testScaffoldRelativePathsService() {
+    let paths = scaffoldRelativePaths("service", "")
+    testing.assertEq(paths.len(), 5)
+    testing.assertEq(paths[0], "osty.toml")
+    testing.assertEq(paths[1], "main.osty")
+    testing.assertEq(paths[2], "routes.osty")
+    testing.assertEq(paths[3], "routes_test.osty")
+    testing.assertEq(paths[4], ".gitignore")
+}
+fn testScaffoldRelativePathsGuiQtQuick() {
+    let paths = scaffoldRelativePaths("gui-qtquick", "")
+    testing.assertEq(paths.len(), 5)
+    testing.assertEq(paths[0], "osty.toml")
+    testing.assertEq(paths[1], "main.osty")
+    testing.assertEq(paths[2], "ui/main.qml")
+    testing.assertEq(paths[3], "README.md")
+    testing.assertEq(paths[4], ".gitignore")
+}
+fn testScaffoldRelativePathsGuiWebView2() {
+    let paths = scaffoldRelativePaths("gui-webview2", "")
+    testing.assertEq(paths.len(), 8)
+    testing.assertEq(paths[0], "osty.toml")
+    testing.assertEq(paths[1], "src/main.osty")
+    testing.assertEq(paths[2], "src/main_test.osty")
+    testing.assertEq(paths[3], "ui/index.html")
+    testing.assertEq(paths[4], "ui/app.css")
+    testing.assertEq(paths[5], "ui/app.js")
+    testing.assertEq(paths[6], "assets/.gitkeep")
+    testing.assertEq(paths[7], ".gitignore")
+}
+fn testScaffoldRelativePathsUnknownFallsBackToBin() {
+    let paths = scaffoldRelativePaths("nonsense", "")
+    testing.assertEq(paths.len(), 4)
+    testing.assertEq(paths[0], "osty.toml")
+    testing.assertEq(paths[1], "main.osty")
+}


### PR DESCRIPTION
## Summary

`internal/scaffold/scaffold.go`의 `expectedPaths` 함수에 담긴
"Kind별로 어떤 파일이 생성되는가"의 정책 (70여 줄짜리 7-way switch)
을 `toolchain/scaffold_policy.osty`로 확장. Go 측은 Kind→이름 매핑
+ path join host glue만 담당.

추가된 정책 (2 fn, 0 struct):

- `scaffoldRelativePaths(kind, workspaceMember) -> List<String>`
  — 각 Kind별 source-order relative path 리스트. forward slash
  separator. unknown Kind는 `bin` layout으로 fallback
- `scaffoldDefaultWorkspaceMember() -> String` — workspace 기본
  멤버 디렉토리 이름 (`"core"`). cmd/osty 플래그 기본값과 한 곳에서
  관리

## 설계

- **OS 비종속 path**: Osty는 forward slash로 path segment를 join
  (`"src/main.osty"`), Go wrapper가 `strings.Split("/") +
  filepath.Join(dir, ...)`로 platform-native separator로 변환.
  Osty 측은 `filepath`에 의존하지 않음
- **Kind enum-as-string**: Go의 `Kind` int 열거형은 그대로 두고
  host-side `kindName(Kind)` mapper가 문자열로 변환
  (`"bin"`/`"lib"`/`"workspace"`/...). enum 표현 결정 (Int 상수
  vs String 상수)을 보류해서 본 PR scope를 좁힘
- **unknown Kind fallback**: Osty 측에서 `kind` 매치 실패 시 bin
  layout 반환 — Go의 `default: // KindBin` 동작 보존

## Go wrapper 축소

`internal/scaffold/scaffold.go`의 `expectedPaths`는 64줄짜리 switch
에서 15줄 wrapper로 줄어듦:

```go
func expectedPaths(dir string, opts Options) []string {
    rels := runner.ScaffoldRelativePaths(kindName(opts.Kind), opts.WorkspaceMember)
    out := make([]string, len(rels))
    for i, rel := range rels {
        segments := strings.Split(rel, "/")
        out[i] = filepath.Join(append([]string{dir}, segments...)...)
    }
    return out
}
```

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/scaffold/... ./internal/runner/...` —
      pass (drift test 포함, 10개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ ./internal/scaffold/` — pass
- [x] 7개 Kind + workspace member default/override + unknown fallback
      케이스로 Osty + Go 양측 unit test

## 이번 세션 누적

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751 | airepair_rewrite v1 | 4 fn + 1 struct |
| #1752 | foreign-loop 리라이터 | 5 fn + 3 struct |
| #1755 | semantic 리라이터 | 5 fn + 2 struct |
| #1757 | source 파싱 + src-trigger predicates | 6 fn + 1 struct |
| #1758 | format use-sort + chain-break | 4 fn + 2 struct |
| (this) | scaffold expectedPaths | 2 fn |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_