### PR TITLE
refactor(codesdoc_policy): Copilot 후속 — raw 브레이스 / O(n) ostyEscape / UTF-8 parity

### DIFF
--- a/internal/runner/codesdoc_policy_test.go
+++ b/internal/runner/codesdoc_policy_test.go
@@ -93,6 +93,11 @@ func TestOstyEscape(t *testing.T) {
 		{"a\rb", `a\rb`},
 		{"a{b}c", `a\{b\}c`},
 		{"한글", "한글"},
+		// Locks parity with the Osty side: non-ASCII runes are
+		// passed through as their original UTF-8 bytes (Go's
+		// b.WriteRune ↔ Osty's Char.toString()), while ASCII
+		// metachars still take the escape path.
+		{`한\글"日{本}`, `한\\글\"日\{本\}`},
 	}
 	for _, c := range cases {
 		if got := OstyEscape(c.in); got != c.want {

--- a/toolchain/codesdoc_policy.osty
+++ b/toolchain/codesdoc_policy.osty
@@ -68,7 +68,7 @@ pub fn stripRangeSuffix(h: String) -> String {
 ///     `\{` escape path during render),
 ///   - a `=>` token (the static-error trigger).
 pub fn unsafeForBootstrapGen(example: String) -> Bool {
-    let hasBrace = strings.contains(example, "{") || strings.contains(example, "}")
+    let hasBrace = strings.contains(example, r"{") || strings.contains(example, r"}")
     let hasFatArrow = strings.contains(example, "=>")
     hasBrace && hasFatArrow
 }
@@ -95,28 +95,28 @@ pub fn proseExample(example: String) -> Bool {
 /// because non-ASCII bytes are never in the switch above.
 pub fn ostyEscape(s: String) -> String {
     let chars = s.chars()
-    let mut out = ""
+    let mut parts: List<String> = []
     let mut i = 0
     for i < chars.len() {
         let c = chars[i]
         if c == '\\' {
-            out = out + "\\\\"
+            parts.push("\\\\")
         } else if c == '"' {
-            out = out + "\\\""
+            parts.push("\\\"")
         } else if c == '\n' {
-            out = out + "\\n"
+            parts.push("\\n")
         } else if c == '\r' {
-            out = out + "\\r"
+            parts.push("\\r")
         } else if c == '\t' {
-            out = out + "\\t"
+            parts.push("\\t")
         } else if c == '\{' {
-            out = out + "\\\{"
+            parts.push("\\\{")
         } else if c == '\}' {
-            out = out + "\\\}"
+            parts.push("\\\}")
         } else {
-            out = out + c.toString()
+            parts.push(c.toString())
         }
         i = i + 1
     }
-    out
+    strings.join(parts, "")
 }

--- a/toolchain/codesdoc_policy_test.osty
+++ b/toolchain/codesdoc_policy_test.osty
@@ -78,3 +78,9 @@ fn testOstyEscapeBraces() {
 fn testOstyEscapePreservesNonAscii() {
     testing.assertEq(ostyEscape("한글"), "한글")
 }
+fn testOstyEscapeMixedNonAsciiAndEscapes() {
+    // Locks parity with the Go snapshot: non-ASCII characters are
+    // emitted as their original UTF-8 bytes via Char.toString(),
+    // ASCII metachars in the middle still take the escape path.
+    testing.assertEq(ostyEscape("한\\글\"日\{本\}"), "한\\\\글\\\"日\\\{本\\\}")
+}


### PR DESCRIPTION
## Summary

PR #1766의 Copilot 리뷰 3건을 별도 PR로 반영.

### 1. `unsafeForBootstrapGen`: brace 리터럴을 raw-string으로

toolchain의 다른 모듈 (lexer / frontend / lsp / formatter_ast / 등 11+
곳)이 `{`/`}` 검사 시 `r"{"` / `r"}"` raw-string을 쓰는데, 본 모듈만
plain `"{"` / `"}"`를 쓰고 있었음. 현재 lexer는 둘 다 통과시키지만
컨벤션 통일이 미래의 escape 룰 변경에 강건. 자기 파일 안의 테스트도
이미 `"\{"` 표기를 쓰므로 일관성 확보.

### 2. `ostyEscape` O(n²) → O(n)

기존 코드는 `out = out + ...`를 char마다 호출 — 대부분의 String
구현에서 O(n²) 복사. harvest 예제가 multi-line이라 무시 못 할
오버헤드. `List<String>` 누적 + `strings.join("", parts)` 한 번
호출로 교체. PR #1764 `finalizeFormatted` 설계와 동일 패턴.

### 3. UTF-8 + 메타문자 mixed parity 테스트

기존 테스트는 순수 한글 `"한글"`만 — Osty 측은 fallback 경로만,
Go 측은 ASCII-passthrough 경로만 exercise. 새 케이스
`한\글"日\{本\}`은 non-ASCII 문자와 ASCII metachar (`\\` `"` `\{` `\}`)
를 섞어서 양측이 같은 UTF-8 바이트 시퀀스를 산출하는지 lock-in.

Osty `Char.toString()` ↔ Go `b.WriteRune(r)` 동치를 보장.

## Test plan

- [x] `.bin/osty check toolchain/codesdoc_policy.osty
      toolchain/codesdoc_policy_test.osty` — 통과
- [x] `go test -count=1 ./internal/runner/ -run TestOstyEscape` —
      pass (mixed UTF-8 케이스 포함)
- [x] `go test -count=1 ./internal/runner/ -run
      TestPolicySnapshotParityWithOsty` — drift 없음
- [x] `codesdoc -in ... -check ERROR_CODES.md` — drift 없음
- [x] `codesdoc -in ... -manifest-check toolchain/diag_manifest.osty` —
      drift 없음
- [x] `codesdoc -in ... -harvest-cases-check toolchain/diag_examples.osty` —
      drift 없음 (실제 harvest 출력이 동일함을 자동 검증)

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_