### PR TITLE
refactor: repair pure 룩업 정책 self-host (toolchain/repair_policy.osty)

### DIFF
--- a/internal/repair/repair.go
+++ b/internal/repair/repair.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/osty/osty/internal/lexer"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -181,29 +182,20 @@ func Source(src []byte) Result {
 	return Result{Source: out, Changes: changes, Skipped: skipped}
 }
 
+// uppercaseBasePrefix delegates to toolchain/repair_policy.osty
+// for the lowercase replacement of an uppercase numeric base
+// prefix.
 func uppercaseBasePrefix(value string) string {
-	if len(value) < 2 || value[0] != '0' {
-		return ""
-	}
-	switch value[1] {
-	case 'X':
-		return "x"
-	case 'B':
-		return "b"
-	case 'O':
-		return "o"
-	default:
-		return ""
-	}
+	return runner.UppercaseBasePrefix(value)
 }
 
+// declarationKeywordReplacement delegates to
+// toolchain/repair_policy.osty for the foreign-keyword → `fn`
+// lookup. Token-context filtering stays in this package's
+// caller.
 func declarationKeywordReplacement(value string) (string, bool) {
-	switch value {
-	case "func", "function", "def":
-		return "fn", true
-	default:
-		return "", false
-	}
+	r := runner.DeclarationKeywordReplacement(value)
+	return r.Value, r.Ok
 }
 
 func looksLikeFnDecl(toks []token.Token, i int) bool {
@@ -305,17 +297,12 @@ func atStatementStart(toks []token.Token, i int) bool {
 	}
 }
 
+// valueIdentifierReplacement delegates to
+// toolchain/repair_policy.osty for the foreign-value → canonical
+// Osty value lookup.
 func valueIdentifierReplacement(value string) (string, bool) {
-	switch value {
-	case "nil", "null":
-		return "None", true
-	case "True":
-		return "true", true
-	case "False":
-		return "false", true
-	default:
-		return "", false
-	}
+	r := runner.ValueIdentifierReplacement(value)
+	return r.Value, r.Ok
 }
 
 func looksLikeValueUse(toks []token.Token, i int) bool {
@@ -455,20 +442,7 @@ func semicolonEdit(src []byte, toks []token.Token, i int) edit {
 }
 
 func lineIndent(src []byte, offset int) string {
-	start := offset
-	for start > 0 && src[start-1] != '\n' {
-		start--
-	}
-	end := start
-	for end < len(src) {
-		switch src[end] {
-		case ' ', '\t':
-			end++
-		default:
-			return string(src[start:end])
-		}
-	}
-	return string(src[start:end])
+	return runner.LineIndent(src, offset)
 }
 
 func nextSignificant(toks []token.Token, start int) token.Token {

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -44,6 +44,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"diag_render.osty",
 		"format_policy.osty",
 		"profile_flags.osty",
+		"repair_policy.osty",
 		"diag_policy.osty",
 		"test_runner.osty",
 		"scaffold_policy.osty",

--- a/internal/runner/repair_policy.go
+++ b/internal/runner/repair_policy.go
@@ -1,0 +1,89 @@
+// repair_policy.go is the Go snapshot of
+// toolchain/repair_policy.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+// RepairLookupResult mirrors toolchain/repair_policy.osty's
+// RepairLookupResult — the outcome of inspecting a token value
+// for a known foreign-language → Osty translation.
+//
+// Osty: toolchain/repair_policy.osty:24
+type RepairLookupResult struct {
+	Value string
+	Ok    bool
+}
+
+// UppercaseBasePrefix recognises numeric literals written with an
+// uppercase base prefix (`0X` / `0B` / `0O`) and returns the
+// lowercase replacement character. Returns "" otherwise.
+//
+// Osty: toolchain/repair_policy.osty:32
+func UppercaseBasePrefix(value string) string {
+	if len(value) < 2 || value[0] != '0' {
+		return ""
+	}
+	switch value[1] {
+	case 'X':
+		return "x"
+	case 'B':
+		return "b"
+	case 'O':
+		return "o"
+	}
+	return ""
+}
+
+// DeclarationKeywordReplacement maps a foreign-language
+// declaration keyword to Osty's `fn`. Token-context filtering
+// stays in the host repair pass.
+//
+// Osty: toolchain/repair_policy.osty:54
+func DeclarationKeywordReplacement(value string) RepairLookupResult {
+	switch value {
+	case "func", "function", "def":
+		return RepairLookupResult{Value: "fn", Ok: true}
+	}
+	return RepairLookupResult{}
+}
+
+// ValueIdentifierReplacement maps a foreign-language value
+// identifier to its Osty canonical form (`nil`/`null` → `None`,
+// `True` → `true`, `False` → `false`).
+//
+// Osty: toolchain/repair_policy.osty:71
+func ValueIdentifierReplacement(value string) RepairLookupResult {
+	switch value {
+	case "nil", "null":
+		return RepairLookupResult{Value: "None", Ok: true}
+	case "True":
+		return RepairLookupResult{Value: "true", Ok: true}
+	case "False":
+		return RepairLookupResult{Value: "false", Ok: true}
+	}
+	return RepairLookupResult{}
+}
+
+// LineIndent returns the leading whitespace prefix of the line
+// that contains byte `offset` in `src`. Only ASCII space (0x20)
+// and tab (0x09) bytes count as indent.
+//
+// Osty: toolchain/repair_policy.osty:91
+func LineIndent(src []byte, offset int) string {
+	start := offset
+	if start > len(src) {
+		start = len(src)
+	}
+	for start > 0 && src[start-1] != '\n' {
+		start--
+	}
+	end := start
+	for end < len(src) {
+		switch src[end] {
+		case ' ', '\t':
+			end++
+		default:
+			return string(src[start:end])
+		}
+	}
+	return string(src[start:end])
+}

--- a/internal/runner/repair_policy_test.go
+++ b/internal/runner/repair_policy_test.go
@@ -1,0 +1,95 @@
+package runner
+
+import "testing"
+
+func TestUppercaseBasePrefix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"0XFF", "x"},
+		{"0X0", "x"},
+		{"0B1010", "b"},
+		{"0O777", "o"},
+		{"0xFF", ""},
+		{"0b10", ""},
+		{"0o7", ""},
+		{"1XFF", ""},
+		{"XX", ""},
+		{"", ""},
+		{"0", ""},
+		{"0Z123", ""},
+		{"0123", ""},
+	}
+	for _, c := range cases {
+		if got := UppercaseBasePrefix(c.in); got != c.want {
+			t.Errorf("UppercaseBasePrefix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDeclarationKeywordReplacement(t *testing.T) {
+	known := []string{"func", "function", "def"}
+	for _, v := range known {
+		r := DeclarationKeywordReplacement(v)
+		if !r.Ok || r.Value != "fn" {
+			t.Errorf("DeclarationKeywordReplacement(%q) = %+v, want {fn true}", v, r)
+		}
+	}
+	unknown := []string{"fn", "let", "", "FUNC"}
+	for _, v := range unknown {
+		r := DeclarationKeywordReplacement(v)
+		if r.Ok {
+			t.Errorf("DeclarationKeywordReplacement(%q).Ok = true, want false", v)
+		}
+	}
+}
+
+func TestValueIdentifierReplacement(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantOk    bool
+		wantValue string
+	}{
+		{"nil", true, "None"},
+		{"null", true, "None"},
+		{"True", true, "true"},
+		{"False", true, "false"},
+		{"None", false, ""},
+		{"true", false, ""},
+		{"false", false, ""},
+		{"", false, ""},
+	}
+	for _, c := range cases {
+		r := ValueIdentifierReplacement(c.in)
+		if r.Ok != c.wantOk || r.Value != c.wantValue {
+			t.Errorf("ValueIdentifierReplacement(%q) = %+v, want {%q %v}",
+				c.in, r, c.wantValue, c.wantOk)
+		}
+	}
+}
+
+func TestLineIndent(t *testing.T) {
+	cases := []struct {
+		name   string
+		src    string
+		offset int
+		want   string
+	}{
+		{"mid-line", "    hello", 8, "    "},
+		{"tab-indent", "\t\thello", 5, "\t\t"},
+		{"no-indent", "hello", 3, ""},
+		{"second-line", "first\n    second", 10, "    "},
+		{"blank-line", "first\n\n    third", 6, ""},
+		{"offset-past-end", "ab", 100, ""},
+		{"mixed-tab-then-non-ws", " \tcode", 4, " \t"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := LineIndent([]byte(c.src), c.offset); got != c.want {
+				t.Errorf("LineIndent(%q, %d) = %q, want %q",
+					c.src, c.offset, got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/repair_policy.osty
+++ b/toolchain/repair_policy.osty
@@ -1,0 +1,109 @@
+/// Pure lookups + tiny string helpers for the parser-level
+/// auto-repair pass (`internal/repair/repair.go`). Host code owns
+/// the token stream traversal, edit application, and source-level
+/// rewriting; this module decides the lexical-only translations
+/// that don't need any token context:
+///
+///   - which uppercase numeric-base prefix needs to be lowercased
+///     (`0X` -> `0x`, `0B` -> `0b`, `0O` -> `0o`);
+///   - which foreign declaration keyword (`func` / `function` /
+///     `def`) maps to Osty's `fn`;
+///   - which foreign value identifier (`nil` / `null` / `True` /
+///     `False`) maps to Osty's canonical form;
+///   - the leading whitespace prefix at a byte offset in source.
+///
+/// Mirrored by `internal/runner/repair_policy.go`. The drift test
+/// under internal/runner keeps the two in sync — the Osty file is
+/// the source of truth at review time.
+use std.strings as strings
+/// RepairLookupResult is the outcome of inspecting a token value
+/// for a known foreign-language → Osty translation. `ok == false`
+/// signals "no canonical rewrite available — leave the source
+/// alone".
+pub struct RepairLookupResult {
+    pub value: String,
+    pub ok: Bool,
+}
+/// uppercaseBasePrefix recognises numeric literals written with
+/// an uppercase base prefix (`0X` / `0B` / `0O`) and returns the
+/// lowercase replacement character. Returns `""` when the value
+/// is not a recognised uppercase-prefix literal.
+///
+/// The host rewriter splices the returned byte over `value[1]`
+/// while keeping the leading `0` and the rest of the literal.
+pub fn uppercaseBasePrefix(value: String) -> String {
+    let bs = value.bytes()
+    if bs.len() < 2 || bs[0].toInt() != 0x30 {
+        return ""
+    }
+    let b1 = bs[1].toInt()
+    if b1 == 0x58 {
+        return "x"
+    }
+    if b1 == 0x42 {
+        return "b"
+    }
+    if b1 == 0x4F {
+        return "o"
+    }
+    ""
+}
+/// declarationKeywordReplacement maps a foreign-language
+/// declaration keyword to Osty's `fn`. The host token-context
+/// check (`looksLikeFnDecl`) decides whether to actually apply
+/// the rewrite.
+pub fn declarationKeywordReplacement(value: String) -> RepairLookupResult {
+    if value == "func" || value == "function" || value == "def" {
+        return RepairLookupResult {value: "fn", ok: true}
+    }
+    RepairLookupResult {value: "", ok: false}
+}
+/// valueIdentifierReplacement maps a foreign-language value
+/// identifier to Osty's canonical form:
+///
+///   - `nil` / `null` -> `None`
+///   - `True` -> `true`
+///   - `False` -> `false`
+///
+/// The host token-context check (`looksLikeValueUse`) decides
+/// whether to actually apply the rewrite.
+pub fn valueIdentifierReplacement(value: String) -> RepairLookupResult {
+    if value == "nil" || value == "null" {
+        return RepairLookupResult {value: "None", ok: true}
+    }
+    if value == "True" {
+        return RepairLookupResult {value: "true", ok: true}
+    }
+    if value == "False" {
+        return RepairLookupResult {value: "false", ok: true}
+    }
+    RepairLookupResult {value: "", ok: false}
+}
+/// lineIndent returns the leading whitespace prefix of the line
+/// that contains byte `offset` in `src`. Only ASCII space (0x20)
+/// and tab (0x09) bytes count as indent; anything else terminates
+/// the prefix.
+///
+/// Used by the auto-repair pass when it needs to insert a new
+/// line with the same indentation as the surrounding code (e.g.
+/// when adding a missing semicolon-replacement newline).
+pub fn lineIndent(src: String, offset: Int) -> String {
+    let bs = src.bytes()
+    let n = bs.len()
+    let mut start = offset
+    if start > n {
+        start = n
+    }
+    for start > 0 && bs[start - 1].toInt() != 0x0A {
+        start = start - 1
+    }
+    let mut end = start
+    for end < n {
+        let b = bs[end].toInt()
+        if b != 0x20 && b != 0x09 {
+            break
+        }
+        end = end + 1
+    }
+    strings.slice(src, start, end)
+}

--- a/toolchain/repair_policy_test.osty
+++ b/toolchain/repair_policy_test.osty
@@ -1,0 +1,89 @@
+use std.testing
+fn testUppercaseBasePrefixHex() {
+    testing.assertEq(uppercaseBasePrefix("0XFF"), "x")
+    testing.assertEq(uppercaseBasePrefix("0X0"), "x")
+}
+fn testUppercaseBasePrefixBinary() {
+    testing.assertEq(uppercaseBasePrefix("0B1010"), "b")
+}
+fn testUppercaseBasePrefixOctal() {
+    testing.assertEq(uppercaseBasePrefix("0O777"), "o")
+}
+fn testUppercaseBasePrefixRejectsLowerCase() {
+    testing.assertEq(uppercaseBasePrefix("0xFF"), "")
+    testing.assertEq(uppercaseBasePrefix("0b10"), "")
+    testing.assertEq(uppercaseBasePrefix("0o7"), "")
+}
+fn testUppercaseBasePrefixRejectsNonZeroPrefix() {
+    testing.assertEq(uppercaseBasePrefix("1XFF"), "")
+    testing.assertEq(uppercaseBasePrefix("XX"), "")
+    testing.assertEq(uppercaseBasePrefix(""), "")
+    testing.assertEq(uppercaseBasePrefix("0"), "")
+}
+fn testUppercaseBasePrefixRejectsUnknownBase() {
+    testing.assertEq(uppercaseBasePrefix("0Z123"), "")
+    testing.assertEq(uppercaseBasePrefix("0123"), "")
+}
+fn testDeclarationKeywordReplacementKnown() {
+    let func_ = declarationKeywordReplacement("func")
+    testing.assert(func_.ok)
+    testing.assertEq(func_.value, "fn")
+    let function = declarationKeywordReplacement("function")
+    testing.assert(function.ok)
+    testing.assertEq(function.value, "fn")
+    let def = declarationKeywordReplacement("def")
+    testing.assert(def.ok)
+    testing.assertEq(def.value, "fn")
+}
+fn testDeclarationKeywordReplacementRejects() {
+    testing.assert(!(declarationKeywordReplacement("fn").ok))
+    testing.assert(!(declarationKeywordReplacement("let").ok))
+    testing.assert(!(declarationKeywordReplacement("").ok))
+    testing.assert(!(declarationKeywordReplacement("FUNC").ok))
+}
+fn testValueIdentifierReplacementNullAliases() {
+    let n1 = valueIdentifierReplacement("nil")
+    testing.assert(n1.ok)
+    testing.assertEq(n1.value, "None")
+    let n2 = valueIdentifierReplacement("null")
+    testing.assert(n2.ok)
+    testing.assertEq(n2.value, "None")
+}
+fn testValueIdentifierReplacementBools() {
+    let t = valueIdentifierReplacement("True")
+    testing.assert(t.ok)
+    testing.assertEq(t.value, "true")
+    let f = valueIdentifierReplacement("False")
+    testing.assert(f.ok)
+    testing.assertEq(f.value, "false")
+}
+fn testValueIdentifierReplacementRejectsCanonical() {
+    testing.assert(!(valueIdentifierReplacement("None").ok))
+    testing.assert(!(valueIdentifierReplacement("true").ok))
+    testing.assert(!(valueIdentifierReplacement("false").ok))
+    testing.assert(!(valueIdentifierReplacement("").ok))
+}
+fn testLineIndentMidLine() {
+    testing.assertEq(lineIndent("    hello", 8), "    ")
+}
+fn testLineIndentTabIndent() {
+    testing.assertEq(lineIndent("\t\thello", 5), "\t\t")
+}
+fn testLineIndentNoIndent() {
+    testing.assertEq(lineIndent("hello", 3), "")
+}
+fn testLineIndentSecondLine() {
+    let src = "first\n    second"
+    testing.assertEq(lineIndent(src, 10), "    ")
+}
+fn testLineIndentBlankLine() {
+    let src = "first\n\n    third"
+    let blank = lineIndent(src, 6)
+    testing.assertEq(blank, "")
+}
+fn testLineIndentOffsetPastEnd() {
+    testing.assertEq(lineIndent("ab", 100), "")
+}
+fn testLineIndentMixedTabsThenNonWhitespace() {
+    testing.assertEq(lineIndent(" \tcode", 4), " \t")
+}


### PR DESCRIPTION
## Summary

`internal/repair/repair.go`의 4개 토큰-비종속 helper를 새
`toolchain/repair_policy.osty`로 이전. 토큰 컨텍스트 검사
(`looksLikeFnDecl`, `looksLikeValueUse` 등)는 host에 그대로 남고,
"이 토큰 값이 알려진 foreign 표기인가"의 lexical 룩업만 toolchain이
담당.

## 이전된 정책 (4 fn + 1 struct)

- `uppercaseBasePrefix(value) -> String` — `0X`/`0B`/`0O` 대문자
  base prefix 인식. 소문자 1바이트 (`x`/`b`/`o`) 반환, unrecognised는
  `""`
- `declarationKeywordReplacement(value) -> RepairLookupResult` —
  foreign 선언 키워드 (`func`/`function`/`def`)를 Osty `fn`으로 매핑
- `valueIdentifierReplacement(value) -> RepairLookupResult` —
  foreign 값 식별자 (`nil`/`null` → `None`, `True` → `true`,
  `False` → `false`)
- `lineIndent(src, offset) -> String` — 주어진 byte offset이 속한
  라인의 leading whitespace prefix (ASCII space/tab만 카운트)

## Go wrapper 축소

Go 측 4개 함수는 모두 1줄 thin wrapper로 줄어듦:

```go
func uppercaseBasePrefix(value string) string {
    return runner.UppercaseBasePrefix(value)
}

func declarationKeywordReplacement(value string) (string, bool) {
    r := runner.DeclarationKeywordReplacement(value)
    return r.Value, r.Ok
}
```

Token-context filtering (`atStatementStart`, `tokenStartsExpr`,
`looksLikeFnDecl` 등)은 host에 그대로 남는다 — Osty 측은 token
arena 인터페이스가 없기 때문에 token-aware 정책은 후속 PR에서
별도 작업.

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/repair/... ./internal/airepair/...
      ./internal/runner/...` — pass (drift test 포함, 13개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run
      'TestAIRepair|TestFmtAIRepair|TestRunRepair'` — pass (2.0s)
- [x] `go vet ./internal/repair/... ./internal/airepair/...
      ./internal/runner/...` — clean

## 이번 세션 누적 (10번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1757 | airepair 정책-free (4 PRs) | 20 fn + 7 struct |
| #1758 | format use-sort + chain-break | 4 fn + 2 struct |
| #1759 | scaffold expectedPaths | 2 fn |
| #1760 | diag render helpers | 4 fn + 1 struct |
| #1761 | diag explain doc-parser | 1 fn + 1 struct |
| #1762 | cmd/codesdoc 통합 (drift 경계 제거) | — (consumer) |
| (this) | repair pure lookups + lineIndent | 4 fn + 1 struct |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_