### PR TITLE
refactor: lockfile Dependency 직렬화 정책 self-host (toolchain/lockfile_policy.osty)

### DIFF
--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -39,6 +39,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/tomlparse"
 )
 
@@ -83,27 +84,19 @@ type Dependency struct {
 //	"name version" (common)
 //	"name version (source)" (when Source is set)
 func (d Dependency) String() string {
-	if d.Source == "" {
-		return fmt.Sprintf("%s %s", d.Name, d.Version)
-	}
-	return fmt.Sprintf("%s %s (%s)", d.Name, d.Version, d.Source)
+	return runner.DependencyString(d.Name, d.Version, d.Source)
 }
 
 // ParseDependency parses the string form back into a Dependency.
 // Returns an error for unrecognized shapes so a hand-edited lockfile
-// doesn't silently deserialize to junk.
+// doesn't silently deserialize to junk. The shape policy lives in
+// toolchain/lockfile_policy.osty.
 func ParseDependency(s string) (Dependency, error) {
-	s = strings.TrimSpace(s)
-	var src string
-	if open := strings.Index(s, "("); open > 0 && strings.HasSuffix(s, ")") {
-		src = s[open+1 : len(s)-1]
-		s = strings.TrimSpace(s[:open])
+	r := runner.ParseDependency(s)
+	if !r.Ok {
+		return Dependency{}, fmt.Errorf("invalid dependency %q", strings.TrimSpace(s))
 	}
-	parts := strings.Fields(s)
-	if len(parts) != 2 {
-		return Dependency{}, fmt.Errorf("invalid dependency %q", s)
-	}
-	return Dependency{Name: parts[0], Version: parts[1], Source: src}, nil
+	return Dependency{Name: r.Name, Version: r.Version, Source: r.Source}, nil
 }
 
 // Read loads osty.lock from dir (the project root directory

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -44,6 +44,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"diag_explain.osty",
 		"diag_render.osty",
 		"format_policy.osty",
+		"lockfile_policy.osty",
 		"profile_features.osty",
 		"profile_flags.osty",
 		"profile_pragma.osty",

--- a/internal/runner/lockfile_policy.go
+++ b/internal/runner/lockfile_policy.go
@@ -1,0 +1,78 @@
+// lockfile_policy.go is the Go snapshot of
+// toolchain/lockfile_policy.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import "strings"
+
+// DependencyParts mirrors toolchain/lockfile_policy.osty's
+// DependencyParts. Ok=false signals a malformed line; the
+// host emits the precise `invalid dependency "..."` diagnostic.
+//
+// Osty: toolchain/lockfile_policy.osty:22
+type DependencyParts struct {
+	Name    string
+	Version string
+	Source  string
+	Ok      bool
+}
+
+// DependencyString renders one lockfile entry as the canonical
+// single-line form. Empty source → `<name> <version>`; otherwise
+// `<name> <version> (<source>)`.
+//
+// Osty: toolchain/lockfile_policy.osty:36
+func DependencyString(name, version, source string) string {
+	if source == "" {
+		return name + " " + version
+	}
+	return name + " " + version + " (" + source + ")"
+}
+
+// ParseDependency is the inverse of DependencyString. Returns
+// Ok=false for malformed shapes (wrong field count, etc.); the
+// host blames the line with `invalid dependency "..."`.
+//
+// Osty: toolchain/lockfile_policy.osty:51
+func ParseDependency(line string) DependencyParts {
+	trimmed := strings.TrimSpace(line)
+	head := trimmed
+	source := ""
+	if strings.HasSuffix(trimmed, ")") {
+		if open := strings.Index(trimmed, "("); open > 0 {
+			source = trimmed[open+1 : len(trimmed)-1]
+			head = strings.TrimSpace(trimmed[:open])
+		}
+	}
+	parts := parseDependencyFields(head)
+	if len(parts) != 2 {
+		return DependencyParts{}
+	}
+	return DependencyParts{Name: parts[0], Version: parts[1], Source: source, Ok: true}
+}
+
+// parseDependencyFields splits `head` on runs of ASCII space /
+// tab. Matches Go's `strings.Fields` for the lockfile's limited
+// alphabet (names/versions never carry CR/LF/VT/FF).
+//
+// Osty: toolchain/lockfile_policy.osty:81
+func parseDependencyFields(head string) []string {
+	var out []string
+	start := -1
+	for i := 0; i < len(head); i++ {
+		b := head[i]
+		isWS := b == ' ' || b == '\t'
+		if isWS {
+			if start >= 0 {
+				out = append(out, head[start:i])
+				start = -1
+			}
+		} else if start < 0 {
+			start = i
+		}
+	}
+	if start >= 0 {
+		out = append(out, head[start:])
+	}
+	return out
+}

--- a/internal/runner/lockfile_policy_test.go
+++ b/internal/runner/lockfile_policy_test.go
@@ -1,0 +1,63 @@
+package runner
+
+import "testing"
+
+func TestDependencyString(t *testing.T) {
+	cases := []struct {
+		name, version, source string
+		want                  string
+	}{
+		{"serde", "1.2.3", "", "serde 1.2.3"},
+		{"serde", "1.2.3", "git+https://github.com/x/y", "serde 1.2.3 (git+https://github.com/x/y)"},
+	}
+	for _, c := range cases {
+		if got := DependencyString(c.name, c.version, c.source); got != c.want {
+			t.Errorf("DependencyString = %q, want %q", got, c.want)
+		}
+	}
+}
+
+func TestParseDependency(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantOk      bool
+		wantName    string
+		wantVersion string
+		wantSource  string
+	}{
+		{"two-fields", "serde 1.2.3", true, "serde", "1.2.3", ""},
+		{"with-source", "serde 1.2.3 (path:./vendor/serde)", true, "serde", "1.2.3", "path:./vendor/serde"},
+		{"trims-leading-trailing", "  serde 1.2.3  ", true, "serde", "1.2.3", ""},
+		{"reject-single-field", "serde", false, "", "", ""},
+		{"reject-too-many-fields", "serde 1.2.3 extra", false, "", "", ""},
+		{"reject-empty", "", false, "", "", ""},
+		{"reject-whitespace-only", "   ", false, "", "", ""},
+		{
+			"source-with-embedded-parens",
+			"crate 0.1.0 (registry+(local))",
+			true, "crate", "0.1.0", "registry+(local)",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ParseDependency(c.in)
+			if got.Ok != c.wantOk || got.Name != c.wantName ||
+				got.Version != c.wantVersion || got.Source != c.wantSource {
+				t.Errorf("ParseDependency(%q) = %+v, want {%q %q %q %v}",
+					c.in, got, c.wantName, c.wantVersion, c.wantSource, c.wantOk)
+			}
+		})
+	}
+}
+
+func TestParseDependencyRoundTrip(t *testing.T) {
+	original := "tokio 1.5.0 (git+https://github.com/tokio-rs/tokio)"
+	p := ParseDependency(original)
+	if !p.Ok {
+		t.Fatalf("parse failed for %q", original)
+	}
+	if got := DependencyString(p.Name, p.Version, p.Source); got != original {
+		t.Errorf("round-trip = %q, want %q", got, original)
+	}
+}

--- a/internal/runner/scaffold_policy.go
+++ b/internal/runner/scaffold_policy.go
@@ -71,6 +71,117 @@ func ScaffoldDefaultWorkspaceMember() string {
 	return "core"
 }
 
+// scaffoldManifestHeader returns the one-line `# ...` banner that
+// introduces an osty.toml for the given kind. Bin/lib/cli/service
+// vary only on this header; GUI variants and workspace use
+// dedicated templates instead.
+//
+// Osty: toolchain/scaffold_policy.osty (internal helper)
+func scaffoldManifestHeader(kind string) string {
+	switch kind {
+	case "lib":
+		return "# Library project; exposes a public API via `pub` declarations."
+	case "cli":
+		return "# CLI app project; main.osty splits parsed Args from the testable run() core."
+	case "service":
+		return "# HTTP service project; main.osty defines Request/Response and a handle() core."
+	case "gui-qtquick":
+		return "# Qt Quick GUI app project; main.osty owns state/events and ui/main.qml owns layout."
+	case "gui-webview2":
+		return "# WebView2 GUI app project; src/main.osty opens ui/index.html through std.gui.webview2."
+	}
+	return "# Binary project; `osty gen main.osty` uses the native LLVM backend and emits LLVM IR for the entry point."
+}
+
+// ScaffoldGenericManifest renders the canonical osty.toml for the
+// bin/lib/cli/service kinds (and is also what RenderManifest emits
+// for the GUI kinds — those swap to the richer templates at
+// writeLayout time only).
+//
+// Osty: toolchain/scaffold_policy.osty:160
+func ScaffoldGenericManifest(kind, name, edition string) string {
+	return scaffoldManifestHeader(kind) + "\n\n" +
+		"[package]\n" +
+		"name = \"" + name + "\"\n" +
+		"version = \"0.1.0\"\n" +
+		"edition = \"" + edition + "\"\n\n" +
+		"[dependencies]\n" +
+		"# Add dependencies here, for example:\n" +
+		"# json-ext = { path = \"../json-ext\" }\n"
+}
+
+// ScaffoldGUIWebView2Manifest renders the Windows WebView2 GUI
+// osty.toml. Includes [gui], [gui.webview2], and the Windows link
+// target table.
+//
+// Osty: toolchain/scaffold_policy.osty:175
+func ScaffoldGUIWebView2Manifest(name, edition string) string {
+	return "# WebView2 GUI app project; src/main.osty opens ui/index.html through std.gui.webview2.\n\n" +
+		"[package]\n" +
+		"name = \"" + name + "\"\n" +
+		"version = \"0.1.0\"\n" +
+		"edition = \"" + edition + "\"\n\n" +
+		"[dependencies]\n\n" +
+		"[bin]\n" +
+		"path = \"src/main.osty\"\n\n" +
+		"[gui]\n" +
+		"backend = \"webview2\"\n" +
+		"entry = \"ui/index.html\"\n\n" +
+		"[gui.webview2]\n" +
+		"devtools = true\n" +
+		"runtime = \"evergreen\"\n\n" +
+		"[target.amd64-windows]\n" +
+		"cgo = true\n" +
+		"link = [\"osty_webview2\", \"WebView2Loader\", \"user32\", \"ole32\"]\n"
+}
+
+// ScaffoldGUIQtQuickManifest renders the Qt Quick GUI osty.toml.
+// Links `osty_qt` across all four supported desktop targets.
+//
+// Osty: toolchain/scaffold_policy.osty:198
+func ScaffoldGUIQtQuickManifest(name, edition string) string {
+	return "# Qt Quick GUI app project; build libosty_qt and make it visible to the linker/runtime.\n\n" +
+		"[package]\n" +
+		"name = \"" + name + "\"\n" +
+		"version = \"0.1.0\"\n" +
+		"edition = \"" + edition + "\"\n\n" +
+		"[dependencies]\n\n" +
+		"[gui]\n" +
+		"backend = \"qtquick\"\n" +
+		"entry = \"ui/main.qml\"\n\n" +
+		"[target.arm64-darwin]\n" +
+		"link = [\"osty_qt\"]\n\n" +
+		"[target.amd64-darwin]\n" +
+		"link = [\"osty_qt\"]\n\n" +
+		"[target.amd64-linux]\n" +
+		"link = [\"osty_qt\"]\n\n" +
+		"[target.amd64-windows]\n" +
+		"link = [\"osty_qt\"]\n"
+}
+
+// ScaffoldWorkspaceManifest renders the virtual-root workspace
+// osty.toml. `name` may be empty (anonymous root); when supplied
+// it surfaces as a leading `# Workspace: NAME` comment. `edition`
+// is currently unused but accepted for API symmetry.
+//
+// Osty: toolchain/scaffold_policy.osty:222
+func ScaffoldWorkspaceManifest(name, edition, member string) string {
+	_ = edition
+	nameLine := ""
+	if name != "" {
+		nameLine = "# Workspace: " + name + "\n"
+	}
+	return nameLine +
+		"# Virtual workspace root. Member paths below are resolved relative\n" +
+		"# to this directory (spec §5). Add members with:\n" +
+		"#\n" +
+		"#     osty new --bin NAME        # inside this directory\n" +
+		"#\n" +
+		"# then append the directory name to the members list below.\n\n" +
+		"[workspace]\n" +
+		"members = [\"" + member + "\"]\n"
+}
+
 // ScaffoldRelativePaths returns the source-order list of relative
 // file paths the scaffolder will write for a project of `kind`.
 // Path separators are forward slashes (`/`); the host joins each

--- a/internal/runner/scaffold_policy_test.go
+++ b/internal/runner/scaffold_policy_test.go
@@ -1,6 +1,9 @@
 package runner
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIsValidScaffoldName(t *testing.T) {
 	valid := []string{
@@ -57,6 +60,82 @@ func TestScaffoldFixtureCapsMatchOstyConstants(t *testing.T) {
 func TestScaffoldDefaultWorkspaceMember(t *testing.T) {
 	if got := ScaffoldDefaultWorkspaceMember(); got != "core" {
 		t.Errorf("ScaffoldDefaultWorkspaceMember() = %q, want %q", got, "core")
+	}
+}
+
+func TestScaffoldGenericManifestHeaders(t *testing.T) {
+	cases := []struct {
+		kind   string
+		header string
+	}{
+		{"bin", "# Binary project;"},
+		{"lib", "# Library project;"},
+		{"cli", "# CLI app project;"},
+		{"service", "# HTTP service project;"},
+		{"gui-qtquick", "# Qt Quick GUI app project;"},
+		{"gui-webview2", "# WebView2 GUI app project;"},
+		{"nonsense", "# Binary project;"},
+	}
+	for _, c := range cases {
+		got := ScaffoldGenericManifest(c.kind, "demo", "0.5")
+		if !strings.HasPrefix(got, c.header) {
+			t.Errorf("kind=%q header missing: %q", c.kind, got[:80])
+		}
+		if !strings.Contains(got, "name = \"demo\"") {
+			t.Errorf("kind=%q missing name field", c.kind)
+		}
+		if !strings.Contains(got, "edition = \"0.5\"") {
+			t.Errorf("kind=%q missing edition field", c.kind)
+		}
+		if !strings.Contains(got, "json-ext = { path = \"../json-ext\" }") {
+			t.Errorf("kind=%q missing dependency hint", c.kind)
+		}
+	}
+}
+
+func TestScaffoldGUIWebView2Manifest(t *testing.T) {
+	got := ScaffoldGUIWebView2Manifest("g", "0.5")
+	for _, want := range []string{
+		"[gui.webview2]", "devtools = true",
+		"[target.amd64-windows]", "WebView2Loader",
+		"name = \"g\"", "edition = \"0.5\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output", want)
+		}
+	}
+}
+
+func TestScaffoldGUIQtQuickManifest(t *testing.T) {
+	got := ScaffoldGUIQtQuickManifest("g", "0.5")
+	for _, target := range []string{
+		"[target.arm64-darwin]", "[target.amd64-darwin]",
+		"[target.amd64-linux]", "[target.amd64-windows]",
+	} {
+		if !strings.Contains(got, target) {
+			t.Errorf("missing target table %q", target)
+		}
+	}
+	// 4 link entries + 1 in the header banner ("build libosty_qt").
+	if strings.Count(got, "osty_qt") != 5 {
+		t.Errorf("osty_qt count = %d, want 5", strings.Count(got, "osty_qt"))
+	}
+}
+
+func TestScaffoldWorkspaceManifest(t *testing.T) {
+	named := ScaffoldWorkspaceManifest("demo-ws", "0.5", "core")
+	if !strings.HasPrefix(named, "# Workspace: demo-ws\n") {
+		t.Errorf("named workspace missing # Workspace banner: %q", named[:60])
+	}
+	if !strings.Contains(named, "members = [\"core\"]") {
+		t.Errorf("missing members table")
+	}
+	anon := ScaffoldWorkspaceManifest("", "0.5", "alpha")
+	if strings.Contains(anon, "# Workspace:") {
+		t.Errorf("anonymous workspace still has # Workspace banner")
+	}
+	if !strings.Contains(anon, "members = [\"alpha\"]") {
+		t.Errorf("missing members table for anon")
 	}
 }
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -593,86 +593,28 @@ func RenderWorkspaceManifest(name, edition, member string) string {
 	return renderWorkspaceManifest(name, edition, member)
 }
 
+// renderManifest delegates the generic per-Kind osty.toml body to
+// toolchain/scaffold_policy.osty. Header text + [package] +
+// [dependencies] hint live there; bin/lib/cli/service share the
+// same body and just swap headers.
 func renderManifest(name, edition string, k Kind) string {
-	header := "# Binary project; `osty gen main.osty` uses the native LLVM backend and emits LLVM IR for the entry point."
-	switch k {
-	case KindLib:
-		header = "# Library project; exposes a public API via `pub` declarations."
-	case KindCli:
-		header = "# CLI app project; main.osty splits parsed Args from the testable run() core."
-	case KindService:
-		header = "# HTTP service project; main.osty defines Request/Response and a handle() core."
-	case KindGUIQtQuick:
-		header = "# Qt Quick GUI app project; main.osty owns state/events and ui/main.qml owns layout."
-	case KindGUIWebView2:
-		header = "# WebView2 GUI app project; src/main.osty opens ui/index.html through std.gui.webview2."
-	}
-	return fmt.Sprintf(`%s
-
-[package]
-name = "%s"
-version = "0.1.0"
-edition = "%s"
-
-[dependencies]
-# Add dependencies here, for example:
-# json-ext = { path = "../json-ext" }
-`, header, name, edition)
+	return runner.ScaffoldGenericManifest(kindName(k), name, edition)
 }
 
+// renderGUIWebView2Manifest delegates to
+// toolchain/scaffold_policy.osty. The richer WebView2 template
+// (with [gui], [gui.webview2], [target.amd64-windows]) is only
+// emitted at writeLayout time; RenderManifest still returns the
+// generic body for KindGUIWebView2.
 func renderGUIWebView2Manifest(name, edition string) string {
-	return fmt.Sprintf(`# WebView2 GUI app project; src/main.osty opens ui/index.html through std.gui.webview2.
-
-[package]
-name = "%s"
-version = "0.1.0"
-edition = "%s"
-
-[dependencies]
-
-[bin]
-path = "src/main.osty"
-
-[gui]
-backend = "webview2"
-entry = "ui/index.html"
-
-[gui.webview2]
-devtools = true
-runtime = "evergreen"
-
-[target.amd64-windows]
-cgo = true
-link = ["osty_webview2", "WebView2Loader", "user32", "ole32"]
-`, name, edition)
+	return runner.ScaffoldGUIWebView2Manifest(name, edition)
 }
 
+// renderGUIQtQuickManifest delegates to
+// toolchain/scaffold_policy.osty. Links `osty_qt` across all four
+// supported desktop targets.
 func renderGUIQtQuickManifest(name, edition string) string {
-	return fmt.Sprintf(`# Qt Quick GUI app project; build libosty_qt and make it visible to the linker/runtime.
-
-[package]
-name = "%s"
-version = "0.1.0"
-edition = "%s"
-
-[dependencies]
-
-[gui]
-backend = "qtquick"
-entry = "ui/main.qml"
-
-[target.arm64-darwin]
-link = ["osty_qt"]
-
-[target.amd64-darwin]
-link = ["osty_qt"]
-
-[target.amd64-linux]
-link = ["osty_qt"]
-
-[target.amd64-windows]
-link = ["osty_qt"]
-`, name, edition)
+	return runner.ScaffoldGUIQtQuickManifest(name, edition)
 }
 
 func renderGUIQtQuickReadme(name string) string {
@@ -698,25 +640,13 @@ osty gui doctor qtquick
 `, name)
 }
 
+// renderWorkspaceManifest delegates to
+// toolchain/scaffold_policy.osty. Edition is currently unused for
+// the virtual root but kept in the signature for symmetry with
+// renderManifest (future [workspace.package] inheritance might
+// surface it).
 func renderWorkspaceManifest(name, edition, member string) string {
-	nameLine := ""
-	if name != "" {
-		nameLine = fmt.Sprintf("# Workspace: %s\n", name)
-	}
-	_ = edition // edition currently unused for the virtual root;
-	// kept in the signature for symmetry with renderManifest so
-	// future additions (e.g. [workspace.package] inheritance) don't
-	// need a plumbing change at call sites.
-	return fmt.Sprintf(`%s# Virtual workspace root. Member paths below are resolved relative
-# to this directory (spec §5). Add members with:
-#
-#     osty new --bin NAME        # inside this directory
-#
-# then append the directory name to the members list below.
-
-[workspace]
-members = ["%s"]
-`, nameLine, member)
+	return runner.ScaffoldWorkspaceManifest(name, edition, member)
 }
 
 const binSourceTemplate = `fn main() {

--- a/toolchain/lockfile_policy.osty
+++ b/toolchain/lockfile_policy.osty
@@ -1,0 +1,101 @@
+/// Pure `osty.lock` Dependency surface — the `name version (source)`
+/// canonical string and its inverse parser. The lockfile generator
+/// uses this to emit deterministic single-line dependency entries
+/// the human-edited form can round-trip through.
+///
+/// Host code (`internal/lockfile`) owns the multi-line lockfile
+/// document, TOML parsing, and filesystem I/O; this module decides
+/// the per-entry string shape.
+///
+/// Mirrored by `internal/runner/lockfile_policy.go`. The drift
+/// test under internal/runner keeps the two in sync — the Osty
+/// file is the source of truth at review time.
+use std.strings as strings
+/// DependencyParts is the outcome of parsing a single dependency
+/// line back into its `(name, version, source)` triple. `ok ==
+/// false` signals a malformed shape so the host emits a precise
+/// `invalid dependency "..."` diagnostic. `source == ""` means the
+/// dependency came from the default registry — no `( ... )` was
+/// appended.
+pub struct DependencyParts {
+    pub name: String,
+    pub version: String,
+    pub source: String,
+    pub ok: Bool,
+}
+/// dependencyString renders one lockfile entry as the canonical
+/// single-line form:
+///
+///   - `<name> <version>` when source is empty (default registry).
+///   - `<name> <version> (<source>)` otherwise (path/git/custom
+///     registry).
+///
+/// The whitespace separator + parenthesised source format is what
+/// the parser below understands; keep the two in lockstep.
+pub fn dependencyString(name: String, version: String, source: String) -> String {
+    if source == "" {
+        return name + " " + version
+    }
+    name + " " + version + " (" + source + ")"
+}
+/// parseDependency is the inverse of `dependencyString`. Accepts:
+///
+///   - `name version`
+///   - `name version (source)`  — `source` may itself contain
+///     whitespace; only the trailing `)` closes the group.
+///
+/// Returns `ok == false` for anything else (wrong field count,
+/// missing closing paren, etc.). The host blames the malformed
+/// line with `invalid dependency "..."`.
+pub fn parseDependency(line: String) -> DependencyParts {
+    let trimmed = strings.trimSpace(line)
+    let mut head = trimmed
+    let mut source = ""
+    if strings.hasSuffix(trimmed, ")") {
+        let openOpt = strings.indexOf(trimmed, "(")
+        match openOpt {
+            Some(open) -> {
+                if open > 0 {
+                    source = strings.slice(trimmed, open + 1, trimmed.len() - 1)
+                    head = strings.trimSpace(strings.slice(trimmed, 0, open))
+                }
+            },
+            None -> {
+            },
+        }
+    }
+    let parts = parseDependencyFields(head)
+    if parts.len() != 2 {
+        return DependencyParts {name: "", version: "", source: "", ok: false}
+    }
+    DependencyParts {name: parts[0], version: parts[1], source: source, ok: true}
+}
+/// parseDependencyFields splits `head` on runs of ASCII space /
+/// tab (matches Go's `strings.Fields` for the limited alphabet
+/// the lockfile lexer accepts — dependency names and versions
+/// never carry CR/LF/VT/FF). Empty runs are dropped so callers
+/// see exactly the non-whitespace tokens.
+fn parseDependencyFields(head: String) -> List<String> {
+    let bs = head.bytes()
+    let n = bs.len()
+    let mut out: List<String> = []
+    let mut start = -1
+    let mut i = 0
+    for i < n {
+        let b = bs[i].toInt()
+        let isWS = b == 0x20 || b == 0x09
+        if isWS {
+            if start >= 0 {
+                out.push(strings.slice(head, start, i))
+                start = -1
+            }
+        } else if start < 0 {
+            start = i
+        }
+        i = i + 1
+    }
+    if start >= 0 {
+        out.push(strings.slice(head, start, n))
+    }
+    out
+}

--- a/toolchain/lockfile_policy_test.osty
+++ b/toolchain/lockfile_policy_test.osty
@@ -1,0 +1,61 @@
+use std.testing
+fn testDependencyStringNoSource() {
+    testing.assertEq(dependencyString("serde", "1.2.3", ""), "serde 1.2.3")
+}
+fn testDependencyStringWithSource() {
+    testing.assertEq(
+        dependencyString("serde", "1.2.3", "git+https://github.com/x/y"),
+        "serde 1.2.3 (git+https://github.com/x/y)",
+    )
+}
+fn testParseDependencyTwoFields() {
+    let r = parseDependency("serde 1.2.3")
+    testing.assert(r.ok)
+    testing.assertEq(r.name, "serde")
+    testing.assertEq(r.version, "1.2.3")
+    testing.assertEq(r.source, "")
+}
+fn testParseDependencyWithSource() {
+    let r = parseDependency("serde 1.2.3 (path:./vendor/serde)")
+    testing.assert(r.ok)
+    testing.assertEq(r.name, "serde")
+    testing.assertEq(r.version, "1.2.3")
+    testing.assertEq(r.source, "path:./vendor/serde")
+}
+fn testParseDependencyTrimsLeadingTrailing() {
+    let r = parseDependency("  serde 1.2.3  ")
+    testing.assert(r.ok)
+    testing.assertEq(r.name, "serde")
+    testing.assertEq(r.version, "1.2.3")
+}
+fn testParseDependencyRejectsSingleField() {
+    let r = parseDependency("serde")
+    testing.assert(!(r.ok))
+}
+fn testParseDependencyRejectsTooManyFields() {
+    let r = parseDependency("serde 1.2.3 extra")
+    testing.assert(!(r.ok))
+}
+fn testParseDependencyRejectsEmpty() {
+    let r = parseDependency("")
+    testing.assert(!(r.ok))
+    let r2 = parseDependency("   ")
+    testing.assert(!(r2.ok))
+}
+fn testParseDependencySourceWithEmbeddedParens() {
+    // The source group is everything between the FIRST `(` and the
+    // closing `)`. Embedded parens inside the source body are kept
+    // as part of the source string.
+    let r = parseDependency("crate 0.1.0 (registry+(local))")
+    testing.assert(r.ok)
+    testing.assertEq(r.source, "registry+(local)")
+}
+fn testParseDependencyRoundTrip() {
+    let original = "tokio 1.5.0 (git+https://github.com/tokio-rs/tokio)"
+    let parsed = parseDependency(original)
+    testing.assert(parsed.ok)
+    testing.assertEq(
+        dependencyString(parsed.name, parsed.version, parsed.source),
+        original,
+    )
+}

--- a/toolchain/scaffold_policy.osty
+++ b/toolchain/scaffold_policy.osty
@@ -126,3 +126,109 @@ pub fn scaffoldRelativePaths(kind: String, workspaceMember: String) -> List<Stri
     }
     ["osty.toml", "main.osty", "main_test.osty", ".gitignore"]
 }
+/// scaffoldManifestHeader returns the one-line `# ...` banner
+/// that introduces an `osty.toml` for the given kind. Bin / lib /
+/// cli / service share the same template body downstream and just
+/// vary on this header; GUI variants and the workspace use
+/// dedicated templates instead.
+fn scaffoldManifestHeader(kind: String) -> String {
+    if kind == "lib" {
+        return "# Library project; exposes a public API via `pub` declarations."
+    }
+    if kind == "cli" {
+        return "# CLI app project; main.osty splits parsed Args from the testable run() core."
+    }
+    if kind == "service" {
+        return "# HTTP service project; main.osty defines Request/Response and a handle() core."
+    }
+    if kind == "gui-qtquick" {
+        return "# Qt Quick GUI app project; main.osty owns state/events and ui/main.qml owns layout."
+    }
+    if kind == "gui-webview2" {
+        return "# WebView2 GUI app project; src/main.osty opens ui/index.html through std.gui.webview2."
+    }
+    "# Binary project; `osty gen main.osty` uses the native LLVM backend and emits LLVM IR for the entry point."
+}
+/// scaffoldGenericManifest renders the canonical `osty.toml` for
+/// the bin/lib/cli/service kinds. GUI variants (gui-qtquick /
+/// gui-webview2) use richer templates that pin link/target/runtime
+/// tables — those have their own renderers.
+pub fn scaffoldGenericManifest(kind: String, name: String, edition: String) -> String {
+    let header = scaffoldManifestHeader(kind)
+    header + "\n\n" +
+        "[package]\n" +
+        "name = \"" + name + "\"\n" +
+        "version = \"0.1.0\"\n" +
+        "edition = \"" + edition + "\"\n\n" +
+        "[dependencies]\n" +
+        "# Add dependencies here, for example:\n" +
+        "# json-ext = \{ path = \"../json-ext\" \}\n"
+}
+/// scaffoldGUIWebView2Manifest renders the Windows WebView2 GUI
+/// `osty.toml`. Includes `[gui]`, `[gui.webview2]`, and the
+/// Windows link target table because the entry needs the native
+/// WebView2 loader + system DLLs.
+pub fn scaffoldGUIWebView2Manifest(name: String, edition: String) -> String {
+    "# WebView2 GUI app project; src/main.osty opens ui/index.html through std.gui.webview2.\n\n" +
+        "[package]\n" +
+        "name = \"" + name + "\"\n" +
+        "version = \"0.1.0\"\n" +
+        "edition = \"" + edition + "\"\n\n" +
+        "[dependencies]\n\n" +
+        "[bin]\n" +
+        "path = \"src/main.osty\"\n\n" +
+        "[gui]\n" +
+        "backend = \"webview2\"\n" +
+        "entry = \"ui/index.html\"\n\n" +
+        "[gui.webview2]\n" +
+        "devtools = true\n" +
+        "runtime = \"evergreen\"\n\n" +
+        "[target.amd64-windows]\n" +
+        "cgo = true\n" +
+        "link = [\"osty_webview2\", \"WebView2Loader\", \"user32\", \"ole32\"]\n"
+}
+/// scaffoldGUIQtQuickManifest renders the Qt Quick GUI
+/// `osty.toml`. The `osty_qt` bridge library is linked across all
+/// four supported desktop targets; users build it once via cmake
+/// from the upstream repository.
+pub fn scaffoldGUIQtQuickManifest(name: String, edition: String) -> String {
+    "# Qt Quick GUI app project; build libosty_qt and make it visible to the linker/runtime.\n\n" +
+        "[package]\n" +
+        "name = \"" + name + "\"\n" +
+        "version = \"0.1.0\"\n" +
+        "edition = \"" + edition + "\"\n\n" +
+        "[dependencies]\n\n" +
+        "[gui]\n" +
+        "backend = \"qtquick\"\n" +
+        "entry = \"ui/main.qml\"\n\n" +
+        "[target.arm64-darwin]\n" +
+        "link = [\"osty_qt\"]\n\n" +
+        "[target.amd64-darwin]\n" +
+        "link = [\"osty_qt\"]\n\n" +
+        "[target.amd64-linux]\n" +
+        "link = [\"osty_qt\"]\n\n" +
+        "[target.amd64-windows]\n" +
+        "link = [\"osty_qt\"]\n"
+}
+/// scaffoldWorkspaceManifest renders the virtual-root workspace
+/// `osty.toml`. `name` may be empty (anonymous virtual root); when
+/// supplied it shows up as a leading `# Workspace: NAME` comment.
+/// `edition` is accepted for API symmetry with the package
+/// renderers but currently unused — a virtual workspace has no
+/// `[package]` table to pin.
+pub fn scaffoldWorkspaceManifest(name: String, edition: String, member: String) -> String {
+    let _ = edition
+    let mut nameLine = ""
+    if name != "" {
+        nameLine = "# Workspace: " + name + "\n"
+    }
+    nameLine +
+        "# Virtual workspace root. Member paths below are resolved relative\n" +
+        "# to this directory (spec §5). Add members with:\n" +
+        "#\n" +
+        "#     osty new --bin NAME        # inside this directory\n" +
+        "#\n" +
+        "# then append the directory name to the members list below.\n\n" +
+        "[workspace]\n" +
+        "members = [\"" + member + "\"]\n"
+}

--- a/toolchain/scaffold_policy_test.osty
+++ b/toolchain/scaffold_policy_test.osty
@@ -1,3 +1,4 @@
+use std.strings as strings
 use std.testing
 fn testIsValidScaffoldNameHappyPaths() {
     testing.assert(isValidScaffoldName("myproj"))
@@ -136,4 +137,66 @@ fn testScaffoldRelativePathsUnknownFallsBackToBin() {
     testing.assertEq(paths.len(), 4)
     testing.assertEq(paths[0], "osty.toml")
     testing.assertEq(paths[1], "main.osty")
+}
+fn testScaffoldGenericManifestBin() {
+    let got = scaffoldGenericManifest("bin", "demo", "0.5")
+    testing.assert(strings.contains(got, "# Binary project;"))
+    testing.assert(strings.contains(got, "name = \"demo\""))
+    testing.assert(strings.contains(got, "edition = \"0.5\""))
+    testing.assert(strings.contains(got, "[dependencies]"))
+    testing.assert(strings.contains(got, "json-ext = \{ path = \"../json-ext\" \}"))
+}
+fn testScaffoldGenericManifestLib() {
+    let got = scaffoldGenericManifest("lib", "mylib", "0.4")
+    testing.assert(strings.contains(got, "# Library project;"))
+    testing.assert(strings.contains(got, "name = \"mylib\""))
+    testing.assert(strings.contains(got, "edition = \"0.4\""))
+}
+fn testScaffoldGenericManifestCliService() {
+    let cli = scaffoldGenericManifest("cli", "app", "0.5")
+    testing.assert(strings.contains(cli, "# CLI app project;"))
+    let svc = scaffoldGenericManifest("service", "api", "0.5")
+    testing.assert(strings.contains(svc, "# HTTP service project;"))
+}
+fn testScaffoldGenericManifestGUIVariants() {
+    // RenderManifest (the public Go entry) calls the generic body
+    // for ALL kinds — only the *header* differs for GUI variants.
+    // The richer GUI manifests are emitted at writeLayout time.
+    let qt = scaffoldGenericManifest("gui-qtquick", "g", "0.5")
+    testing.assert(strings.contains(qt, "# Qt Quick GUI app project;"))
+    testing.assert(strings.contains(qt, "[dependencies]"))
+    let wv = scaffoldGenericManifest("gui-webview2", "g", "0.5")
+    testing.assert(strings.contains(wv, "# WebView2 GUI app project;"))
+}
+fn testScaffoldGenericManifestUnknownFallsBackToBinHeader() {
+    let got = scaffoldGenericManifest("nonsense", "demo", "0.5")
+    testing.assert(strings.contains(got, "# Binary project;"))
+}
+fn testScaffoldGUIWebView2ManifestStructure() {
+    let got = scaffoldGUIWebView2Manifest("g", "0.5")
+    testing.assert(strings.contains(got, "[gui.webview2]"))
+    testing.assert(strings.contains(got, "devtools = true"))
+    testing.assert(strings.contains(got, "[target.amd64-windows]"))
+    testing.assert(strings.contains(got, "WebView2Loader"))
+    testing.assert(strings.contains(got, "name = \"g\""))
+    testing.assert(strings.contains(got, "edition = \"0.5\""))
+}
+fn testScaffoldGUIQtQuickManifestLinksAllTargets() {
+    let got = scaffoldGUIQtQuickManifest("g", "0.5")
+    testing.assert(strings.contains(got, "[target.arm64-darwin]"))
+    testing.assert(strings.contains(got, "[target.amd64-darwin]"))
+    testing.assert(strings.contains(got, "[target.amd64-linux]"))
+    testing.assert(strings.contains(got, "[target.amd64-windows]"))
+    testing.assert(strings.contains(got, "osty_qt"))
+}
+fn testScaffoldWorkspaceManifestNamed() {
+    let got = scaffoldWorkspaceManifest("demo-ws", "0.5", "core")
+    testing.assert(strings.contains(got, "# Workspace: demo-ws"))
+    testing.assert(strings.contains(got, "[workspace]"))
+    testing.assert(strings.contains(got, "members = [\"core\"]"))
+}
+fn testScaffoldWorkspaceManifestAnonymous() {
+    let got = scaffoldWorkspaceManifest("", "0.5", "alpha")
+    testing.assert(!(strings.contains(got, "# Workspace:")))
+    testing.assert(strings.contains(got, "members = [\"alpha\"]"))
 }


### PR DESCRIPTION
## Summary

`internal/lockfile/lockfile.go`의 두 직렬화 함수를 새
`toolchain/lockfile_policy.osty`로 이전. osty.lock 단일 라인
dependency 엔트리의 canonical 형식 (`name version (source)`)이 이제
toolchain의 source-of-truth.

## 이전된 정책 (2 fn + 1 struct)

- `dependencyString(name, version, source) -> String` — source가
  비어있으면 `name version`, 아니면 `name version (source)`
- `parseDependency(line) -> DependencyParts { name, version, source, ok }`
  — 위의 inverse:
  1. trimSpace
  2. trailing `)` 검사 + first `(` 찾아서 source 그룹 추출
  3. 남은 head를 ASCII space/tab으로 split — 정확히 2개 토큰이면
     `ok=true`

`DependencyParts` 구조체로 Go의 `(Dependency, error)` 튜플 shape를
Osty 표현으로 풀어냄. host는 `ok=false` 시 legacy
`invalid dependency "..."` error 메시지 형식 유지.

## Edge case: embedded parens

`crate 0.1.0 (registry+(local))` 같이 source group 안에 paren이
있어도 first `(` + trailing `)`로 잘 추출 — Go reference의
`strings.Index(s, "(")` 한 번 + `strings.HasSuffix(s, ")")` 결합
동치.

## Go wrapper 축소

```go
func (d Dependency) String() string {
    return runner.DependencyString(d.Name, d.Version, d.Source)
}

func ParseDependency(s string) (Dependency, error) {
    r := runner.ParseDependency(s)
    if !r.Ok {
        return Dependency{}, fmt.Errorf("invalid dependency %q", strings.TrimSpace(s))
    }
    return Dependency{Name: r.Name, Version: r.Version, Source: r.Source}, nil
}
```

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/lockfile/... ./internal/runner/...
      ./internal/pkgmgr/...` — pass (drift 포함, 17개 ostySources)
- [x] Round-trip 테스트 (parseDependency → dependencyString ==
      original) Osty + Go 양측
- [x] Edge cases: trim leading/trailing, embedded parens, empty
      input, wrong field count

## 이번 세션 누적 (20번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1774 | airepair / codesdoc 정책-free + profile 완전 self-host + format/scaffold/diag/repair 기초 | (기존) |
| (this) | lockfile Dependency 직렬화 | 2 fn + 1 struct |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_