### PR TITLE
perf(diag_explain): trimExampleBlock indent count without temp string

### DIFF
--- a/toolchain/diag_explain.osty
+++ b/toolchain/diag_explain.osty
@@ -159,8 +159,16 @@ fn trimExampleBlock(lines: List<String>) -> String {
         if strings.trimSpace(l) == "" {
             continue
         }
-        let leadingTrimmed = strings.trimStartChars(l, " ")
-        let count = l.len() - leadingTrimmed.len()
+        // Count leading ASCII spaces directly from the byte view —
+        // strings.trimStartChars allocates a new String per line just
+        // to measure a prefix length, which is wasteful for example
+        // blocks of any size.
+        let lbs = l.bytes()
+        let lbn = lbs.len()
+        let mut count = 0
+        for count < lbn && lbs[count].toInt() == 0x20 {
+            count = count + 1
+        }
         if minIndent < 0 || count < minIndent {
             minIndent = count
         }


### PR DESCRIPTION
## Summary

이전 세션 self-review에서 식별한 hot-path 정리. PR 시리즈
#1751–#1769를 마치고 모인 코드 리뷰에서 발견한 4건의 hazard 중
가장 작고 안전한 첫 번째 fix.

## 문제

`toolchain/diag_explain.osty::trimExampleBlock`은 common-indent
계산을 위해 example 블록의 모든 비어있지 않은 라인에 대해
`strings.trimStartChars(l, " ")`를 호출 — leading ASCII space를
제거한 새 `String`을 만들고 length만 빼서 indent count를 구함.
큰 example 블록에서 라인 수만큼 임시 String 할당이 발생.

## 변경

byte-loop으로 직접 카운트:

```osty
let lbs = l.bytes()
let lbn = lbs.len()
let mut count = 0
for count < lbn && lbs[count].toInt() == 0x20 {
    count = count + 1
}
```

의미는 byte-for-byte 동일 (ASCII space 0x20만 카운트, tab/CR 비포함
— Go 스냅샷의 `len(strings.TrimLeft(l, " "))`와 동치).

## Test plan

- [x] `.bin/osty check toolchain/diag_explain.osty
      toolchain/diag_explain_test.osty` — 0 진단
- [x] `go test -count=1 ./internal/runner/ -run
      'TestParseExplainDoc|TestPolicySnapshotParityWithOsty'` — pass
- [x] `codesdoc -check ERROR_CODES.md` — drift 없음
- [x] `codesdoc -manifest-check toolchain/diag_manifest.osty` — drift
      없음
- [x] `codesdoc -harvest-cases-check toolchain/diag_examples.osty` —
      drift 없음
- [x] `.bin/osty explain E0001` 출력 byte-identical

Go 스냅샷 (`runner.trimExampleBlock`)은 이미 효율적이라 변경 없음.
drift_test는 시그니처만 검증하므로 통과.

## 이번 세션 누적 (16번째 PR)

self-review에서 식별한 4개 hazard 중 1개 처리. 나머지:
- drift_test 의미 동치성 강화 (architecture)
- migration self-checklist 문서화
- runner sync 부담 완화 (architecture)

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_