### PR TITLE
refactor: codesdoc rangeSuffix + harvestPhaseFor self-host (codesdoc 정책-free 도달)

### DIFF
--- a/cmd/codesdoc/main.go
+++ b/cmd/codesdoc/main.go
@@ -469,21 +469,17 @@ func defaultHeadingFor(code string) string {
 	return runner.DefaultHeadingFor(code)
 }
 
-// rangeSuffix appends an Exxxx–Eyyyy range to the heading if the
-// entries span more than one code.
+// rangeSuffix delegates to toolchain/codesdoc_policy.osty for the
+// suffix policy. The host extracts the low/high code values from
+// the (already-sorted) entry slice and hands them across as
+// primitives.
 func rangeSuffix(heading string, entries []codeEntry) string {
 	if len(entries) == 0 {
 		return heading
 	}
 	lo := entries[0].Value
 	hi := entries[len(entries)-1].Value
-	if strings.Contains(heading, "(") {
-		return heading
-	}
-	if lo == hi {
-		return fmt.Sprintf("%s (%s)", heading, lo)
-	}
-	return fmt.Sprintf("%s (%s–%s)", heading, lo, hi)
+	return runner.RangeSuffix(heading, lo, hi)
 }
 
 // ---- render ----
@@ -627,28 +623,10 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
 
 // ---- harvest render ----
 
-// harvestPhaseForFamily maps the Osty DiagnosticFamily variant name to
-// the self-host pipeline stage that can observe the diagnostic. The
-// Osty-side harvest runner dispatches to selfResolveSource vs
-// frontendCheckSource vs selfLintSource based on this phase string.
-//
-// Manifest/Scaffold codes aren't reachable from a String input via the
-// current self-host entry points, so they're tagged "skip" and the
-// harvest runner never executes them.
-var harvestPhaseForFamily = map[string]string{
-	"FamilyLexical":      "resolve",
-	"FamilyDeclaration":  "resolve",
-	"FamilyExpression":   "resolve",
-	"FamilyTypePattern":  "resolve",
-	"FamilyAnnotation":   "resolve",
-	"FamilyResolution":   "resolve",
-	"FamilyControlFlow":  "check",
-	"FamilyTypeChecking": "check",
-	"FamilyWarning":      "check",
-	"FamilyLint":         "lint",
-	"FamilyManifest":     "skip",
-	"FamilyScaffold":     "skip",
-}
+// harvestPhaseForFamily delegates to toolchain/codesdoc_policy.osty.
+// The Osty-side harvest runner dispatches to selfResolveSource /
+// frontendCheckSource / selfLintSource based on this phase string;
+// the table itself lives in `codesdoc_policy.osty::harvestPhaseFor`.
 
 // unsafeForBootstrapGen reports whether an example string would trip
 // the Go-hosted bootstrap transpiler's lexer when embedded as an Osty
@@ -698,10 +676,7 @@ pub fn diagHarvestCases() -> List<DiagHarvestCase> {
 	first := true
 	for _, g := range doc.Groups {
 		fam := familyForHeading(g.Heading)
-		phase, ok := harvestPhaseForFamily[fam]
-		if !ok {
-			phase = "skip"
-		}
+		phase := runner.HarvestPhaseFor(fam)
 		for _, e := range g.Entries {
 			if e.Doc.Example == "" {
 				continue

--- a/internal/runner/codesdoc_policy.go
+++ b/internal/runner/codesdoc_policy.go
@@ -170,3 +170,51 @@ func FamilyForHeading(heading string) string {
 	}
 	return ""
 }
+
+// RangeSuffix appends an `Exxxx-Eyyyy` (or single `Exxxx`) range
+// to a phase `heading`. Empty range (both lo and hi empty)
+// returns the heading unchanged so the caller's no-entries path
+// is a no-op. If the heading already carries a `(...)` suffix
+// from a prior pass it's left untouched. `lo == hi` collapses to
+// the single-code form.
+//
+// Osty: toolchain/codesdoc_policy.osty:227
+func RangeSuffix(heading, lo, hi string) string {
+	if lo == "" && hi == "" {
+		return heading
+	}
+	if strings.Contains(heading, "(") {
+		return heading
+	}
+	if lo == hi {
+		return heading + " (" + lo + ")"
+	}
+	return heading + " (" + lo + "–" + hi + ")"
+}
+
+// HarvestPhaseFor maps a `DiagnosticFamily` variant name to the
+// self-host pipeline stage that can observe the diagnostic
+// (`resolve` / `check` / `lint` / `skip`). Unknown families
+// collapse to `skip` so the harvest runner silently drops them.
+//
+// Osty: toolchain/codesdoc_policy.osty:253
+func HarvestPhaseFor(family string) string {
+	switch family {
+	case "FamilyLexical",
+		"FamilyDeclaration",
+		"FamilyExpression",
+		"FamilyTypePattern",
+		"FamilyAnnotation",
+		"FamilyResolution":
+		return "resolve"
+	case "FamilyControlFlow",
+		"FamilyTypeChecking",
+		"FamilyWarning":
+		return "check"
+	case "FamilyLint":
+		return "lint"
+	case "FamilyManifest", "FamilyScaffold":
+		return "skip"
+	}
+	return "skip"
+}

--- a/internal/runner/codesdoc_policy_test.go
+++ b/internal/runner/codesdoc_policy_test.go
@@ -120,6 +120,57 @@ func TestCodesdocHeadingPrefixRulesOrder(t *testing.T) {
 	}
 }
 
+func TestRangeSuffix(t *testing.T) {
+	cases := []struct {
+		name    string
+		heading string
+		lo      string
+		hi      string
+		want    string
+	}{
+		{"multiple-codes", "Lexical", "E0001", "E0099", "Lexical (E0001–E0099)"},
+		{"single-code", "Deprecation warning", "W0750", "W0750", "Deprecation warning (W0750)"},
+		{"empty-range", "Lexical", "", "", "Lexical"},
+		{"already-suffixed", "Lexical (E0001-E0099)", "E0100", "E0199", "Lexical (E0001-E0099)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RangeSuffix(c.heading, c.lo, c.hi); got != c.want {
+				t.Errorf("RangeSuffix(%q, %q, %q) = %q, want %q",
+					c.heading, c.lo, c.hi, got, c.want)
+			}
+		})
+	}
+}
+
+func TestHarvestPhaseFor(t *testing.T) {
+	cases := []struct {
+		family string
+		want   string
+	}{
+		{"FamilyLexical", "resolve"},
+		{"FamilyDeclaration", "resolve"},
+		{"FamilyExpression", "resolve"},
+		{"FamilyTypePattern", "resolve"},
+		{"FamilyAnnotation", "resolve"},
+		{"FamilyResolution", "resolve"},
+		{"FamilyControlFlow", "check"},
+		{"FamilyTypeChecking", "check"},
+		{"FamilyWarning", "check"},
+		{"FamilyLint", "lint"},
+		{"FamilyManifest", "skip"},
+		{"FamilyScaffold", "skip"},
+		{"FamilyUnknown", "skip"},
+		{"", "skip"},
+		{"NotAFamily", "skip"},
+	}
+	for _, c := range cases {
+		if got := HarvestPhaseFor(c.family); got != c.want {
+			t.Errorf("HarvestPhaseFor(%q) = %q, want %q", c.family, got, c.want)
+		}
+	}
+}
+
 func TestOstyEscape(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/toolchain/codesdoc_policy.osty
+++ b/toolchain/codesdoc_policy.osty
@@ -209,3 +209,77 @@ pub fn familyForHeading(heading: String) -> String {
     }
     ""
 }
+/// rangeSuffix appends an `Exxxx-Eyyyy` (or single `Exxxx`) range
+/// to a phase `heading` when the entries span at least one code.
+/// Empty range (`lo == ""` AND `hi == ""`) returns the heading
+/// unchanged — that's the no-entries path the host caller covers
+/// via `len(entries) == 0`.
+///
+/// Idempotency: if `heading` already carries a `(...)` suffix the
+/// caller's previous pass added, return it untouched. cmd/codesdoc
+/// occasionally re-uses already-suffixed headings via
+/// `stripRangeSuffix`/`familyForHeading` round-trip, and we don't
+/// want a doubled `(E0001-E0099) (E0001)`.
+///
+/// `lo == hi` collapses to the single-code form.
+pub fn rangeSuffix(heading: String, lo: String, hi: String) -> String {
+    if lo == "" && hi == "" {
+        return heading
+    }
+    if strings.contains(heading, "(") {
+        return heading
+    }
+    if lo == hi {
+        return heading + " (" + lo + ")"
+    }
+    heading + " (" + lo + "–" + hi + ")"
+}
+/// harvestPhaseFor maps a DiagnosticFamily variant name (e.g.
+/// `FamilyLexical`) to the self-host pipeline stage that can
+/// observe the diagnostic (`resolve` / `check` / `lint` / `skip`).
+/// Unknown families collapse to `skip` so the harvest runner
+/// silently drops them rather than executing a runner that
+/// doesn't apply.
+///
+/// Manifest/Scaffold codes aren't reachable from a String input
+/// via the current self-host entry points; they're tagged `skip`
+/// here so the harvest runner never tries to execute them.
+pub fn harvestPhaseFor(family: String) -> String {
+    if family == "FamilyLexical" {
+        return "resolve"
+    }
+    if family == "FamilyDeclaration" {
+        return "resolve"
+    }
+    if family == "FamilyExpression" {
+        return "resolve"
+    }
+    if family == "FamilyTypePattern" {
+        return "resolve"
+    }
+    if family == "FamilyAnnotation" {
+        return "resolve"
+    }
+    if family == "FamilyResolution" {
+        return "resolve"
+    }
+    if family == "FamilyControlFlow" {
+        return "check"
+    }
+    if family == "FamilyTypeChecking" {
+        return "check"
+    }
+    if family == "FamilyWarning" {
+        return "check"
+    }
+    if family == "FamilyLint" {
+        return "lint"
+    }
+    if family == "FamilyManifest" {
+        return "skip"
+    }
+    if family == "FamilyScaffold" {
+        return "skip"
+    }
+    "skip"
+}

--- a/toolchain/codesdoc_policy_test.osty
+++ b/toolchain/codesdoc_policy_test.osty
@@ -118,3 +118,40 @@ fn testCodesdocHeadingPrefixRulesOrder() {
     testing.assertEq(rules[0].family, "FamilyManifest")
     testing.assertEq(rules[2].prefix, "Type checking")
 }
+fn testRangeSuffixMultipleCodes() {
+    testing.assertEq(rangeSuffix("Lexical", "E0001", "E0099"), "Lexical (E0001–E0099)")
+}
+fn testRangeSuffixSingleCode() {
+    testing.assertEq(rangeSuffix("Deprecation warning", "W0750", "W0750"), "Deprecation warning (W0750)")
+}
+fn testRangeSuffixEmptyRangeReturnsHeading() {
+    testing.assertEq(rangeSuffix("Lexical", "", ""), "Lexical")
+}
+fn testRangeSuffixSkipsAlreadySuffixed() {
+    testing.assertEq(rangeSuffix("Lexical (E0001-E0099)", "E0100", "E0199"), "Lexical (E0001-E0099)")
+}
+fn testHarvestPhaseForResolveFamilies() {
+    testing.assertEq(harvestPhaseFor("FamilyLexical"), "resolve")
+    testing.assertEq(harvestPhaseFor("FamilyDeclaration"), "resolve")
+    testing.assertEq(harvestPhaseFor("FamilyExpression"), "resolve")
+    testing.assertEq(harvestPhaseFor("FamilyTypePattern"), "resolve")
+    testing.assertEq(harvestPhaseFor("FamilyAnnotation"), "resolve")
+    testing.assertEq(harvestPhaseFor("FamilyResolution"), "resolve")
+}
+fn testHarvestPhaseForCheckFamilies() {
+    testing.assertEq(harvestPhaseFor("FamilyControlFlow"), "check")
+    testing.assertEq(harvestPhaseFor("FamilyTypeChecking"), "check")
+    testing.assertEq(harvestPhaseFor("FamilyWarning"), "check")
+}
+fn testHarvestPhaseForLintFamily() {
+    testing.assertEq(harvestPhaseFor("FamilyLint"), "lint")
+}
+fn testHarvestPhaseForSkipFamilies() {
+    testing.assertEq(harvestPhaseFor("FamilyManifest"), "skip")
+    testing.assertEq(harvestPhaseFor("FamilyScaffold"), "skip")
+}
+fn testHarvestPhaseForUnknownDefaultsToSkip() {
+    testing.assertEq(harvestPhaseFor("FamilyUnknown"), "skip")
+    testing.assertEq(harvestPhaseFor(""), "skip")
+    testing.assertEq(harvestPhaseFor("NotAFamily"), "skip")
+}


### PR DESCRIPTION
## Summary

PR #1772의 마무리. `cmd/codesdoc`의 마지막 두 마이너 정책을
`toolchain/codesdoc_policy.osty`로 이전. **이제 cmd/codesdoc은 결정
로직 0줄** — Go AST 순회, file I/O, render 템플릿만 host에 남는다.

## 이전된 정책 (2 fn)

- `rangeSuffix(heading, lo, hi) -> String` — phase heading에
  `(Exxxx-Eyyyy)` 또는 단일 `(Exxxx)` suffix 추가. 이미 `(...)`
  suffix가 있으면 idempotent. 빈 range (`lo == "" && hi == ""`)는
  헤딩 그대로
- `harvestPhaseFor(family) -> String` — `DiagnosticFamily` →
  self-host pipeline 단계 (`resolve` / `check` / `lint` / `skip`)
  매핑. unknown family는 `skip` default (host의 `if !ok` fallback도
  Osty 측에서 처리)

## Go wrapper 변화

- `rangeSuffix`: entries에서 `lo`/`hi` value 추출만 하고
  `runner.RangeSuffix` 위임. `fmt.Sprintf` 의존 제거
- `harvestPhaseForFamily` map (12 entries) 통째 삭제. 호출 사이트
  (`renderHarvest`)는 `runner.HarvestPhaseFor(fam)` 직접 호출 — host
  의 manual fallback 코드도 제거

## codesdoc 정책-free 회고

이전부터:
- #1762: 파서 통합 (`runner.ParseExplainDoc`)
- #1766: 5개 pure helpers (`defaultHeadingFor` 등)
- #1767: Copilot 후속 polish
- #1772: `familyForHeading` + 분류 테이블

이번 PR로 codesdoc 정책 마이그레이션 완료. host에 남은 건:
- `parseCodes` (Go AST 순회)
- `runMarkdown` / `runManifest` / `runHarvest` (file I/O + render
  template)
- 4개 thin wrapper (`parseDocComment` / `familyForHeading` /
  `rangeSuffix` / `defaultHeadingFor` 등 — 모두 1~3줄)

## Test plan

- [x] `.bin/osty check toolchain/codesdoc_policy.osty
      toolchain/codesdoc_policy_test.osty` — 0 진단
- [x] `go test -count=1 ./internal/runner/ -run
      'TestRangeSuffix|TestHarvestPhaseFor|TestPolicySnapshotParityWithOsty'` —
      pass (16개 ostySources)
- [x] `codesdoc -check ERROR_CODES.md` — drift 없음
- [x] `codesdoc -manifest-check toolchain/diag_manifest.osty` — drift
      없음
- [x] `codesdoc -harvest-cases-check toolchain/diag_examples.osty` —
      drift 없음 (실제 harvest 출력이 동일함을 검증; phase tagging
      regression catch 가능)
- [x] 14개 신규 단위 테스트 (`rangeSuffix` multiple/single/empty/
      already-suffixed, `harvestPhaseFor` 12 family + 3 unknown
      fallback) Osty + Go 양측

## 이번 세션 누적 (18번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1769 | airepair + format + scaffold + diag + repair + profile | (기존) |
| #1771 | `trimExampleBlock` perf | — |
| #1772 | codesdoc `familyForHeading` + 분류 테이블 | 3 fn + 1 struct |
| (this) | codesdoc `rangeSuffix` + `harvestPhaseFor` | 2 fn |

cmd/codesdoc 정책-free.

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_