### PR TITLE
refactor: formatter finalize 정책 self-host (toolchain/format_policy.osty 확장)

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/token"
@@ -298,45 +299,8 @@ func (p *printer) rawString(s string) { p.buf.WriteString(s) }
 // finalize walks the formatted buffer once, producing the final bytes:
 // trailing whitespace on each line is stripped, runs of blank lines
 // collapse to a single blank, leading blank lines are removed, and the
-// output ends with exactly one newline. A single pass avoids the two
-// full-buffer copies that a bytes.Split-based approach would require.
+// output ends with exactly one newline. Policy lives in
+// toolchain/format_policy.osty; this wrapper just delegates.
 func finalize(in []byte) []byte {
-	out := bytes.Buffer{}
-	out.Grow(len(in) + 1)
-	lineStart := 0
-	prevBlank := false
-	leading := true
-	writeLine := func(line []byte) {
-		// Trim trailing spaces/tabs.
-		end := len(line)
-		for end > 0 && (line[end-1] == ' ' || line[end-1] == '\t') {
-			end--
-		}
-		blank := end == 0
-		if blank && (leading || prevBlank) {
-			return
-		}
-		leading = false
-		out.Write(line[:end])
-		out.WriteByte('\n')
-		prevBlank = blank
-	}
-	for i := 0; i < len(in); i++ {
-		if in[i] == '\n' {
-			writeLine(in[lineStart:i])
-			lineStart = i + 1
-		}
-	}
-	if lineStart < len(in) {
-		writeLine(in[lineStart:])
-	}
-	b := out.Bytes()
-	// Drop any trailing blank line(s) but keep exactly one final newline.
-	for len(b) >= 2 && b[len(b)-1] == '\n' && b[len(b)-2] == '\n' {
-		b = b[:len(b)-1]
-	}
-	if len(b) == 0 || b[len(b)-1] != '\n' {
-		b = append(b, '\n')
-	}
-	return b
+	return runner.FinalizeFormatted(in)
 }

--- a/internal/runner/format_policy.go
+++ b/internal/runner/format_policy.go
@@ -96,3 +96,53 @@ func ShouldBreakChain(baseEndLine int, segs []ChainSegLines) bool {
 	}
 	return false
 }
+
+// FinalizeFormatted normalises the formatter's raw output into
+// the canonical on-disk shape:
+//
+//   - Every line has its trailing ASCII space (0x20) and tab
+//     (0x09) bytes stripped.
+//   - Consecutive blank lines collapse to a single blank.
+//   - Leading blank lines are removed.
+//   - Output ends with exactly one newline byte.
+//
+// Non-ASCII content and intra-line whitespace are preserved
+// byte-for-byte.
+//
+// Osty: toolchain/format_policy.osty:130
+func FinalizeFormatted(in []byte) []byte {
+	out := make([]byte, 0, len(in)+1)
+	lineStart := 0
+	prevBlank := false
+	leading := true
+	writeLine := func(line []byte) {
+		end := len(line)
+		for end > 0 && (line[end-1] == ' ' || line[end-1] == '\t') {
+			end--
+		}
+		blank := end == 0
+		if blank && (leading || prevBlank) {
+			return
+		}
+		leading = false
+		out = append(out, line[:end]...)
+		out = append(out, '\n')
+		prevBlank = blank
+	}
+	for i := 0; i < len(in); i++ {
+		if in[i] == '\n' {
+			writeLine(in[lineStart:i])
+			lineStart = i + 1
+		}
+	}
+	if lineStart < len(in) {
+		writeLine(in[lineStart:])
+	}
+	for len(out) >= 2 && out[len(out)-1] == '\n' && out[len(out)-2] == '\n' {
+		out = out[:len(out)-1]
+	}
+	if len(out) == 0 || out[len(out)-1] != '\n' {
+		out = append(out, '\n')
+	}
+	return out
+}

--- a/internal/runner/format_policy_test.go
+++ b/internal/runner/format_policy_test.go
@@ -73,6 +73,35 @@ func TestUseCSurfaceLibName(t *testing.T) {
 	}
 }
 
+func TestFinalizeFormatted(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"adds-trailing-newline", "hello", "hello\n"},
+		{"keeps-single-newline", "hello\n", "hello\n"},
+		{"collapses-trailing-newlines", "hello\n\n\n", "hello\n"},
+		{"trims-trailing-spaces", "a  \nb\t\n", "a\nb\n"},
+		{"collapses-blank-lines", "a\n\n\nb\n", "a\n\nb\n"},
+		{"drops-leading-blanks", "\n\nhello\n", "hello\n"},
+		{"all-blanks-reduces", "\n\n\n", "\n"},
+		{"empty", "", "\n"},
+		{"preserves-intra-line-ws", "a   b\n", "a   b\n"},
+		{"trims-mixed-tabs-spaces", "line \t \nnext", "line\nnext\n"},
+		{"no-trailing-newline-body", "a\nb", "a\nb\n"},
+		{"preserves-non-ascii", "한글 \n", "한글\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := string(FinalizeFormatted([]byte(c.in)))
+			if got != c.want {
+				t.Errorf("FinalizeFormatted(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 func TestShouldBreakChain(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/toolchain/format_policy.osty
+++ b/toolchain/format_policy.osty
@@ -154,7 +154,7 @@ pub fn finalizeFormatted(input: String) -> String {
         prevBlank = result.prevBlank
     }
     for out.len() >= 2 && out[out.len() - 1].toInt() == 0x0A && out[out.len() - 2].toInt() == 0x0A {
-        out = formatPolicyDropLast(out)
+        let _ = out.pop()
     }
     if out.len() == 0 || out[out.len() - 1].toInt() != 0x0A {
         out.push(formatPolicyNewlineByte())
@@ -188,16 +188,6 @@ fn formatPolicyWriteLine(out: List<Byte>, bs: List<Byte>, start: Int, end: Int, 
     }
     acc.push(formatPolicyNewlineByte())
     FinalizeWriteResult {out: acc, leading: false, prevBlank: blank}
-}
-fn formatPolicyDropLast(xs: List<Byte>) -> List<Byte> {
-    let mut out: List<Byte> = []
-    let mut i = 0
-    let n = xs.len() - 1
-    for i < n {
-        out.push(xs[i])
-        i = i + 1
-    }
-    out
 }
 fn formatPolicyNewlineByte() -> Byte {
     let n: Int = 0x0A

--- a/toolchain/format_policy.osty
+++ b/toolchain/format_policy.osty
@@ -14,6 +14,7 @@
 /// Mirrored by `internal/runner/format_policy.go`. The drift test
 /// under internal/runner keeps the two in sync — the Osty file is
 /// the source of truth at review time.
+use std.bytes as bytes
 use std.strings as strings
 /// CSurfaceLib is the outcome of inspecting a FFI runtime path
 /// for the `runtime.cabi.<lib>` sugar. `ok == false` leaves `lib`
@@ -112,4 +113,93 @@ pub fn shouldBreakChain(baseEndLine: Int, segs: List<ChainSegLines>) -> Bool {
         prev = s.endLine
     }
     false
+}
+/// finalizeFormatted normalises the formatter's raw output into
+/// the canonical on-disk shape:
+///
+///   - Every line has its trailing ASCII space (0x20) and tab
+///     (0x09) bytes stripped.
+///   - Consecutive blank lines collapse to a single blank.
+///   - Leading blank lines (before any non-blank line) are
+///     removed entirely.
+///   - The output ends with exactly one newline byte.
+///
+/// Non-ASCII characters and intra-line whitespace are preserved
+/// byte-for-byte. The function is the formatter's last pass
+/// before write — host code in `internal/format` produces the
+/// `strings.Builder`-style raw output, then hands the bytes here
+/// for normalisation.
+pub fn finalizeFormatted(input: String) -> String {
+    let bs = input.bytes()
+    let n = bs.len()
+    let mut out: List<Byte> = []
+    let mut lineStart = 0
+    let mut prevBlank = false
+    let mut leading = true
+    let mut i = 0
+    for i < n {
+        if bs[i].toInt() == 0x0A {
+            let result = formatPolicyWriteLine(out, bs, lineStart, i, leading, prevBlank)
+            out = result.out
+            leading = result.leading
+            prevBlank = result.prevBlank
+            lineStart = i + 1
+        }
+        i = i + 1
+    }
+    if lineStart < n {
+        let result = formatPolicyWriteLine(out, bs, lineStart, n, leading, prevBlank)
+        out = result.out
+        leading = result.leading
+        prevBlank = result.prevBlank
+    }
+    for out.len() >= 2 && out[out.len() - 1].toInt() == 0x0A && out[out.len() - 2].toInt() == 0x0A {
+        out = formatPolicyDropLast(out)
+    }
+    if out.len() == 0 || out[out.len() - 1].toInt() != 0x0A {
+        out.push(formatPolicyNewlineByte())
+    }
+    let buf = bytes.from(out)
+    bytes.toString(buf).unwrapOr(input)
+}
+struct FinalizeWriteResult {
+    out: List<Byte>,
+    leading: Bool,
+    prevBlank: Bool,
+}
+fn formatPolicyWriteLine(out: List<Byte>, bs: List<Byte>, start: Int, end: Int, leading: Bool, prevBlank: Bool) -> FinalizeWriteResult {
+    let mut e = end
+    for e > start {
+        let b = bs[e - 1].toInt()
+        if b != 0x20 && b != 0x09 {
+            break
+        }
+        e = e - 1
+    }
+    let blank = e == start
+    if blank && (leading || prevBlank) {
+        return FinalizeWriteResult {out: out, leading: leading, prevBlank: prevBlank}
+    }
+    let mut acc = out
+    let mut j = start
+    for j < e {
+        acc.push(bs[j])
+        j = j + 1
+    }
+    acc.push(formatPolicyNewlineByte())
+    FinalizeWriteResult {out: acc, leading: false, prevBlank: blank}
+}
+fn formatPolicyDropLast(xs: List<Byte>) -> List<Byte> {
+    let mut out: List<Byte> = []
+    let mut i = 0
+    let n = xs.len() - 1
+    for i < n {
+        out.push(xs[i])
+        i = i + 1
+    }
+    out
+}
+fn formatPolicyNewlineByte() -> Byte {
+    let n: Int = 0x0A
+    n.toByte()
 }

--- a/toolchain/format_policy_test.osty
+++ b/toolchain/format_policy_test.osty
@@ -82,3 +82,39 @@ fn testShouldBreakChainMultiLineCallStaysFlat() {
     ]
     testing.assert(!(shouldBreakChain(1, segs)))
 }
+fn testFinalizeFormattedAddsTrailingNewline() {
+    testing.assertEq(finalizeFormatted("hello"), "hello\n")
+}
+fn testFinalizeFormattedKeepsSingleTrailingNewline() {
+    testing.assertEq(finalizeFormatted("hello\n"), "hello\n")
+}
+fn testFinalizeFormattedCollapsesTrailingNewlines() {
+    testing.assertEq(finalizeFormatted("hello\n\n\n"), "hello\n")
+}
+fn testFinalizeFormattedTrimsTrailingSpaces() {
+    testing.assertEq(finalizeFormatted("a  \nb\t\n"), "a\nb\n")
+}
+fn testFinalizeFormattedCollapsesBlankLines() {
+    testing.assertEq(finalizeFormatted("a\n\n\nb\n"), "a\n\nb\n")
+}
+fn testFinalizeFormattedDropsLeadingBlanks() {
+    testing.assertEq(finalizeFormatted("\n\nhello\n"), "hello\n")
+}
+fn testFinalizeFormattedAllBlanksReducesToOneNewline() {
+    testing.assertEq(finalizeFormatted("\n\n\n"), "\n")
+}
+fn testFinalizeFormattedEmpty() {
+    testing.assertEq(finalizeFormatted(""), "\n")
+}
+fn testFinalizeFormattedPreservesIntraLineWhitespace() {
+    testing.assertEq(finalizeFormatted("a   b\n"), "a   b\n")
+}
+fn testFinalizeFormattedTrimsTabsAndSpacesMixed() {
+    testing.assertEq(finalizeFormatted("line \t \nnext"), "line\nnext\n")
+}
+fn testFinalizeFormattedNoTrailingNewlineWithBody() {
+    testing.assertEq(finalizeFormatted("a\nb"), "a\nb\n")
+}
+fn testFinalizeFormattedPreservesNonAscii() {
+    testing.assertEq(finalizeFormatted("한글 \n"), "한글\n")
+}


### PR DESCRIPTION
## Summary

`internal/format/format.go`의 `finalize` 함수 (formatter raw 출력을
canonical on-disk 형태로 정규화)를 self-host. PR #1758에서 만든
`toolchain/format_policy.osty`에 통합.

## 이전된 정책 (1 fn 추가)

`finalizeFormatted(input: String) -> String`:

- 각 라인의 trailing ASCII space (0x20) + tab (0x09) 트림
- 연속 빈 라인을 단일 빈 라인으로 축약
- 선행 빈 라인 제거
- 출력은 정확히 하나의 trailing newline으로 끝남
- 비-ASCII content + intra-line whitespace는 byte-for-byte 보존

## 설계 노트

- **List<Byte> 누적**: Osty는 Go의 `bytes.Buffer.Grow()` 같은 capacity
  힌트가 없으므로 `List<Byte>` 누적 + `bytes.toString` 최종 변환
- **명시적 mut state thread**: Osty closure는 enclosing scope의 mut
  state 캡처가 제한적이므로 `FinalizeWriteResult { out, leading,
  prevBlank }` 구조체로 한 번에 반환
- **bytes.toString fallback**: `.unwrapOr(input)` — 모든 입력 바이트가
  원본 String의 일부였으므로 결과도 valid UTF-8 보장되지만, 안전을
  위해 fallback

## Go wrapper 축소

`internal/format/format.go::finalize`는 ~40줄짜리 함수에서 3줄 thin
wrapper로 줄어듦:

```go
func finalize(in []byte) []byte {
    return runner.FinalizeFormatted(in)
}
```

`bytes.Buffer` import는 여전히 다른 곳 (printer state)에서 사용되므로
유지.

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/format/... ./internal/runner/...` —
      pass (drift test 포함, 13개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run TestFmt` — pass (5.9s)
- [x] 12개 케이스 (empty / all-blanks / mixed tabs+spaces / 비-ASCII
      preservation / leading-blank drop / trailing-newline 보장)
      Osty + Go 양측 unit test

## 이번 세션 누적 (11번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1757 | airepair 정책-free | 20 fn + 7 struct |
| #1758 | format use-sort + chain-break | 4 fn + 2 struct |
| #1759 | scaffold expectedPaths | 2 fn |
| #1760 | diag render helpers | 4 fn + 1 struct |
| #1761 | diag explain doc-parser | 1 fn + 1 struct |
| #1762 | cmd/codesdoc 통합 | — (consumer) |
| #1763 | repair pure lookups + lineIndent | 4 fn + 1 struct |
| (this) | format finalize | 1 fn |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_