### PR TITLE
[codex] selfhost MIR LIR Proto boundary

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -98,7 +98,7 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 		pkgName = "main"
 	}
 	command := "lir-proto-lower"
-	if req.Source == "" && req.MIR != nil {
+	if req.MIR != nil {
 		command = "lir-proto-lower-mir-json"
 	}
 	args := []string{command, sourcePath, "--package-name=" + pkgName}
@@ -159,11 +159,10 @@ func resolveOstySelfBin() (string, error) {
 	return bin, nil
 }
 
-// stageSource writes the request's source bytes to a temp file so
-// the osty-self subcommand can open it. The original `sourcePath`
-// is preserved as the basename when set (callers expect the file
-// name to round-trip through the staged copy for diagnostic
-// `source_filename` lines).
+// stageInput writes either the source text or the already-lowered MIR
+// JSON to a temp file so the osty-self subcommand can open it. MIR
+// wins even when callers attach source text for diagnostics; otherwise
+// the bridge silently re-enters source lowering and loses the MIR path.
 func stageInput(req nativelirproto.Request) (string, func(), error) {
 	root, err := os.MkdirTemp("", "osty-native-lirproto-*")
 	if err != nil {
@@ -176,7 +175,7 @@ func stageInput(req nativelirproto.Request) (string, func(), error) {
 		name = filepath.Base(req.SourcePath)
 	}
 	data := []byte(req.Source)
-	if req.Source == "" && req.MIR != nil {
+	if req.MIR != nil {
 		name = strings.TrimSuffix(name, filepath.Ext(name)) + ".mir.json"
 		encoded, err := json.Marshal(req.MIR)
 		if err != nil {

--- a/cmd/osty-native-lirproto/main_test.go
+++ b/cmd/osty-native-lirproto/main_test.go
@@ -134,6 +134,68 @@ func TestRunInvokesOstySelfWithRequestArgs(t *testing.T) {
 	}
 }
 
+// TestRunMIRPayloadInvokesMirJSONSubcommand pins the production
+// self-host boundary: once the caller has already produced MIR, the
+// bridge must not silently fall back to source re-lowering just because
+// the request still carries source text for diagnostics.
+func TestRunMIRPayloadInvokesMirJSONSubcommand(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	captureDir := t.TempDir()
+	captureArgs := filepath.Join(captureDir, "args.json")
+	captureMIR := filepath.Join(captureDir, "main.mir.json")
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_SOURCE", captureMIR)
+	t.Setenv("FAKE_OSTY_SELF_STDOUT", "; lir-proto MIR IR\ndefine i64 @main() {\n  ret i64 42\n}\n")
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		Source:      "fn stale_source_path_should_not_be_lowered() {}\n",
+		Target:      "x86_64-unknown-linux-gnu",
+		MIR: map[string]any{
+			"version":     1,
+			"packageName": "main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if resp.Declined {
+		t.Fatalf("Declined = true, want false: %+v", resp)
+	}
+
+	args := readCapturedArgs(t, captureArgs)
+	if len(args) < 3 {
+		t.Fatalf("captured args too short: %v", args)
+	}
+	if args[0] != "lir-proto-lower-mir-json" {
+		t.Fatalf("args[0] = %q, want lir-proto-lower-mir-json", args[0])
+	}
+	if !strings.HasSuffix(args[1], "main.mir.json") {
+		t.Fatalf("args[1] = %q, want staged main.mir.json path", args[1])
+	}
+	if !contains(args, "--target=x86_64-unknown-linux-gnu") {
+		t.Fatalf("args missing target: %v", args)
+	}
+	staged := readFile(t, captureMIR)
+	if strings.Contains(staged, "stale_source_path_should_not_be_lowered") {
+		t.Fatalf("staged MIR unexpectedly contains source text: %q", staged)
+	}
+	if !strings.Contains(staged, `"version":1`) || !strings.Contains(staged, `"packageName":"main"`) {
+		t.Fatalf("staged MIR content unexpected: %q", staged)
+	}
+}
+
 // TestRunDeclinesWhenOstySelfExitsNonZero pins the second
 // fall-back: a non-zero exit from osty-self (parse failure,
 // unsupported MIR shape, etc.) lands as a `declined: true`

--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -80,14 +80,9 @@ func tryMIRRequestViaLIRProto(req llvmgenRequest) ([]byte, []string, bool) {
 	if req.MIR == nil {
 		return nil, []string{"lir-proto bridge skipped: MIR payload missing"}, false
 	}
-	source := req.MIR.Source
-	if source == "" {
-		return nil, []string{"lir-proto bridge skipped: original source text not attached to MIR payload"}, false
-	}
 	resp, err := nativelirproto.Run(req.MIR.SourcePath, nativelirproto.Request{
 		PackageName: req.MIR.PackageName,
 		SourcePath:  req.MIR.SourcePath,
-		Source:      source,
 		Target:      req.MIR.Target,
 		MIR:         req.MIR.Module,
 	})

--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -76,7 +76,6 @@ func TestRunMIRPayloadPrefersLIRProtoWhenSelected(t *testing.T) {
 		MIR: &llvmgenMIRInput{
 			PackageName: entry.PackageName,
 			SourcePath:  entry.SourcePath,
-			Source:      string(entry.Source),
 			Target:      "x86_64-unknown-linux-gnu",
 			Module:      payload,
 		},
@@ -96,13 +95,14 @@ func TestRunMIRPayloadPrefersLIRProtoWhenSelected(t *testing.T) {
 		t.Fatalf("response did not use LIR Proto IR: %#v", resp)
 	}
 	var lirReq struct {
-		PackageName string `json:"packageName"`
-		SourcePath  string `json:"sourcePath"`
-		Source      string `json:"source"`
-		Target      string `json:"target"`
+		PackageName string          `json:"packageName"`
+		SourcePath  string          `json:"sourcePath"`
+		Source      string          `json:"source"`
+		Target      string          `json:"target"`
+		MIR         json.RawMessage `json:"mir"`
 	}
 	decodeCapturedLIRRequest(t, capture, &lirReq)
-	if lirReq.PackageName != "main" || lirReq.SourcePath != entry.SourcePath || lirReq.Source == "" || lirReq.Target != "x86_64-unknown-linux-gnu" {
+	if lirReq.PackageName != "main" || lirReq.SourcePath != entry.SourcePath || lirReq.Source != "" || lirReq.Target != "x86_64-unknown-linux-gnu" || len(lirReq.MIR) == 0 {
 		t.Fatalf("captured LIR request = %#v", lirReq)
 	}
 }

--- a/internal/ir/validate.go
+++ b/internal/ir/validate.go
@@ -443,7 +443,11 @@ func (v *validator) validateExpr(e Expr) {
 				continue
 			}
 			if p.Type == nil {
-				v.addf("Closure: param[%d] nil Type", i)
+				name := p.Name
+				if name == "" {
+					name = "<pattern>"
+				}
+				v.addf("Closure at %d:%d: param[%d] %q nil Type", e.SpanV.Start.Line, e.SpanV.Start.Column, i, name)
 				continue
 			}
 			v.validateType(p.Type, fmt.Sprintf("Closure param[%d]", i))

--- a/internal/nativelirproto/exec.go
+++ b/internal/nativelirproto/exec.go
@@ -4,12 +4,9 @@
 // JSON-encodes the request, spawns the binary, and decodes the JSON
 // response.
 //
-// Today the binary's internals are a thin Go wrapper around the
-// existing MIR-direct emitter (so gate-on output matches gate-off
-// exactly). The wire shape is what matters for Phase 7: a future
-// slice will replace the binary's body with a real call into the
-// Osty-owned `toolchain/lir_proto.osty` lowerer without touching
-// any caller of this package.
+// The subprocess stages source requests for `lir-proto-lower` and MIR
+// requests for `lir-proto-lower-mir-json`, keeping callers on the same
+// JSON wire shape while the Osty-owned LIR Proto backend grows behind it.
 package nativelirproto
 
 import (

--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -530,9 +530,11 @@ func TestSelfhostDoctorRunsSourceProbe(t *testing.T) {
 		"lirLowerMirModule(",
 		"lirRenderModule(",
 		"LLVM IR renderer produced no return instruction",
+		"selfRebuildBundleSource",
+		"selfRebuildRunClang",
 		"osty-self source compiler: enabled",
 		"osty-self self-rebuild probe: OK",
-		"full toolchain directory rebuild/link orchestration",
+		"osty-self self-rebuild driver: source bundle -> clang object/runtime link",
 	} {
 		if !strings.Contains(text, needle) {
 			t.Errorf("doctor probe missing %q", needle)

--- a/toolchain/diag_explain.osty
+++ b/toolchain/diag_explain.osty
@@ -136,7 +136,11 @@ fn explainFlushPara(st: ExplainParseState) -> ExplainParseState {
 /// trimAllLines applies `strings.trimSpace` to every line. Empty
 /// input returns an empty list.
 fn trimAllLines(xs: List<String>) -> List<String> {
-    xs.map(|s| strings.trimSpace(s))
+    let mut out: List<String> = []
+    for line in xs {
+        out.push(strings.trimSpace(line))
+    }
+    out
 }
 /// trimExampleBlock strips leading/trailing blank lines and a
 /// common leading-space prefix from the example block, then

--- a/toolchain/format_policy.osty
+++ b/toolchain/format_policy.osty
@@ -157,7 +157,7 @@ pub fn finalizeFormatted(input: String) -> String {
         let _ = out.pop()
     }
     if out.len() == 0 || out[out.len() - 1].toInt() != 0x0A {
-        out.push(formatPolicyNewlineByte())
+        out.push(0x0A.toByte())
     }
     let buf = bytes.from(out)
     bytes.toString(buf).unwrapOr(input)
@@ -186,10 +186,6 @@ fn formatPolicyWriteLine(out: List<Byte>, bs: List<Byte>, start: Int, end: Int, 
         acc.push(bs[j])
         j = j + 1
     }
-    acc.push(formatPolicyNewlineByte())
+    acc.push(0x0A.toByte())
     FinalizeWriteResult {out: acc, leading: false, prevBlank: blank}
-}
-fn formatPolicyNewlineByte() -> Byte {
-    let n: Int = 0x0A
-    n.toByte()
 }

--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -68,12 +68,265 @@ fn currentExecutable() -> String {
     }
     args[0]
 }
+fn selfRebuildOptionValue(args: List<String>, name: String) -> String {
+    let prefix = name + "="
+    let mut i = 0
+    for i < args.len() {
+        let arg = args[i]
+        if strings.hasPrefix(arg, prefix) {
+            return strings.trimPrefix(arg, prefix)
+        }
+        if arg == name && i + 1 < args.len() {
+            return args[i + 1]
+        }
+        i = i + 1
+    }
+    ""
+}
+fn selfRebuildRepoRoot(toolchainDir: String) -> String {
+    if strings.hasSuffix(toolchainDir, "/toolchain") {
+        return strings.trimSuffix(toolchainDir, "/toolchain")
+    }
+    selfRebuildPath(toolchainDir, "..")
+}
+fn selfRebuildIsToolchainSource(path: String) -> Bool {
+    strings.hasSuffix(path, ".osty") && !(strings.hasSuffix(path, "_test.osty")) && !(strings.contains(path, "/.osty/")) && !(strings.hasSuffix(path, "/ci.osty"))
+}
+fn selfRebuildStripDriverImports(src: String) -> String {
+    let mut out: List<String> = []
+    for line in strings.split(src, "\n") {
+        if line == "use std.env" || line == "use std.fs" || line == "use std.os" || line == "use std.process" || line == "use std.strings" {
+        } else {
+            out.push(line)
+        }
+    }
+    strings.join(out, "\n")
+}
+fn selfRebuildBundleSource(toolchainDir: String) -> String {
+    let paths = match fs.walk(toolchainDir) {
+        Ok(p) -> p,
+        Err(e) -> {
+            let _ = e
+            eprint("osty-self rebuild: walk toolchain sources failed\n")
+            return ""
+        },
+    }
+    let mut parts: List<String> = ["use std.env", "use std.fs", "use std.os", "use std.process", "use std.strings", ""]
+    for path in paths {
+        if selfRebuildIsToolchainSource(path) {
+            let src = match fs.readToString(path) {
+                Ok(s) -> s,
+                Err(e) -> {
+                    let _ = e
+                    eprint("osty-self rebuild: read source failed: " + path + "\n")
+                    return ""
+                },
+            }
+            parts.push("// ---- " + path + " ----")
+            parts.push(selfRebuildStripDriverImports(src))
+            parts.push("")
+        }
+    }
+    strings.join(parts, "\n")
+}
+fn selfRebuildClangCompileObjectArgs(target: String, irPath: String, objectPath: String) -> List<String> {
+    let mut args: List<String> = []
+    if target != "" {
+        args.push("-target")
+        args.push(target)
+    }
+    args.push("-O3")
+    args.push("-flto=thin")
+    if strings.contains(target, "x86_64") || strings.contains(target, "amd64") {
+        args.push("-march=x86-64-v3")
+    }
+    args.push("-c")
+    args.push(irPath)
+    args.push("-o")
+    args.push(objectPath)
+    args
+}
+fn selfRebuildClangCompileRuntimeArgs(target: String, sourcePath: String, objectPath: String) -> List<String> {
+    let mut args: List<String> = []
+    if target != "" {
+        args.push("-target")
+        args.push(target)
+    }
+    if !(strings.contains(target, "windows")) {
+        args.push("-pthread")
+    }
+    args.push("-O3")
+    args.push("-flto=thin")
+    args.push("-std=c11")
+    args.push("-c")
+    args.push(sourcePath)
+    args.push("-o")
+    args.push(objectPath)
+    args
+}
+fn selfRebuildHostIsDarwin() -> Bool {
+    match os.execWith("uname", ["-s"], "", {:}, 0) {
+        Ok(out) -> strings.trimSpace(out.stdout) == "Darwin",
+        Err(_) -> false,
+    }
+}
+fn selfRebuildIsDarwinTarget(target: String) -> Bool {
+    if target == "" {
+        return selfRebuildHostIsDarwin()
+    }
+    strings.contains(target, "darwin") || strings.contains(target, "apple")
+}
+fn selfRebuildClangLinkArgs(target: String, objectPath: String, runtimeObjectPath: String, binaryPath: String) -> List<String> {
+    let mut args: List<String> = []
+    if target != "" {
+        args.push("-target")
+        args.push(target)
+    }
+    args.push("-O3")
+    args.push("-flto=thin")
+    args.push(objectPath)
+    args.push(runtimeObjectPath)
+    if !(strings.contains(target, "windows")) {
+        args.push("-pthread")
+        args.push("-lz")
+    }
+    args.push("-o")
+    args.push(binaryPath)
+    if !(strings.contains(target, "windows")) {
+        args.push("-lm")
+    }
+    if selfRebuildIsDarwinTarget(target) {
+        args.push("-framework")
+        args.push("Security")
+        args.push("-framework")
+        args.push("CoreFoundation")
+    }
+    if strings.contains(target, "windows") {
+        args.push("-ladvapi32")
+    }
+    args
+}
+fn selfRebuildRunClang(action: String, args: List<String>) -> String {
+    let out = match os.execWith("clang", args, "", {:}, 0) {
+        Ok(o) -> o,
+        Err(e) -> {
+            let _ = e
+            return "clang " + action + " failed to start"
+        },
+    }
+    if out.exitCode == 0 && !out.timedOut {
+        return ""
+    }
+    let msg = strings.trimSpace(out.stderr + "\n" + out.stdout)
+    "clang " + action + " failed\ncommand: clang " + strings.join(args, " ") + "\n" + msg
+}
+fn selfRebuildRunSelfLower(exe: String, bundlePath: String, target: String) -> String {
+    let mut args: List<String> = ["lir-proto-lower", bundlePath, "--package-name=main"]
+    if target != "" {
+        args.push("--target=" + target)
+    }
+    let out = match os.execWith(exe, args, "", {:}, 0) {
+        Ok(o) -> o,
+        Err(e) -> {
+            let _ = e
+            eprint("osty-self rebuild: self LIR Proto lower failed to start\n")
+            return ""
+        },
+    }
+    if out.exitCode == 0 && !out.timedOut && out.stdout != "" {
+        return out.stdout
+    }
+    eprint("osty-self rebuild: self LIR Proto lower failed\n")
+    eprint(strings.trimSpace(out.stderr + "\n" + out.stdout) + "\n")
+    ""
+}
 fn runSelfRebuild(args: List<String>) -> Int {
     let toolchainDir = lastArg(args)
-    let _ = selfRebuildPath(toolchainDir, ".osty/out/debug/llvm/osty-self")
-    eprint("osty-self rebuild blocked: source-to-LIR probe is live, but full toolchain rebuild/link orchestration is not.\n")
-    eprint("missing entrypoint: Osty-owned self-rebuild driver must bundle toolchain sources, lower via LIR Proto, link the runtime, and stage the next osty-self.\n")
-    2
+    let target = selfRebuildOptionValue(args, "--target")
+    let repoRoot = selfRebuildRepoRoot(toolchainDir)
+    let outDir = selfRebuildPath(toolchainDir, ".osty/out/debug/llvm")
+    let runtimeDir = selfRebuildPath(outDir, "runtime")
+    let bundlePath = selfRebuildPath(outDir, "self-rebuild-bundle.osty")
+    let irPath = selfRebuildPath(outDir, "main.ll")
+    let objectPath = selfRebuildPath(outDir, "main.o")
+    let runtimeSourceInRepo = selfRebuildPath(repoRoot, "internal/backend/runtime/osty_runtime.c")
+    let runtimeSourcePath = selfRebuildPath(runtimeDir, "osty_runtime.c")
+    let runtimeObjectPath = selfRebuildPath(runtimeDir, "osty_runtime.o")
+    let binaryPath = selfRebuildPath(outDir, "osty-self")
+    match fs.mkdirAll(runtimeDir) {
+        Ok(_) -> {
+        },
+        Err(e) -> {
+            let _ = e
+            eprint("osty-self rebuild: mkdir failed\n")
+            return 1
+        },
+    }
+    let source = selfRebuildBundleSource(toolchainDir)
+    if source == "" {
+        return 1
+    }
+    match fs.writeString(bundlePath, source) {
+        Ok(_) -> {
+        },
+        Err(e) -> {
+            let _ = e
+            eprint("osty-self rebuild: write bundle failed\n")
+            return 1
+        },
+    }
+    let exe = currentExecutable()
+    if exe == "" {
+        eprint("osty-self rebuild: executable not found\n")
+        return 1
+    }
+    let irText = selfRebuildRunSelfLower(exe, bundlePath, target)
+    if irText == "" {
+        return 1
+    }
+    match fs.writeString(irPath, irText) {
+        Ok(_) -> {
+        },
+        Err(e) -> {
+            let _ = e
+            eprint("osty-self rebuild: write LLVM IR failed\n")
+            return 1
+        },
+    }
+    let runtimeSource = match fs.readToString(runtimeSourceInRepo) {
+        Ok(s) -> s,
+        Err(e) -> {
+            let _ = e
+            eprint("osty-self rebuild: read runtime source failed\n")
+            return 1
+        },
+    }
+    match fs.writeString(runtimeSourcePath, runtimeSource) {
+        Ok(_) -> {
+        },
+        Err(e) -> {
+            let _ = e
+            eprint("osty-self rebuild: write runtime source failed\n")
+            return 1
+        },
+    }
+    let compileObjectErr = selfRebuildRunClang("compile object", selfRebuildClangCompileObjectArgs(target, irPath, objectPath))
+    if compileObjectErr != "" {
+        eprint("osty-self rebuild: " + compileObjectErr + "\n")
+        return 1
+    }
+    let compileRuntimeErr = selfRebuildRunClang("compile runtime", selfRebuildClangCompileRuntimeArgs(target, runtimeSourcePath, runtimeObjectPath))
+    if compileRuntimeErr != "" {
+        eprint("osty-self rebuild: " + compileRuntimeErr + "\n")
+        return 1
+    }
+    let linkErr = selfRebuildRunClang("link binary", selfRebuildClangLinkArgs(target, objectPath, runtimeObjectPath, binaryPath))
+    if linkErr != "" {
+        eprint("osty-self rebuild: " + linkErr + "\n")
+        return 1
+    }
+    println("osty-self self-rebuild: wrote " + binaryPath)
+    0
 }
 fn selfhostProbeSource() -> String {
     "fn main() -> Int {\n    let x = 41\n    return x + 1\n}\n"
@@ -133,7 +386,7 @@ fn runSelfhostDoctor() -> Int {
     println("osty-self source compiler: enabled")
     println("osty-self pipeline: source -> HIR -> Mono -> MIR -> LIR Proto -> LLVM IR")
     println("osty-self self-rebuild probe: OK")
-    println("osty-self missing stage: full toolchain directory rebuild/link orchestration")
+    println("osty-self self-rebuild driver: source bundle -> clang object/runtime link")
     0
 }
 /// runCompile is the Phase 0 self-host pipeline entry: read a source


### PR DESCRIPTION
## Summary
- add the real self-rebuild driver path in toolchain/main.osty, including source bundling, self LIR Proto lowering, clang object/runtime compilation, and final osty-self link
- force MIR payloads through the MIR JSON LIR Proto boundary instead of silently re-lowering attached source text
- remove two selfhost-hostile source shapes found while checking the path: higher-order trim map in diag_explain and the tiny newline helper in format_policy

## Validation
- .bin/osty check --airepair=false toolchain
- go test -count=1 -vet=off ./cmd/osty-native-lirproto ./cmd/osty-native-llvmgen ./internal/selfhost
- git diff --check origin/main..HEAD

## Notes
Full self-rebuild is not claimed green here; this PR removes the false source fallback and leaves the remaining work at the real MIR JSON subcommand boundary.