### PR TITLE
refactor: diag explain doc-parser self-host (toolchain/diag_explain.osty)

### DIFF
--- a/internal/diag/explain.go
+++ b/internal/diag/explain.go
@@ -18,6 +18,8 @@ import (
 	"go/token"
 	"sort"
 	"strings"
+
+	"github.com/osty/osty/internal/runner"
 )
 
 //go:embed codes.go
@@ -106,16 +108,16 @@ func AllCodes() []CodeDoc {
 	return out
 }
 
-// ---- parsing helpers (trimmed port of cmd/codesdoc/main.go) ----
+// ---- parsing helpers (host glue around runner.ParseExplainDoc) ----
 
-type parsedExplainDoc struct {
-	Summary string
-	Body    []string
-	Spec    string
-	Example string
-	Fix     string
-}
+// parsedExplainDoc aliases runner.ParsedExplainDoc so the local
+// init wiring keeps its existing field names. The parsing policy
+// itself lives in toolchain/diag_explain.osty.
+type parsedExplainDoc = runner.ParsedExplainDoc
 
+// parseExplainDoc strips the `//` prefix and an optional leading
+// space from each comment in `cg`, then delegates to the
+// toolchain policy for the actual sectioning.
 func parseExplainDoc(cg *ast.CommentGroup) parsedExplainDoc {
 	if cg == nil {
 		return parsedExplainDoc{}
@@ -128,102 +130,7 @@ func parseExplainDoc(cg *ast.CommentGroup) parsedExplainDoc {
 		}
 		lines = append(lines, text)
 	}
-
-	var doc parsedExplainDoc
-	var exampleLines []string
-	var bodyParas [][]string
-	var curPara []string
-
-	flushPara := func() {
-		if len(curPara) == 0 {
-			return
-		}
-		if doc.Summary == "" {
-			joined := strings.Join(trimAllLines(curPara), " ")
-			joined = strings.TrimSuffix(joined, ".")
-			if joined != "" {
-				doc.Summary = joined + "."
-			}
-		} else {
-			bodyParas = append(bodyParas, append([]string(nil), curPara...))
-		}
-		curPara = nil
-	}
-
-	section := ""
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		switch {
-		case strings.HasPrefix(trimmed, "Spec:"):
-			flushPara()
-			section = ""
-			doc.Spec = strings.TrimSpace(strings.TrimPrefix(trimmed, "Spec:"))
-			continue
-		case strings.HasPrefix(trimmed, "Fix:"):
-			flushPara()
-			section = ""
-			doc.Fix = strings.TrimSpace(strings.TrimPrefix(trimmed, "Fix:"))
-			continue
-		case trimmed == "Example:":
-			flushPara()
-			section = "example"
-			continue
-		}
-		if section == "example" {
-			exampleLines = append(exampleLines, line)
-			continue
-		}
-		if trimmed == "" {
-			flushPara()
-			continue
-		}
-		curPara = append(curPara, line)
-	}
-	flushPara()
-
-	for _, p := range bodyParas {
-		doc.Body = append(doc.Body, strings.Join(trimAllLines(p), " "))
-	}
-	if len(exampleLines) > 0 {
-		doc.Example = trimExampleBlock(exampleLines)
-	}
-	return doc
-}
-
-func trimAllLines(xs []string) []string {
-	out := make([]string, len(xs))
-	for i, s := range xs {
-		out[i] = strings.TrimSpace(s)
-	}
-	return out
-}
-
-func trimExampleBlock(lines []string) string {
-	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
-		lines = lines[:len(lines)-1]
-	}
-	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
-		lines = lines[1:]
-	}
-	minIndent := -1
-	for _, l := range lines {
-		if strings.TrimSpace(l) == "" {
-			continue
-		}
-		count := len(l) - len(strings.TrimLeft(l, " "))
-		if minIndent < 0 || count < minIndent {
-			minIndent = count
-		}
-	}
-	if minIndent <= 0 {
-		return strings.Join(lines, "\n")
-	}
-	for i, l := range lines {
-		if len(l) >= minIndent {
-			lines[i] = l[minIndent:]
-		}
-	}
-	return strings.Join(lines, "\n")
+	return runner.ParseExplainDoc(lines)
 }
 
 func firstCommentLine(cg *ast.CommentGroup) string {

--- a/internal/runner/diag_explain_policy.go
+++ b/internal/runner/diag_explain_policy.go
@@ -1,0 +1,154 @@
+// diag_explain_policy.go is the Go snapshot of
+// toolchain/diag_explain.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import "strings"
+
+// ParsedExplainDoc mirrors toolchain/diag_explain.osty's
+// ParsedExplainDoc — the structured outcome of parsing one
+// CodeXxx constant's doc comment.
+//
+// Osty: toolchain/diag_explain.osty:31
+type ParsedExplainDoc struct {
+	Summary string
+	Body    []string
+	Spec    string
+	Example string
+	Fix     string
+}
+
+// explainParseState is the Go mirror of the Osty
+// `ExplainParseState` private struct. Threading it through pure
+// helpers keeps the top-level loop a flat scan over `lines`.
+type explainParseState struct {
+	summary      string
+	spec         string
+	fix          string
+	bodyParas    [][]string
+	curPara      []string
+	exampleLines []string
+	section      string
+}
+
+// ParseExplainDoc walks a list of already-preprocessed comment
+// lines (caller-side: `//` prefix and one optional leading space
+// already stripped) and returns the structured doc.
+//
+// Osty: toolchain/diag_explain.osty:60
+func ParseExplainDoc(lines []string) ParsedExplainDoc {
+	st := explainParseState{}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "Spec:"):
+			st = explainFlushPara(st)
+			st.section = ""
+			st.spec = strings.TrimSpace(strings.TrimPrefix(trimmed, "Spec:"))
+			continue
+		case strings.HasPrefix(trimmed, "Fix:"):
+			st = explainFlushPara(st)
+			st.section = ""
+			st.fix = strings.TrimSpace(strings.TrimPrefix(trimmed, "Fix:"))
+			continue
+		case trimmed == "Example:":
+			st = explainFlushPara(st)
+			st.section = "example"
+			continue
+		}
+		if st.section == "example" {
+			st.exampleLines = append(st.exampleLines, line)
+			continue
+		}
+		if trimmed == "" {
+			st = explainFlushPara(st)
+			continue
+		}
+		st.curPara = append(st.curPara, line)
+	}
+	st = explainFlushPara(st)
+
+	doc := ParsedExplainDoc{
+		Summary: st.summary,
+		Spec:    st.spec,
+		Fix:     st.fix,
+	}
+	for _, para := range st.bodyParas {
+		doc.Body = append(doc.Body, strings.Join(trimAllLines(para), " "))
+	}
+	if len(st.exampleLines) > 0 {
+		doc.Example = trimExampleBlock(st.exampleLines)
+	}
+	return doc
+}
+
+// explainFlushPara dispatches `st.curPara` to summary or body,
+// then clears `curPara`. The first non-empty paragraph becomes
+// the summary (single line, trailing `.` enforced).
+//
+// Osty: toolchain/diag_explain.osty:118
+func explainFlushPara(st explainParseState) explainParseState {
+	if len(st.curPara) == 0 {
+		return st
+	}
+	if st.summary == "" {
+		joined := strings.Join(trimAllLines(st.curPara), " ")
+		stripped := strings.TrimSuffix(joined, ".")
+		if stripped != "" {
+			st.summary = stripped + "."
+		}
+	} else {
+		paraCopy := append([]string(nil), st.curPara...)
+		st.bodyParas = append(st.bodyParas, paraCopy)
+	}
+	st.curPara = nil
+	return st
+}
+
+// trimAllLines applies strings.TrimSpace to every line.
+//
+// Osty: toolchain/diag_explain.osty:138
+func trimAllLines(xs []string) []string {
+	out := make([]string, len(xs))
+	for i, s := range xs {
+		out[i] = strings.TrimSpace(s)
+	}
+	return out
+}
+
+// trimExampleBlock strips leading/trailing blank lines and a
+// common leading-space prefix, then joins with `\n`. Tabs do not
+// count towards the common-indent calculation.
+//
+// Osty: toolchain/diag_explain.osty:146
+func trimExampleBlock(lines []string) string {
+	bs := lines
+	for len(bs) > 0 && strings.TrimSpace(bs[len(bs)-1]) == "" {
+		bs = bs[:len(bs)-1]
+	}
+	for len(bs) > 0 && strings.TrimSpace(bs[0]) == "" {
+		bs = bs[1:]
+	}
+	minIndent := -1
+	for _, l := range bs {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		count := len(l) - len(strings.TrimLeft(l, " "))
+		if minIndent < 0 || count < minIndent {
+			minIndent = count
+		}
+	}
+	if minIndent <= 0 {
+		return strings.Join(bs, "\n")
+	}
+	out := make([]string, len(bs))
+	for i, l := range bs {
+		if len(l) >= minIndent {
+			out[i] = l[minIndent:]
+		} else {
+			out[i] = l
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/internal/runner/diag_explain_policy_test.go
+++ b/internal/runner/diag_explain_policy_test.go
@@ -1,0 +1,130 @@
+package runner
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseExplainDocEmpty(t *testing.T) {
+	d := ParseExplainDoc(nil)
+	if d.Summary != "" || len(d.Body) != 0 || d.Spec != "" || d.Example != "" || d.Fix != "" {
+		t.Errorf("empty input → non-empty doc: %+v", d)
+	}
+}
+
+func TestParseExplainDocSummaryTrailingPeriod(t *testing.T) {
+	if got := ParseExplainDoc([]string{"A short summary"}).Summary; got != "A short summary." {
+		t.Errorf("Summary = %q, want %q", got, "A short summary.")
+	}
+	if got := ParseExplainDoc([]string{"A short summary."}).Summary; got != "A short summary." {
+		t.Errorf("Summary preserves period = %q", got)
+	}
+}
+
+func TestParseExplainDocMultilineSummary(t *testing.T) {
+	d := ParseExplainDoc([]string{"First line", "second line", "third"})
+	if d.Summary != "First line second line third." {
+		t.Errorf("Summary = %q", d.Summary)
+	}
+	if len(d.Body) != 0 {
+		t.Errorf("Body should be empty, got %v", d.Body)
+	}
+}
+
+func TestParseExplainDocBodyParagraphs(t *testing.T) {
+	d := ParseExplainDoc([]string{
+		"Summary.", "",
+		"First.", "",
+		"Second.", "Continued.",
+	})
+	want := []string{"First.", "Second. Continued."}
+	if !reflect.DeepEqual(d.Body, want) {
+		t.Errorf("Body = %v, want %v", d.Body, want)
+	}
+}
+
+func TestParseExplainDocSpec(t *testing.T) {
+	d := ParseExplainDoc([]string{"Summary.", "Spec: §1.6.3"})
+	if d.Spec != "§1.6.3" {
+		t.Errorf("Spec = %q", d.Spec)
+	}
+}
+
+func TestParseExplainDocFix(t *testing.T) {
+	d := ParseExplainDoc([]string{"Summary.", "Fix: close the string with a matching quote"})
+	if d.Fix != "close the string with a matching quote" {
+		t.Errorf("Fix = %q", d.Fix)
+	}
+}
+
+func TestParseExplainDocExampleBlock(t *testing.T) {
+	d := ParseExplainDoc([]string{
+		"Summary.",
+		"Example:",
+		"    let x = \"unterminated",
+		"    let y = 1",
+	})
+	want := "let x = \"unterminated\nlet y = 1"
+	if d.Example != want {
+		t.Errorf("Example = %q, want %q", d.Example, want)
+	}
+}
+
+func TestParseExplainDocExampleStripsLeadingBlanks(t *testing.T) {
+	d := ParseExplainDoc([]string{
+		"Summary.",
+		"Example:",
+		"",
+		"    line",
+		"",
+	})
+	if d.Example != "line" {
+		t.Errorf("Example = %q", d.Example)
+	}
+}
+
+func TestParseExplainDocExampleNoCommonIndent(t *testing.T) {
+	d := ParseExplainDoc([]string{
+		"Summary.",
+		"Example:",
+		"no leading space",
+		"    indented",
+	})
+	if d.Example != "no leading space\n    indented" {
+		t.Errorf("Example = %q", d.Example)
+	}
+}
+
+func TestParseExplainDocAllSections(t *testing.T) {
+	d := ParseExplainDoc([]string{
+		"Headline.",
+		"",
+		"Body paragraph.",
+		"Spec: §2.2",
+		"Fix: do the right thing",
+		"Example:",
+		"    println(\"ok\")",
+	})
+	if d.Summary != "Headline." {
+		t.Errorf("Summary = %q", d.Summary)
+	}
+	if !reflect.DeepEqual(d.Body, []string{"Body paragraph."}) {
+		t.Errorf("Body = %v", d.Body)
+	}
+	if d.Spec != "§2.2" {
+		t.Errorf("Spec = %q", d.Spec)
+	}
+	if d.Fix != "do the right thing" {
+		t.Errorf("Fix = %q", d.Fix)
+	}
+	if d.Example != `println("ok")` {
+		t.Errorf("Example = %q", d.Example)
+	}
+}
+
+func TestParseExplainDocBlankSummarySkipped(t *testing.T) {
+	d := ParseExplainDoc([]string{"."})
+	if d.Summary != "" {
+		t.Errorf("Summary should be empty for bare period, got %q", d.Summary)
+	}
+}

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -40,6 +40,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"airepair_flags.osty",
 		"airepair_rewrite.osty",
 		"airepair_source.osty",
+		"diag_explain.osty",
 		"diag_render.osty",
 		"format_policy.osty",
 		"profile_flags.osty",

--- a/toolchain/diag_explain.osty
+++ b/toolchain/diag_explain.osty
@@ -1,0 +1,185 @@
+/// Pure doc-comment parser for the diagnostic-explanation
+/// surface (`osty explain`, LSP hover for error codes, future IDE
+/// plugins). Host code in `internal/diag/explain.go` owns the
+/// Go-AST traversal that yields the per-constant doc comment as
+/// already-preprocessed lines (leading `//` and a single space
+/// trimmed); this module decides what those lines mean —
+/// section delimiters, paragraph flow, example-block indent
+/// trimming.
+///
+/// Mirrored by `internal/runner/diag_explain_policy.go`. The
+/// drift test under internal/runner keeps the two in sync — the
+/// Osty file is the source of truth at review time.
+///
+/// Trimmed port of the same parser in `cmd/codesdoc/main.go`. The
+/// two implementations must agree byte-for-byte; the markdown
+/// reference `ERROR_CODES.md` and the runtime explain surface are
+/// regenerated from the same `codes.go` doc comments.
+use std.strings as strings
+/// ParsedExplainDoc is the structured outcome of parsing one
+/// CodeXxx constant's doc comment.
+///
+///   - `summary`: first paragraph collapsed onto one line, with a
+///     trailing `.` enforced.
+///   - `body`: zero or more subsequent prose paragraphs, each
+///     collapsed onto one line.
+///   - `spec`: the text after the literal `Spec:` line, empty
+///     when absent.
+///   - `example`: the code block under `Example:`, with the
+///     common leading whitespace stripped.
+///   - `fix`: the text after the literal `Fix:` line, empty when
+///     absent.
+pub struct ParsedExplainDoc {
+    pub summary: String,
+    pub body: List<String>,
+    pub spec: String,
+    pub example: String,
+    pub fix: String,
+}
+/// ExplainParseState holds the loop's mutable state. Threading
+/// it through pure helpers keeps `parseExplainDoc` itself a flat
+/// loop the host can reason about line-by-line.
+struct ExplainParseState {
+    summary: String,
+    spec: String,
+    fix: String,
+    bodyParas: List<List<String>>,
+    curPara: List<String>,
+    exampleLines: List<String>,
+    section: String,
+}
+/// parseExplainDoc walks a list of already-preprocessed comment
+/// lines (caller-side: `//` prefix and one optional leading space
+/// already stripped) and returns the structured doc.
+///
+/// Section markers (`Spec:` / `Fix:` / `Example:`) flush the
+/// current paragraph before redirecting subsequent lines. A blank
+/// line flushes a paragraph. The first non-empty paragraph
+/// becomes the summary (one line, trailing `.` enforced); any
+/// later paragraphs join the body.
+pub fn parseExplainDoc(lines: List<String>) -> ParsedExplainDoc {
+    let mut st = ExplainParseState {
+        summary: "",
+        spec: "",
+        fix: "",
+        bodyParas: [],
+        curPara: [],
+        exampleLines: [],
+        section: "",
+    }
+    for line in lines {
+        let trimmed = strings.trimSpace(line)
+        if strings.hasPrefix(trimmed, "Spec:") {
+            st = explainFlushPara(st)
+            st.section = ""
+            st.spec = strings.trimSpace(strings.trimPrefix(trimmed, "Spec:"))
+            continue
+        }
+        if strings.hasPrefix(trimmed, "Fix:") {
+            st = explainFlushPara(st)
+            st.section = ""
+            st.fix = strings.trimSpace(strings.trimPrefix(trimmed, "Fix:"))
+            continue
+        }
+        if trimmed == "Example:" {
+            st = explainFlushPara(st)
+            st.section = "example"
+            continue
+        }
+        if st.section == "example" {
+            st.exampleLines.push(line)
+            continue
+        }
+        if trimmed == "" {
+            st = explainFlushPara(st)
+            continue
+        }
+        st.curPara.push(line)
+    }
+    st = explainFlushPara(st)
+    let mut doc = ParsedExplainDoc {
+        summary: st.summary,
+        body: [],
+        spec: st.spec,
+        example: "",
+        fix: st.fix,
+    }
+    for para in st.bodyParas {
+        doc.body.push(strings.join(trimAllLines(para), " "))
+    }
+    if st.exampleLines.len() > 0 {
+        doc.example = trimExampleBlock(st.exampleLines)
+    }
+    doc
+}
+/// explainFlushPara dispatches `st.curPara` to summary or body,
+/// then clears `curPara`. The first non-empty paragraph becomes
+/// the summary (single line, trailing `.` enforced); subsequent
+/// paragraphs are appended to `bodyParas` for later joining.
+fn explainFlushPara(st: ExplainParseState) -> ExplainParseState {
+    if st.curPara.len() == 0 {
+        return st
+    }
+    let mut out = st
+    if out.summary == "" {
+        let joined = strings.join(trimAllLines(out.curPara), " ")
+        let stripped = strings.trimSuffix(joined, ".")
+        if stripped != "" {
+            out.summary = stripped + "."
+        }
+    } else {
+        out.bodyParas.push(out.curPara)
+    }
+    out.curPara = []
+    out
+}
+/// trimAllLines applies `strings.trimSpace` to every line. Empty
+/// input returns an empty list.
+fn trimAllLines(xs: List<String>) -> List<String> {
+    xs.map(|s| strings.trimSpace(s))
+}
+/// trimExampleBlock strips leading/trailing blank lines and a
+/// common leading-space prefix from the example block, then
+/// joins with `\n`. Tabs do not count towards the common-indent
+/// calculation — only ASCII space (0x20).
+fn trimExampleBlock(lines: List<String>) -> String {
+    let mut bs = lines
+    for bs.len() > 0 && strings.trimSpace(bs[bs.len() - 1]) == "" {
+        bs = exampleSlice(bs, 0, bs.len() - 1)
+    }
+    for bs.len() > 0 && strings.trimSpace(bs[0]) == "" {
+        bs = exampleSlice(bs, 1, bs.len())
+    }
+    let mut minIndent = -1
+    for l in bs {
+        if strings.trimSpace(l) == "" {
+            continue
+        }
+        let leadingTrimmed = strings.trimStartChars(l, " ")
+        let count = l.len() - leadingTrimmed.len()
+        if minIndent < 0 || count < minIndent {
+            minIndent = count
+        }
+    }
+    if minIndent <= 0 {
+        return strings.join(bs, "\n")
+    }
+    let mut out: List<String> = []
+    for l in bs {
+        if l.len() >= minIndent {
+            out.push(strings.slice(l, minIndent, l.len()))
+        } else {
+            out.push(l)
+        }
+    }
+    strings.join(out, "\n")
+}
+fn exampleSlice(xs: List<String>, start: Int, end: Int) -> List<String> {
+    let mut out: List<String> = []
+    let mut i = start
+    for i < end {
+        out.push(xs[i])
+        i = i + 1
+    }
+    out
+}

--- a/toolchain/diag_explain_test.osty
+++ b/toolchain/diag_explain_test.osty
@@ -1,0 +1,98 @@
+use std.testing
+fn testParseExplainDocEmpty() {
+    let d = parseExplainDoc([])
+    testing.assertEq(d.summary, "")
+    testing.assertEq(d.body.len(), 0)
+    testing.assertEq(d.spec, "")
+    testing.assertEq(d.example, "")
+    testing.assertEq(d.fix, "")
+}
+fn testParseExplainDocSummaryAddsTrailingPeriod() {
+    let d = parseExplainDoc(["A short summary"])
+    testing.assertEq(d.summary, "A short summary.")
+}
+fn testParseExplainDocSummaryPreservesExistingPeriod() {
+    let d = parseExplainDoc(["A short summary."])
+    testing.assertEq(d.summary, "A short summary.")
+}
+fn testParseExplainDocMultilineSummary() {
+    let d = parseExplainDoc(["First line", "second line", "third"])
+    testing.assertEq(d.summary, "First line second line third.")
+    testing.assertEq(d.body.len(), 0)
+}
+fn testParseExplainDocBodyParagraph() {
+    let d = parseExplainDoc(["Summary.", "", "Body line one.", "Body line two."])
+    testing.assertEq(d.summary, "Summary.")
+    testing.assertEq(d.body.len(), 1)
+    testing.assertEq(d.body[0], "Body line one. Body line two.")
+}
+fn testParseExplainDocMultipleBodyParagraphs() {
+    let d = parseExplainDoc(["Summary.", "", "First.", "", "Second.", "Continued."])
+    testing.assertEq(d.body.len(), 2)
+    testing.assertEq(d.body[0], "First.")
+    testing.assertEq(d.body[1], "Second. Continued.")
+}
+fn testParseExplainDocSpec() {
+    let d = parseExplainDoc(["Summary.", "Spec: §1.6.3"])
+    testing.assertEq(d.summary, "Summary.")
+    testing.assertEq(d.spec, "§1.6.3")
+}
+fn testParseExplainDocFix() {
+    let d = parseExplainDoc(["Summary.", "Fix: close the string with a matching quote"])
+    testing.assertEq(d.fix, "close the string with a matching quote")
+}
+fn testParseExplainDocExampleBlock() {
+    let d = parseExplainDoc([
+        "Summary.",
+        "Example:",
+        "    let x = \"unterminated",
+        "    let y = 1",
+    ])
+    testing.assertEq(d.example, "let x = \"unterminated\nlet y = 1")
+}
+fn testParseExplainDocExampleStripsLeadingBlanks() {
+    let d = parseExplainDoc([
+        "Summary.",
+        "Example:",
+        "",
+        "    line",
+        "",
+    ])
+    testing.assertEq(d.example, "line")
+}
+fn testParseExplainDocExampleNoCommonIndent() {
+    let d = parseExplainDoc([
+        "Summary.",
+        "Example:",
+        "no leading space",
+        "    indented",
+    ])
+    testing.assertEq(d.example, "no leading space\n    indented")
+}
+fn testParseExplainDocSummaryThenSpecOnly() {
+    let d = parseExplainDoc(["A summary line.", "Spec: §X"])
+    testing.assertEq(d.summary, "A summary line.")
+    testing.assertEq(d.body.len(), 0)
+    testing.assertEq(d.spec, "§X")
+}
+fn testParseExplainDocAllSections() {
+    let d = parseExplainDoc([
+        "Headline.",
+        "",
+        "Body paragraph.",
+        "Spec: §2.2",
+        "Fix: do the right thing",
+        "Example:",
+        "    println(\"ok\")",
+    ])
+    testing.assertEq(d.summary, "Headline.")
+    testing.assertEq(d.body.len(), 1)
+    testing.assertEq(d.body[0], "Body paragraph.")
+    testing.assertEq(d.spec, "§2.2")
+    testing.assertEq(d.fix, "do the right thing")
+    testing.assertEq(d.example, "println(\"ok\")")
+}
+fn testParseExplainDocBlankSummarySkipped() {
+    let d = parseExplainDoc(["."])
+    testing.assertEq(d.summary, "")
+}


### PR DESCRIPTION
## Summary

`internal/diag/explain.go`의 doc-comment 파서 (parseExplainDoc +
trimAllLines + trimExampleBlock, 총 ~100줄)를 새
`toolchain/diag_explain.osty`로 이전.

`osty explain <code>` 서브커맨드 + LSP hover (미래)가 CodeXxx 상수
doc-comment를 런타임에 파싱해 구조화된 explanation을 만드는데,
sectioning/paragraph flow/example-block 정규화는 모두 toolchain이
담당하게 된다. Go 쪽은 `*ast.CommentGroup` 순회 + `//` prefix 제거만
host glue로 남는다.

## 이전된 정책 (1 fn + 1 struct, internal helpers 2개)

- `ParsedExplainDoc { summary, body, spec, example, fix }`
- `parseExplainDoc(lines: List<String>) -> ParsedExplainDoc`
  · `Spec:` / `Fix:` / `Example:` 섹션 디스패처
  · 빈 라인은 단락 플러시
  · 첫 비어있지 않은 단락 → summary (one-line, trailing `.` 강제)
  · 나머지 단락 → body (각각 one-line으로 join)
- internal `trimExampleBlock` — 앞뒤 공백 라인 제거 + 공통
  leading-space prefix 제거. tabs는 카운트 안 함 (ASCII space만)
- internal `trimAllLines`

## Go wrapper 축소

`parseExplainDoc(*ast.CommentGroup)` 함수는 31줄짜리 파서에서 19줄
preprocessor + 1줄 runner 호출로 줄어듦:

```go
func parseExplainDoc(cg *ast.CommentGroup) parsedExplainDoc {
    if cg == nil { return parsedExplainDoc{} }
    lines := make([]string, 0, len(cg.List))
    for _, c := range cg.List {
        text := strings.TrimPrefix(c.Text, "//")
        if strings.HasPrefix(text, " ") { text = text[1:] }
        lines = append(lines, text)
    }
    return runner.ParseExplainDoc(lines)
}
```

`parsedExplainDoc`는 `type parsedExplainDoc = runner.ParsedExplainDoc`
alias로 유지 — 내부 init wiring의 기존 필드 이름 그대로 사용.

## drift 경계 메모

`cmd/codesdoc/main.go`도 ERROR_CODES.md 생성을 위해 동일한
doc-comment 형식을 자체 파서로 처리한다 (Go 측 주석에 "trimmed
port" 표시). 본 PR scope에서는 cmd/codesdoc는 건드리지 않음 — 두
파서가 의도적으로 동기화된 상태를 유지해야 한다는 invariant는
보존됨. 추후 PR에서 cmd/codesdoc도 같은 runner shim을 호출하도록
정리하면 한 single source-of-truth로 통합 가능.

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/diag/... ./internal/runner/...` —
      pass (drift test 포함, 12개 ostySources)
- [x] `go run ./cmd/codesdoc -in internal/diag/codes.go -check
      ERROR_CODES.md` — drift 없음 (cmd/codesdoc는 별도 파서지만
      산출물 일치 유지)
- [x] 수동 sanity: `.bin/osty explain E0001` 런타임 explain 표면이
      정상 렌더링됨을 확인
- [x] front-end matrix (`./internal/lexer ./internal/parser
      ./internal/resolve ./internal/check ./internal/diag
      ./internal/format ./internal/lint ./internal/pipeline`) — pass

## 이번 세션 누적

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751 | airepair_rewrite v1 | 4 fn + 1 struct |
| #1752 | foreign-loop 리라이터 | 5 fn + 3 struct |
| #1755 | semantic 리라이터 | 5 fn + 2 struct |
| #1757 | source 파싱 + src-trigger predicates | 6 fn + 1 struct |
| #1758 | format use-sort + chain-break | 4 fn + 2 struct |
| #1759 | scaffold expectedPaths | 2 fn |
| #1760 | diag render helpers | 4 fn + 1 struct |
| (this) | diag explain doc-parser | 1 fn + 1 struct |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_