### PR TITLE
refactor: profile OptLevelFlags + expandFeatures self-host (toolchain/profile_features.osty)

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -271,14 +271,7 @@ func (p *Profile) OptLevelFlags() []string {
 	if p == nil {
 		return nil
 	}
-	switch p.OptLevel {
-	case 0:
-		return []string{"-gcflags=all=-N -l"}
-	case 1:
-		return []string{"-gcflags=all=-l"}
-	default:
-		return nil
-	}
+	return runner.OptLevelFlags(p.OptLevel)
 }
 
 // GoEnv collects the environment overrides this resolved config
@@ -391,49 +384,12 @@ func (c *Config) Resolve(profileName, triple string, requestedFeatures []string,
 	return &Resolved{Profile: p, Target: t, Features: feats}, nil
 }
 
-// expandFeatures computes the transitive closure of requested + (if
-// useDefaults is true) default-feature names through c.Features.
-// Unknown feature names are passed through unchanged — feature
-// cross-linking to deps is the concern of the resolver layer, not
-// this package.
+// expandFeatures delegates to toolchain/profile_features.osty for
+// the deterministic BFS closure over c.Features. Unknown feature
+// names pass through unchanged — feature cross-linking to deps is
+// the concern of the resolver layer.
 func (c *Config) expandFeatures(requested []string, useDefaults bool) []string {
-	seed := map[string]struct{}{}
-	if useDefaults {
-		for _, f := range c.DefaultFeatures {
-			seed[f] = struct{}{}
-		}
-	}
-	for _, f := range requested {
-		seed[f] = struct{}{}
-	}
-	// BFS through c.Features.
-	out := map[string]struct{}{}
-	queue := make([]string, 0, len(seed))
-	for f := range seed {
-		queue = append(queue, f)
-	}
-	for len(queue) > 0 {
-		f := queue[0]
-		queue = queue[1:]
-		if _, done := out[f]; done {
-			continue
-		}
-		out[f] = struct{}{}
-		for _, child := range c.Features[f] {
-			// "<dep>/<feat>" references are left intact — a future
-			// pkgmgr hook will interpret them. For the local
-			// closure we only recurse on bare feature names.
-			if !strings.Contains(child, "/") {
-				queue = append(queue, child)
-			}
-		}
-	}
-	names := make([]string, 0, len(out))
-	for f := range out {
-		names = append(names, f)
-	}
-	sort.Strings(names)
-	return names
+	return runner.ExpandFeatures(c.Features, c.DefaultFeatures, requested, useDefaults)
 }
 
 // ReadFeaturePragma scans the first ~32 lines of src for a line of

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -44,6 +44,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"diag_explain.osty",
 		"diag_render.osty",
 		"format_policy.osty",
+		"profile_features.osty",
 		"profile_flags.osty",
 		"profile_pragma.osty",
 		"repair_policy.osty",

--- a/internal/runner/profile_features_policy.go
+++ b/internal/runner/profile_features_policy.go
@@ -1,0 +1,75 @@
+// profile_features_policy.go is the Go snapshot of
+// toolchain/profile_features.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import (
+	"sort"
+	"strings"
+)
+
+// OptLevelFlags returns the `-gcflags` argv chunk for an integer
+// optimisation level. Levels outside {0, 1} return nil so the
+// user's profile-level `GoFlags` controls alone.
+//
+// Osty: toolchain/profile_features.osty:26
+func OptLevelFlags(level int) []string {
+	switch level {
+	case 0:
+		return []string{"-gcflags=all=-N -l"}
+	case 1:
+		return []string{"-gcflags=all=-l"}
+	}
+	return nil
+}
+
+// ExpandFeatures computes the deterministic transitive closure of
+// `requested` (and, when useDefaults is true, `defaults`) through
+// the feature graph `features`. Result is sorted by name for
+// stable downstream consumers.
+//
+// Feature tokens that contain a `/` (e.g. `serde/derive`) are not
+// recursed through `features` — they land in the output set so
+// the resolver sees the full requested list, but children come
+// from the package-manager layer.
+//
+// Osty: toolchain/profile_features.osty:55
+func ExpandFeatures(features map[string][]string, defaults, requested []string, useDefaults bool) []string {
+	seen := map[string]bool{}
+	queue := make([]string, 0, len(defaults)+len(requested))
+	if useDefaults {
+		for _, f := range defaults {
+			if !seen[f] {
+				seen[f] = true
+				queue = append(queue, f)
+			}
+		}
+	}
+	for _, f := range requested {
+		if !seen[f] {
+			seen[f] = true
+			queue = append(queue, f)
+		}
+	}
+	visited := map[string]bool{}
+	var out []string
+	for head := 0; head < len(queue); head++ {
+		f := queue[head]
+		if visited[f] {
+			continue
+		}
+		visited[f] = true
+		out = append(out, f)
+		if strings.Contains(f, "/") {
+			continue
+		}
+		for _, child := range features[f] {
+			if !seen[child] {
+				seen[child] = true
+				queue = append(queue, child)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runner/profile_features_policy.go
+++ b/internal/runner/profile_features_policy.go
@@ -28,12 +28,13 @@ func OptLevelFlags(level int) []string {
 // the feature graph `features`. Result is sorted by name for
 // stable downstream consumers.
 //
-// Feature tokens that contain a `/` (e.g. `serde/derive`) are not
-// recursed through `features` — they land in the output set so
-// the resolver sees the full requested list, but children come
-// from the package-manager layer.
+// Cross-package tokens (`<dep>/<feat>`) reached as children are
+// filtered out so they never join the local closure — downstream
+// `Resolved.GoFlags()` would otherwise emit `feat_dep/feat` build
+// tags, which Go rejects. Top-level `<dep>/<feat>` tokens passed
+// in via requested/defaults still land in the output.
 //
-// Osty: toolchain/profile_features.osty:55
+// Osty: toolchain/profile_features.osty:60
 func ExpandFeatures(features map[string][]string, defaults, requested []string, useDefaults bool) []string {
 	seen := map[string]bool{}
 	queue := make([]string, 0, len(defaults)+len(requested))
@@ -60,10 +61,13 @@ func ExpandFeatures(features map[string][]string, defaults, requested []string, 
 		}
 		visited[f] = true
 		out = append(out, f)
-		if strings.Contains(f, "/") {
-			continue
-		}
 		for _, child := range features[f] {
+			// Drop transitive cross-package refs at the enqueue
+			// site — they must NOT enter the local closure
+			// (prevents "feat_dep/feat" Go build tags downstream).
+			if strings.Contains(child, "/") {
+				continue
+			}
 			if !seen[child] {
 				seen[child] = true
 				queue = append(queue, child)

--- a/internal/runner/profile_features_policy_test.go
+++ b/internal/runner/profile_features_policy_test.go
@@ -71,12 +71,22 @@ func TestExpandFeatures(t *testing.T) {
 			want: []string{"a", "b", "c"},
 		},
 		{
-			name: "cross-package-not-recursed",
+			// Transitive cross-package tokens MUST be filtered —
+			// downstream `feat_<name>` Go build tags can't carry `/`.
+			name: "transitive-cross-package-dropped",
 			features: map[string][]string{
 				"a": {"dep/feat", "b"},
 			},
 			requested: []string{"a"}, useDefaults: false,
-			want: []string{"a", "b", "dep/feat"},
+			want: []string{"a", "b"},
+		},
+		{
+			// Top-level cross-package tokens DO land in the output —
+			// resolver layer interprets them separately.
+			name:     "top-level-cross-package-kept",
+			features: map[string][]string{},
+			requested: []string{"dep/feat"}, useDefaults: false,
+			want: []string{"dep/feat"},
 		},
 		{
 			name: "unknown-passes-through", features: map[string][]string{},

--- a/internal/runner/profile_features_policy_test.go
+++ b/internal/runner/profile_features_policy_test.go
@@ -1,0 +1,113 @@
+package runner
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOptLevelFlags(t *testing.T) {
+	cases := []struct {
+		level int
+		want  []string
+	}{
+		{0, []string{"-gcflags=all=-N -l"}},
+		{1, []string{"-gcflags=all=-l"}},
+		{2, nil},
+		{3, nil},
+		{99, nil},
+	}
+	for _, c := range cases {
+		got := OptLevelFlags(c.level)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("OptLevelFlags(%d) = %v, want %v", c.level, got, c.want)
+		}
+	}
+}
+
+func TestExpandFeatures(t *testing.T) {
+	cases := []struct {
+		name        string
+		features    map[string][]string
+		defaults    []string
+		requested   []string
+		useDefaults bool
+		want        []string
+	}{
+		{
+			name: "empty", features: map[string][]string{}, defaults: nil, requested: nil,
+			useDefaults: false, want: nil,
+		},
+		{
+			name: "use-defaults-only", features: map[string][]string{},
+			defaults: []string{"a", "b"}, requested: nil, useDefaults: true,
+			want: []string{"a", "b"},
+		},
+		{
+			name: "ignores-defaults-when-false", features: map[string][]string{},
+			defaults: []string{"a", "b"}, requested: nil, useDefaults: false,
+			want: nil,
+		},
+		{
+			name: "union-requested-with-defaults", features: map[string][]string{},
+			defaults: []string{"b"}, requested: []string{"a"}, useDefaults: true,
+			want: []string{"a", "b"},
+		},
+		{
+			name: "recurses-into-children",
+			features: map[string][]string{
+				"a": {"b", "c"},
+				"b": {"d"},
+			},
+			requested: []string{"a"}, useDefaults: false,
+			want: []string{"a", "b", "c", "d"},
+		},
+		{
+			name: "dedupes",
+			features: map[string][]string{
+				"a": {"b"},
+				"c": {"b"},
+			},
+			requested: []string{"a", "c"}, useDefaults: false,
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "cross-package-not-recursed",
+			features: map[string][]string{
+				"a": {"dep/feat", "b"},
+			},
+			requested: []string{"a"}, useDefaults: false,
+			want: []string{"a", "b", "dep/feat"},
+		},
+		{
+			name: "unknown-passes-through", features: map[string][]string{},
+			requested: []string{"unknown"}, useDefaults: false,
+			want: []string{"unknown"},
+		},
+		{
+			name: "cycle-safe",
+			features: map[string][]string{
+				"a": {"b"},
+				"b": {"a"},
+			},
+			requested: []string{"a"}, useDefaults: false,
+			want: []string{"a", "b"},
+		},
+		{
+			name: "deterministic-sort",
+			features: map[string][]string{
+				"z": {"a"},
+				"m": {"x"},
+			},
+			requested: []string{"z", "m"}, useDefaults: false,
+			want: []string{"a", "m", "x", "z"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ExpandFeatures(c.features, c.defaults, c.requested, c.useDefaults)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("ExpandFeatures(...) = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/profile_features.osty
+++ b/toolchain/profile_features.osty
@@ -35,11 +35,13 @@ pub fn optLevelFlags(level: Int) -> List<String> {
 /// through the feature graph `features`. The result is sorted by
 /// name for stable downstream consumers.
 ///
-/// Feature tokens that contain a `/` (e.g. `serde/derive`) are
-/// **not** recursed through `features` — they're cross-package
-/// references that the package-manager layer interprets later.
-/// They still land in the output set so the resolver sees the
-/// full requested list.
+/// Cross-package feature tokens (`<dep>/<feat>`) reached as
+/// **children** during BFS are filtered out — they're not part of
+/// the local closure and would corrupt downstream consumers like
+/// `Resolved.GoFlags()` that build `feat_<name>` Go build tags
+/// (slashes aren't valid in build tags). Top-level `<dep>/<feat>`
+/// tokens that come in via `requested`/`defaults` directly do
+/// land in the output so the resolver layer can still see them.
 ///
 /// Unknown bare feature names (no entry in `features`) are passed
 /// through unchanged; cross-checking is the resolver's concern.
@@ -71,15 +73,18 @@ pub fn expandFeatures(features: Map<String, List<String>>, defaults: List<String
         }
         visited.insert(f, true)
         out.push(f)
-        // Cross-package "<dep>/<feat>" refs land in the output but
-        // don't recurse through the local features map.
-        if strings.contains(f, "/") {
-            continue
-        }
         let children = features.get(f)
         match children {
             Some(list) -> {
                 for child in list {
+                    // Drop transitive cross-package refs at the
+                    // enqueue site — they must NOT enter the
+                    // local closure (matches the Go reference
+                    // semantics, prevents "feat_dep/feat" build
+                    // tags downstream).
+                    if strings.contains(child, "/") {
+                        continue
+                    }
                     if !seen.containsKey(child) {
                         seen.insert(child, true)
                         queue.push(child)

--- a/toolchain/profile_features.osty
+++ b/toolchain/profile_features.osty
@@ -1,0 +1,114 @@
+/// Pure compute helpers for `internal/profile` that don't need a
+/// live `manifest.*` struct — just the primitive inputs the
+/// `Config` and `Profile` types hold:
+///
+///   - `optLevelFlags`: the `-gcflags=all=-N -l` / `-gcflags=all=-l`
+///     fixed list that backs a profile's `OptLevel`.
+///   - `expandFeatures`: BFS closure over a feature-name graph
+///     keyed by `Map<String, List<String>>`, with `/`-suffixed
+///     "<dep>/<feat>" tokens passed through opaque.
+///
+/// Mirrored by `internal/runner/profile_features_policy.go`. The
+/// drift test under internal/runner keeps the two in sync — the
+/// Osty file is the source of truth at review time.
+use std.strings as strings
+/// optLevelFlags returns the `-gcflags` argv chunk for an
+/// integer optimisation level. Levels outside {0, 1} return an
+/// empty list — the user's profile-level `GoFlags` takes over for
+/// the default cases.
+///
+///   - level 0 (debug): `-gcflags=all=-N -l` — no optimisation,
+///     no inlining
+///   - level 1 (light): `-gcflags=all=-l` — no inlining
+///   - level 2+: empty (let `GoFlags` handle it)
+pub fn optLevelFlags(level: Int) -> List<String> {
+    if level == 0 {
+        return ["-gcflags=all=-N -l"]
+    }
+    if level == 1 {
+        return ["-gcflags=all=-l"]
+    }
+    []
+}
+/// expandFeatures computes the deterministic transitive closure
+/// of `requested` (and, when `useDefaults` is true, `defaults`)
+/// through the feature graph `features`. The result is sorted by
+/// name for stable downstream consumers.
+///
+/// Feature tokens that contain a `/` (e.g. `serde/derive`) are
+/// **not** recursed through `features` — they're cross-package
+/// references that the package-manager layer interprets later.
+/// They still land in the output set so the resolver sees the
+/// full requested list.
+///
+/// Unknown bare feature names (no entry in `features`) are passed
+/// through unchanged; cross-checking is the resolver's concern.
+pub fn expandFeatures(features: Map<String, List<String>>, defaults: List<String>, requested: List<String>, useDefaults: Bool) -> List<String> {
+    let mut seen: Map<String, Bool> = {:}
+    let mut queue: List<String> = []
+    if useDefaults {
+        for f in defaults {
+            if !seen.containsKey(f) {
+                seen.insert(f, true)
+                queue.push(f)
+            }
+        }
+    }
+    for f in requested {
+        if !seen.containsKey(f) {
+            seen.insert(f, true)
+            queue.push(f)
+        }
+    }
+    let mut visited: Map<String, Bool> = {:}
+    let mut out: List<String> = []
+    let mut head = 0
+    for head < queue.len() {
+        let f = queue[head]
+        head = head + 1
+        if visited.containsKey(f) {
+            continue
+        }
+        visited.insert(f, true)
+        out.push(f)
+        // Cross-package "<dep>/<feat>" refs land in the output but
+        // don't recurse through the local features map.
+        if strings.contains(f, "/") {
+            continue
+        }
+        let children = features.get(f)
+        match children {
+            Some(list) -> {
+                for child in list {
+                    if !seen.containsKey(child) {
+                        seen.insert(child, true)
+                        queue.push(child)
+                    }
+                }
+            },
+            None -> {
+            },
+        }
+    }
+    expandFeaturesSorted(out)
+}
+/// expandFeaturesSorted sorts the closure list in lex order. The
+/// Go side uses `sort.Strings`; the Osty version uses an in-place
+/// insertion sort over the `List<String>` because the standard
+/// library doesn't yet expose a generic sort on `List<T>`.
+fn expandFeaturesSorted(xs: List<String>) -> List<String> {
+    let mut out = xs
+    let n = out.len()
+    let mut i = 1
+    for i < n {
+        let cur = out[i]
+        let mut j = i
+        for j > 0 && out[j - 1] > cur {
+            out[j] = out[j - 1]
+            j = j - 1
+        }
+        out[j] = cur
+        i = i + 1
+    }
+    out
+}

--- a/toolchain/profile_features_test.osty
+++ b/toolchain/profile_features_test.osty
@@ -58,13 +58,24 @@ fn testExpandFeaturesDedupes() {
     testing.assertEq(out[1], "b")
     testing.assertEq(out[2], "c")
 }
-fn testExpandFeaturesPassesThroughCrossPackage() {
+fn testExpandFeaturesDropsTransitiveCrossPackage() {
+    // `dep/feat` reached as a child must NOT land in the closure
+    // — downstream consumers turn each name into a `feat_<name>`
+    // Go build tag, and `/` is invalid in build tags.
     let features: Map<String, List<String>> = {"a": ["dep/feat", "b"]}
     let out = expandFeatures(features, [], ["a"], false)
-    testing.assertEq(out.len(), 3)
+    testing.assertEq(out.len(), 2)
     testing.assertEq(out[0], "a")
     testing.assertEq(out[1], "b")
-    testing.assertEq(out[2], "dep/feat")
+}
+fn testExpandFeaturesKeepsTopLevelCrossPackage() {
+    // Top-level cross-package refs (passed in via requested or
+    // defaults) DO survive — the resolver layer interprets them
+    // separately. Only transitive ones get filtered.
+    let features: Map<String, List<String>> = {:}
+    let out = expandFeatures(features, [], ["dep/feat"], false)
+    testing.assertEq(out.len(), 1)
+    testing.assertEq(out[0], "dep/feat")
 }
 fn testExpandFeaturesPassesThroughUnknown() {
     let features: Map<String, List<String>> = {:}

--- a/toolchain/profile_features_test.osty
+++ b/toolchain/profile_features_test.osty
@@ -1,0 +1,90 @@
+use std.testing
+fn testOptLevelFlagsZero() {
+    let flags = optLevelFlags(0)
+    testing.assertEq(flags.len(), 1)
+    testing.assertEq(flags[0], "-gcflags=all=-N -l")
+}
+fn testOptLevelFlagsOne() {
+    let flags = optLevelFlags(1)
+    testing.assertEq(flags.len(), 1)
+    testing.assertEq(flags[0], "-gcflags=all=-l")
+}
+fn testOptLevelFlagsDefault() {
+    let flags = optLevelFlags(2)
+    testing.assertEq(flags.len(), 0)
+}
+fn testOptLevelFlagsHigherLevels() {
+    testing.assertEq(optLevelFlags(3).len(), 0)
+    testing.assertEq(optLevelFlags(99).len(), 0)
+}
+fn testExpandFeaturesEmptyRequest() {
+    let features: Map<String, List<String>> = {:}
+    let out = expandFeatures(features, [], [], false)
+    testing.assertEq(out.len(), 0)
+}
+fn testExpandFeaturesUseDefaultsOnly() {
+    let features: Map<String, List<String>> = {:}
+    let out = expandFeatures(features, ["a", "b"], [], true)
+    testing.assertEq(out.len(), 2)
+    testing.assertEq(out[0], "a")
+    testing.assertEq(out[1], "b")
+}
+fn testExpandFeaturesIgnoresDefaultsWhenFalse() {
+    let features: Map<String, List<String>> = {:}
+    let out = expandFeatures(features, ["a", "b"], [], false)
+    testing.assertEq(out.len(), 0)
+}
+fn testExpandFeaturesUnionRequestedWithDefaults() {
+    let features: Map<String, List<String>> = {:}
+    let out = expandFeatures(features, ["a"], ["b"], true)
+    testing.assertEq(out.len(), 2)
+    testing.assertEq(out[0], "a")
+    testing.assertEq(out[1], "b")
+}
+fn testExpandFeaturesRecursesIntoChildren() {
+    let features: Map<String, List<String>> = {"a": ["b", "c"], "b": ["d"]}
+    let out = expandFeatures(features, [], ["a"], false)
+    testing.assertEq(out.len(), 4)
+    testing.assertEq(out[0], "a")
+    testing.assertEq(out[1], "b")
+    testing.assertEq(out[2], "c")
+    testing.assertEq(out[3], "d")
+}
+fn testExpandFeaturesDedupes() {
+    let features: Map<String, List<String>> = {"a": ["b"], "c": ["b"]}
+    let out = expandFeatures(features, [], ["a", "c"], false)
+    testing.assertEq(out.len(), 3)
+    testing.assertEq(out[0], "a")
+    testing.assertEq(out[1], "b")
+    testing.assertEq(out[2], "c")
+}
+fn testExpandFeaturesPassesThroughCrossPackage() {
+    let features: Map<String, List<String>> = {"a": ["dep/feat", "b"]}
+    let out = expandFeatures(features, [], ["a"], false)
+    testing.assertEq(out.len(), 3)
+    testing.assertEq(out[0], "a")
+    testing.assertEq(out[1], "b")
+    testing.assertEq(out[2], "dep/feat")
+}
+fn testExpandFeaturesPassesThroughUnknown() {
+    let features: Map<String, List<String>> = {:}
+    let out = expandFeatures(features, [], ["unknown"], false)
+    testing.assertEq(out.len(), 1)
+    testing.assertEq(out[0], "unknown")
+}
+fn testExpandFeaturesNoInfiniteLoopOnCycle() {
+    let features: Map<String, List<String>> = {"a": ["b"], "b": ["a"]}
+    let out = expandFeatures(features, [], ["a"], false)
+    testing.assertEq(out.len(), 2)
+    testing.assertEq(out[0], "a")
+    testing.assertEq(out[1], "b")
+}
+fn testExpandFeaturesSortsDeterministically() {
+    let features: Map<String, List<String>> = {"z": ["a"], "m": ["x"]}
+    let out = expandFeatures(features, [], ["z", "m"], false)
+    testing.assertEq(out.len(), 4)
+    testing.assertEq(out[0], "a")
+    testing.assertEq(out[1], "m")
+    testing.assertEq(out[2], "x")
+    testing.assertEq(out[3], "z")
+}


### PR DESCRIPTION
## Summary

PR #1768의 후속. `internal/profile/profile.go`에 남은 2개 pure 컴퓨트
helper를 새 `toolchain/profile_features.osty`로 이전.

## 이전된 정책 (2 pub fn)

- `optLevelFlags(level: Int) -> List<String>` — 정수 `OptLevel` 별
  `-gcflags` argv chunk. `{0, 1}` 외 레벨은 빈 리스트 (사용자
  `GoFlags`가 그 영역을 담당)
- `expandFeatures(features, defaults, requested, useDefaults) ->
  List<String>` — feature graph BFS 결정론적 closure. `<dep>/<feat>`
  형태의 cross-package 토큰은 recurse 안 하고 결과에만 포함,
  사이클 안전, 결과는 lex-sort

## 설계 노트

- **Free fn 변환**: Go의 `(p *Profile) OptLevelFlags()` /
  `(c *Config) expandFeatures()`는 받는 데이터(int / map+list)만
  필요. Osty로 옮기면서 메서드를 free fn으로 평탄화 — manifest 등
  Go-specific struct 의존 없이 호출 가능
- **In-place insertion sort**: Osty stdlib의 generic List<T> sort가
  아직 없어 BFS 결과 정렬은 `expandFeaturesSorted` private helper로
  자체 구현. Go 측은 `sort.Strings` 그대로

## Go wrapper 축소

```go
func (p *Profile) OptLevelFlags() []string {
    if p == nil { return nil }
    return runner.OptLevelFlags(p.OptLevel)
}

func (c *Config) expandFeatures(requested []string, useDefaults bool) []string {
    return runner.ExpandFeatures(c.Features, c.DefaultFeatures, requested, useDefaults)
}
```

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/profile/... ./internal/runner/...` —
      pass (drift 포함, 16개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run
      'TestProfile|TestFeature|TestBuild|TestTriple'` — pass
- [x] Edge case: cycle safety, dedup, cross-package passthrough,
      deterministic sort 모두 Osty + Go 양측 단위 테스트

## 이번 세션 누적 (15번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1757 | airepair 정책-free | 20 fn + 7 struct |
| #1758 | format use-sort + chain-break | 4 fn + 2 struct |
| #1759 | scaffold expectedPaths | 2 fn |
| #1760 | diag render helpers | 4 fn + 1 struct |
| #1761 | diag explain doc-parser | 1 fn + 1 struct |
| #1762 | cmd/codesdoc 파서 통합 | — |
| #1763 | repair pure lookups | 4 fn + 1 struct |
| #1764 | format finalize | 1 fn |
| #1766 | codesdoc pure helpers | 5 fn |
| #1767 | codesdoc Copilot 후속 | — (polish) |
| #1768 | profile triple/pragma 파서 | 3 fn + 2 struct |
| (this) | profile OptLevelFlags + expandFeatures | 2 fn |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_