### PR TITLE
refactor: codesdoc pure helpers self-host (toolchain/codesdoc_policy.osty)

### DIFF
--- a/cmd/codesdoc/main.go
+++ b/cmd/codesdoc/main.go
@@ -462,19 +462,11 @@ func parseDocComment(cg *ast.CommentGroup) parsedDoc {
 	return runner.ParseExplainDoc(lines)
 }
 
-// defaultHeadingFor invents a heading when the const block has no
-// leading doc comment. Rare — only hit during development of new
-// blocks.
+// defaultHeadingFor delegates to toolchain/codesdoc_policy.osty
+// for the default phase heading when the const block has no
+// leading doc comment.
 func defaultHeadingFor(code string) string {
-	switch {
-	case strings.HasPrefix(code, "E"):
-		return "Errors starting at " + code
-	case strings.HasPrefix(code, "W"):
-		return "Warnings starting at " + code
-	case strings.HasPrefix(code, "L"):
-		return "Lint warnings starting at " + code
-	}
-	return "Miscellaneous"
+	return runner.DefaultHeadingFor(code)
 }
 
 // rangeSuffix appends an Exxxx–Eyyyy range to the heading if the
@@ -650,13 +642,10 @@ func familyForHeading(heading string) string {
 	return ""
 }
 
-// stripRangeSuffix removes the " (Exxxx–Eyyyy)" suffix that
-// rangeSuffix appends to phase headings for markdown rendering.
+// stripRangeSuffix delegates to toolchain/codesdoc_policy.osty
+// for removing the " (Exxxx-Eyyyy)" suffix from phase headings.
 func stripRangeSuffix(h string) string {
-	if i := strings.LastIndex(h, " ("); i >= 0 {
-		return strings.TrimSpace(h[:i])
-	}
-	return strings.TrimSpace(h)
+	return runner.StripRangeSuffix(h)
 }
 
 // renderManifest emits the Osty source for toolchain/diag_manifest.osty.
@@ -727,50 +716,18 @@ var harvestPhaseForFamily = map[string]string{
 // string literal. Today the known trigger is the `\{` + `=>` pair; add
 // more conditions here (instead of broadening the filter) so each
 // carved-out code stays traceable.
+// unsafeForBootstrapGen / proseExample / ostyEscape delegate to
+// toolchain/codesdoc_policy.osty.
 func unsafeForBootstrapGen(example string) bool {
-	hasBrace := strings.Contains(example, "{") || strings.Contains(example, "}")
-	hasFatArrow := strings.Contains(example, "=>")
-	return hasBrace && hasFatArrow
+	return runner.UnsafeForBootstrapGen(example)
 }
 
-// proseExample reports whether an example contains prose placeholders
-// (triple-dot, unicode right-arrow, ellipsis) that make it unrunnable
-// as real Osty source. These examples illustrate the rule in
-// ERROR_CODES.md but can't be harvested — skip them rather than emit
-// known-failing cases.
 func proseExample(example string) bool {
-	return strings.Contains(example, "...") ||
-		strings.Contains(example, "…") ||
-		strings.Contains(example, "→")
+	return runner.ProseExample(example)
 }
 
-// ostyEscape escapes a byte slice so it's safe to drop inside an Osty
-// regular string literal ("..."). Covers interpolation braces (§1.6.3)
-// and the usual control chars.
 func ostyEscape(s string) string {
-	var b strings.Builder
-	b.Grow(len(s) + 8)
-	for _, r := range s {
-		switch r {
-		case '\\':
-			b.WriteString(`\\`)
-		case '"':
-			b.WriteString(`\"`)
-		case '\n':
-			b.WriteString(`\n`)
-		case '\r':
-			b.WriteString(`\r`)
-		case '\t':
-			b.WriteString(`\t`)
-		case '{':
-			b.WriteString(`\{`)
-		case '}':
-			b.WriteString(`\}`)
-		default:
-			b.WriteRune(r)
-		}
-	}
-	return b.String()
+	return runner.OstyEscape(s)
 }
 
 // renderHarvest emits the Osty source for toolchain/diag_examples.osty,

--- a/internal/runner/codesdoc_policy.go
+++ b/internal/runner/codesdoc_policy.go
@@ -1,0 +1,89 @@
+// codesdoc_policy.go is the Go snapshot of
+// toolchain/codesdoc_policy.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import "strings"
+
+// DefaultHeadingFor invents a phase heading when the const block
+// has no leading doc comment. Mapping uses the first byte:
+// E → Errors, W → Warnings, L → Lint, else Miscellaneous.
+//
+// Osty: toolchain/codesdoc_policy.osty:32
+func DefaultHeadingFor(code string) string {
+	switch {
+	case strings.HasPrefix(code, "E"):
+		return "Errors starting at " + code
+	case strings.HasPrefix(code, "W"):
+		return "Warnings starting at " + code
+	case strings.HasPrefix(code, "L"):
+		return "Lint warnings starting at " + code
+	}
+	return "Miscellaneous"
+}
+
+// StripRangeSuffix removes the ` (Exxxx-Eyyyy)` (or ` (Exxxx)`)
+// suffix that rangeSuffix appends to phase headings for markdown
+// rendering. Used before mapping a heading to its
+// DiagnosticFamily variant.
+//
+// Osty: toolchain/codesdoc_policy.osty:54
+func StripRangeSuffix(h string) string {
+	if i := strings.LastIndex(h, " ("); i >= 0 {
+		return strings.TrimSpace(h[:i])
+	}
+	return strings.TrimSpace(h)
+}
+
+// UnsafeForBootstrapGen guards against Example blocks that the
+// bootstrap-gen lexer mishandles. Fires when both a `{`/`}` byte
+// and a `=>` token are present.
+//
+// Osty: toolchain/codesdoc_policy.osty:71
+func UnsafeForBootstrapGen(example string) bool {
+	hasBrace := strings.Contains(example, "{") || strings.Contains(example, "}")
+	hasFatArrow := strings.Contains(example, "=>")
+	return hasBrace && hasFatArrow
+}
+
+// ProseExample reports whether an Example block contains prose
+// placeholders (`...`, `…`, `→`) that make it unrunnable as real
+// Osty source.
+//
+// Osty: toolchain/codesdoc_policy.osty:83
+func ProseExample(example string) bool {
+	return strings.Contains(example, "...") ||
+		strings.Contains(example, "…") ||
+		strings.Contains(example, "→")
+}
+
+// OstyEscape escapes `s` so it's safe to splice inside an Osty
+// regular-string literal. Escape set: backslash, double quote,
+// LF, CR, tab, `{`, `}`. All other bytes pass through.
+//
+// Osty: toolchain/codesdoc_policy.osty:101
+func OstyEscape(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '{':
+			b.WriteString(`\{`)
+		case '}':
+			b.WriteString(`\}`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/runner/codesdoc_policy_test.go
+++ b/internal/runner/codesdoc_policy_test.go
@@ -1,0 +1,102 @@
+package runner
+
+import "testing"
+
+func TestDefaultHeadingFor(t *testing.T) {
+	cases := []struct {
+		code string
+		want string
+	}{
+		{"E0001", "Errors starting at E0001"},
+		{"E0500", "Errors starting at E0500"},
+		{"W0750", "Warnings starting at W0750"},
+		{"L0001", "Lint warnings starting at L0001"},
+		{"X1234", "Miscellaneous"},
+		{"", "Miscellaneous"},
+	}
+	for _, c := range cases {
+		if got := DefaultHeadingFor(c.code); got != c.want {
+			t.Errorf("DefaultHeadingFor(%q) = %q, want %q", c.code, got, c.want)
+		}
+	}
+}
+
+func TestStripRangeSuffix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Lexical (E0001-E0099)", "Lexical"},
+		{"Manifest (E2017)", "Manifest"},
+		{"Lexical", "Lexical"},
+		{"", ""},
+		{"  Lexical  ", "Lexical"},
+		{"Foo (bar) (E0001)", "Foo (bar)"},
+	}
+	for _, c := range cases {
+		if got := StripRangeSuffix(c.in); got != c.want {
+			t.Errorf("StripRangeSuffix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestUnsafeForBootstrapGen(t *testing.T) {
+	yes := []string{
+		"match x { A => B }",
+		"let f = fn (x) => { x }",
+	}
+	for _, in := range yes {
+		if !UnsafeForBootstrapGen(in) {
+			t.Errorf("UnsafeForBootstrapGen(%q) = false, want true", in)
+		}
+	}
+	no := []string{
+		"fn main() {}", // brace only
+		"{ a, b }",     // brace only
+		"x => y",       // fat arrow only
+		"let x = 1",    // neither
+		"",
+	}
+	for _, in := range no {
+		if UnsafeForBootstrapGen(in) {
+			t.Errorf("UnsafeForBootstrapGen(%q) = true, want false", in)
+		}
+	}
+}
+
+func TestProseExample(t *testing.T) {
+	yes := []string{"foo(...)", "a ... b", "a … b", "x → y"}
+	for _, in := range yes {
+		if !ProseExample(in) {
+			t.Errorf("ProseExample(%q) = false, want true", in)
+		}
+	}
+	no := []string{"let x = 1", "", "a -> b"}
+	for _, in := range no {
+		if ProseExample(in) {
+			t.Errorf("ProseExample(%q) = true, want false", in)
+		}
+	}
+}
+
+func TestOstyEscape(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"hello", "hello"},
+		{"", ""},
+		{`a\b`, `a\\b`},
+		{`a"b`, `a\"b`},
+		{"a\nb", `a\nb`},
+		{"a\tb", `a\tb`},
+		{"a\rb", `a\rb`},
+		{"a{b}c", `a\{b\}c`},
+		{"한글", "한글"},
+	}
+	for _, c := range cases {
+		if got := OstyEscape(c.in); got != c.want {
+			t.Errorf("OstyEscape(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -40,6 +40,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"airepair_flags.osty",
 		"airepair_rewrite.osty",
 		"airepair_source.osty",
+		"codesdoc_policy.osty",
 		"diag_explain.osty",
 		"diag_render.osty",
 		"format_policy.osty",

--- a/toolchain/codesdoc_policy.osty
+++ b/toolchain/codesdoc_policy.osty
@@ -1,0 +1,122 @@
+/// Pure helpers for `cmd/codesdoc`, the build-time generator that
+/// derives `ERROR_CODES.md`, `toolchain/diag_manifest.osty`, and
+/// `toolchain/diag_examples.osty` from `internal/diag/codes.go`.
+///
+/// Host code in `cmd/codesdoc/main.go` owns the Go-AST walk, file
+/// I/O, and per-section rendering; this module decides the small
+/// lexical transformations that are pure functions of strings:
+///
+///   - the default phase heading for a code whose const block has
+///     no doc comment;
+///   - removing the auto-appended `(Exxxx–Eyyyy)` range suffix
+///     before mapping a heading to a `DiagnosticFamily`;
+///   - whether an Example block from a doc comment is currently
+///     unsafe to splice into the harvest fixtures (bootstrap-gen
+///     lexer hazard) or is a prose pseudocode block that can't be
+///     run as real Osty source;
+///   - escaping a payload for a regular Osty string literal.
+///
+/// Mirrored by `internal/runner/codesdoc_policy.go`. The drift
+/// test under internal/runner keeps the two in sync — the Osty
+/// file is the source of truth at review time.
+use std.strings as strings
+/// defaultHeadingFor invents a phase heading when the const block
+/// has no leading doc comment. Rare — only hit while developing
+/// a new phase grouping. The mapping uses the first byte:
+///
+///   - `E` → `Errors starting at <code>`
+///   - `W` → `Warnings starting at <code>`
+///   - `L` → `Lint warnings starting at <code>`
+///   - anything else → `Miscellaneous`
+pub fn defaultHeadingFor(code: String) -> String {
+    if strings.hasPrefix(code, "E") {
+        return "Errors starting at " + code
+    }
+    if strings.hasPrefix(code, "W") {
+        return "Warnings starting at " + code
+    }
+    if strings.hasPrefix(code, "L") {
+        return "Lint warnings starting at " + code
+    }
+    "Miscellaneous"
+}
+/// stripRangeSuffix removes the ` (Exxxx-Eyyyy)` (or ` (Exxxx)`)
+/// suffix that `rangeSuffix` appends to phase headings for
+/// markdown rendering. Used before mapping a heading to its
+/// DiagnosticFamily variant.
+///
+/// Returns `strings.trimSpace(h)` when no ` (` is present so
+/// "Lexical" and "Lexical (E0001–E0099)" both normalise to
+/// "Lexical".
+pub fn stripRangeSuffix(h: String) -> String {
+    let pos = strings.lastIndexOf(h, " (")
+    match pos {
+        Some(i) -> strings.trimSpace(strings.slice(h, 0, i)),
+        None -> strings.trimSpace(h),
+    }
+}
+/// unsafeForBootstrapGen guards against Example blocks that the
+/// bootstrap-gen lexer mishandles when they get spliced into the
+/// selfhost bundle as a string literal. Specifically, the
+/// historical lexer treats `\{` inside a string as the start of an
+/// interpolation, and then chokes on tokens like `=>` that are a
+/// static error outside an expression context.
+///
+/// The conservative check fires only when **both** signals are
+/// present, since each in isolation is fine to harvest:
+///   - any `{` or `}` byte in the example (would trigger the
+///     `\{` escape path during render),
+///   - a `=>` token (the static-error trigger).
+pub fn unsafeForBootstrapGen(example: String) -> Bool {
+    let hasBrace = strings.contains(example, "{") || strings.contains(example, "}")
+    let hasFatArrow = strings.contains(example, "=>")
+    hasBrace && hasFatArrow
+}
+/// proseExample reports whether an Example block contains prose
+/// placeholders (`...`, `…`, `→`) that make it unrunnable as real
+/// Osty source. These examples illustrate the rule in
+/// `ERROR_CODES.md` but the harvest runner skips them rather than
+/// emit known-failing cases.
+pub fn proseExample(example: String) -> Bool {
+    strings.contains(example, "...") ||
+        strings.contains(example, "…") ||
+        strings.contains(example, "→")
+}
+/// ostyEscape escapes `s` so it's safe to splice inside an Osty
+/// regular-string literal (`"..."`). The escape set is the
+/// minimum needed to round-trip arbitrary bytes:
+///
+///   - backslash → `\\`
+///   - double quote → `\"`
+///   - newline → `\n`, CR → `\r`, tab → `\t`
+///   - `{` / `}` → `\{` / `\}` (§1.6.3 interpolation braces)
+///
+/// All other bytes pass through. The escape preserves UTF-8
+/// because non-ASCII bytes are never in the switch above.
+pub fn ostyEscape(s: String) -> String {
+    let chars = s.chars()
+    let mut out = ""
+    let mut i = 0
+    for i < chars.len() {
+        let c = chars[i]
+        if c == '\\' {
+            out = out + "\\\\"
+        } else if c == '"' {
+            out = out + "\\\""
+        } else if c == '\n' {
+            out = out + "\\n"
+        } else if c == '\r' {
+            out = out + "\\r"
+        } else if c == '\t' {
+            out = out + "\\t"
+        } else if c == '\{' {
+            out = out + "\\\{"
+        } else if c == '\}' {
+            out = out + "\\\}"
+        } else {
+            out = out + c.toString()
+        }
+        i = i + 1
+    }
+    out
+}

--- a/toolchain/codesdoc_policy_test.osty
+++ b/toolchain/codesdoc_policy_test.osty
@@ -1,0 +1,80 @@
+use std.testing
+fn testDefaultHeadingForErrors() {
+    testing.assertEq(defaultHeadingFor("E0001"), "Errors starting at E0001")
+    testing.assertEq(defaultHeadingFor("E0500"), "Errors starting at E0500")
+}
+fn testDefaultHeadingForWarnings() {
+    testing.assertEq(defaultHeadingFor("W0750"), "Warnings starting at W0750")
+}
+fn testDefaultHeadingForLint() {
+    testing.assertEq(defaultHeadingFor("L0001"), "Lint warnings starting at L0001")
+}
+fn testDefaultHeadingForMiscellaneous() {
+    testing.assertEq(defaultHeadingFor("X1234"), "Miscellaneous")
+    testing.assertEq(defaultHeadingFor(""), "Miscellaneous")
+}
+fn testStripRangeSuffixWithRange() {
+    testing.assertEq(stripRangeSuffix("Lexical (E0001-E0099)"), "Lexical")
+    testing.assertEq(stripRangeSuffix("Manifest (E2017)"), "Manifest")
+}
+fn testStripRangeSuffixWithoutRange() {
+    testing.assertEq(stripRangeSuffix("Lexical"), "Lexical")
+    testing.assertEq(stripRangeSuffix(""), "")
+}
+fn testStripRangeSuffixTrimsSpace() {
+    testing.assertEq(stripRangeSuffix("  Lexical  "), "Lexical")
+}
+fn testStripRangeSuffixUsesLastOccurrence() {
+    testing.assertEq(stripRangeSuffix("Foo (bar) (E0001)"), "Foo (bar)")
+}
+fn testUnsafeForBootstrapGenBraceAndFatArrow() {
+    testing.assert(unsafeForBootstrapGen("match x \{ A => B \}"))
+    testing.assert(unsafeForBootstrapGen("let f = fn (x) => \{ x \}"))
+}
+fn testUnsafeForBootstrapGenBraceOnly() {
+    testing.assert(!(unsafeForBootstrapGen("fn main() \{}")))
+    testing.assert(!(unsafeForBootstrapGen("\{ a, b \}")))
+}
+fn testUnsafeForBootstrapGenFatArrowOnly() {
+    testing.assert(!(unsafeForBootstrapGen("x => y")))
+}
+fn testUnsafeForBootstrapGenNeither() {
+    testing.assert(!(unsafeForBootstrapGen("let x = 1")))
+    testing.assert(!(unsafeForBootstrapGen("")))
+}
+fn testProseExampleEllipsisDots() {
+    testing.assert(proseExample("foo(...)"))
+    testing.assert(proseExample("a ... b"))
+}
+fn testProseExampleUnicodeEllipsis() {
+    testing.assert(proseExample("a … b"))
+}
+fn testProseExampleUnicodeArrow() {
+    testing.assert(proseExample("x → y"))
+}
+fn testProseExampleClean() {
+    testing.assert(!(proseExample("let x = 1")))
+    testing.assert(!(proseExample("")))
+    testing.assert(!(proseExample("a -> b")))
+}
+fn testOstyEscapePlain() {
+    testing.assertEq(ostyEscape("hello"), "hello")
+    testing.assertEq(ostyEscape(""), "")
+}
+fn testOstyEscapeBackslash() {
+    testing.assertEq(ostyEscape("a\\b"), "a\\\\b")
+}
+fn testOstyEscapeDoubleQuote() {
+    testing.assertEq(ostyEscape("a\"b"), "a\\\"b")
+}
+fn testOstyEscapeControlChars() {
+    testing.assertEq(ostyEscape("a\nb"), "a\\nb")
+    testing.assertEq(ostyEscape("a\tb"), "a\\tb")
+    testing.assertEq(ostyEscape("a\rb"), "a\\rb")
+}
+fn testOstyEscapeBraces() {
+    testing.assertEq(ostyEscape("a\{b\}c"), "a\\\{b\\\}c")
+}
+fn testOstyEscapePreservesNonAscii() {
+    testing.assertEq(ostyEscape("한글"), "한글")
+}


### PR DESCRIPTION
## Summary

PR #1762의 후속. `cmd/codesdoc/main.go`의 5개 토큰-비종속 pure helper
를 새 `toolchain/codesdoc_policy.osty`로 이전. `cmd/codesdoc`는
빌드타임 generator지만 정책 관점에서는 toolchain (ERROR_CODES.md /
diag_manifest.osty / diag_examples.osty 등 toolchain 산출물 생성).

## 이전된 정책 (5 fn)

- `defaultHeadingFor(code) -> String` — 코드 prefix (E/W/L)로 phase
  heading 결정. 매치 없으면 `"Miscellaneous"`
- `stripRangeSuffix(h) -> String` — `(Exxxx-Eyyyy)` 자동 suffix 제거.
  `familyForHeading` 정규화 단계
- `unsafeForBootstrapGen(example) -> Bool` — bootstrap-gen lexer가
  잘못 처리하는 `\{`+`=>` 조합 예제 가드. 두 시그널 모두 있을 때만
  true
- `proseExample(example) -> Bool` — prose placeholder (`...`/`…`/`→`)
  존재 여부. 실행 불가능 예제 스킵용
- `ostyEscape(s) -> String` — Osty regular string literal 안에 splice
  안전한 escape (`\\`, `\"`, `\n`, `\r`, `\t`, `\{`, `\}`)

## Go wrapper 축소

5개 함수 모두 thin wrapper. 가장 큰 `ostyEscape`는 ~25줄짜리
switch에서 3줄로:

```go
func ostyEscape(s string) string {
    return runner.OstyEscape(s)
}
```

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go run ./cmd/codesdoc -in internal/diag/codes.go -check
      ERROR_CODES.md` — drift 없음
- [x] `go run ./cmd/codesdoc -in internal/diag/codes.go
      -manifest-check toolchain/diag_manifest.osty` — drift 없음
- [x] `go run ./cmd/codesdoc -in internal/diag/codes.go
      -harvest-cases-check toolchain/diag_examples.osty` — drift 없음
- [x] `go test -count=1 ./internal/runner/...` — pass (drift test
      포함, 14개 ostySources)
- [x] `go vet ./cmd/codesdoc/... ./internal/runner/...` — clean
- [x] 5개 함수 × 다중 케이스 (UTF-8 non-ASCII, edge cases) Osty + Go
      양측 unit test

## 이번 세션 누적 (12번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1757 | airepair 정책-free | 20 fn + 7 struct |
| #1758 | format use-sort + chain-break | 4 fn + 2 struct |
| #1759 | scaffold expectedPaths | 2 fn |
| #1760 | diag render helpers | 4 fn + 1 struct |
| #1761 | diag explain doc-parser | 1 fn + 1 struct |
| #1762 | cmd/codesdoc 파서 통합 | — (consumer) |
| #1763 | repair pure lookups | 4 fn + 1 struct |
| #1764 | format finalize + .pop() fix | 1 fn |
| (this) | codesdoc pure helpers | 5 fn |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_