### PR TITLE
refactor: diag formatter pure helpers self-host (toolchain/diag_render.osty)

### DIFF
--- a/internal/diag/format.go
+++ b/internal/diag/format.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/osty/osty/internal/runner"
 )
 
 // Formatter renders Diagnostics with source-snippet caret underlines.
@@ -390,62 +392,33 @@ func (f *Formatter) colorizeCaretRow(row string, sev Severity, _ bool) string {
 }
 
 // colToRuneIndex converts a 1-based column (counted in Unicode code
-// points) to a 0-based index into the given rune slice.
+// points) to a 0-based index into the given rune slice. Policy lives
+// in toolchain/diag_render.osty; this wrapper just hands `len(runes)`
+// over since the policy only needs the length.
 func colToRuneIndex(runes []rune, col int) int {
-	if col <= 1 {
-		return 0
-	}
-	idx := col - 1
-	if idx > len(runes) {
-		idx = len(runes)
-	}
-	return idx
+	return runner.ColToRuneIndex(len(runes), col)
 }
 
 // lineBounds returns the [start, end) byte offsets of the given 1-based
 // line in src, exclusive of the trailing newline. Returns (-1, -1) if
-// out of range.
+// out of range. Policy lives in toolchain/diag_render.osty.
 func lineBounds(src []byte, line int) (int, int) {
-	if line <= 0 {
-		return -1, -1
-	}
-	cur := 1
-	start := 0
-	for i := 0; i < len(src); i++ {
-		if cur == line && src[i] == '\n' {
-			return start, i
-		}
-		if src[i] == '\n' {
-			cur++
-			start = i + 1
-		}
-	}
-	if cur == line {
-		return start, len(src)
-	}
-	return -1, -1
+	r := runner.LineBounds(src, line)
+	return r.Start, r.End
 }
 
+// digitWidth returns the decimal-digit count for `n`. Policy lives
+// in toolchain/diag_render.osty.
 func digitWidth(n int) int {
-	if n < 10 {
-		return 1
-	}
-	w := 0
-	for n > 0 {
-		w++
-		n /= 10
-	}
-	return w
+	return runner.DigitWidth(n)
 }
 
+// padInt left-pads `n` with spaces to `width` columns. Policy lives
+// in toolchain/diag_render.osty.
 func padInt(n, width int) string {
-	s := fmt.Sprintf("%d", n)
-	if len(s) >= width {
-		return s
-	}
-	return strings.Repeat(" ", width-len(s)) + s
+	return runner.PadInt(n, width)
 }
 
-// Ensure utf8 remains imported; used by colToRuneIndex when the caller
-// passes a byte column (handled implicitly via []rune).
+// Ensure utf8 remains imported; the snippet writer still calls it
+// even though the col→rune index policy now lives in Osty.
 var _ = utf8.RuneLen

--- a/internal/runner/diag_render_policy.go
+++ b/internal/runner/diag_render_policy.go
@@ -1,0 +1,94 @@
+// diag_render_policy.go is the Go snapshot of
+// toolchain/diag_render.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LineBoundsResult mirrors toolchain/diag_render.osty's
+// LineBoundsResult. Start/End are -1 when the requested line is
+// out of range; callers test `Start < 0` to detect the miss.
+//
+// Osty: toolchain/diag_render.osty:19
+type LineBoundsResult struct {
+	Start int
+	End   int
+}
+
+// ColToRuneIndex converts a 1-based column (counted in Unicode
+// scalar values) to a 0-based index into a rune sequence of
+// `runeCount` elements. Columns <= 1 map to 0; columns past the
+// end clamp to runeCount.
+//
+// Osty: toolchain/diag_render.osty:29
+func ColToRuneIndex(runeCount, col int) int {
+	if col <= 1 {
+		return 0
+	}
+	idx := col - 1
+	if idx > runeCount {
+		idx = runeCount
+	}
+	return idx
+}
+
+// DigitWidth returns the number of decimal digits needed to
+// render `n`. `n < 10` returns 1 (covers 0 and any small
+// negative); otherwise count by repeated division.
+//
+// Osty: toolchain/diag_render.osty:45
+func DigitWidth(n int) int {
+	if n < 10 {
+		return 1
+	}
+	w := 0
+	for n > 0 {
+		w++
+		n /= 10
+	}
+	return w
+}
+
+// PadInt renders `n` and left-pads it with spaces to `width`
+// columns. When the rendered number already has at least `width`
+// characters the unpadded form is returned.
+//
+// Osty: toolchain/diag_render.osty:62
+func PadInt(n, width int) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) >= width {
+		return s
+	}
+	return strings.Repeat(" ", width-len(s)) + s
+}
+
+// LineBounds returns the [start, end) byte offsets of the 1-based
+// `line` in `src`, exclusive of the trailing newline. Returns
+// (-1, -1) when line <= 0 or the source has fewer than `line`
+// lines. The final line is reported even when it has no trailing
+// newline.
+//
+// Osty: toolchain/diag_render.osty:78
+func LineBounds(src []byte, line int) LineBoundsResult {
+	if line <= 0 {
+		return LineBoundsResult{Start: -1, End: -1}
+	}
+	cur := 1
+	start := 0
+	for i := 0; i < len(src); i++ {
+		if cur == line && src[i] == '\n' {
+			return LineBoundsResult{Start: start, End: i}
+		}
+		if src[i] == '\n' {
+			cur++
+			start = i + 1
+		}
+	}
+	if cur == line {
+		return LineBoundsResult{Start: start, End: len(src)}
+	}
+	return LineBoundsResult{Start: -1, End: -1}
+}

--- a/internal/runner/diag_render_policy_test.go
+++ b/internal/runner/diag_render_policy_test.go
@@ -1,0 +1,95 @@
+package runner
+
+import "testing"
+
+func TestColToRuneIndex(t *testing.T) {
+	cases := []struct {
+		name      string
+		runeCount int
+		col       int
+		want      int
+	}{
+		{"col<=1 returns 0", 10, 1, 0},
+		{"col=0 returns 0", 10, 0, 0},
+		{"negative col returns 0", 10, -5, 0},
+		{"mid column", 10, 5, 4},
+		{"last index", 10, 10, 9},
+		{"past end clamps", 10, 11, 10},
+		{"way past end clamps", 10, 100, 10},
+		{"empty seq col 1", 0, 1, 0},
+		{"empty seq col 5", 0, 5, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ColToRuneIndex(c.runeCount, c.col); got != c.want {
+				t.Errorf("ColToRuneIndex(%d, %d) = %d, want %d",
+					c.runeCount, c.col, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDigitWidth(t *testing.T) {
+	cases := []struct {
+		n    int
+		want int
+	}{
+		{0, 1}, {1, 1}, {9, 1},
+		{10, 2}, {99, 2},
+		{100, 3}, {1234, 4}, {99999, 5},
+	}
+	for _, c := range cases {
+		if got := DigitWidth(c.n); got != c.want {
+			t.Errorf("DigitWidth(%d) = %d, want %d", c.n, got, c.want)
+		}
+	}
+}
+
+func TestPadInt(t *testing.T) {
+	cases := []struct {
+		n     int
+		width int
+		want  string
+	}{
+		{5, 3, "  5"},
+		{42, 4, "  42"},
+		{123, 3, "123"},
+		{1234, 3, "1234"},
+		{7, 0, "7"},
+	}
+	for _, c := range cases {
+		if got := PadInt(c.n, c.width); got != c.want {
+			t.Errorf("PadInt(%d, %d) = %q, want %q", c.n, c.width, got, c.want)
+		}
+	}
+}
+
+func TestLineBounds(t *testing.T) {
+	cases := []struct {
+		name      string
+		src       string
+		line      int
+		wantStart int
+		wantEnd   int
+	}{
+		{"first line", "alpha\nbeta\ngamma", 1, 0, 5},
+		{"mid line", "alpha\nbeta\ngamma", 2, 6, 10},
+		{"last no newline", "alpha\nbeta\ngamma", 3, 11, 16},
+		{"last with newline", "alpha\nbeta\n", 2, 6, 10},
+		{"out of range", "alpha\nbeta\n", 5, -1, -1},
+		{"line zero", "alpha\nbeta\n", 0, -1, -1},
+		{"negative line", "alpha\nbeta\n", -3, -1, -1},
+		{"blank line", "a\n\nb", 2, 2, 2},
+		{"empty source line 1 spans empty range", "", 1, 0, 0},
+		{"empty source line 2 misses", "", 2, -1, -1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := LineBounds([]byte(c.src), c.line)
+			if got.Start != c.wantStart || got.End != c.wantEnd {
+				t.Errorf("LineBounds(%q, %d) = {%d, %d}, want {%d, %d}",
+					c.src, c.line, got.Start, got.End, c.wantStart, c.wantEnd)
+			}
+		})
+	}
+}

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -40,6 +40,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"airepair_flags.osty",
 		"airepair_rewrite.osty",
 		"airepair_source.osty",
+		"diag_render.osty",
 		"format_policy.osty",
 		"profile_flags.osty",
 		"diag_policy.osty",

--- a/toolchain/diag_render.osty
+++ b/toolchain/diag_render.osty
@@ -1,0 +1,104 @@
+/// Pure renderer helpers shared by the diagnostic formatter
+/// (internal/diag/format.go). The host owns ANSI escape emission,
+/// snippet extraction, and the actual `bytes.Buffer` writes; this
+/// module decides the tiny arithmetic / lookup pieces:
+///
+///   - mapping a 1-based column to a 0-based rune index,
+///   - computing the gutter width for line numbers,
+///   - padding integers to a fixed column width,
+///   - locating the byte range of a 1-based line in a source
+///     buffer.
+///
+/// Mirrored by `internal/runner/diag_render_policy.go`. The drift
+/// test under internal/runner keeps the two in sync — the Osty
+/// file is the source of truth at review time.
+use std.strings as strings
+/// LineBoundsResult is `[start, end)` byte offsets of a 1-based
+/// line in a source buffer, exclusive of the trailing newline.
+/// Both fields are `-1` when the line is out of range; callers
+/// check `start < 0` to detect the miss.
+pub struct LineBoundsResult {
+    pub start: Int,
+    pub end: Int,
+}
+/// colToRuneIndex converts a 1-based column (counted in Unicode
+/// scalar values) to a 0-based index into a rune sequence of
+/// `runeCount` elements. Columns `<= 1` map to `0`; columns past
+/// the end clamp to `runeCount`. The actual rune values are not
+/// needed — only the length — so callers pass `runes.len()`.
+pub fn colToRuneIndex(runeCount: Int, col: Int) -> Int {
+    if col <= 1 {
+        return 0
+    }
+    let mut idx = col - 1
+    if idx > runeCount {
+        idx = runeCount
+    }
+    idx
+}
+/// digitWidth returns the number of decimal digits needed to
+/// render `n`. Used to size the gutter for the line-number
+/// column. Mirrors the Go original exactly:
+///
+///   - `n < 10` returns `1` (covers `0` and any small negative).
+///   - Otherwise count the decimal digits by repeated division.
+///
+/// Negative `n` >= 10 is not exercised by the formatter (line
+/// numbers are always positive), so the underflow behaviour is
+/// not specified here.
+pub fn digitWidth(n: Int) -> Int {
+    if n < 10 {
+        return 1
+    }
+    let mut w = 0
+    let mut x = n
+    for x > 0 {
+        w = w + 1
+        x = x / 10
+    }
+    w
+}
+/// padInt renders `n` and left-pads it with spaces to `width`
+/// columns. When the rendered number already has at least
+/// `width` characters the unpadded form is returned.
+pub fn padInt(n: Int, width: Int) -> String {
+    let s = "{n}"
+    if s.len() >= width {
+        return s
+    }
+    strings.repeat(" ", width - s.len()) + s
+}
+/// lineBounds returns the `[start, end)` byte offsets of the
+/// 1-based `line` in `src`, exclusive of the trailing newline.
+/// Returns `start = -1, end = -1` when:
+///
+///   - `line <= 0`,
+///   - the source has fewer than `line` lines.
+///
+/// The final line is reported even when it has no trailing
+/// newline.
+pub fn lineBounds(src: String, line: Int) -> LineBoundsResult {
+    if line <= 0 {
+        return LineBoundsResult {start: -1, end: -1}
+    }
+    let bs = src.bytes()
+    let n = bs.len()
+    let mut cur = 1
+    let mut start = 0
+    let mut i = 0
+    for i < n {
+        let b = bs[i].toInt()
+        if cur == line && b == 0x0A {
+            return LineBoundsResult {start: start, end: i}
+        }
+        if b == 0x0A {
+            cur = cur + 1
+            start = i + 1
+        }
+        i = i + 1
+    }
+    if cur == line {
+        return LineBoundsResult {start: start, end: n}
+    }
+    LineBoundsResult {start: -1, end: -1}
+}

--- a/toolchain/diag_render_test.osty
+++ b/toolchain/diag_render_test.osty
@@ -1,0 +1,87 @@
+use std.testing
+fn testColToRuneIndexClampsAtZero() {
+    testing.assertEq(colToRuneIndex(10, 1), 0)
+    testing.assertEq(colToRuneIndex(10, 0), 0)
+    testing.assertEq(colToRuneIndex(10, -5), 0)
+}
+fn testColToRuneIndexMidColumn() {
+    testing.assertEq(colToRuneIndex(10, 5), 4)
+    testing.assertEq(colToRuneIndex(10, 10), 9)
+}
+fn testColToRuneIndexPastEndClamps() {
+    testing.assertEq(colToRuneIndex(10, 11), 10)
+    testing.assertEq(colToRuneIndex(10, 100), 10)
+}
+fn testColToRuneIndexEmpty() {
+    testing.assertEq(colToRuneIndex(0, 1), 0)
+    testing.assertEq(colToRuneIndex(0, 5), 0)
+}
+fn testDigitWidthSingleDigits() {
+    testing.assertEq(digitWidth(0), 1)
+    testing.assertEq(digitWidth(1), 1)
+    testing.assertEq(digitWidth(9), 1)
+}
+fn testDigitWidthMultiDigit() {
+    testing.assertEq(digitWidth(10), 2)
+    testing.assertEq(digitWidth(99), 2)
+    testing.assertEq(digitWidth(100), 3)
+    testing.assertEq(digitWidth(1234), 4)
+    testing.assertEq(digitWidth(99999), 5)
+}
+fn testPadIntPadsLeftWithSpaces() {
+    testing.assertEq(padInt(5, 3), "  5")
+    testing.assertEq(padInt(42, 4), "  42")
+}
+fn testPadIntNoPaddingWhenWideEnough() {
+    testing.assertEq(padInt(123, 3), "123")
+    testing.assertEq(padInt(1234, 3), "1234")
+}
+fn testPadIntZeroWidth() {
+    testing.assertEq(padInt(7, 0), "7")
+}
+fn testLineBoundsFirstLine() {
+    let r = lineBounds("alpha\nbeta\ngamma", 1)
+    testing.assertEq(r.start, 0)
+    testing.assertEq(r.end, 5)
+}
+fn testLineBoundsMidLine() {
+    let r = lineBounds("alpha\nbeta\ngamma", 2)
+    testing.assertEq(r.start, 6)
+    testing.assertEq(r.end, 10)
+}
+fn testLineBoundsLastLineNoNewline() {
+    let r = lineBounds("alpha\nbeta\ngamma", 3)
+    testing.assertEq(r.start, 11)
+    testing.assertEq(r.end, 16)
+}
+fn testLineBoundsLastLineWithNewline() {
+    let r = lineBounds("alpha\nbeta\n", 2)
+    testing.assertEq(r.start, 6)
+    testing.assertEq(r.end, 10)
+}
+fn testLineBoundsOutOfRange() {
+    let r = lineBounds("alpha\nbeta\n", 5)
+    testing.assertEq(r.start, -1)
+    testing.assertEq(r.end, -1)
+}
+fn testLineBoundsNonPositiveLine() {
+    let r = lineBounds("alpha\nbeta\n", 0)
+    testing.assertEq(r.start, -1)
+    let r2 = lineBounds("alpha\nbeta\n", -3)
+    testing.assertEq(r2.start, -1)
+}
+fn testLineBoundsBlankLine() {
+    let r = lineBounds("a\n\nb", 2)
+    testing.assertEq(r.start, 2)
+    testing.assertEq(r.end, 2)
+}
+fn testLineBoundsEmptySourceLineOneSpansEmpty() {
+    let r = lineBounds("", 1)
+    testing.assertEq(r.start, 0)
+    testing.assertEq(r.end, 0)
+}
+fn testLineBoundsEmptySourceLineTwoMisses() {
+    let r = lineBounds("", 2)
+    testing.assertEq(r.start, -1)
+    testing.assertEq(r.end, -1)
+}


### PR DESCRIPTION
## Summary

`internal/diag/format.go`에 남아있던 4개 순수 helper를 새
`toolchain/diag_render.osty`로 이전. diag formatter는 ANSI escape
emission, snippet 추출, `bytes.Buffer` 출력 같은 host I/O만 담당
하고 작은 산수(컬럼/오프셋/패딩)는 toolchain이 담당.

이전된 정책 (4 fn + 1 struct):

- `colToRuneIndex(runeCount, col) -> Int` — 1-based 컬럼을 0-based
  rune 인덱스로 변환 (col<=1은 0, past-end는 runeCount로 clamp)
- `digitWidth(n) -> Int` — 라인 번호 거터 폭 (`n<10`은 1, 그 외 반복
  나눗셈)
- `padInt(n, width) -> String` — 정수를 width 컬럼에 맞춰 왼쪽 공백
  패딩
- `lineBounds(src, line) -> LineBoundsResult` — 1-based 라인의 byte
  [start, end) 범위 (out-of-range는 -1/-1)

## API 단순화

`colToRuneIndex`는 Go 원본이 `[]rune` 전체를 받지만 내용은 안 보고
`len(runes)`만 사용. Osty 표면은 `runeCount: Int`로 단순화 — host가
`len(runes)` 호출 한 번만 하면 됨.

`lineBounds`는 Go의 `(int, int)` 다중 반환 대신
`LineBoundsResult { start, end }` 구조체로 명시화. host wrapper에서
`return r.Start, r.End`로 기존 시그니처 유지.

## Edge case

빈 소스에서 `lineBounds(line=1)`은 Go 원본대로 `(0, 0)` 반환 — 빈
라인 1이 존재하는 셈. `line >= 2`부터는 `(-1, -1)`. Osty + Go 양쪽
테스트에 이 케이스 명시.

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/diag/... ./internal/runner/...` —
      pass (drift test 포함, 11개 ostySources)
- [x] `go test -count=1 -vet=off ./internal/lexer ./internal/parser
      ./internal/resolve ./internal/check ./internal/diag
      ./internal/format ./internal/lint ./internal/pipeline` — pass
- [x] 수동 sanity: 잘못된 `.osty` 파일에 대해 caret + 라인 거터 +
      패딩이 정상 렌더링되는지 `.bin/osty check`로 확인

## 이번 세션 누적

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751 | airepair_rewrite v1 | 4 fn + 1 struct |
| #1752 | foreign-loop 리라이터 | 5 fn + 3 struct |
| #1755 | semantic 리라이터 | 5 fn + 2 struct |
| #1757 | source 파싱 + src-trigger predicates | 6 fn + 1 struct |
| #1758 | format use-sort + chain-break | 4 fn + 2 struct |
| #1759 | scaffold expectedPaths | 2 fn |
| (this) | diag render helpers | 4 fn + 1 struct |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_