### PR TITLE
refactor: profile GoFlags + FileNeedsFeatures self-host (toolchain/profile_features.osty 확장)

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -326,34 +326,7 @@ func (r *Resolved) GoFlags() []string {
 	if r == nil || r.Profile == nil {
 		return nil
 	}
-	var flags []string
-	optFlags := r.Profile.OptLevelFlags()
-	flags = append(flags, optFlags...)
-	seen := map[string]bool{}
-	for _, f := range optFlags {
-		seen[f] = true
-	}
-	for _, f := range r.Profile.GoFlags {
-		if seen[f] {
-			continue
-		}
-		flags = append(flags, f)
-		seen[f] = true
-	}
-	stripFlag := "-ldflags=-s -w"
-	if r.Profile.Strip && !seen[stripFlag] {
-		flags = append(flags, stripFlag)
-		seen[stripFlag] = true
-	}
-	if len(r.Features) > 0 {
-		tags := make([]string, 0, len(r.Features))
-		for _, f := range r.Features {
-			tags = append(tags, "feat_"+f)
-		}
-		sort.Strings(tags)
-		flags = append(flags, "-tags="+strings.Join(tags, ","))
-	}
-	return flags
+	return runner.GoFlags(r.Profile.OptLevel, r.Profile.GoFlags, r.Profile.Strip, r.Features)
 }
 
 // Resolve builds a Resolved from a profile name, an optional target
@@ -410,12 +383,10 @@ func ReadFeaturePragma(src []byte) []string {
 // every required feature is present in `active`. Files without a
 // pragma are unconditionally included. Returns (ok, missing) where
 // missing is the first feature that wasn't active.
+// FileNeedsFeatures delegates to toolchain/profile_features.osty.
+// The result struct collapses to the legacy (ok, missing) tuple
+// shape callers expect.
 func FileNeedsFeatures(src []byte, active map[string]bool) (bool, string) {
-	needed := ReadFeaturePragma(src)
-	for _, f := range needed {
-		if !active[f] {
-			return false, f
-		}
-	}
-	return true, ""
+	r := runner.FileNeedsFeatures(src, active)
+	return r.Ok, r.Missing
 }

--- a/internal/runner/profile_features_policy.go
+++ b/internal/runner/profile_features_policy.go
@@ -8,6 +8,17 @@ import (
 	"strings"
 )
 
+// FeatureCheckResult mirrors toolchain/profile_features.osty's
+// FeatureCheckResult — the structured outcome of fileNeedsFeatures.
+// Ok=false leaves Missing populated with the first missing feature
+// name so the host can blame it in a diagnostic.
+//
+// Osty: toolchain/profile_features.osty:130
+type FeatureCheckResult struct {
+	Ok      bool
+	Missing string
+}
+
 // OptLevelFlags returns the `-gcflags` argv chunk for an integer
 // optimisation level. Levels outside {0, 1} return nil so the
 // user's profile-level `GoFlags` controls alone.
@@ -76,4 +87,63 @@ func ExpandFeatures(features map[string][]string, defaults, requested []string, 
 	}
 	sort.Strings(out)
 	return out
+}
+
+// GoFlags assembles the flat `go build` flag list for a resolved
+// profile/target/feature config. Order:
+//
+//  1. OptLevelFlags(optLevel) — debug/light switches.
+//  2. profileGoFlags from the merged manifest profile, deduped
+//     against (1).
+//  3. `-ldflags=-s -w` when strip is true, deduped.
+//  4. `-tags=feat_<name>,...` when features non-empty; tags sorted.
+//
+// Feature names map 1:1 to Go build tags so generated code can
+// gate via `//go:build feat_<name>`.
+//
+// Osty: toolchain/profile_features.osty:80
+func GoFlags(optLevel int, profileGoFlags []string, strip bool, features []string) []string {
+	var flags []string
+	seen := map[string]bool{}
+	for _, f := range OptLevelFlags(optLevel) {
+		if !seen[f] {
+			flags = append(flags, f)
+			seen[f] = true
+		}
+	}
+	for _, f := range profileGoFlags {
+		if !seen[f] {
+			flags = append(flags, f)
+			seen[f] = true
+		}
+	}
+	const stripFlag = "-ldflags=-s -w"
+	if strip && !seen[stripFlag] {
+		flags = append(flags, stripFlag)
+		seen[stripFlag] = true
+	}
+	if len(features) > 0 {
+		tags := make([]string, 0, len(features))
+		for _, f := range features {
+			tags = append(tags, "feat_"+f)
+		}
+		sort.Strings(tags)
+		flags = append(flags, "-tags="+strings.Join(tags, ","))
+	}
+	return flags
+}
+
+// FileNeedsFeatures reads the file-header `// @feature:` pragma
+// from `src` and checks every required feature against the
+// `active` map. Returns Ok=true with empty Missing when every
+// required feature is active (or when no pragma is present).
+//
+// Osty: toolchain/profile_features.osty:139
+func FileNeedsFeatures(src []byte, active map[string]bool) FeatureCheckResult {
+	for _, f := range ReadFeaturePragma(src) {
+		if !active[f] {
+			return FeatureCheckResult{Ok: false, Missing: f}
+		}
+	}
+	return FeatureCheckResult{Ok: true}
 }

--- a/internal/runner/profile_features_policy_test.go
+++ b/internal/runner/profile_features_policy_test.go
@@ -24,6 +24,86 @@ func TestOptLevelFlags(t *testing.T) {
 	}
 }
 
+func TestGoFlags(t *testing.T) {
+	cases := []struct {
+		name           string
+		optLevel       int
+		profileGoFlags []string
+		strip          bool
+		features       []string
+		want           []string
+	}{
+		{
+			name: "opt-level-only", optLevel: 0,
+			want: []string{"-gcflags=all=-N -l"},
+		},
+		{
+			name: "dedupes-opt-against-profile", optLevel: 0,
+			profileGoFlags: []string{"-gcflags=all=-N -l", "-trimpath"},
+			want:           []string{"-gcflags=all=-N -l", "-trimpath"},
+		},
+		{
+			name: "appends-strip", optLevel: 2,
+			profileGoFlags: []string{"-trimpath"}, strip: true,
+			want: []string{"-trimpath", "-ldflags=-s -w"},
+		},
+		{
+			name: "strip-dedupes", optLevel: 2,
+			profileGoFlags: []string{"-ldflags=-s -w"}, strip: true,
+			want: []string{"-ldflags=-s -w"},
+		},
+		{
+			name: "features-emit-sorted-tags", optLevel: 2,
+			features: []string{"x", "a", "m"},
+			want:     []string{"-tags=feat_a,feat_m,feat_x"},
+		},
+		{
+			name: "features-empty-omits-tags", optLevel: 2,
+			want: nil,
+		},
+		{
+			name: "full-stack", optLevel: 0,
+			profileGoFlags: []string{"-trimpath"}, strip: true,
+			features: []string{"foo", "bar"},
+			want: []string{
+				"-gcflags=all=-N -l", "-trimpath",
+				"-ldflags=-s -w", "-tags=feat_bar,feat_foo",
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := GoFlags(c.optLevel, c.profileGoFlags, c.strip, c.features)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("GoFlags(...) = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestFileNeedsFeatures(t *testing.T) {
+	cases := []struct {
+		name       string
+		src        string
+		active     map[string]bool
+		wantOk     bool
+		wantMissin string
+	}{
+		{"no-pragma", "let x = 1\n", map[string]bool{}, true, ""},
+		{"all-present", "// @feature: a, b\nlet x = 1\n", map[string]bool{"a": true, "b": true}, true, ""},
+		{"missing-returns-first", "// @feature: a, b\nlet x = 1\n", map[string]bool{"a": true}, false, "b"},
+		{"inactive-counts-as-missing", "// @feature: a\nlet x = 1\n", map[string]bool{"a": false}, false, "a"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := FileNeedsFeatures([]byte(c.src), c.active)
+			if got.Ok != c.wantOk || got.Missing != c.wantMissin {
+				t.Errorf("FileNeedsFeatures = %+v, want {ok:%v missing:%q}", got, c.wantOk, c.wantMissin)
+			}
+		})
+	}
+}
+
 func TestExpandFeatures(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/internal/runner/profile_features_policy_test.go
+++ b/internal/runner/profile_features_policy_test.go
@@ -87,7 +87,7 @@ func TestFileNeedsFeatures(t *testing.T) {
 		src        string
 		active     map[string]bool
 		wantOk     bool
-		wantMissin string
+		wantMissing string
 	}{
 		{"no-pragma", "let x = 1\n", map[string]bool{}, true, ""},
 		{"all-present", "// @feature: a, b\nlet x = 1\n", map[string]bool{"a": true, "b": true}, true, ""},
@@ -97,8 +97,8 @@ func TestFileNeedsFeatures(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got := FileNeedsFeatures([]byte(c.src), c.active)
-			if got.Ok != c.wantOk || got.Missing != c.wantMissin {
-				t.Errorf("FileNeedsFeatures = %+v, want {ok:%v missing:%q}", got, c.wantOk, c.wantMissin)
+			if got.Ok != c.wantOk || got.Missing != c.wantMissing {
+				t.Errorf("FileNeedsFeatures = %+v, want {ok:%v missing:%q}", got, c.wantOk, c.wantMissing)
 			}
 		})
 	}

--- a/toolchain/profile_features.osty
+++ b/toolchain/profile_features.osty
@@ -117,3 +117,77 @@ fn expandFeaturesSorted(xs: List<String>) -> List<String> {
     }
     out
 }
+/// goFlags assembles the flat `go build` flag list for a resolved
+/// profile/target/feature config. Order (matches Go reference):
+///
+///   1. `optLevelFlags(optLevel)` — debug/light optimisation
+///      switches.
+///   2. `profileGoFlags` — the merged manifest profile's GoFlags,
+///      with deduplication against (1).
+///   3. `-ldflags=-s -w` when `strip` is true (deduplicated).
+///   4. `-tags=feat_<name>,feat_<name>,...` when `features` is
+///      non-empty; tag names sorted for determinism.
+///
+/// Feature names map 1:1 to Go build tags so conditional
+/// generated code can gate via `//go:build feat_<name>`.
+pub fn goFlags(optLevel: Int, profileGoFlags: List<String>, strip: Bool, features: List<String>) -> List<String> {
+    let mut flags: List<String> = []
+    let mut seen: Map<String, Bool> = {:}
+    let optFlags = optLevelFlags(optLevel)
+    for f in optFlags {
+        if !seen.containsKey(f) {
+            flags.push(f)
+            seen.insert(f, true)
+        }
+    }
+    for f in profileGoFlags {
+        if !seen.containsKey(f) {
+            flags.push(f)
+            seen.insert(f, true)
+        }
+    }
+    let stripFlag = "-ldflags=-s -w"
+    if strip && !seen.containsKey(stripFlag) {
+        flags.push(stripFlag)
+        seen.insert(stripFlag, true)
+    }
+    if features.len() > 0 {
+        let mut tags: List<String> = []
+        for f in features {
+            tags.push("feat_" + f)
+        }
+        tags = expandFeaturesSorted(tags)
+        flags.push("-tags=" + strings.join(tags, ","))
+    }
+    flags
+}
+/// FeatureCheckResult is the outcome of `fileNeedsFeatures` —
+/// `ok == false` carries the first missing feature in `missing`
+/// so the host can blame it in a diagnostic.
+pub struct FeatureCheckResult {
+    pub ok: Bool,
+    pub missing: String,
+}
+/// fileNeedsFeatures reads the file-header `// @feature:` pragma
+/// from `src` and checks every required feature against the
+/// `active` map. Returns ok=true (and empty missing) when every
+/// required feature is active, or when the file has no pragma.
+/// The host treats ok=false as "this file is gated off — skip
+/// build" and uses `missing` in the diagnostic.
+pub fn fileNeedsFeatures(src: String, active: Map<String, Bool>) -> FeatureCheckResult {
+    let needed = readFeaturePragma(src)
+    for f in needed {
+        let entry = active.get(f)
+        match entry {
+            Some(on) -> {
+                if !on {
+                    return FeatureCheckResult {ok: false, missing: f}
+                }
+            },
+            None -> {
+                return FeatureCheckResult {ok: false, missing: f}
+            },
+        }
+    }
+    FeatureCheckResult {ok: true, missing: ""}
+}

--- a/toolchain/profile_features_test.osty
+++ b/toolchain/profile_features_test.osty
@@ -99,3 +99,67 @@ fn testExpandFeaturesSortsDeterministically() {
     testing.assertEq(out[2], "x")
     testing.assertEq(out[3], "z")
 }
+fn testGoFlagsOptLevelOnly() {
+    let flags = goFlags(0, [], false, [])
+    testing.assertEq(flags.len(), 1)
+    testing.assertEq(flags[0], "-gcflags=all=-N -l")
+}
+fn testGoFlagsDedupesOptLevelAgainstProfile() {
+    // Profile also lists the -gcflags=all=-N -l flag — should appear once.
+    let flags = goFlags(0, ["-gcflags=all=-N -l", "-trimpath"], false, [])
+    testing.assertEq(flags.len(), 2)
+    testing.assertEq(flags[0], "-gcflags=all=-N -l")
+    testing.assertEq(flags[1], "-trimpath")
+}
+fn testGoFlagsAppendsStrip() {
+    let flags = goFlags(2, ["-trimpath"], true, [])
+    testing.assertEq(flags.len(), 2)
+    testing.assertEq(flags[0], "-trimpath")
+    testing.assertEq(flags[1], "-ldflags=-s -w")
+}
+fn testGoFlagsStripDedupes() {
+    let flags = goFlags(2, ["-ldflags=-s -w"], true, [])
+    testing.assertEq(flags.len(), 1)
+    testing.assertEq(flags[0], "-ldflags=-s -w")
+}
+fn testGoFlagsFeaturesEmitsTags() {
+    let flags = goFlags(2, [], false, ["x", "a", "m"])
+    testing.assertEq(flags.len(), 1)
+    testing.assertEq(flags[0], "-tags=feat_a,feat_m,feat_x")
+}
+fn testGoFlagsFeaturesEmptyOmitsTags() {
+    let flags = goFlags(2, [], false, [])
+    testing.assertEq(flags.len(), 0)
+}
+fn testGoFlagsFullStack() {
+    let flags = goFlags(0, ["-trimpath"], true, ["foo", "bar"])
+    testing.assertEq(flags.len(), 4)
+    testing.assertEq(flags[0], "-gcflags=all=-N -l")
+    testing.assertEq(flags[1], "-trimpath")
+    testing.assertEq(flags[2], "-ldflags=-s -w")
+    testing.assertEq(flags[3], "-tags=feat_bar,feat_foo")
+}
+fn testFileNeedsFeaturesNoPragma() {
+    let active: Map<String, Bool> = {:}
+    let r = fileNeedsFeatures("let x = 1\n", active)
+    testing.assert(r.ok)
+    testing.assertEq(r.missing, "")
+}
+fn testFileNeedsFeaturesAllPresent() {
+    let active: Map<String, Bool> = {"a": true, "b": true}
+    let r = fileNeedsFeatures("// @feature: a, b\nlet x = 1\n", active)
+    testing.assert(r.ok)
+}
+fn testFileNeedsFeaturesMissingReturnsFirst() {
+    let active: Map<String, Bool> = {"a": true}
+    let r = fileNeedsFeatures("// @feature: a, b\nlet x = 1\n", active)
+    testing.assert(!(r.ok))
+    testing.assertEq(r.missing, "b")
+}
+fn testFileNeedsFeaturesInactiveCountsAsMissing() {
+    // Present but false → counts as missing (active was switched off).
+    let active: Map<String, Bool> = {"a": false}
+    let r = fileNeedsFeatures("// @feature: a\nlet x = 1\n", active)
+    testing.assert(!(r.ok))
+    testing.assertEq(r.missing, "a")
+}


### PR DESCRIPTION
## Summary

PR #1768 / #1769의 후속. `internal/profile/profile.go`의 두 남은
compute helper를 `toolchain/profile_features.osty`로 이전. 이제
internal/profile은 pure 정책을 한 줄도 들고 있지 않음.

## 이전된 정책 (2 fn + 1 struct)

- `goFlags(optLevel, profileGoFlags, strip, features) -> List<String>`
  — `go build` argv 조립:
  1. `optLevelFlags(optLevel)` (debug/light gcflags)
  2. `profileGoFlags` (manifest 머지된 사용자 GoFlags, 중복 제거)
  3. `-ldflags=-s -w` strip=true 시 (중복 제거)
  4. `-tags=feat_<name>,...` features 비어있지 않을 때, 정렬된 태그 한 줄

- `fileNeedsFeatures(src, active) -> FeatureCheckResult { ok, missing }`
  — 소스 첫 ~32 라인의 `// @feature:` pragma 추출 (`readFeaturePragma`
  delegation) + active map 체크. 첫 missing feature 이름 반환.

- `FeatureCheckResult` struct — `(bool, string)` Go 튜플 shape의
  Osty 구조체 표현

## Go wrapper 축소

- `Resolved.GoFlags()`: ~30줄 + sort + dedup → 4줄
  ```go
  func (r *Resolved) GoFlags() []string {
      if r == nil || r.Profile == nil { return nil }
      return runner.GoFlags(r.Profile.OptLevel, r.Profile.GoFlags,
          r.Profile.Strip, r.Features)
  }
  ```
- `FileNeedsFeatures(src, active)`: legacy `(ok, missing)` tuple
  shape 유지 — `FeatureCheckResult`를 풀어서 반환

## internal/profile 자체 회고

이전부터:
- #1768: `parseTriple` / `readFeaturePragma` / `parsePragmaFeatureList`
- #1769: `optLevelFlags` / `expandFeatures`
- (this): `goFlags` / `fileNeedsFeatures`

이번 PR로 `internal/profile`의 pure compute 정책 100% toolchain
이전. host에 남는 건:
- `BuildConfig` (manifest 머지)
- `Resolve` (Config orchestration)
- `Clone()` / `ProfileNames()` / `TargetNames()` 등 Go-type bound
  메서드

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/profile/... ./internal/runner/...` —
      pass (drift 포함, 16개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run
      'TestBuild|TestRun|TestProfile|TestFeature'` — pass (8.3s)
- [x] Edge cases: opt-level dedup, strip dedup, empty features,
      full-stack flag interleave, pragma missing/inactive 양측 단위
      테스트

## 이번 세션 누적 (19번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1773 | airepair / codesdoc 정책-free + format/scaffold/diag/repair/profile 기초 | (기존) |
| (this) | profile GoFlags + FileNeedsFeatures | 2 fn + 1 struct |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_