### PR TITLE
[codex] selfhost source LIR probe hardening

### DIFF
--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -504,12 +504,10 @@ func TestPhase0SelfHostWiringExists(t *testing.T) {
 	}
 }
 
-// TestPhase0DoctorMessageReflectsProgress pins the wording of the
-// `--selfhost-doctor` output so a future revert of `runSelfhostDoctor`
-// (which used to claim the module emitter was wholly missing) can't
-// silently regress the surfaced status. Expanded coverage will tighten
-// these bands as Phase 1+ lands.
-func TestPhase0DoctorMessageReflectsProgress(t *testing.T) {
+// TestSelfhostDoctorRunsSourceProbe pins the `--selfhost-doctor`
+// source probe so the status cannot drift back to a text-only Phase 0
+// claim while the real LIR Proto path regresses underneath it.
+func TestSelfhostDoctorRunsSourceProbe(t *testing.T) {
 	root, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatalf("abs root: %v", err)
@@ -520,18 +518,24 @@ func TestPhase0DoctorMessageReflectsProgress(t *testing.T) {
 	}
 	text := string(src)
 	// The doctor must NOT keep saying "missing stage: MIR-to-LLVM
-	// module emitter" once mirEmitModule is wired (Phase 0). It SHOULD
-	// surface the next dependency wall (per-instruction body emission).
+	// module emitter" once LIR Proto lowering is wired. It SHOULD run a
+	// small source pipeline and only mark the source compiler enabled
+	// when that probe reaches rendered LLVM IR.
 	regressed := regexp.MustCompile(`missing stage:\s*MIR-to-LLVM module emitter`)
 	if regressed.MatchString(text) {
-		t.Fatalf("doctor still claims module emitter is missing — Phase 0 mirEmitModule should have flipped this status")
+		t.Fatalf("doctor still claims module emitter is missing; LIR Proto lowering should have flipped this status")
 	}
 	for _, needle := range []string{
-		"phase 0",
-		"per-instruction body emission",
+		"selfhostProbeError",
+		"lirLowerMirModule(",
+		"lirRenderModule(",
+		"LLVM IR renderer produced no return instruction",
+		"osty-self source compiler: enabled",
+		"osty-self self-rebuild probe: OK",
+		"full toolchain directory rebuild/link orchestration",
 	} {
-		if !strings.Contains(strings.ToLower(text), needle) {
-			t.Errorf("doctor message missing %q (Phase 0 status surface)", needle)
+		if !strings.Contains(text, needle) {
+			t.Errorf("doctor probe missing %q", needle)
 		}
 	}
 }

--- a/toolchain/frontend.osty
+++ b/toolchain/frontend.osty
@@ -732,6 +732,7 @@ pub fn emptyFrontLexSummary() -> FrontLexSummary {
 pub fn frontendLexStream(source: String) -> FrontLexStream {
     let units = strings.split(source, "")
     let unitCount = stringUnitCount(source)
+    let positions = frontBuildPositionIndex(units, unitCount)
     let mut tokens: List<FrontLexToken> = []
     let mut diagnostics: List<FrontLexDiagnostic> = []
     let mut comments: List<FrontComment> = []
@@ -758,7 +759,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
             let unit = frontUnitAt(units, idx)
             let next = frontUnitAt(units, idx + 1)
             let third = frontUnitAt(units, idx + 2)
-            let start = frontPositionAt(units, idx)
+            let start = frontPositionFromIndex(positions, idx)
             if atFileStart && unit == "\u{FEFF}" {
                 bomStripped = bomStripped + 1
             } else if atFileStart && unit == "#" && next == "!" {
@@ -772,14 +773,14 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let consumed = frontNewlineConsumed(unit, next)
                 atFileStart = false
                 if insertTerm && parenDepth == 0 && !(frontNextSuppressesTerm(units, idx + consumed, unitCount)) {
-                    tokens.push(frontLexTokenFromScan(units, idx, consumed, FrontNewline, 0, false, 0, false))
+                    tokens.push(frontLexTokenFromScanIndexed(positions, idx, consumed, FrontNewline, 0, false, 0, false))
                     tokenIndex = tokenIndex + 1
                     insertTerm = false
                 }
                 skip = consumed - 1
             } else if unit == "/" && next == "/" {
                 let consumed = frontLineCommentSkip(units, idx + 2, unitCount) + 1
-                let end = frontPositionAt(units, idx + consumed)
+                let end = frontPositionFromIndex(positions, idx + consumed)
                 atFileStart = false
                 if third == "/" && frontUnitAt(units, idx + 3) != "/" {
                     comments.push(frontComment(FrontCommentDoc, start, end, 1))
@@ -792,7 +793,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 skip = consumed - 1
             } else if unit == "/" && next == "*" {
                 let block = frontBlockCommentSkip(units, idx, unitCount)
-                let end = frontPositionAt(units, idx + block.consumed)
+                let end = frontPositionFromIndex(positions, idx + block.consumed)
                 atFileStart = false
                 comments.push(frontComment(FrontCommentBlock, start, end, frontCommentLineCount(start, end)))
                 if !(block.ok) {
@@ -804,7 +805,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let leadingDocLines = frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
                 atFileStart = false
                 let ownerToken = tokenIndex
-                tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
+                tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
                 let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
@@ -822,7 +823,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 tripleIndentErrors = tripleIndentErrors + facts.tripleIndentErrors
                 escapeErrors = escapeErrors + facts.escapeErrors
                 if scan.errors > 0 {
-                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, FrontRawString, scan), start, frontPositionAt(units, idx + scan.consumed)))
+                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, FrontRawString, scan), start, frontPositionFromIndex(positions, idx + scan.consumed)))
                 }
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
@@ -837,7 +838,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let leadingDocLines = frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
                 atFileStart = false
                 let ownerToken = tokenIndex
-                tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
+                tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
                 let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
@@ -855,7 +856,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 tripleIndentErrors = tripleIndentErrors + facts.tripleIndentErrors
                 escapeErrors = escapeErrors + facts.escapeErrors
                 if scan.errors > 0 {
-                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, byteScanKind, scan), start, frontPositionAt(units, idx + scan.consumed)))
+                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, byteScanKind, scan), start, frontPositionFromIndex(positions, idx + scan.consumed)))
                 }
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
@@ -865,7 +866,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let leadingDocLines = frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
                 atFileStart = false
                 let ownerToken = tokenIndex
-                tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
+                tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
                 let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
@@ -883,7 +884,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 tripleIndentErrors = tripleIndentErrors + facts.tripleIndentErrors
                 escapeErrors = escapeErrors + facts.escapeErrors
                 if scan.errors > 0 {
-                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, FrontByte, scan), start, frontPositionAt(units, idx + scan.consumed)))
+                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, FrontByte, scan), start, frontPositionFromIndex(positions, idx + scan.consumed)))
                 }
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
@@ -893,7 +894,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let leadingDocLines = frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
                 atFileStart = false
                 let ownerToken = tokenIndex
-                tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
+                tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
                 let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
@@ -911,7 +912,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 tripleIndentErrors = tripleIndentErrors + facts.tripleIndentErrors
                 escapeErrors = escapeErrors + facts.escapeErrors
                 if scan.errors > 0 {
-                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, FrontString, scan), start, frontPositionAt(units, idx + scan.consumed)))
+                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, FrontString, scan), start, frontPositionFromIndex(positions, idx + scan.consumed)))
                 }
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
@@ -920,7 +921,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let scan = frontLabelScan(units, idx, unitCount)
                 let leadingDocLines = frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
                 atFileStart = false
-                tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLines, false, 0, false))
+                tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, false, 0, false))
                 tokenIndex = tokenIndex + 1
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
@@ -930,7 +931,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let leadingDocLines = frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
                 atFileStart = false
                 let ownerToken = tokenIndex
-                tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
+                tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
                 let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
@@ -948,7 +949,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 tripleIndentErrors = tripleIndentErrors + facts.tripleIndentErrors
                 escapeErrors = escapeErrors + facts.escapeErrors
                 if scan.errors > 0 {
-                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, FrontChar, scan), start, frontPositionAt(units, idx + scan.consumed)))
+                    diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, idx, unitCount, FrontChar, scan), start, frontPositionFromIndex(positions, idx + scan.consumed)))
                 }
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
@@ -957,13 +958,13 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let scan = frontNumberScan(units, idx, unitCount)
                 let leadingDocLines = frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
                 atFileStart = false
-                tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, scan.baseLiteral))
+                tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, scan.baseLiteral))
                 tokenIndex = tokenIndex + 1
                 if scan.uppercaseBasePrefix {
-                    diagnostics.push(frontLexDiagnostic(FrontDiagUppercaseBasePrefix, start, frontPositionAt(units, idx + 2)))
+                    diagnostics.push(frontLexDiagnostic(FrontDiagUppercaseBasePrefix, start, frontPositionFromIndex(positions, idx + 2)))
                 }
                 if frontNumberHasBadSeparator(units, idx, scan.consumed) {
-                    diagnostics.push(frontLexDiagnostic(FrontDiagBadNumericSeparator, start, frontPositionAt(units, idx + scan.consumed)))
+                    diagnostics.push(frontLexDiagnostic(FrontDiagBadNumericSeparator, start, frontPositionFromIndex(positions, idx + scan.consumed)))
                 }
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
@@ -972,7 +973,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let scan = frontIdentScan(units, idx, unitCount)
                 let leadingDocLines = frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
                 atFileStart = false
-                tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLines, false, 0, false))
+                tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, false, 0, false))
                 tokenIndex = tokenIndex + 1
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
@@ -982,7 +983,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let leadingDocLines = frontAttachedDocLines(pendingDocLines, docLastLine, start.line)
                 atFileStart = false
                 if scan.ok {
-                    tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, scan.kind, leadingDocLines, false, 0, false))
+                    tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, false, 0, false))
                     tokenIndex = tokenIndex + 1
                     if scan.kind == FrontLParen || scan.kind == FrontLBracket {
                         parenDepth = parenDepth + 1
@@ -994,9 +995,9 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                     insertTerm = frontKindInsertsTerm(scan.kind)
                 } else {
                     let diagCode = frontIllegalDiagnosticCode(units, idx, scan)
-                    tokens.push(frontLexTokenFromScan(units, idx, scan.consumed, FrontIllegal, leadingDocLines, false, 0, false))
+                    tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, FrontIllegal, leadingDocLines, false, 0, false))
                     tokenIndex = tokenIndex + 1
-                    diagnostics.push(frontLexDiagnostic(diagCode, start, frontPositionAt(units, idx + scan.consumed)))
+                    diagnostics.push(frontLexDiagnostic(diagCode, start, frontPositionFromIndex(positions, idx + scan.consumed)))
                     insertTerm = false
                 }
                 pendingDocLines = 0
@@ -1004,7 +1005,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
             }
         }
     }
-    let eofPos = frontPositionAt(units, unitCount)
+    let eofPos = frontPositionFromIndex(positions, unitCount)
     if insertTerm {
         tokens.push(frontLexToken(FrontNewline, eofPos, eofPos, 0, 0, false, 0, false))
         tokenIndex = tokenIndex + 1
@@ -1015,6 +1016,53 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
 }
 pub fn frontLexTokenFromScan(units: List<String>, start: Int, consumed: Int, kind: FrontTokenKind, leadingDocLines: Int, triple: Bool, interpolations: Int, baseLiteral: Bool) -> FrontLexToken {
     frontLexToken(kind, frontPositionAt(units, start), frontPositionAt(units, start + consumed), consumed, leadingDocLines, triple, interpolations, baseLiteral)
+}
+pub fn frontLexTokenFromScanIndexed(positions: List<FrontPos>, start: Int, consumed: Int, kind: FrontTokenKind, leadingDocLines: Int, triple: Bool, interpolations: Int, baseLiteral: Bool) -> FrontLexToken {
+    frontLexToken(kind, frontPositionFromIndex(positions, start), frontPositionFromIndex(positions, start + consumed), consumed, leadingDocLines, triple, interpolations, baseLiteral)
+}
+pub fn frontBuildPositionIndex(units: List<String>, unitCount: Int) -> List<FrontPos> {
+    let mut positions: List<FrontPos> = []
+    let mut offset = 0
+    let mut line = 1
+    let mut column = 1
+    let mut skipLf = false
+    for idx in 0..unitCount {
+        positions.push(frontPos(offset, line, column))
+        let unit = frontUnitAt(units, idx)
+        let next = frontUnitAt(units, idx + 1)
+        if skipLf {
+            skipLf = false
+            offset = offset + 1
+        } else if unit == "\r" {
+            line = line + 1
+            column = 1
+            offset = offset + 1
+            if next == "\n" {
+                skipLf = true
+            }
+        } else if unit == "\n" {
+            line = line + 1
+            column = 1
+            offset = offset + 1
+        } else {
+            column = column + 1
+            offset = offset + 1
+        }
+    }
+    positions.push(frontPos(offset, line, column))
+    positions
+}
+pub fn frontPositionFromIndex(positions: List<FrontPos>, target: Int) -> FrontPos {
+    if positions.len() == 0 {
+        return emptyFrontPos()
+    }
+    if target <= 0 {
+        return positions[0]
+    }
+    if target >= positions.len() {
+        return positions[positions.len() - 1]
+    }
+    positions[target]
 }
 pub fn frontPositionAt(units: List<String>, target: Int) -> FrontPos {
     let mut offset = 0

--- a/toolchain/frontend_test.osty
+++ b/toolchain/frontend_test.osty
@@ -1,3 +1,4 @@
+use std.strings as strings
 use std.testing
 fn testFrontendLexerSummarizesCompilerTokens() {
     let summary = frontendLexSummary(r"pub fn add ( value : Int ) -> Int { let answer = 42 }")
@@ -50,6 +51,20 @@ fn testFrontendLexerHandlesBomShebangAndCrLf() {
     testing.assertEq(summary.punctuation, 4)
     testing.assertEq(summary.newlines, 2)
     testing.assertEq(summary.errors, 0)
+}
+fn testFrontendLexerPositionIndexMatchesLegacyScanner() {
+    let source = "a\r\nb\nc"
+    let units = strings.split(source, "")
+    let unitCount = stringUnitCount(source)
+    let positions = frontBuildPositionIndex(units, unitCount)
+    let limit = unitCount + 1
+    for idx in 0..limit {
+        let indexed = frontPositionFromIndex(positions, idx)
+        let scanned = frontPositionAt(units, idx)
+        testing.assertEq(indexed.offset, scanned.offset)
+        testing.assertEq(indexed.line, scanned.line)
+        testing.assertEq(indexed.column, scanned.column)
+    }
 }
 fn testFrontendLexerHandlesBasePrefixesAndExponentFloats() {
     let summary = frontendLexSummary("0xFF 0B101 0o77 3.0e+2 1..10")

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2236,7 +2236,7 @@ pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModul
         for instr in bb.instrs {
             lirLowerMirInstr(l, instr)
         }
-        let term = lirLowerMirTerm(l, bb.term, ret)
+        let term = lirLowerMirBlockTerm(l, bb, ret)
         for extra in l.extraBlocks {
             blocks.push(extra)
         }
@@ -2254,6 +2254,40 @@ pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModul
         l.out.functions.push(outFn)
     }
     LirLowerResult {module: l.out, diagnostics: l.diagnostics}
+}
+fn lirLowerMirBlockTerm(l: LirMirFunctionLowerer, bb: MirBasicBlock, ret: LirType) -> LirTerm {
+    if bb.term.kind == MirTermGoto {
+        let mut t = lirBr(lirLabelForMirBlock(l, bb.termTarget))
+        if bb.termLoopBackEdge && lirFnHasLoopHints(l.fn_) {
+            t.loopMDRef = lirNextLoopMD(l, l.fn_)
+        }
+        return t
+    }
+    if bb.term.kind == MirTermBranch {
+        let cond = lirLowerMirOperand(l, bb.termCond, "Bool", lirIntType(1))
+        if cond.typ.llvm != "i1" {
+            lirLowerError(l, LirDiagUnsupported, "branch condition requires i1, got `" + cond.typ.llvm + "`", "term.branch")
+            return lirUnreachable()
+        }
+        let mut t = lirCondBr(cond.value, lirLabelForMirBlock(l, bb.termThenBlock), lirLabelForMirBlock(l, bb.termElseBlock))
+        if bb.termLoopBackEdge && lirFnHasLoopHints(l.fn_) {
+            t.loopMDRef = lirNextLoopMD(l, l.fn_)
+        }
+        return t
+    }
+    if bb.term.kind == MirTermSwitchInt {
+        let scrutinee = lirLowerMirOperand(l, bb.termCond, bb.termCond.typ, lirTypeInvalid())
+        if scrutinee.typ.className != LirTypeInt {
+            lirLowerError(l, LirDiagUnsupported, "switch scrutinee requires integer type, got `" + scrutinee.typ.llvm + "`", "term.switch")
+            return lirUnreachable()
+        }
+        let mut cases: List<LirSwitchCase> = []
+        for c in bb.termCases {
+            cases.push(lirSwitchCase(lirIntToString(c.value), lirLabelForMirBlock(l, c.target)))
+        }
+        return lirSwitch(scrutinee.typ, scrutinee.value, lirLabelForMirBlock(l, bb.termTarget), cases)
+    }
+    lirLowerMirTerm(l, bb.term, ret)
 }
 // External / intrinsic MIR functions: emit `declare <ret> @<name>(<params>)`
 // and skip body. These are FFI imports (`use go "..."`), declared

--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -71,9 +71,49 @@ fn currentExecutable() -> String {
 fn runSelfRebuild(args: List<String>) -> Int {
     let toolchainDir = lastArg(args)
     let _ = selfRebuildPath(toolchainDir, ".osty/out/debug/llvm/osty-self")
-    eprint("osty-self rebuild blocked: real self-rebuild requires an Osty-owned MIR-to-LLVM module emitter.\n")
-    eprint("missing entrypoint: toolchain/mir_generator.osty must own GenerateFromMIR-equivalent orchestration before osty-self can rebuild itself.\n")
+    eprint("osty-self rebuild blocked: source-to-LIR probe is live, but full toolchain rebuild/link orchestration is not.\n")
+    eprint("missing entrypoint: Osty-owned self-rebuild driver must bundle toolchain sources, lower via LIR Proto, link the runtime, and stage the next osty-self.\n")
     2
+}
+fn selfhostProbeSource() -> String {
+    "fn main() -> Int {\n    let x = 41\n    return x + 1\n}\n"
+}
+fn selfhostProbeError() -> String {
+    let source = selfhostProbeSource()
+    let hir = hirLowerSource("main", source)
+    let mir = mirLowerModule(hir)
+    let mirErrs = mirValidateModule(mir)
+    if mirErrs.len() != 0 {
+        return "MIR validation failed: " + strings.join(mirErrs, "; ")
+    }
+    let cfg = lirLowerConfig("main", "<selfhost-doctor>", "")
+    let result = lirLowerMirModule(cfg, mir)
+    if !lirLowerOK(result) {
+        let mut rendered: List<String> = []
+        for d in result.diagnostics {
+            if d.severity == LirSeverityError {
+                rendered.push(lirDiagnosticRender(d))
+            }
+        }
+        if rendered.len() == 0 {
+            return "LIR Proto lowering failed without an error diagnostic"
+        }
+        return strings.join(rendered, "; ")
+    }
+    let irText = lirRenderModule(result.module)
+    if irText == "" {
+        return "LLVM IR renderer returned empty output"
+    }
+    if !strings.contains(irText, "define") {
+        return "LLVM IR renderer produced no function definition"
+    }
+    if !strings.contains(irText, "ret ") {
+        return "LLVM IR renderer produced no return instruction"
+    }
+    if strings.contains(irText, "body omitted") || strings.contains(irText, "function bodies stubbed") {
+        return "LLVM IR renderer still reports stubbed function bodies"
+    }
+    ""
 }
 fn runSelfhostDoctor() -> Int {
     let exe = currentExecutable()
@@ -81,11 +121,19 @@ fn runSelfhostDoctor() -> Int {
         eprint("osty-self self-rebuild probe failed: executable not found\n")
         return 2
     }
+    let probeError = selfhostProbeError()
     println("osty-self mode: self-rebuild")
     println("osty-self host compiler: disabled")
-    println("osty-self source compiler: phase 0 (module skeleton only)")
-    println("osty-self pipeline: source -> HIR -> Mono -> MIR -> LLVM IR (function bodies stubbed)")
-    println("osty-self missing stage: per-instruction body emission (Phase 1+)")
+    if probeError != "" {
+        println("osty-self source compiler: disabled")
+        println("osty-self pipeline: source -> HIR -> Mono -> MIR -> LIR Proto -> LLVM IR")
+        eprint("osty-self self-rebuild probe failed: " + probeError + "\n")
+        return 1
+    }
+    println("osty-self source compiler: enabled")
+    println("osty-self pipeline: source -> HIR -> Mono -> MIR -> LIR Proto -> LLVM IR")
+    println("osty-self self-rebuild probe: OK")
+    println("osty-self missing stage: full toolchain directory rebuild/link orchestration")
     0
 }
 /// runCompile is the Phase 0 self-host pipeline entry: read a source

--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -808,50 +808,26 @@ pub fn mirTermInvalid() -> MirTerm {
     MirTerm {kind: MirTermInvalid, span: mirNoSpan(), target: -1, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: false}
 }
 pub fn mirGotoTerm(target: Int, span: MirSpan) -> MirTerm {
-    let mut t = mirTermInvalid()
-    t.kind = MirTermGoto
-    t.target = target
-    t.span = span
-    t
+    MirTerm {kind: MirTermGoto, span, target, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: false}
 }
 /// Goto terminator that closes one iteration of an enclosing loop. The
 /// LIR-Proto backend attaches `!llvm.loop` metadata to the resulting
 /// `br label %header` so vectorize / unroll / parallel hints land on
 /// the correct back-edge.
 pub fn mirGotoBackEdgeTerm(target: Int, span: MirSpan) -> MirTerm {
-    let mut t = mirGotoTerm(target, span)
-    t.loopBackEdge = true
-    t
+    MirTerm {kind: MirTermGoto, span, target, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: true}
 }
 pub fn mirBranchTerm(cond: MirOperand, thenB: Int, elseB: Int, span: MirSpan) -> MirTerm {
-    let mut t = mirTermInvalid()
-    t.kind = MirTermBranch
-    t.cond = cond
-    t.thenBlock = thenB
-    t.elseBlock = elseB
-    t.span = span
-    t
+    MirTerm {kind: MirTermBranch, span, target: -1, thenBlock: thenB, elseBlock: elseB, cases: [], cond, loopBackEdge: false}
 }
 pub fn mirSwitchIntTerm(scrutinee: MirOperand, cases: List<MirSwitchCase>, default: Int, span: MirSpan) -> MirTerm {
-    let mut t = mirTermInvalid()
-    t.kind = MirTermSwitchInt
-    t.cond = scrutinee
-    t.cases = cases
-    t.target = default
-    t.span = span
-    t
+    MirTerm {kind: MirTermSwitchInt, span, target: default, thenBlock: -1, elseBlock: -1, cases, cond: scrutinee, loopBackEdge: false}
 }
 pub fn mirReturnTerm(span: MirSpan) -> MirTerm {
-    let mut t = mirTermInvalid()
-    t.kind = MirTermReturn
-    t.span = span
-    t
+    MirTerm {kind: MirTermReturn, span, target: -1, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: false}
 }
 pub fn mirUnreachableTerm(span: MirSpan) -> MirTerm {
-    let mut t = mirTermInvalid()
-    t.kind = MirTermUnreachable
-    t.span = span
-    t
+    MirTerm {kind: MirTermUnreachable, span, target: -1, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: false}
 }
 // ====================================================================
 // Locals, Basic blocks, Functions
@@ -877,16 +853,86 @@ pub struct MirBasicBlock {
     pub instrs: List<MirInstr>,
     pub term: MirTerm,
     pub hasTerm: Bool,
+    pub termTarget: Int,
+    pub termThenBlock: Int,
+    pub termElseBlock: Int,
+    pub termCases: List<MirSwitchCase>,
+    pub termCond: MirOperand,
+    pub termLoopBackEdge: Bool,
     pub span: MirSpan,
 }
 pub fn mirBasicBlock(id: Int, span: MirSpan) -> MirBasicBlock {
-    MirBasicBlock {id, instrs: [], term: mirTermInvalid(), hasTerm: false, span}
+    MirBasicBlock {id, instrs: [], term: mirTermInvalid(), hasTerm: false, termTarget: -1, termThenBlock: -1, termElseBlock: -1, termCases: [], termCond: mirOperandInvalid(), termLoopBackEdge: false, span}
 }
 pub fn mirBlockAppend(block: MirBasicBlock, instr: MirInstr) {
     block.instrs.push(instr)
 }
 pub fn mirBlockSetTerminator(block: MirBasicBlock, t: MirTerm) {
-    block.term = t
+    block.term.kind = t.kind
+    block.term.span = t.span
+    block.term.target = t.target
+    block.term.thenBlock = t.thenBlock
+    block.term.elseBlock = t.elseBlock
+    block.term.cases = t.cases
+    block.term.cond = t.cond
+    block.term.loopBackEdge = t.loopBackEdge
+    block.termTarget = t.target
+    block.termThenBlock = t.thenBlock
+    block.termElseBlock = t.elseBlock
+    block.termCases = t.cases
+    block.termCond = t.cond
+    block.termLoopBackEdge = t.loopBackEdge
+    block.hasTerm = true
+}
+pub fn mirBlockSetGotoTerminator(block: MirBasicBlock, target: Int, span: MirSpan, loopBackEdge: Bool) {
+    block.term.kind = MirTermGoto
+    block.term.span = span
+    block.term.target = target
+    block.term.thenBlock = -1
+    block.term.elseBlock = -1
+    block.term.cases = []
+    block.term.cond = mirOperandInvalid()
+    block.term.loopBackEdge = loopBackEdge
+    block.termTarget = target
+    block.termThenBlock = -1
+    block.termElseBlock = -1
+    block.termCases = []
+    block.termCond = mirOperandInvalid()
+    block.termLoopBackEdge = loopBackEdge
+    block.hasTerm = true
+}
+pub fn mirBlockSetBranchTerminator(block: MirBasicBlock, cond: MirOperand, thenB: Int, elseB: Int, span: MirSpan) {
+    block.term.kind = MirTermBranch
+    block.term.span = span
+    block.term.target = -1
+    block.term.thenBlock = thenB
+    block.term.elseBlock = elseB
+    block.term.cases = []
+    block.term.cond = cond
+    block.term.loopBackEdge = false
+    block.termTarget = -1
+    block.termThenBlock = thenB
+    block.termElseBlock = elseB
+    block.termCases = []
+    block.termCond = cond
+    block.termLoopBackEdge = false
+    block.hasTerm = true
+}
+pub fn mirBlockSetSwitchIntTerminator(block: MirBasicBlock, scrutinee: MirOperand, cases: List<MirSwitchCase>, default: Int, span: MirSpan) {
+    block.term.kind = MirTermSwitchInt
+    block.term.span = span
+    block.term.target = default
+    block.term.thenBlock = -1
+    block.term.elseBlock = -1
+    block.term.cases = cases
+    block.term.cond = scrutinee
+    block.term.loopBackEdge = false
+    block.termTarget = default
+    block.termThenBlock = -1
+    block.termElseBlock = -1
+    block.termCases = cases
+    block.termCond = scrutinee
+    block.termLoopBackEdge = false
     block.hasTerm = true
 }
 /// MirFunction is one lowered function: parameters, return slot, locals
@@ -976,6 +1022,9 @@ pub fn mirFunctionNewLocal(func: MirFunction, name: String, typ: String, mutable
     func.locals.push(local)
     id
 }
+pub fn mirFunctionAddParam(func: MirFunction, id: Int) {
+    func.params.push(id)
+}
 /// mirFunctionNewBlock appends a fresh block with no instructions and no
 /// terminator. Callers must install a terminator before printing.
 pub fn mirFunctionNewBlock(func: MirFunction, span: MirSpan) -> Int {
@@ -995,6 +1044,24 @@ pub fn mirFunctionTerminate(func: MirFunction, blockId: Int, term: MirTerm) {
         return
     }
     mirBlockSetTerminator(func.blocks[blockId], term)
+}
+pub fn mirFunctionTerminateGoto(func: MirFunction, blockId: Int, target: Int, span: MirSpan, loopBackEdge: Bool) {
+    if blockId < 0 || blockId >= func.blocks.len() {
+        return
+    }
+    mirBlockSetGotoTerminator(func.blocks[blockId], target, span, loopBackEdge)
+}
+pub fn mirFunctionTerminateBranch(func: MirFunction, blockId: Int, cond: MirOperand, thenB: Int, elseB: Int, span: MirSpan) {
+    if blockId < 0 || blockId >= func.blocks.len() {
+        return
+    }
+    mirBlockSetBranchTerminator(func.blocks[blockId], cond, thenB, elseB, span)
+}
+pub fn mirFunctionTerminateSwitchInt(func: MirFunction, blockId: Int, scrutinee: MirOperand, cases: List<MirSwitchCase>, default: Int, span: MirSpan) {
+    if blockId < 0 || blockId >= func.blocks.len() {
+        return
+    }
+    mirBlockSetSwitchIntTerminator(func.blocks[blockId], scrutinee, cases, default, span)
 }
 pub fn mirFunctionLocal(func: MirFunction, id: Int) -> MirLocal {
     if id < 0 || id >= func.locals.len() {
@@ -1134,6 +1201,27 @@ pub fn mirSuccessors(t: MirTerm) -> List<Int> {
     }
     out
 }
+pub fn mirBlockSuccessors(bb: MirBasicBlock) -> List<Int> {
+    let mut out: List<Int> = []
+    match bb.term.kind {
+        MirTermGoto -> {
+            out.push(bb.termTarget)
+        },
+        MirTermBranch -> {
+            out.push(bb.termThenBlock)
+            out.push(bb.termElseBlock)
+        },
+        MirTermSwitchInt -> {
+            for c in bb.termCases {
+                out.push(c.target)
+            }
+            out.push(bb.termTarget)
+        },
+        _ -> {
+        },
+    }
+    out
+}
 /// mirReachableBlocks returns the set of block IDs reachable from
 /// `func.entry` by walking terminator successors. The result is encoded
 /// as a List<Bool> parallel to `func.blocks`; unreachable blocks map to
@@ -1169,7 +1257,7 @@ pub fn mirReachableBlocks(func: MirFunction) -> List<Bool> {
         if !(bb.hasTerm) {
             continue
         }
-        let succs = mirSuccessors(bb.term)
+        let succs = mirBlockSuccessors(bb)
         for s in succs {
             if s >= 0 && s < n && !(seen[s]) {
                 stack.push(s)
@@ -1280,7 +1368,7 @@ fn mirPrintBlock(bb: MirBasicBlock, func: MirFunction) -> String {
         parts.push("{mirIndent(2)}{mirPrintInstr(instr, func)}\n")
     }
     if bb.hasTerm {
-        parts.push("{mirIndent(2)}{mirPrintTerm(bb.term, func)}\n")
+        parts.push("{mirIndent(2)}{mirPrintBlockTerm(bb, func)}\n")
     } else {
         parts.push("{mirIndent(2)}<missing terminator>\n")
     }
@@ -1319,6 +1407,30 @@ fn mirPrintCallee(i: MirInstr, func: MirFunction) -> String {
         return "*" + mirPrintOperand(i.calleeOperand, func)
     }
     "(?)"
+}
+// B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+fn mirPrintBlockTerm(bb: MirBasicBlock, func: MirFunction) -> String {
+    match bb.term.kind {
+        MirTermGoto -> "goto -> bb" + mirIntToString(bb.termTarget),
+        MirTermBranch -> "branch " + mirPrintOperand(bb.termCond, func) + " -> [true: bb" + mirIntToString(bb.termThenBlock) + ", false: bb" + mirIntToString(bb.termElseBlock) + "]",
+        MirTermSwitchInt -> {
+            let mut armParts: List<String> = []
+            for c in bb.termCases {
+                let label = if c.label == "" {
+                    mirIntToString(c.value)
+                } else {
+                    c.label
+                }
+                armParts.push("{label} -> bb{mirIntToString(c.target)}")
+            }
+            armParts.push("_ -> bb{mirIntToString(bb.termTarget)}")
+            let arms = strings.join(armParts, ", ")
+            "switchInt {mirPrintOperand(bb.termCond, func)} -> [{arms}]"
+        },
+        MirTermReturn -> "return",
+        MirTermUnreachable -> "unreachable",
+        _ -> "(invalid terminator)",
+    }
 }
 // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
 fn mirPrintTerm(t: MirTerm, func: MirFunction) -> String {

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -735,7 +735,7 @@ pub fn mirLowerSeedFunction(out: MirFunction, params: List<HirParam>, retT: HirT
         let paramSpan = mirSpanFromHir(p.span)
         let id = mirFunctionNewLocal(out, paramName, paramTypeText, true, paramSpan)
         out.locals[id].isParam = true
-        out.params.push(id)
+        mirFunctionAddParam(out, id)
         idx = idx + 1
     }
     let entry = mirFunctionNewBlock(out, span)
@@ -1288,6 +1288,34 @@ pub fn mirLowerTerminate(bs: MirLowerBodyState, t: MirTerm) {
     }
     mirFunctionTerminate(bs.fn_, bs.cur, t)
 }
+pub fn mirLowerTerminateGoto(bs: MirLowerBodyState, target: Int, span: MirSpan) {
+    let bb = mirLowerCurrentBlock(bs)
+    if bb.hasTerm {
+        return
+    }
+    mirFunctionTerminateGoto(bs.fn_, bs.cur, target, span, false)
+}
+pub fn mirLowerTerminateGotoBackEdge(bs: MirLowerBodyState, target: Int, span: MirSpan) {
+    let bb = mirLowerCurrentBlock(bs)
+    if bb.hasTerm {
+        return
+    }
+    mirFunctionTerminateGoto(bs.fn_, bs.cur, target, span, true)
+}
+pub fn mirLowerTerminateBranch(bs: MirLowerBodyState, cond: MirOperand, thenB: Int, elseB: Int, span: MirSpan) {
+    let bb = mirLowerCurrentBlock(bs)
+    if bb.hasTerm {
+        return
+    }
+    mirFunctionTerminateBranch(bs.fn_, bs.cur, cond, thenB, elseB, span)
+}
+pub fn mirLowerTerminateSwitchInt(bs: MirLowerBodyState, scrutinee: MirOperand, cases: List<MirSwitchCase>, default: Int, span: MirSpan) {
+    let bb = mirLowerCurrentBlock(bs)
+    if bb.hasTerm {
+        return
+    }
+    mirFunctionTerminateSwitchInt(bs.fn_, bs.cur, scrutinee, cases, default, span)
+}
 /// mirLowerSwitchTo installs a new cursor block and returns the
 /// previous id.
 pub fn mirLowerSwitchTo(bs: MirLowerBodyState, id: Int) -> Int {
@@ -1303,7 +1331,7 @@ pub fn mirLowerNewBlock(bs: MirLowerBodyState, span: MirSpan) -> Int {
 /// mirLowerGotoBlock terminates the current block with a goto and
 /// switches the cursor to `target`.
 pub fn mirLowerGotoBlock(bs: MirLowerBodyState, target: Int, span: MirSpan) {
-    mirLowerTerminate(bs, mirGotoTerm(target, span))
+    mirLowerTerminateGoto(bs, target, span)
     bs.cur = target
 }
 // ---- Defer helpers -------------------------------------------------
@@ -2081,7 +2109,7 @@ pub fn mirLowerBreakStmt(bs: MirLowerBodyState, s: HirStmt) {
     let top = bs.loopStack[bs.loopStack.len() - 1]
     mirLowerReplayDefersFromDepth(bs, top.deferDepth, span)
     mirLowerEmitStorageDeadFromDepth(bs, top.scopeDepth)
-    mirLowerTerminate(bs, mirGotoTerm(top.breakBlock, span))
+    mirLowerTerminateGoto(bs, top.breakBlock, span)
 }
 pub fn mirLowerContinueStmt(bs: MirLowerBodyState, s: HirStmt) {
     if bs.loopStack.len() == 0 {
@@ -2092,7 +2120,7 @@ pub fn mirLowerContinueStmt(bs: MirLowerBodyState, s: HirStmt) {
     let top = bs.loopStack[bs.loopStack.len() - 1]
     mirLowerReplayDefersFromDepth(bs, top.deferDepth, span)
     mirLowerEmitStorageDeadFromDepth(bs, top.scopeDepth)
-    mirLowerTerminate(bs, mirGotoTerm(top.continueBlock, span))
+    mirLowerTerminateGoto(bs, top.continueBlock, span)
 }
 // ====================================================================
 // Control flow + assignment statement lowering
@@ -2306,15 +2334,15 @@ pub fn mirLowerIfStmt(bs: MirLowerBodyState, s: HirStmt) {
     let thenBB = mirLowerNewBlock(bs, span)
     let elseBB = mirLowerNewBlock(bs, span)
     let merge = mirLowerNewBlock(bs, span)
-    mirLowerTerminate(bs, mirBranchTerm(cond, thenBB, elseBB, span))
+    mirLowerTerminateBranch(bs, cond, thenBB, elseBB, span)
     bs.cur = thenBB
     mirLowerIfArm(bs, s.ifThen)
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = elseBB
     if s.ifHasElse {
         mirLowerIfArm(bs, s.ifElse)
     }
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = merge
 }
 // Then arm.
@@ -2356,12 +2384,12 @@ fn mirLowerForInfinite(bs: MirLowerBodyState, s: HirStmt) {
     let header = mirLowerNewBlock(bs, span)
     let body = mirLowerNewBlock(bs, span)
     let exit = mirLowerNewBlock(bs, span)
-    mirLowerTerminate(bs, mirGotoTerm(header, span))
+    mirLowerTerminateGoto(bs, header, span)
     bs.cur = header
-    mirLowerTerminate(bs, mirGotoTerm(body, span))
+    mirLowerTerminateGoto(bs, body, span)
     bs.cur = body
     mirLowerForBodyWithFrames(bs, s.forBody, header, exit)
-    mirLowerTerminate(bs, mirGotoBackEdgeTerm(header, span))
+    mirLowerTerminateGotoBackEdge(bs, header, span)
     bs.cur = exit
 }
 fn mirLowerForWhile(bs: MirLowerBodyState, s: HirStmt) {
@@ -2369,17 +2397,17 @@ fn mirLowerForWhile(bs: MirLowerBodyState, s: HirStmt) {
     let header = mirLowerNewBlock(bs, span)
     let body = mirLowerNewBlock(bs, span)
     let exit = mirLowerNewBlock(bs, span)
-    mirLowerTerminate(bs, mirGotoTerm(header, span))
+    mirLowerTerminateGoto(bs, header, span)
     bs.cur = header
     let cond = if s.forHasCond {
         mirLowerExprAsOperand(bs, s.forCond)
     } else {
         mirOperandConst(mirConstBool(true))
     }
-    mirLowerTerminate(bs, mirBranchTerm(cond, body, exit, span))
+    mirLowerTerminateBranch(bs, cond, body, exit, span)
     bs.cur = body
     mirLowerForBodyWithFrames(bs, s.forBody, header, exit)
-    mirLowerTerminate(bs, mirGotoBackEdgeTerm(header, span))
+    mirLowerTerminateGotoBackEdge(bs, header, span)
     bs.cur = exit
 }
 fn mirLowerForRange(bs: MirLowerBodyState, s: HirStmt) {
@@ -2399,7 +2427,7 @@ fn mirLowerForRange(bs: MirLowerBodyState, s: HirStmt) {
     let body = mirLowerNewBlock(bs, span)
     let step = mirLowerNewBlock(bs, span)
     let exit = mirLowerNewBlock(bs, span)
-    mirLowerTerminate(bs, mirGotoTerm(header, span))
+    mirLowerTerminateGoto(bs, header, span)
     bs.cur = header
     let cmpOp = if s.forInclusive {
         MirBinLeq
@@ -2412,16 +2440,16 @@ fn mirLowerForRange(bs: MirLowerBodyState, s: HirStmt) {
     let rv = mirRVBinary(cmpOp, leftOp, rightOp, "Bool")
     mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(cmp), rv, span))
     let condOp = mirOperandCopy(mirPlace(cmp), "Bool")
-    mirLowerTerminate(bs, mirBranchTerm(condOp, body, exit, span))
+    mirLowerTerminateBranch(bs, condOp, body, exit, span)
     bs.cur = body
     mirLowerBindName(bs, s.forVar, idx)
     mirLowerForBodyWithFramesStep(bs, s.forBody, step, exit)
-    mirLowerTerminate(bs, mirGotoTerm(step, span))
+    mirLowerTerminateGoto(bs, step, span)
     bs.cur = step
     let oneOp = mirOperandConst(mirConstInt(1, "Int"))
     let stepRV = mirRVBinary(MirBinAdd, mirOperandCopy(mirPlace(idx), "Int"), oneOp, "Int")
     mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(idx), stepRV, span))
-    mirLowerTerminate(bs, mirGotoBackEdgeTerm(header, span))
+    mirLowerTerminateGotoBackEdge(bs, header, span)
     bs.cur = exit
 }
 // Index + end slots.
@@ -2500,7 +2528,7 @@ fn mirLowerForRangePseudoBinding(bs: MirLowerBodyState, s: HirStmt, rb: MirLower
     let body = mirLowerNewBlock(bs, span)
     let step = mirLowerNewBlock(bs, span)
     let exit = mirLowerNewBlock(bs, span)
-    mirLowerTerminate(bs, mirGotoTerm(header, span))
+    mirLowerTerminateGoto(bs, header, span)
     bs.cur = header
     let cmpOp = if rb.inclusive {
         MirBinLeq
@@ -2513,16 +2541,16 @@ fn mirLowerForRangePseudoBinding(bs: MirLowerBodyState, s: HirStmt, rb: MirLower
     let rv = mirRVBinary(cmpOp, leftOp, rightOp, "Bool")
     mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(cmp), rv, span))
     let condOp = mirOperandCopy(mirPlace(cmp), "Bool")
-    mirLowerTerminate(bs, mirBranchTerm(condOp, body, exit, span))
+    mirLowerTerminateBranch(bs, condOp, body, exit, span)
     bs.cur = body
     mirLowerBindName(bs, s.forVar, idx)
     mirLowerForBodyWithFramesStep(bs, s.forBody, step, exit)
-    mirLowerTerminate(bs, mirGotoTerm(step, span))
+    mirLowerTerminateGoto(bs, step, span)
     bs.cur = step
     let oneOp = mirOperandConst(mirConstInt(1, "Int"))
     let stepRV = mirRVBinary(MirBinAdd, mirOperandCopy(mirPlace(idx), "Int"), oneOp, "Int")
     mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(idx), stepRV, span))
-    mirLowerTerminate(bs, mirGotoBackEdgeTerm(header, span))
+    mirLowerTerminateGotoBackEdge(bs, header, span)
     bs.cur = exit
 }
 /// mirLowerIsRangeIntOrCharType reports whether `t` is `Range<Int>`
@@ -2566,12 +2594,12 @@ fn mirLowerForInList(bs: MirLowerBodyState, s: HirStmt, iterT: HirType, span: Mi
     let body = mirLowerNewBlock(bs, span)
     let step = mirLowerNewBlock(bs, span)
     let exit = mirLowerNewBlock(bs, span)
-    mirLowerTerminate(bs, mirGotoTerm(header, span))
+    mirLowerTerminateGoto(bs, header, span)
     bs.cur = header
     let cmp = mirLowerFreshTemp(bs, hirTBool(), span)
     let cmpRV = mirRVBinary(MirBinLt, mirOperandCopy(mirPlace(idx), "Int"), mirOperandCopy(mirPlace(lenLocal), "Int"), "Bool")
     mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(cmp), cmpRV, span))
-    mirLowerTerminate(bs, mirBranchTerm(mirOperandCopy(mirPlace(cmp), "Bool"), body, exit, span))
+    mirLowerTerminateBranch(bs, mirOperandCopy(mirPlace(cmp), "Bool"), body, exit, span)
     bs.cur = body
     mirLowerPushScope(bs)
     mirLowerPushDeferScope(bs)
@@ -2582,11 +2610,11 @@ fn mirLowerForInList(bs: MirLowerBodyState, s: HirStmt, iterT: HirType, span: Mi
     mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(elemLocal), mirRVUse(mirOperandCopy(elemPlace, elemTypeText)), span))
     mirLowerBindForElement(bs, s, elemLocal, elemT, span)
     mirLowerForBodyAlreadyFramed(bs, s.forBody, span)
-    mirLowerTerminate(bs, mirGotoTerm(step, span))
+    mirLowerTerminateGoto(bs, step, span)
     bs.cur = step
     let stepRV = mirRVBinary(MirBinAdd, mirOperandCopy(mirPlace(idx), "Int"), mirOperandConst(mirConstInt(1, "Int")), "Int")
     mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(idx), stepRV, span))
-    mirLowerTerminate(bs, mirGotoBackEdgeTerm(header, span))
+    mirLowerTerminateGotoBackEdge(bs, header, span)
     bs.cur = exit
 }
 // Capture iterable once so len/index reads are stable across the loop.
@@ -2604,7 +2632,7 @@ fn mirLowerForInChannel(bs: MirLowerBodyState, s: HirStmt, iterT: HirType, span:
     let body = mirLowerNewBlock(bs, span)
     let step = mirLowerNewBlock(bs, span)
     let exit = mirLowerNewBlock(bs, span)
-    mirLowerTerminate(bs, mirGotoTerm(header, span))
+    mirLowerTerminateGoto(bs, header, span)
     bs.cur = header
     let recvLocal = mirLowerNewLocal(bs, "_recv", optT, false, span)
     let mut recvArgs: List<MirOperand> = []
@@ -2614,7 +2642,7 @@ fn mirLowerForInChannel(bs: MirLowerBodyState, s: HirStmt, iterT: HirType, span:
     mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(disc), mirRVDiscriminant(mirPlace(recvLocal), "Int"), span))
     let mut cases: List<MirSwitchCase> = []
     cases.push(mirSwitchCase(mirLowerSomeTagOf(optT), body, "Some"))
-    mirLowerTerminate(bs, mirSwitchIntTerm(mirOperandCopy(mirPlace(disc), "Int"), cases, exit, span))
+    mirLowerTerminateSwitchInt(bs, mirOperandCopy(mirPlace(disc), "Int"), cases, exit, span)
     bs.cur = body
     mirLowerPushScope(bs)
     mirLowerPushDeferScope(bs)
@@ -2625,9 +2653,9 @@ fn mirLowerForInChannel(bs: MirLowerBodyState, s: HirStmt, iterT: HirType, span:
     mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(elemLocal), mirRVUse(mirOperandCopy(payload, elemTypeText)), span))
     mirLowerBindForElement(bs, s, elemLocal, elemT, span)
     mirLowerForBodyAlreadyFramed(bs, s.forBody, span)
-    mirLowerTerminate(bs, mirGotoTerm(step, span))
+    mirLowerTerminateGoto(bs, step, span)
     bs.cur = step
-    mirLowerTerminate(bs, mirGotoBackEdgeTerm(header, span))
+    mirLowerTerminateGotoBackEdge(bs, header, span)
     bs.cur = exit
 }
 fn mirLowerBindForElement(bs: MirLowerBodyState, s: HirStmt, elemLocal: Int, elemT: HirType, span: MirSpan) {
@@ -3174,17 +3202,17 @@ pub fn mirLowerIfExprInto(bs: MirLowerBodyState, e: HirExpr, dest: MirPlace, des
     let thenBB = mirLowerNewBlock(bs, span)
     let elseBB = mirLowerNewBlock(bs, span)
     let merge = mirLowerNewBlock(bs, span)
-    mirLowerTerminate(bs, mirBranchTerm(cond, thenBB, elseBB, span))
+    mirLowerTerminateBranch(bs, cond, thenBB, elseBB, span)
     bs.cur = thenBB
     if e.ifExprThen.len() > 0 {
         mirLowerIfExprArm(bs, e.ifExprThen[0], dest, destT)
     }
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = elseBB
     if e.ifExprElse.len() > 0 {
         mirLowerIfExprArm(bs, e.ifExprElse[0], dest, destT)
     }
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = merge
 }
 // Then arm
@@ -3250,19 +3278,19 @@ pub fn mirLowerCoalesceExprInto(bs: MirLowerBodyState, e: HirExpr, dest: MirPlac
     let discOp = mirOperandCopy(mirPlace(disc), "Int")
     let mut cases: List<MirSwitchCase> = []
     cases.push(mirSwitchCase(mirLowerSomeTagOf(leftT), someBB, "Some"))
-    mirLowerTerminate(bs, mirSwitchIntTerm(discOp, cases, noneBB, span))
+    mirLowerTerminateSwitchInt(bs, discOp, cases, noneBB, span)
     bs.cur = someBB
     let destTypeText = hirTypeString(destT)
     let payloadProj = mirVariantProj(mirLowerSomeTagOf(leftT), "Some", 0, destTypeText)
     let payloadPlace = mirPlaceProject(mirPlace(leftLocal), payloadProj)
     let payloadOp = mirOperandCopy(payloadPlace, destTypeText)
     mirLowerEmitInstr(bs, mirAssignInstr(dest, mirRVUse(payloadOp), span))
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = noneBB
     if e.coalesceRight.len() > 0 {
         mirLowerExprIntoPlace(bs, e.coalesceRight[0], dest, destT)
     }
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = merge
     mirLowerPopScope(bs)
 }
@@ -3306,7 +3334,7 @@ fn mirLowerOptionalFieldInto(bs: MirLowerBodyState, e: HirExpr, dest: MirPlace, 
     let discOp = mirOperandCopy(mirPlace(disc), "Int")
     let mut cases: List<MirSwitchCase> = []
     cases.push(mirSwitchCase(mirLowerSomeTagOf(recvT), someBB, "Some"))
-    mirLowerTerminate(bs, mirSwitchIntTerm(discOp, cases, noneBB, span))
+    mirLowerTerminateSwitchInt(bs, discOp, cases, noneBB, span)
     bs.cur = someBB
     let innerT = if recvT.kind == HirTypeOptional && recvT.optionalInner.len() > 0 {
         recvT.optionalInner[0]
@@ -3327,11 +3355,11 @@ fn mirLowerOptionalFieldInto(bs: MirLowerBodyState, e: HirExpr, dest: MirPlace, 
     someFields.push(fieldOp)
     let someRV = mirRVVariant(mirLowerSomeTagOf(destT), "Some", someFields, hirTypeString(destT))
     mirLowerEmitInstr(bs, mirAssignInstr(dest, someRV, span))
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = noneBB
     let noneRV = mirRVNullary(MirNullaryNone, hirTypeString(destT))
     mirLowerEmitInstr(bs, mirAssignInstr(dest, noneRV, span))
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = merge
 }
 // Some path: project payload → field, wrap as Some(field).
@@ -4094,7 +4122,7 @@ fn mirLowerMatchCore(bs: MirLowerBodyState, scrutinee: HirExpr, arms: List<HirMa
     } else {
         mirLowerNoteIssue(bs.l, "mir_lower: match without decision tree — routing to arm 0")
         if armBlocks.len() > 0 {
-            mirLowerTerminate(bs, mirGotoTerm(armBlocks[0], span))
+            mirLowerTerminateGoto(bs, armBlocks[0], span)
         } else {
             mirLowerTerminate(bs, mirUnreachableTerm(span))
         }
@@ -4117,7 +4145,7 @@ fn mirLowerMatchCore(bs: MirLowerBodyState, scrutinee: HirExpr, arms: List<HirMa
         mirLowerReplayTopFrame(bs, mirSpanFromHir(arm.body.span))
         mirLowerPopDeferScope(bs)
         mirLowerPopScope(bs)
-        mirLowerTerminate(bs, mirGotoTerm(merge, mirSpanFromHir(arm.span)))
+        mirLowerTerminateGoto(bs, merge, mirSpanFromHir(arm.span))
         i = i + 1
     }
     bs.cur = merge
@@ -4280,7 +4308,7 @@ pub fn mirLowerQuestionInto(bs: MirLowerBodyState, e: HirExpr, dest: MirPlace, d
     let okName = mirLowerOkVariantName(xT)
     let mut cases: List<MirSwitchCase> = []
     cases.push(mirSwitchCase(okTag, okBB, okName))
-    mirLowerTerminate(bs, mirSwitchIntTerm(discOp, cases, errBB, span))
+    mirLowerTerminateSwitchInt(bs, discOp, cases, errBB, span)
     bs.cur = errBB
     mirLowerRebuildErrorIntoReturn(bs, tmp, xT, span)
     mirLowerRunDefers(bs, span)
@@ -4397,7 +4425,7 @@ fn mirLowerIfLetVariant(bs: MirLowerBodyState, e: HirExpr, scrutLocal: Int, scru
         0
     }
     cases.push(mirSwitchCase(switchIdx, thenBB, pat.variantName))
-    mirLowerTerminate(bs, mirSwitchIntTerm(discOp, cases, elseBB, span))
+    mirLowerTerminateSwitchInt(bs, discOp, cases, elseBB, span)
     bs.cur = thenBB
     mirLowerPushScope(bs)
     mirLowerPushDeferScope(bs)
@@ -4414,7 +4442,7 @@ fn mirLowerIfLetVariant(bs: MirLowerBodyState, e: HirExpr, scrutLocal: Int, scru
     }
     mirLowerPopDeferScope(bs)
     mirLowerPopScope(bs)
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = elseBB
     if e.ifLetHasElse && e.ifLetElse.len() > 0 {
         let body = e.ifLetElse[0]
@@ -4430,7 +4458,7 @@ fn mirLowerIfLetVariant(bs: MirLowerBodyState, e: HirExpr, scrutLocal: Int, scru
         mirLowerPopDeferScope(bs)
         mirLowerPopScope(bs)
     }
-    mirLowerTerminate(bs, mirGotoTerm(merge, span))
+    mirLowerTerminateGoto(bs, merge, span)
     bs.cur = merge
 }
 // Discriminant + SwitchInt.
@@ -5979,7 +6007,7 @@ pub fn mirLowerClosureRValue(bs: MirLowerBodyState, e: HirExpr, hint: HirType) -
     let envType = mirLowerClosureEnvType()
     let envLocal = mirFunctionNewLocal(lifted, "_env", hirTypeString(envType), false, span)
     lifted.locals[envLocal].isParam = true
-    lifted.params.push(envLocal)
+    mirFunctionAddParam(lifted, envLocal)
     let mut userIdx = 0
     for p in e.closureParams {
         let paramName = if p.name == "" {
@@ -5994,7 +6022,7 @@ pub fn mirLowerClosureRValue(bs: MirLowerBodyState, e: HirExpr, hint: HirType) -
         }
         let id = mirFunctionNewLocal(lifted, paramName, hirTypeString(pt), false, mirSpanFromHir(p.span))
         lifted.locals[id].isParam = true
-        lifted.params.push(id)
+        mirFunctionAddParam(lifted, id)
         userIdx = userIdx + 1
     }
     let entry = mirFunctionNewBlock(lifted, span)
@@ -6213,7 +6241,7 @@ fn mirLowerDecisionLeaf(mc: MirLowerMatchContext, node: HirDecisionNode) {
         mirLowerTerminate(mc.bs, mirUnreachableTerm(mc.span))
         return
     }
-    mirLowerTerminate(mc.bs, mirGotoTerm(mc.armBlocks[idx], mc.span))
+    mirLowerTerminateGoto(mc.bs, mc.armBlocks[idx], mc.span)
 }
 fn mirLowerDecisionBind(mc: MirLowerMatchContext, node: HirDecisionNode) {
     let derivedType = if node.bindHasProj {
@@ -6257,7 +6285,7 @@ fn mirLowerDecisionGuard(mc: MirLowerMatchContext, node: HirDecisionNode) {
     let cond = mirLowerExprAsOperand(mc.bs, node.guardCond[0])
     let thenBB = mirLowerNewBlock(mc.bs, mc.span)
     let elseBB = mirLowerNewBlock(mc.bs, mc.span)
-    mirLowerTerminate(mc.bs, mirBranchTerm(cond, thenBB, elseBB, mc.span))
+    mirLowerTerminateBranch(mc.bs, cond, thenBB, elseBB, mc.span)
     mc.bs.cur = thenBB
     if node.guardThen.len() > 0 {
         mirLowerDecisionTree(mc, node.guardThen[0])
@@ -6305,7 +6333,7 @@ fn mirLowerSwitchVariant(mc: MirLowerMatchContext, node: HirDecisionNode) {
         i = i + 1
     }
     let discOp = mirOperandCopy(mirPlace(disc), "Int")
-    mirLowerTerminate(mc.bs, mirSwitchIntTerm(discOp, cases, defaultBB, mc.span))
+    mirLowerTerminateSwitchInt(mc.bs, discOp, cases, defaultBB, mc.span)
     let mut j = 0
     for c in node.switchCases {
         mc.bs.cur = caseBlocks[j]
@@ -6329,7 +6357,7 @@ fn mirLowerSwitchBool(mc: MirLowerMatchContext, node: HirDecisionNode) {
     let thenBB = mirLowerNewBlock(mc.bs, mc.span)
     let elseBB = mirLowerNewBlock(mc.bs, mc.span)
     let condOp = mirOperandCopy(projPlace, "Bool")
-    mirLowerTerminate(mc.bs, mirBranchTerm(condOp, thenBB, elseBB, mc.span))
+    mirLowerTerminateBranch(mc.bs, condOp, thenBB, elseBB, mc.span)
     let mut trueHandled = false
     let mut falseHandled = false
     for c in node.switchCases {
@@ -6426,7 +6454,7 @@ fn mirLowerSwitchLit(mc: MirLowerMatchContext, node: HirDecisionNode) {
         let cmpRV = mirRVBinary(MirBinEq, lhs, rhs, "Bool")
         mirLowerEmitInstr(mc.bs, mirAssignInstr(mirPlace(cmp), cmpRV, mc.span))
         let cmpOp = mirOperandCopy(mirPlace(cmp), "Bool")
-        mirLowerTerminate(mc.bs, mirBranchTerm(cmpOp, caseBB, next, mc.span))
+        mirLowerTerminateBranch(mc.bs, cmpOp, caseBB, next, mc.span)
         mc.bs.cur = caseBB
         mirLowerDecisionTree(mc, c.body)
         mc.bs.cur = testBB
@@ -6460,7 +6488,7 @@ fn mirLowerSwitchLitInt(mc: MirLowerMatchContext, node: HirDecisionNode, projPla
     }
     let defaultBB = mirLowerNewBlock(mc.bs, mc.span)
     let scrutOp = mirOperandCopy(projPlace, projTypeText)
-    mirLowerTerminate(mc.bs, mirSwitchIntTerm(scrutOp, cases, defaultBB, mc.span))
+    mirLowerTerminateSwitchInt(mc.bs, scrutOp, cases, defaultBB, mc.span)
     let mut j = 0
     for c in node.switchCases {
         mc.bs.cur = bodies[j]

--- a/toolchain/mir_optimize.osty
+++ b/toolchain/mir_optimize.osty
@@ -203,7 +203,7 @@ fn mirBuildPredecessors(func: MirFunction) -> List<List<Int>> {
     let mut bi = 0
     for bb in func.blocks {
         if bb.hasTerm {
-            for succ in mirSuccessors(bb.term) {
+            for succ in mirBlockSuccessors(bb) {
                 if succ >= 0 && succ < n {
                     preds[succ].push(bi)
                 }
@@ -328,7 +328,7 @@ fn mirComputeBlockStates(func: MirFunction) -> List<MirConstState> {
             continue
         }
         exitStates[id] = outState
-        for succ in mirSuccessors(bb.term) {
+        for succ in mirBlockSuccessors(bb) {
             if succ < 0 || succ >= n {
                 continue
             }
@@ -405,7 +405,7 @@ fn mirPropagateBlock(bb: MirBasicBlock, known: List<MirConst>) -> Bool {
         i = i + 1
     }
     if bb.hasTerm {
-        if mirRewriteTerminatorCond(bb.term, known) {
+        if mirRewriteBlockTerminatorCond(bb, known) {
             changed = true
         }
         if mirFoldTerminator(bb) {
@@ -522,15 +522,23 @@ fn mirRewritePlaceProjections(p: MirPlace, known: List<MirConst>) -> Bool {
     }
     changed
 }
-/// mirRewriteTerminatorCond substitutes a const into a Branch's `cond`
+/// mirRewriteBlockTerminatorCond substitutes a const into a Branch's `cond`
 /// or a SwitchInt's scrutinee when possible. Returns true on
 /// substitution.
-fn mirRewriteTerminatorCond(t: MirTerm, known: List<MirConst>) -> Bool {
-    if t.kind == MirTermBranch {
-        return mirSubstituteOperandInPlace(t.cond, known)
+fn mirRewriteBlockTerminatorCond(bb: MirBasicBlock, known: List<MirConst>) -> Bool {
+    if bb.term.kind == MirTermBranch {
+        if mirSubstituteOperandInPlace(bb.termCond, known) {
+            bb.term.cond = bb.termCond
+            return true
+        }
+        return false
     }
-    if t.kind == MirTermSwitchInt {
-        return mirSubstituteOperandInPlace(t.cond, known)
+    if bb.term.kind == MirTermSwitchInt {
+        if mirSubstituteOperandInPlace(bb.termCond, known) {
+            bb.term.cond = bb.termCond
+            return true
+        }
+        return false
     }
     false
 }
@@ -580,36 +588,36 @@ fn mirClearKnown(known: List<MirConst>, id: Int) {
 fn mirFoldTerminator(bb: MirBasicBlock) -> Bool {
     match bb.term.kind {
         MirTermBranch -> {
-            if bb.term.cond.kind != MirOpConst {
+            if bb.termCond.kind != MirOpConst {
                 return false
             }
-            if bb.term.cond.const.kind != MirConstBool {
+            if bb.termCond.const.kind != MirConstBool {
                 return false
             }
-            let target = if bb.term.cond.const.boolValue {
-                bb.term.thenBlock
+            let target = if bb.termCond.const.boolValue {
+                bb.termThenBlock
             } else {
-                bb.term.elseBlock
+                bb.termElseBlock
             }
-            bb.term = mirGotoTerm(target, bb.term.span)
+            mirBlockSetGotoTerminator(bb, target, bb.term.span, false)
             true
         },
         MirTermSwitchInt -> {
-            if bb.term.cond.kind != MirOpConst {
+            if bb.termCond.kind != MirOpConst {
                 return false
             }
-            if bb.term.cond.const.kind != MirConstInt {
+            if bb.termCond.const.kind != MirConstInt {
                 return false
             }
-            let scrutinee = bb.term.cond.const.intValue
-            let mut target = bb.term.target
-            for c in bb.term.cases {
+            let scrutinee = bb.termCond.const.intValue
+            let mut target = bb.termTarget
+            for c in bb.termCases {
                 if c.value == scrutinee {
                     target = c.target
                     break
                 }
             }
-            bb.term = mirGotoTerm(target, bb.term.span)
+            mirBlockSetGotoTerminator(bb, target, bb.term.span, false)
             true
         },
         _ -> false,
@@ -660,45 +668,58 @@ fn mirCollapseBlockEdges(bb: MirBasicBlock, func: MirFunction) -> Bool {
     let termKind = bb.term.kind
     match termKind {
         MirTermGoto -> {
-            let curTarget = bb.term.target
+            let curTarget = bb.termTarget
             let nextTarget = mirResolveEmptyGoto(func, curTarget)
             if nextTarget != curTarget {
-                bb.term.target = nextTarget
+                mirBlockSetGotoTerminator(bb, nextTarget, bb.term.span, bb.termLoopBackEdge)
                 changed = true
             }
         },
         MirTermBranch -> {
-            let curThen = bb.term.thenBlock
+            let mut thenTarget = bb.termThenBlock
+            let mut elseTarget = bb.termElseBlock
+            let curThen = thenTarget
             let nextThen = mirResolveEmptyGoto(func, curThen)
             if nextThen != curThen {
-                bb.term.thenBlock = nextThen
+                thenTarget = nextThen
                 changed = true
             }
-            let curElse = bb.term.elseBlock
+            let curElse = elseTarget
             let nextElse = mirResolveEmptyGoto(func, curElse)
             if nextElse != curElse {
-                bb.term.elseBlock = nextElse
+                elseTarget = nextElse
                 changed = true
+            }
+            if changed {
+                mirBlockSetBranchTerminator(bb, bb.termCond, thenTarget, elseTarget, bb.term.span)
             }
         },
         MirTermSwitchInt -> {
-            let cases = bb.term.cases
+            let cases = bb.termCases
             let nCases = cases.len()
+            let mut newCases: List<MirSwitchCase> = []
             let mut ci = 0
             for _iter in 0..nCases {
-                let curTarget = bb.term.cases[ci].target
+                let curCase = cases[ci]
+                let curTarget = curCase.target
                 let newTarget = mirResolveEmptyGoto(func, curTarget)
                 if newTarget != curTarget {
-                    bb.term.cases[ci] = mirSwitchCaseSetTarget(bb.term.cases[ci], newTarget)
+                    newCases.push(mirSwitchCaseSetTarget(curCase, newTarget))
                     changed = true
+                } else {
+                    newCases.push(curCase)
                 }
                 ci = ci + 1
             }
-            let curDefault = bb.term.target
-            let newDefault = mirResolveEmptyGoto(func, curDefault)
-            if newDefault != curDefault {
-                bb.term.target = newDefault
+            let curDefault = bb.termTarget
+            let mut newDefault = curDefault
+            let resolvedDefault = mirResolveEmptyGoto(func, curDefault)
+            if resolvedDefault != curDefault {
+                newDefault = resolvedDefault
                 changed = true
+            }
+            if changed {
+                mirBlockSetSwitchIntTerminator(bb, bb.termCond, newCases, newDefault, bb.term.span)
             }
         },
         _ -> {
@@ -735,7 +756,7 @@ fn mirResolveEmptyGoto(func: MirFunction, target: Int) -> Int {
             return cur
         }
         seen[cur] = true
-        cur = bb.term.target
+        cur = bb.termTarget
     }
     cur
 }
@@ -899,10 +920,10 @@ fn mirCollectLocalReads(func: MirFunction) -> List<Int> {
         if bb.hasTerm {
             match bb.term.kind {
                 MirTermBranch -> {
-                    mirCountOperandReads(bb.term.cond, reads)
+                    mirCountOperandReads(bb.termCond, reads)
                 },
                 MirTermSwitchInt -> {
-                    mirCountOperandReads(bb.term.cond, reads)
+                    mirCountOperandReads(bb.termCond, reads)
                 },
                 MirTermReturn -> {
                     if func.returnLocal >= 0 && func.returnLocal < nLocals {

--- a/toolchain/mir_validator.osty
+++ b/toolchain/mir_validator.osty
@@ -209,6 +209,53 @@ fn mirValidateBlock(func: MirFunction, bb: MirBasicBlock) -> List<String> {
         errs.push("function \"{func.name}\" bb{bb.id}: missing terminator")
         return errs
     }
+    if bb.term.kind == MirTermGoto {
+        let rErrs = mirValidateBlockRef(func, bb, bb.termTarget, "goto.target")
+        for e in rErrs {
+            errs.push(e)
+        }
+        return errs
+    }
+    if bb.term.kind == MirTermBranch {
+        let oErrs = mirValidateOperand(func, bb, bb.termCond, "branch.cond")
+        for e in oErrs {
+            errs.push(e)
+        }
+        let thenErrs = mirValidateBlockRef(func, bb, bb.termThenBlock, "branch.thenBlock")
+        for e in thenErrs {
+            errs.push(e)
+        }
+        let elseErrs = mirValidateBlockRef(func, bb, bb.termElseBlock, "branch.elseBlock")
+        for e in elseErrs {
+            errs.push(e)
+        }
+        return errs
+    }
+    if bb.term.kind == MirTermSwitchInt {
+        let oErrs = mirValidateOperand(func, bb, bb.termCond, "switchInt.scrutinee")
+        for e in oErrs {
+            errs.push(e)
+        }
+        let mut seenVals: List<Int> = []
+        let mut ci = 0
+        for c in bb.termCases {
+            let rErrs = mirValidateBlockRef(func, bb, c.target, "switchInt.cases[{ci}]")
+            for e in rErrs {
+                errs.push(e)
+            }
+            if listContainsInt(seenVals, c.value) {
+                errs.push("function \"{func.name}\" bb{bb.id}: switchInt.cases[{ci}] value {c.value} duplicates an earlier case")
+            } else {
+                seenVals.push(c.value)
+            }
+            ci = ci + 1
+        }
+        let defErrs = mirValidateBlockRef(func, bb, bb.termTarget, "switchInt.default")
+        for e in defErrs {
+            errs.push(e)
+        }
+        return errs
+    }
     let tErrs = mirValidateTerm(func, bb, bb.term)
     for e in tErrs {
         errs.push(e)


### PR DESCRIPTION
## Summary
- add a real `osty-self --selfhost-doctor` source probe through HIR, MIR validation, LIR Proto lowering, and LLVM IR rendering
- keep MIR terminator payloads mirrored on basic blocks so selfhost/LIR paths avoid stale nested payload state
- speed up frontend lexing position lookup with an indexed position table and lock the behavior with a regression test

## Validation
- `.bin/osty check --airepair=false toolchain`
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestPhase0SelfHostWiringExists|TestSelfhostDoctorRunsSourceProbe'`\n- `git diff --check origin/main...HEAD`\n\n## Notes\n- Full self-rebuild is still not claimed complete; `runSelfRebuild` now reports the remaining full toolchain directory rebuild/link orchestration wall instead of the stale Phase 0 emitter message.\n- Broad `go test ./internal/selfhost` currently hits an unrelated parse snapshot drift in `TestParseSnapshot/testdata_spec_negative_reject`.