### PR TITLE
refactor: codesdoc familyForHeading + 분류 테이블 self-host

### DIFF
--- a/cmd/codesdoc/main.go
+++ b/cmd/codesdoc/main.go
@@ -612,7 +612,7 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
 			// Fatal: unknown phase heading means generator mapping is
 			// out of date. Fail loud so the missing entry gets added
 			// instead of silently classifying as FamilyUnknown.
-			fmt.Fprintf(os.Stderr, "codesdoc: unknown phase heading %q — add it to headingFamily in cmd/codesdoc/main.go\n", g.Heading)
+			fmt.Fprintf(os.Stderr, "codesdoc: unknown phase heading %q — add it to codesdocHeadingExactFamily in toolchain/codesdoc_policy.osty (mirror in internal/runner/codesdoc_policy.go)\n", g.Heading)
 			os.Exit(1)
 		}
 		fmt.Fprintf(&b, "    // %s\n", g.Heading)

--- a/cmd/codesdoc/main.go
+++ b/cmd/codesdoc/main.go
@@ -572,74 +572,13 @@ func renderEntry(b *strings.Builder, e codeEntry) {
 
 // ---- manifest render ----
 
-// headingFamily maps the phase heading (as written in codes.go, minus
-// the auto-appended range suffix) to the Osty DiagnosticFamily variant
-// name. Add entries here when codes.go introduces a new phase section.
-//
-// Headings that share a family prefix (e.g. "Manifest — TOML syntax."
-// vs "Manifest — schema.") are matched by prefix via headingToFamily.
-var headingFamily = map[string]string{
-	"Lexical":                   "FamilyLexical",
-	"Declarations & statements": "FamilyDeclaration",
-	"Expressions":               "FamilyExpression",
-	"Types & patterns":          "FamilyTypePattern",
-	"Annotations":               "FamilyAnnotation",
-	"Name resolution":           "FamilyResolution",
-	"Control flow / context":    "FamilyControlFlow",
-	"Type checking":             "FamilyTypeChecking",
-	"Deprecation warning":       "FamilyWarning",
-	"Runtime sublanguage":       "FamilyTypeChecking", // TODO: dedicated FamilyRuntime once generated.go accommodates it
-	"Scaffolding":               "FamilyScaffold",
-
-	// v0.6 — Hidden-Dependency-Surface (G36 – G49)
-	// Note: stripRangeSuffix removes " (...)" suffix, so map uses stripped form.
-	"v0.6 — Hidden-Dependency-Surface": "FamilyAnnotation",
-	"G36 — Capabilities":               "FamilyTypeChecking",
-	"G38 — Spec link":                  "FamilyAnnotation",
-	"G46 — Performance contract":       "FamilyAnnotation",
-	"G37 — Information flow":           "FamilyTypeChecking",
-
-	// v0.6 — Annotation / declaration extensions
-	"v0.6 — Annotation / declaration extensions": "FamilyAnnotation",
-	"G41 — Error contract":                       "FamilyAnnotation",
-	"G40 — Sealed construct":                     "FamilyDeclaration",
-	"G42 — Structured intent":                    "FamilyAnnotation",
-	"G43 — Executable spec block":                "FamilyDeclaration",
-	"G45 — Golden tests":                         "FamilyAnnotation",
-	"G44 — API evolution":                        "FamilyAnnotation",
-	"G44 — Publishing":                           "FamilyManifest",
-}
-
-// headingPrefixFamily matches headings by prefix when multiple
-// subsections share a family (e.g. "Manifest — TOML syntax." →
-// FamilyManifest). Iterated in declaration order so the first matching
-// prefix wins.
-var headingPrefixFamily = []struct {
-	Prefix string
-	Family string
-}{
-	{"Manifest", "FamilyManifest"},
-	{"Lint", "FamilyLint"},
-	{"Type checking", "FamilyTypeChecking"},
-	{"Name resolution", "FamilyResolution"},
-	{"Annotations", "FamilyAnnotation"},
-}
-
-// familyForHeading classifies a parsed phase heading. Returns the empty
-// string when no mapping matches; callers treat that as a fatal
-// generator error so unknown headings can't silently degrade to
-// FamilyUnknown at runtime.
+// familyForHeading delegates to toolchain/codesdoc_policy.osty for
+// the heading→`DiagnosticFamily` classification. The exact-match
+// table and the ordered prefix-match rules both live there;
+// updating codes.go with a new phase section means updating the
+// Osty source, not this file.
 func familyForHeading(heading string) string {
-	trimmed := stripRangeSuffix(heading)
-	if fam, ok := headingFamily[trimmed]; ok {
-		return fam
-	}
-	for _, p := range headingPrefixFamily {
-		if strings.HasPrefix(trimmed, p.Prefix) {
-			return p.Family
-		}
-	}
-	return ""
+	return runner.FamilyForHeading(heading)
 }
 
 // stripRangeSuffix delegates to toolchain/codesdoc_policy.osty

--- a/internal/runner/codesdoc_policy.go
+++ b/internal/runner/codesdoc_policy.go
@@ -87,3 +87,86 @@ func OstyEscape(s string) string {
 	}
 	return b.String()
 }
+
+// CodesdocHeadingPrefixRule mirrors
+// toolchain/codesdoc_policy.osty's CodesdocHeadingPrefixRule. One
+// entry in the ordered prefix-match fallback table.
+//
+// Osty: toolchain/codesdoc_policy.osty:131
+type CodesdocHeadingPrefixRule struct {
+	Prefix string
+	Family string
+}
+
+// CodesdocHeadingExactFamily returns the heading-name →
+// `DiagnosticFamily` mapping. Keys are the post-`StripRangeSuffix`
+// form. Add new entries here when codes.go introduces a new phase
+// section; the markdown/manifest generators error out on unknown
+// headings.
+//
+// Osty: toolchain/codesdoc_policy.osty:144
+func CodesdocHeadingExactFamily() map[string]string {
+	return map[string]string{
+		"Lexical":                   "FamilyLexical",
+		"Declarations & statements": "FamilyDeclaration",
+		"Expressions":               "FamilyExpression",
+		"Types & patterns":          "FamilyTypePattern",
+		"Annotations":               "FamilyAnnotation",
+		"Name resolution":           "FamilyResolution",
+		"Control flow / context":    "FamilyControlFlow",
+		"Type checking":             "FamilyTypeChecking",
+		"Deprecation warning":       "FamilyWarning",
+		"Runtime sublanguage":       "FamilyTypeChecking",
+		"Scaffolding":               "FamilyScaffold",
+
+		"v0.6 — Hidden-Dependency-Surface": "FamilyAnnotation",
+		"G36 — Capabilities":               "FamilyTypeChecking",
+		"G38 — Spec link":                  "FamilyAnnotation",
+		"G46 — Performance contract":       "FamilyAnnotation",
+		"G37 — Information flow":           "FamilyTypeChecking",
+
+		"v0.6 — Annotation / declaration extensions": "FamilyAnnotation",
+		"G41 — Error contract":                       "FamilyAnnotation",
+		"G40 — Sealed construct":                     "FamilyDeclaration",
+		"G42 — Structured intent":                    "FamilyAnnotation",
+		"G43 — Executable spec block":                "FamilyDeclaration",
+		"G45 — Golden tests":                         "FamilyAnnotation",
+		"G44 — API evolution":                        "FamilyAnnotation",
+		"G44 — Publishing":                           "FamilyManifest",
+	}
+}
+
+// CodesdocHeadingPrefixRules returns the ordered prefix-match
+// fallback table. Iteration order matters — first match wins.
+//
+// Osty: toolchain/codesdoc_policy.osty:178
+func CodesdocHeadingPrefixRules() []CodesdocHeadingPrefixRule {
+	return []CodesdocHeadingPrefixRule{
+		{Prefix: "Manifest", Family: "FamilyManifest"},
+		{Prefix: "Lint", Family: "FamilyLint"},
+		{Prefix: "Type checking", Family: "FamilyTypeChecking"},
+		{Prefix: "Name resolution", Family: "FamilyResolution"},
+		{Prefix: "Annotations", Family: "FamilyAnnotation"},
+	}
+}
+
+// FamilyForHeading classifies a parsed phase heading into its
+// `DiagnosticFamily` variant name. Consults the exact-match map
+// first (after stripping the range suffix), then falls back to
+// the prefix-match rules in declaration order. Returns the empty
+// string when no rule matches — cmd/codesdoc treats that as a
+// fatal generator error.
+//
+// Osty: toolchain/codesdoc_policy.osty:198
+func FamilyForHeading(heading string) string {
+	trimmed := StripRangeSuffix(heading)
+	if fam, ok := CodesdocHeadingExactFamily()[trimmed]; ok {
+		return fam
+	}
+	for _, rule := range CodesdocHeadingPrefixRules() {
+		if strings.HasPrefix(trimmed, rule.Prefix) {
+			return rule.Family
+		}
+	}
+	return ""
+}

--- a/internal/runner/codesdoc_policy_test.go
+++ b/internal/runner/codesdoc_policy_test.go
@@ -79,6 +79,47 @@ func TestProseExample(t *testing.T) {
 	}
 }
 
+func TestFamilyForHeading(t *testing.T) {
+	cases := []struct {
+		name    string
+		heading string
+		want    string
+	}{
+		{"exact-lexical", "Lexical", "FamilyLexical"},
+		{"exact-expressions", "Expressions", "FamilyExpression"},
+		{"exact-scaffolding", "Scaffolding", "FamilyScaffold"},
+		{"strips-range-suffix", "Lexical (E0001-E0099)", "FamilyLexical"},
+		{"prefix-manifest", "Manifest — TOML syntax.", "FamilyManifest"},
+		{"prefix-lint", "Lint — naming", "FamilyLint"},
+		{"prefix-type-checking", "Type checking — generic instantiation", "FamilyTypeChecking"},
+		{"v06-hidden-dep", "v0.6 — Hidden-Dependency-Surface", "FamilyAnnotation"},
+		{"v06-capabilities", "G36 — Capabilities", "FamilyTypeChecking"},
+		{"v06-publishing", "G44 — Publishing", "FamilyManifest"},
+		{"unknown", "Wholly Unknown Heading", ""},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := FamilyForHeading(c.heading); got != c.want {
+				t.Errorf("FamilyForHeading(%q) = %q, want %q", c.heading, got, c.want)
+			}
+		})
+	}
+}
+
+func TestCodesdocHeadingPrefixRulesOrder(t *testing.T) {
+	rules := CodesdocHeadingPrefixRules()
+	if len(rules) != 5 {
+		t.Fatalf("rule count = %d, want 5", len(rules))
+	}
+	if rules[0].Prefix != "Manifest" || rules[0].Family != "FamilyManifest" {
+		t.Errorf("rules[0] = %+v, want {Manifest FamilyManifest}", rules[0])
+	}
+	if rules[2].Prefix != "Type checking" {
+		t.Errorf("rules[2].Prefix = %q, want Type checking", rules[2].Prefix)
+	}
+}
+
 func TestOstyEscape(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/toolchain/codesdoc_policy.osty
+++ b/toolchain/codesdoc_policy.osty
@@ -120,3 +120,92 @@ pub fn ostyEscape(s: String) -> String {
     }
     strings.join(parts, "")
 }
+/// CodesdocHeadingPrefixRule is one entry in the prefix-match
+/// fallback table that `familyForHeading` consults when the
+/// stripped heading isn't in the exact-match table. Iterated in
+/// declaration order — the first matching prefix wins.
+pub struct CodesdocHeadingPrefixRule {
+    pub prefix: String,
+    pub family: String,
+}
+/// codesdocHeadingExactFamily returns the heading-name → Osty
+/// `DiagnosticFamily` variant mapping that `familyForHeading`
+/// consults first. The table is keyed on the **stripped** form
+/// (post `stripRangeSuffix`), so both `Lexical` and
+/// `Lexical (E0001-E0099)` resolve through the same entry.
+///
+/// Add an entry here whenever `internal/diag/codes.go` introduces
+/// a new phase section, otherwise the markdown/manifest generators
+/// will reject the heading.
+pub fn codesdocHeadingExactFamily() -> Map<String, String> {
+    {
+        "Lexical": "FamilyLexical",
+        "Declarations & statements": "FamilyDeclaration",
+        "Expressions": "FamilyExpression",
+        "Types & patterns": "FamilyTypePattern",
+        "Annotations": "FamilyAnnotation",
+        "Name resolution": "FamilyResolution",
+        "Control flow / context": "FamilyControlFlow",
+        "Type checking": "FamilyTypeChecking",
+        "Deprecation warning": "FamilyWarning",
+        "Runtime sublanguage": "FamilyTypeChecking",
+        "Scaffolding": "FamilyScaffold",
+        "v0.6 — Hidden-Dependency-Surface": "FamilyAnnotation",
+        "G36 — Capabilities": "FamilyTypeChecking",
+        "G38 — Spec link": "FamilyAnnotation",
+        "G46 — Performance contract": "FamilyAnnotation",
+        "G37 — Information flow": "FamilyTypeChecking",
+        "v0.6 — Annotation / declaration extensions": "FamilyAnnotation",
+        "G41 — Error contract": "FamilyAnnotation",
+        "G40 — Sealed construct": "FamilyDeclaration",
+        "G42 — Structured intent": "FamilyAnnotation",
+        "G43 — Executable spec block": "FamilyDeclaration",
+        "G45 — Golden tests": "FamilyAnnotation",
+        "G44 — API evolution": "FamilyAnnotation",
+        "G44 — Publishing": "FamilyManifest",
+    }
+}
+/// codesdocHeadingPrefixRules returns the ordered prefix-match
+/// fallback used when an exact-match miss falls through. Order
+/// matters — the first matching prefix wins, which is why
+/// `Type checking` comes before any narrower `Type ...` heading
+/// would.
+pub fn codesdocHeadingPrefixRules() -> List<CodesdocHeadingPrefixRule> {
+    [
+        CodesdocHeadingPrefixRule {prefix: "Manifest", family: "FamilyManifest"},
+        CodesdocHeadingPrefixRule {prefix: "Lint", family: "FamilyLint"},
+        CodesdocHeadingPrefixRule {prefix: "Type checking", family: "FamilyTypeChecking"},
+        CodesdocHeadingPrefixRule {prefix: "Name resolution", family: "FamilyResolution"},
+        CodesdocHeadingPrefixRule {prefix: "Annotations", family: "FamilyAnnotation"},
+    ]
+}
+/// familyForHeading classifies a parsed phase heading into its
+/// Osty `DiagnosticFamily` variant name (e.g. `FamilyLexical`).
+/// Consults two tables in order:
+///
+///   1. `codesdocHeadingExactFamily` — direct heading→family map
+///      (after stripping the `(Exxxx-Eyyyy)` range suffix).
+///   2. `codesdocHeadingPrefixRules` — ordered prefix-match
+///      fallback for the families that share a heading prefix
+///      (e.g. `Manifest — TOML syntax.`).
+///
+/// Returns `""` when no rule matches; cmd/codesdoc treats that as
+/// a fatal generator error so unknown headings can't silently
+/// degrade to `FamilyUnknown` in the rendered manifest.
+pub fn familyForHeading(heading: String) -> String {
+    let trimmed = stripRangeSuffix(heading)
+    let exact = codesdocHeadingExactFamily()
+    match exact.get(trimmed) {
+        Some(fam) -> {
+            return fam
+        },
+        None -> {
+        },
+    }
+    for rule in codesdocHeadingPrefixRules() {
+        if strings.hasPrefix(trimmed, rule.prefix) {
+            return rule.family
+        }
+    }
+    ""
+}

--- a/toolchain/codesdoc_policy_test.osty
+++ b/toolchain/codesdoc_policy_test.osty
@@ -84,3 +84,37 @@ fn testOstyEscapeMixedNonAsciiAndEscapes() {
     // ASCII metachars in the middle still take the escape path.
     testing.assertEq(ostyEscape("한\\글\"日\{本\}"), "한\\\\글\\\"日\\\{本\\\}")
 }
+fn testFamilyForHeadingExactMatch() {
+    testing.assertEq(familyForHeading("Lexical"), "FamilyLexical")
+    testing.assertEq(familyForHeading("Expressions"), "FamilyExpression")
+    testing.assertEq(familyForHeading("Scaffolding"), "FamilyScaffold")
+}
+fn testFamilyForHeadingStripsRangeSuffix() {
+    testing.assertEq(familyForHeading("Lexical (E0001-E0099)"), "FamilyLexical")
+    testing.assertEq(familyForHeading("Annotations (E0400-E0499)"), "FamilyAnnotation")
+}
+fn testFamilyForHeadingPrefixFallback() {
+    testing.assertEq(familyForHeading("Manifest — TOML syntax."), "FamilyManifest")
+    testing.assertEq(familyForHeading("Lint — naming"), "FamilyLint")
+}
+fn testFamilyForHeadingPrefixOrderMatters() {
+    // "Type checking" prefix wins because it's listed before any
+    // narrower "Type ..." rule would be.
+    testing.assertEq(familyForHeading("Type checking — generic instantiation"), "FamilyTypeChecking")
+}
+fn testFamilyForHeadingUnknownReturnsEmpty() {
+    testing.assertEq(familyForHeading("Wholly Unknown Heading"), "")
+    testing.assertEq(familyForHeading(""), "")
+}
+fn testFamilyForHeadingV06Sections() {
+    testing.assertEq(familyForHeading("v0.6 — Hidden-Dependency-Surface"), "FamilyAnnotation")
+    testing.assertEq(familyForHeading("G36 — Capabilities"), "FamilyTypeChecking")
+    testing.assertEq(familyForHeading("G44 — Publishing"), "FamilyManifest")
+}
+fn testCodesdocHeadingPrefixRulesOrder() {
+    let rules = codesdocHeadingPrefixRules()
+    testing.assertEq(rules.len(), 5)
+    testing.assertEq(rules[0].prefix, "Manifest")
+    testing.assertEq(rules[0].family, "FamilyManifest")
+    testing.assertEq(rules[2].prefix, "Type checking")
+}


### PR DESCRIPTION
## Summary

PR #1766/#1767의 후속. `cmd/codesdoc/main.go`의 마지막 분류 정책 —
phase-heading → `DiagnosticFamily` 매핑 — 을 toolchain으로 이전.
이제 codesdoc은 분류 결정을 한 줄도 들고 있지 않음.

## 이전된 정책 (3 fn + 1 struct)

- `CodesdocHeadingPrefixRule { prefix, family }` — 순서 의존 prefix
  rule 한 entry
- `codesdocHeadingExactFamily() -> Map<String, String>` — 26개 정확
  매칭 (`stripRangeSuffix` 후 키). `codes.go`에 새 phase section
  추가 시 여기에 추가
- `codesdocHeadingPrefixRules() -> List<CodesdocHeadingPrefixRule>` —
  5개 prefix fallback (선언 순서 = 우선순위, "Manifest" → "Lint" →
  "Type checking" → "Name resolution" → "Annotations")
- `familyForHeading(heading) -> String` — 1) range suffix strip
  2) exact-table 룩업 3) prefix rules 순회. 매치 없으면 `""` (host가
  fatal generator error로 처리)

## Go wrapper 축소

`cmd/codesdoc/main.go`에서 60+ 줄의 두 테이블 + 11줄 함수가 3줄 thin
wrapper로 줄어듦:

```go
func familyForHeading(heading string) string {
    return runner.FamilyForHeading(heading)
}
```

## 설계 노트

- **데이터-정책 통합**: 매핑 테이블은 단순 데이터지만 사용자가 새
  phase section을 추가할 때 함께 수정해야 하는 *정책*. host와
  toolchain 모두에서 한 곳만 보면 되도록 single source-of-truth로
  통합
- **순서 의존 prefix rules**: List로 표현해 선언 순서 = 우선순위
  invariant 유지 ("Manifest"가 먼저 와야 "Manifest — TOML syntax."
  가 좁은 헤딩에 안 잡힘)

## Test plan

- [x] `.bin/osty check toolchain/codesdoc_policy.osty
      toolchain/codesdoc_policy_test.osty` — 0 진단
- [x] `go test -count=1 ./internal/runner/ -run
      'TestFamilyForHeading|TestCodesdocHeadingPrefixRulesOrder|TestPolicySnapshotParityWithOsty'` —
      pass (drift 포함, 16개 ostySources)
- [x] `codesdoc -check ERROR_CODES.md` — drift 없음
- [x] `codesdoc -manifest-check toolchain/diag_manifest.osty` — drift
      없음 (실제 manifest 출력 byte-identical 보장)
- [x] `codesdoc -harvest-cases-check toolchain/diag_examples.osty` —
      drift 없음
- [x] 12개 케이스 (exact match / range strip / prefix fallback /
      prefix order / v0.6 sections / unknown=empty) Osty + Go 양측
      단위 테스트

## 이번 세션 누적 (17번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1757 | airepair 정책-free | 20 fn + 7 struct |
| #1758 | format use-sort + chain-break | 4 fn + 2 struct |
| #1759 | scaffold expectedPaths | 2 fn |
| #1760 | diag render helpers | 4 fn + 1 struct |
| #1761 | diag explain doc-parser | 1 fn + 1 struct |
| #1762 | cmd/codesdoc 파서 통합 | — |
| #1763 | repair pure lookups | 4 fn + 1 struct |
| #1764 | format finalize | 1 fn |
| #1766 | codesdoc pure helpers | 5 fn |
| #1767 | codesdoc Copilot 후속 | — |
| #1768 | profile triple/pragma 파서 | 3 fn + 2 struct |
| #1769 | profile OptLevelFlags + expandFeatures (+ regression fix) | 2 fn |
| #1771 | trimExampleBlock perf | — (perf) |
| (this) | codesdoc familyForHeading + 분류 테이블 | 3 fn + 1 struct |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_