### PR TITLE
refactor: profile triple/pragma 파서 self-host (toolchain/profile_pragma.osty)

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/osty/osty/internal/runner"
 )
 
 // Built-in profile names. Any additional profile declared in the
@@ -111,12 +113,15 @@ func (t *Target) Clone() *Target {
 // if the triple isn't in the expected form. The toolchain does not
 // try to validate against Go's internal GOOS/GOARCH table — unknown
 // combinations are surfaced by `go build` itself.
+// ParseTriple delegates to toolchain/profile_pragma.osty. The host
+// wrapper preserves the legacy (arch, os, err) shape by lifting the
+// policy's `Ok` flag into a formatted error message.
 func ParseTriple(triple string) (arch, os string, err error) {
-	parts := strings.SplitN(triple, "-", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	r := runner.ParseTriple(triple)
+	if !r.Ok {
 		return "", "", fmt.Errorf("invalid target triple %q (want <arch>-<os>)", triple)
 	}
-	return parts[0], parts[1], nil
+	return r.Arch, r.OS, nil
 }
 
 // Config is the merged view of built-in defaults + manifest-declared
@@ -440,32 +445,9 @@ func (c *Config) expandFeatures(requested []string, useDefaults bool) []string {
 // starts with "@feature:" — so the check doesn't need a parser pass.
 // Callers (build driver, gen emitter) combine this with the active
 // feature set to decide whether the file participates in the build.
+// ReadFeaturePragma delegates to toolchain/profile_pragma.osty.
 func ReadFeaturePragma(src []byte) []string {
-	const maxLines = 32
-	line := 0
-	start := 0
-	for i := 0; i <= len(src) && line < maxLines; i++ {
-		// Logical line break at '\n' or at EOF.
-		if i < len(src) && src[i] != '\n' {
-			continue
-		}
-		raw := string(src[start:i])
-		trimmed := featTrim(raw)
-		if after, ok := featStrip(trimmed, "// @feature:"); ok {
-			return parseFeatureList(after)
-		}
-		if after, ok := featStrip(trimmed, "//@feature:"); ok {
-			return parseFeatureList(after)
-		}
-		// Stop as soon as we hit a non-comment, non-blank line —
-		// feature pragmas must live at the top of the file.
-		if trimmed != "" && !featHas(trimmed, "//") && !featHas(trimmed, "/*") {
-			return nil
-		}
-		start = i + 1
-		line++
-	}
-	return nil
+	return runner.ReadFeaturePragma(src)
 }
 
 // FileNeedsFeatures reads src's feature pragma and reports whether
@@ -482,46 +464,10 @@ func FileNeedsFeatures(src []byte, active map[string]bool) (bool, string) {
 	return true, ""
 }
 
+// parseFeatureList delegates to toolchain/profile_pragma.osty.
+// Note: this is the pragma-side parser (comma + space + tab
+// separators). The CLI `--features=a,b` parser lives in
+// toolchain/profile_flags.osty under the same name.
 func parseFeatureList(s string) []string {
-	var out []string
-	cur := ""
-	flush := func() {
-		t := featTrim(cur)
-		if t != "" {
-			out = append(out, t)
-		}
-		cur = ""
-	}
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c == ',' || c == ' ' || c == '\t' {
-			flush()
-			continue
-		}
-		cur += string(c)
-	}
-	flush()
-	return out
-}
-
-func featTrim(s string) string {
-	i, j := 0, len(s)
-	for i < j && (s[i] == ' ' || s[i] == '\t' || s[i] == '\r') {
-		i++
-	}
-	for j > i && (s[j-1] == ' ' || s[j-1] == '\t' || s[j-1] == '\r') {
-		j--
-	}
-	return s[i:j]
-}
-
-func featStrip(s, p string) (string, bool) {
-	if len(s) >= len(p) && s[:len(p)] == p {
-		return s[len(p):], true
-	}
-	return "", false
-}
-
-func featHas(s, p string) bool {
-	return len(s) >= len(p) && s[:len(p)] == p
+	return runner.ParsePragmaFeatureList(s)
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -463,11 +463,3 @@ func FileNeedsFeatures(src []byte, active map[string]bool) (bool, string) {
 	}
 	return true, ""
 }
-
-// parseFeatureList delegates to toolchain/profile_pragma.osty.
-// Note: this is the pragma-side parser (comma + space + tab
-// separators). The CLI `--features=a,b` parser lives in
-// toolchain/profile_flags.osty under the same name.
-func parseFeatureList(s string) []string {
-	return runner.ParsePragmaFeatureList(s)
-}

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -45,6 +45,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"diag_render.osty",
 		"format_policy.osty",
 		"profile_flags.osty",
+		"profile_pragma.osty",
 		"repair_policy.osty",
 		"diag_policy.osty",
 		"test_runner.osty",

--- a/internal/runner/profile_pragma_policy.go
+++ b/internal/runner/profile_pragma_policy.go
@@ -1,0 +1,125 @@
+// profile_pragma_policy.go is the Go snapshot of
+// toolchain/profile_pragma.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import "strings"
+
+// TripleParseResult mirrors toolchain/profile_pragma.osty's
+// TripleParseResult. Ok=false leaves Arch/OS empty.
+//
+// Osty: toolchain/profile_pragma.osty:31
+type TripleParseResult struct {
+	Arch string
+	OS   string
+	Ok   bool
+}
+
+// PragmaStripResult is the outcome of `pragmaStrip`. The Rest
+// field carries the line content after the matched prefix when
+// Ok=true, otherwise empty.
+//
+// Osty: toolchain/profile_pragma.osty (internal helper)
+type PragmaStripResult struct {
+	Rest string
+	Ok   bool
+}
+
+// ParseTriple splits an `<arch>-<os>` target triple on the first
+// `-` so the OS half can carry further dashes
+// (`x86_64-apple-darwin` → arch=`x86_64`, os=`apple-darwin`).
+// Both halves must be non-empty.
+//
+// Osty: toolchain/profile_pragma.osty:40
+func ParseTriple(triple string) TripleParseResult {
+	parts := strings.SplitN(triple, "-", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return TripleParseResult{}
+	}
+	return TripleParseResult{Arch: parts[0], OS: parts[1], Ok: true}
+}
+
+// ReadFeaturePragma scans the first 32 logical lines of `src` for
+// a `// @feature: a, b c` pragma. Returns an empty slice when no
+// pragma is found in the prefix window or when a non-comment,
+// non-blank line appears before one. Both `// @feature:` and
+// `//@feature:` prefixes are accepted.
+//
+// Osty: toolchain/profile_pragma.osty:60
+func ReadFeaturePragma(src []byte) []string {
+	const maxLines = 32
+	line := 0
+	start := 0
+	for i := 0; i <= len(src) && line < maxLines; i++ {
+		if i < len(src) && src[i] != '\n' {
+			continue
+		}
+		raw := string(src[start:i])
+		trimmed := pragmaTrim(raw)
+		if r := pragmaStrip(trimmed, "// @feature:"); r.Ok {
+			return ParsePragmaFeatureList(r.Rest)
+		}
+		if r := pragmaStrip(trimmed, "//@feature:"); r.Ok {
+			return ParsePragmaFeatureList(r.Rest)
+		}
+		if trimmed != "" && !strings.HasPrefix(trimmed, "//") && !strings.HasPrefix(trimmed, "/*") {
+			return nil
+		}
+		start = i + 1
+		line++
+	}
+	return nil
+}
+
+// ParsePragmaFeatureList splits a pragma payload on any of
+// `,` / ` ` / `\t`, trims each token (ASCII space, tab, CR), and
+// drops empty entries.
+//
+// Osty: toolchain/profile_pragma.osty:96
+func ParsePragmaFeatureList(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ',' || c == ' ' || c == '\t' {
+			if start < i {
+				token := pragmaTrim(s[start:i])
+				if token != "" {
+					out = append(out, token)
+				}
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		token := pragmaTrim(s[start:])
+		if token != "" {
+			out = append(out, token)
+		}
+	}
+	return out
+}
+
+// pragmaTrim matches Go's `featTrim` — strips leading/trailing
+// ASCII space (0x20), tab (0x09), and CR (0x0D).
+//
+// Osty: toolchain/profile_pragma.osty (internal helper)
+func pragmaTrim(s string) string {
+	i, j := 0, len(s)
+	for i < j && (s[i] == ' ' || s[i] == '\t' || s[i] == '\r') {
+		i++
+	}
+	for j > i && (s[j-1] == ' ' || s[j-1] == '\t' || s[j-1] == '\r') {
+		j--
+	}
+	return s[i:j]
+}
+
+// pragmaStrip matches Go's `featStrip` — returns rest-if-prefix
+// shape so callers can branch on Ok and consume Rest.
+func pragmaStrip(s, p string) PragmaStripResult {
+	if strings.HasPrefix(s, p) {
+		return PragmaStripResult{Rest: s[len(p):], Ok: true}
+	}
+	return PragmaStripResult{}
+}

--- a/internal/runner/profile_pragma_policy_test.go
+++ b/internal/runner/profile_pragma_policy_test.go
@@ -1,0 +1,76 @@
+package runner
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseTriple(t *testing.T) {
+	cases := []struct {
+		name   string
+		triple string
+		ok     bool
+		arch   string
+		os     string
+	}{
+		{"simple", "x86_64-linux", true, "x86_64", "linux"},
+		{"internal-dashes", "x86_64-apple-darwin", true, "x86_64", "apple-darwin"},
+		{"no-dash", "x86_64", false, "", ""},
+		{"empty-arch", "-linux", false, "", ""},
+		{"empty-os", "x86_64-", false, "", ""},
+		{"empty", "", false, "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ParseTriple(c.triple)
+			if got.Ok != c.ok || got.Arch != c.arch || got.OS != c.os {
+				t.Errorf("ParseTriple(%q) = %+v, want {%q %q %v}",
+					c.triple, got, c.arch, c.os, c.ok)
+			}
+		})
+	}
+}
+
+func TestReadFeaturePragma(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"line-comment", "// @feature: a, b\nlet x = 1\n", []string{"a", "b"}},
+		{"tight-comment", "//@feature: foo bar\n", []string{"foo", "bar"}},
+		{"skips-blank-and-comments", "\n// preamble comment\n// @feature: x\n", []string{"x"}},
+		{"stops-at-first-code", "let x = 1\n// @feature: ignored\n", nil},
+		{"no-pragma", "let x = 1\nlet y = 2\n", nil},
+		{"mixed-separators", "// @feature: a, b c\td\n", []string{"a", "b", "c", "d"}},
+		{"crlf-line", "// @feature: a\r, b\r\n", []string{"a", "b"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ReadFeaturePragma([]byte(c.src))
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("ReadFeaturePragma(%q) = %v, want %v", c.src, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParsePragmaFeatureList(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"a,b,c", []string{"a", "b", "c"}},
+		{"a b c", []string{"a", "b", "c"}},
+		{"a\tb\tc", []string{"a", "b", "c"}},
+		{"a,,b , c", []string{"a", "b", "c"}},
+		{"", nil},
+		{"   ", nil},
+	}
+	for _, c := range cases {
+		got := ParsePragmaFeatureList(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("ParsePragmaFeatureList(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/toolchain/profile_pragma.osty
+++ b/toolchain/profile_pragma.osty
@@ -1,0 +1,165 @@
+/// Pure parsers for the profile/target/feature surface in
+/// `internal/profile`. Host code owns manifest stitching, Config
+/// merging, and feature-graph expansion; this module decides:
+///
+///   - how to split an `<arch>-<os>` target triple,
+///   - how to scan the first ~32 lines of a source file for a
+///     `// @feature: a, b c` pragma and return the active list,
+///   - the pragma-specific feature-list lexer (comma / space /
+///     tab separator, ASCII whitespace trim, drop empties).
+///
+/// Note that the CLI `--features=a,b` flag has its own
+/// pragma-independent parser in `toolchain/profile_flags.osty`
+/// (`parseFeatureList`) — that one splits on commas only and is
+/// used by `osty build` / `osty run` / `osty test` flag handling.
+/// The pragma scanner here lives separately because file-level
+/// pragmas are whitespace-delimited too.
+///
+/// Mirrored by `internal/runner/profile_pragma_policy.go`. The
+/// drift test under internal/runner keeps the two in sync — the
+/// Osty file is the source of truth at review time.
+use std.strings as strings
+/// TripleParseResult is the structured outcome of splitting an
+/// `<arch>-<os>` target triple. `ok == false` signals a malformed
+/// triple (missing dash, empty arch, or empty OS) and leaves
+/// `arch`/`os` empty.
+///
+/// The OS part keeps any internal dashes (e.g.
+/// `x86_64-apple-darwin` → arch=`x86_64`, os=`apple-darwin`)
+/// because callers downstream use the full second segment as the
+/// platform identifier.
+pub struct TripleParseResult {
+    pub arch: String,
+    pub os: String,
+    pub ok: Bool,
+}
+/// parseTriple splits `triple` once on the first `-` so the OS
+/// half can carry further dashes (`apple-darwin`, `unknown-linux`,
+/// etc.). Both halves must be non-empty.
+pub fn parseTriple(triple: String) -> TripleParseResult {
+    let parts = strings.splitN(triple, "-", 2)
+    if parts.len() != 2 || parts[0] == "" || parts[1] == "" {
+        return TripleParseResult {arch: "", os: "", ok: false}
+    }
+    TripleParseResult {arch: parts[0], os: parts[1], ok: true}
+}
+/// readFeaturePragma scans the first 32 logical lines of `src`
+/// for a `// @feature: a, b c` pragma and returns the list of
+/// features it activates. Returns an empty list when:
+///
+///   - no pragma is found in the prefix window,
+///   - a non-comment, non-blank line is encountered before any
+///     pragma (pragmas must live at the top of the file).
+///
+/// Both `// @feature:` and `//@feature:` prefixes are accepted so
+/// the formatter's "space after `//`" preference doesn't bind the
+/// pragma's recognition.
+pub fn readFeaturePragma(src: String) -> List<String> {
+    let maxLines = 32
+    let bs = src.bytes()
+    let n = bs.len()
+    let mut start = 0
+    let mut line = 0
+    let mut i = 0
+    for i <= n && line < maxLines {
+        let atEOF = i == n
+        let atNL = !atEOF && bs[i].toInt() == 0x0A
+        if !atEOF && !atNL {
+            i = i + 1
+            continue
+        }
+        let raw = strings.slice(src, start, i)
+        let trimmed = pragmaTrim(raw)
+        let lineComment = pragmaStrip(trimmed, "// @feature:")
+        if lineComment.ok {
+            return parsePragmaFeatureList(lineComment.rest)
+        }
+        let tightComment = pragmaStrip(trimmed, "//@feature:")
+        if tightComment.ok {
+            return parsePragmaFeatureList(tightComment.rest)
+        }
+        if trimmed != "" && !pragmaHasPrefix(trimmed, "//") && !pragmaHasPrefix(trimmed, "/*") {
+            return []
+        }
+        start = i + 1
+        line = line + 1
+        i = i + 1
+    }
+    []
+}
+/// PragmaStripResult is the outcome of `pragmaStrip` — the rest
+/// of the line after the matched prefix, or `{rest: "", ok:
+/// false}` when the prefix didn't match.
+pub struct PragmaStripResult {
+    pub rest: String,
+    pub ok: Bool,
+}
+/// parsePragmaFeatureList splits a pragma payload on any of
+/// `,` / ` ` / `\t`, trims each token (matches Go's featTrim:
+/// ASCII space, tab, CR), and drops empty entries.
+pub fn parsePragmaFeatureList(s: String) -> List<String> {
+    let bs = s.bytes()
+    let n = bs.len()
+    let mut out: List<String> = []
+    let mut start = 0
+    let mut i = 0
+    for i < n {
+        let b = bs[i].toInt()
+        if b == 0x2C || b == 0x20 || b == 0x09 {
+            if start < i {
+                let token = pragmaTrim(strings.slice(s, start, i))
+                if token != "" {
+                    out.push(token)
+                }
+            }
+            start = i + 1
+        }
+        i = i + 1
+    }
+    if start < n {
+        let token = pragmaTrim(strings.slice(s, start, n))
+        if token != "" {
+            out.push(token)
+        }
+    }
+    out
+}
+/// pragmaTrim matches Go's `featTrim` — strips leading/trailing
+/// ASCII space (0x20), tab (0x09), and CR (0x0D). Does not touch
+/// other Unicode whitespace.
+fn pragmaTrim(s: String) -> String {
+    let bs = s.bytes()
+    let n = bs.len()
+    let mut i = 0
+    let mut j = n
+    for i < j {
+        let b = bs[i].toInt()
+        if b != 0x20 && b != 0x09 && b != 0x0D {
+            break
+        }
+        i = i + 1
+    }
+    for j > i {
+        let b = bs[j - 1].toInt()
+        if b != 0x20 && b != 0x09 && b != 0x0D {
+            break
+        }
+        j = j - 1
+    }
+    strings.slice(s, i, j)
+}
+/// pragmaHasPrefix matches Go's `featHas`. Used only inside this
+/// module for the non-comment-line detector in
+/// `readFeaturePragma`.
+fn pragmaHasPrefix(s: String, p: String) -> Bool {
+    strings.hasPrefix(s, p)
+}
+/// pragmaStrip matches Go's `featStrip` — return-rest-if-prefix
+/// shape. Returns `{rest: s[len(p)..], ok: true}` when `s` starts
+/// with `p`, otherwise `{rest: "", ok: false}`.
+fn pragmaStrip(s: String, p: String) -> PragmaStripResult {
+    if strings.hasPrefix(s, p) {
+        return PragmaStripResult {rest: strings.slice(s, p.len(), s.len()), ok: true}
+    }
+    PragmaStripResult {rest: "", ok: false}
+}

--- a/toolchain/profile_pragma_test.osty
+++ b/toolchain/profile_pragma_test.osty
@@ -1,0 +1,102 @@
+use std.testing
+fn testParseTripleSimple() {
+    let r = parseTriple("x86_64-linux")
+    testing.assert(r.ok)
+    testing.assertEq(r.arch, "x86_64")
+    testing.assertEq(r.os, "linux")
+}
+fn testParseTripleKeepsInternalDashes() {
+    let r = parseTriple("x86_64-apple-darwin")
+    testing.assert(r.ok)
+    testing.assertEq(r.arch, "x86_64")
+    testing.assertEq(r.os, "apple-darwin")
+}
+fn testParseTripleRejectsMissingDash() {
+    let r = parseTriple("x86_64")
+    testing.assert(!(r.ok))
+    testing.assertEq(r.arch, "")
+    testing.assertEq(r.os, "")
+}
+fn testParseTripleRejectsEmptyArch() {
+    let r = parseTriple("-linux")
+    testing.assert(!(r.ok))
+}
+fn testParseTripleRejectsEmptyOS() {
+    let r = parseTriple("x86_64-")
+    testing.assert(!(r.ok))
+}
+fn testParseTripleRejectsEmpty() {
+    let r = parseTriple("")
+    testing.assert(!(r.ok))
+}
+fn testReadFeaturePragmaLineComment() {
+    let src = "// @feature: a, b\nlet x = 1\n"
+    let features = readFeaturePragma(src)
+    testing.assertEq(features.len(), 2)
+    testing.assertEq(features[0], "a")
+    testing.assertEq(features[1], "b")
+}
+fn testReadFeaturePragmaTightComment() {
+    let src = "//@feature: foo bar\n"
+    let features = readFeaturePragma(src)
+    testing.assertEq(features.len(), 2)
+    testing.assertEq(features[0], "foo")
+    testing.assertEq(features[1], "bar")
+}
+fn testReadFeaturePragmaSkipsBlankAndCommentLines() {
+    let src = "\n// preamble comment\n// @feature: x\n"
+    let features = readFeaturePragma(src)
+    testing.assertEq(features.len(), 1)
+    testing.assertEq(features[0], "x")
+}
+fn testReadFeaturePragmaStopsAtFirstCode() {
+    let src = "let x = 1\n// @feature: ignored\n"
+    let features = readFeaturePragma(src)
+    testing.assertEq(features.len(), 0)
+}
+fn testReadFeaturePragmaNoPragmaReturnsEmpty() {
+    let src = "let x = 1\nlet y = 2\n"
+    let features = readFeaturePragma(src)
+    testing.assertEq(features.len(), 0)
+}
+fn testReadFeaturePragmaMixedSeparators() {
+    let src = "// @feature: a, b c\td\n"
+    let features = readFeaturePragma(src)
+    testing.assertEq(features.len(), 4)
+    testing.assertEq(features[0], "a")
+    testing.assertEq(features[1], "b")
+    testing.assertEq(features[2], "c")
+    testing.assertEq(features[3], "d")
+}
+fn testParsePragmaFeatureListCommaOnly() {
+    let r = parsePragmaFeatureList("a,b,c")
+    testing.assertEq(r.len(), 3)
+    testing.assertEq(r[0], "a")
+}
+fn testParsePragmaFeatureListSpaceOnly() {
+    let r = parsePragmaFeatureList("a b c")
+    testing.assertEq(r.len(), 3)
+    testing.assertEq(r[1], "b")
+}
+fn testParsePragmaFeatureListTabSeparator() {
+    let r = parsePragmaFeatureList("a\tb\tc")
+    testing.assertEq(r.len(), 3)
+}
+fn testParsePragmaFeatureListDropsEmpty() {
+    let r = parsePragmaFeatureList("a,,b , c")
+    testing.assertEq(r.len(), 3)
+    testing.assertEq(r[0], "a")
+    testing.assertEq(r[1], "b")
+    testing.assertEq(r[2], "c")
+}
+fn testParsePragmaFeatureListEmpty() {
+    let r = parsePragmaFeatureList("")
+    testing.assertEq(r.len(), 0)
+}
+fn testReadFeaturePragmaCRLFLine() {
+    let src = "// @feature: a\r, b\r\n"
+    let features = readFeaturePragma(src)
+    testing.assertEq(features.len(), 2)
+    testing.assertEq(features[0], "a")
+    testing.assertEq(features[1], "b")
+}


### PR DESCRIPTION
## Summary

`internal/profile/profile.go`의 3개 pure parser + 3개 internal helper
를 새 `toolchain/profile_pragma.osty`로 이전. 14번째 self-host 단계.

## 이전된 정책 (3 pub fn + 2 struct + 2 private helper)

- `parseTriple(triple) -> TripleParseResult` — `<arch>-<os>` 타겟
  triple을 **첫 `-` 한 번만** 분할 (`x86_64-apple-darwin` →
  arch=`x86_64`, os=`apple-darwin`). Go의 `strings.SplitN(s, "-", 2)`
  동치 — `strings.split`로 분할하면 OS 내부 dash가 깨지므로 stdlib의
  `splitN` 사용
- `readFeaturePragma(src) -> List<String>` — 소스 첫 32 라인에서
  `// @feature: a, b c` (또는 tight `//@feature:`) 형식의 pragma
  탐색. 비주석/비공백 라인 만나면 종료 (pragma는 파일 머리에만)
- `parsePragmaFeatureList(s) -> List<String>` — pragma payload를
  `,` / ` ` / `\t` separator로 분할, ASCII space/tab/CR trim, 빈 토큰
  제거

## 이름 충돌 회피

`toolchain/profile_flags.osty::parseFeatureList`는 이미 존재 — 그건
CLI `--features=a,b` 파서로 comma만 분할. 본 PR의
`parsePragmaFeatureList`는 pragma용으로 comma + space + tab 모두
분할. 두 정책이 다른 lexer를 유지해야 하므로 모듈 분리.

## Go wrapper 변화

- `ParseTriple`은 legacy `(arch, os, error)` shape 유지 —
  `runner.ParseTriple`의 `Ok=false`를 `fmt.Errorf`로 변환
- `ReadFeaturePragma` / `parseFeatureList` (file-local)는 1줄 thin
  wrapper
- `featTrim` / `featStrip` / `featHas` 로컬 helper 4개 삭제

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/profile/... ./internal/runner/...` —
      pass (drift 포함, 15개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run
      'TestProfile|TestFeature|TestTriple'` — pass
- [x] `go vet ./internal/profile/...` — clean
- [x] Edge case: triple internal dash 보존, pragma CRLF 라인, mixed
      separators 모두 Osty + Go 양측 단위 테스트

## 이번 세션 누적 (14번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1757 | airepair 정책-free | 20 fn + 7 struct |
| #1758 | format use-sort + chain-break | 4 fn + 2 struct |
| #1759 | scaffold expectedPaths | 2 fn |
| #1760 | diag render helpers | 4 fn + 1 struct |
| #1761 | diag explain doc-parser | 1 fn + 1 struct |
| #1762 | cmd/codesdoc 파서 통합 | — (consumer) |
| #1763 | repair pure lookups | 4 fn + 1 struct |
| #1764 | format finalize | 1 fn |
| #1766 | codesdoc pure helpers | 5 fn |
| #1767 | codesdoc Copilot 후속 (raw braces / O(n) / parity) | — (polish) |
| (this) | profile triple/pragma 파서 | 3 fn + 2 struct |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_