### PR TITLE
refactor: airepair accept/reject 스코어링 self-host (toolchain/airepair_decide.osty)

### DIFF
--- a/internal/airepair/airepair.go
+++ b/internal/airepair/airepair.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/repair"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/stdlib"
@@ -273,7 +274,19 @@ func explainRejectedReason(mode Mode, before, after ProbeStats) string {
 }
 
 func repairedChanged(repaired repair.Result) bool {
-	return len(repaired.Changes) > 0 || repaired.Skipped > 0
+	return runner.RepairedChanged(len(repaired.Changes), repaired.Skipped)
+}
+
+// statsToRunner adapts the airepair-local ProbeStats to the
+// flattened runner.ProbeStats shape the toolchain scorers see.
+func statsToRunner(s ProbeStats) runner.ProbeStats {
+	return runner.ProbeStats{
+		Parse:         runner.ProbeStageStats{Errors: s.Parse.Errors, Warnings: s.Parse.Warnings},
+		Resolve:       runner.ProbeStageStats{Errors: s.Resolve.Errors, Warnings: s.Resolve.Warnings},
+		Check:         runner.ProbeStageStats{Errors: s.Check.Errors, Warnings: s.Check.Warnings},
+		TotalErrors:   s.TotalErrors,
+		TotalWarnings: s.TotalWarnings,
+	}
 }
 
 func (r Result) ResidualPrimaryCode() string {
@@ -426,75 +439,15 @@ func isAccepted(mode Mode, before, after ProbeStats, repaired repair.Result) boo
 //	 0 when they are equivalent for that mode
 //	-1 when after regresses the source for that mode
 func compareParseAssist(before, after ProbeStats) int {
-	if after.Parse.Errors != before.Parse.Errors {
-		if after.Parse.Errors < before.Parse.Errors {
-			return 1
-		}
-		return -1
-	}
-	if after.TotalErrors != before.TotalErrors {
-		if after.TotalErrors < before.TotalErrors {
-			return 1
-		}
-		return -1
-	}
-	if after.TotalWarnings != before.TotalWarnings {
-		if after.TotalWarnings < before.TotalWarnings {
-			return 1
-		}
-		return -1
-	}
-	return 0
+	return runner.CompareParseAssist(statsToRunner(before), statsToRunner(after))
 }
 
 func compareAutoAssist(before, after ProbeStats) int {
-	if after.Parse.Errors != before.Parse.Errors {
-		if after.Parse.Errors < before.Parse.Errors {
-			return 1
-		}
-		return -1
-	}
-	if after.Resolve.Errors != before.Resolve.Errors {
-		if after.Resolve.Errors < before.Resolve.Errors {
-			return 1
-		}
-		return -1
-	}
-	if after.Check.Errors != before.Check.Errors {
-		if after.Check.Errors < before.Check.Errors {
-			return 1
-		}
-		return -1
-	}
-	if after.TotalWarnings != before.TotalWarnings {
-		if after.TotalWarnings < before.TotalWarnings {
-			return 1
-		}
-		return -1
-	}
-	return 0
+	return runner.CompareAutoAssist(statsToRunner(before), statsToRunner(after))
 }
 
 func compareFrontEndAssist(before, after ProbeStats) int {
-	if after.TotalErrors != before.TotalErrors {
-		if after.TotalErrors < before.TotalErrors {
-			return 1
-		}
-		return -1
-	}
-	if after.Parse.Errors != before.Parse.Errors {
-		if after.Parse.Errors < before.Parse.Errors {
-			return 1
-		}
-		return -1
-	}
-	if after.TotalWarnings != before.TotalWarnings {
-		if after.TotalWarnings < before.TotalWarnings {
-			return 1
-		}
-		return -1
-	}
-	return 0
+	return runner.CompareFrontEndAssist(statsToRunner(before), statsToRunner(after))
 }
 
 func checkOptsForSource(src []byte) check.Opts {

--- a/internal/runner/airepair_decide_policy.go
+++ b/internal/runner/airepair_decide_policy.go
@@ -1,0 +1,120 @@
+// airepair_decide_policy.go is the Go snapshot of
+// toolchain/airepair_decide.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+// ProbeStageStats mirrors toolchain/airepair_decide.osty's
+// ProbeStageStats — per-stage diagnostic counts.
+//
+// Osty: toolchain/airepair_decide.osty:17
+type ProbeStageStats struct {
+	Errors   int
+	Warnings int
+}
+
+// ProbeStats mirrors toolchain/airepair_decide.osty's ProbeStats
+// — per-source pipeline snapshot the accept/reject scorers
+// compare.
+//
+// Osty: toolchain/airepair_decide.osty:25
+type ProbeStats struct {
+	Parse         ProbeStageStats
+	Resolve       ProbeStageStats
+	Check         ProbeStageStats
+	TotalErrors   int
+	TotalWarnings int
+}
+
+// CompareParseAssist returns +1 when `after` improves on `before`
+// for parse-only assist, -1 on regression, 0 on tie. Priority:
+// parse errors → total errors → total warnings.
+//
+// Osty: toolchain/airepair_decide.osty:45
+func CompareParseAssist(before, after ProbeStats) int {
+	if after.Parse.Errors != before.Parse.Errors {
+		if after.Parse.Errors < before.Parse.Errors {
+			return 1
+		}
+		return -1
+	}
+	if after.TotalErrors != before.TotalErrors {
+		if after.TotalErrors < before.TotalErrors {
+			return 1
+		}
+		return -1
+	}
+	if after.TotalWarnings != before.TotalWarnings {
+		if after.TotalWarnings < before.TotalWarnings {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
+// CompareAutoAssist scores default mode: parse → resolve → check
+// → total warnings.
+//
+// Osty: toolchain/airepair_decide.osty:71
+func CompareAutoAssist(before, after ProbeStats) int {
+	if after.Parse.Errors != before.Parse.Errors {
+		if after.Parse.Errors < before.Parse.Errors {
+			return 1
+		}
+		return -1
+	}
+	if after.Resolve.Errors != before.Resolve.Errors {
+		if after.Resolve.Errors < before.Resolve.Errors {
+			return 1
+		}
+		return -1
+	}
+	if after.Check.Errors != before.Check.Errors {
+		if after.Check.Errors < before.Check.Errors {
+			return 1
+		}
+		return -1
+	}
+	if after.TotalWarnings != before.TotalWarnings {
+		if after.TotalWarnings < before.TotalWarnings {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
+// CompareFrontEndAssist scores front-end mode: total errors → parse
+// errors → total warnings.
+//
+// Osty: toolchain/airepair_decide.osty:99
+func CompareFrontEndAssist(before, after ProbeStats) int {
+	if after.TotalErrors != before.TotalErrors {
+		if after.TotalErrors < before.TotalErrors {
+			return 1
+		}
+		return -1
+	}
+	if after.Parse.Errors != before.Parse.Errors {
+		if after.Parse.Errors < before.Parse.Errors {
+			return 1
+		}
+		return -1
+	}
+	if after.TotalWarnings != before.TotalWarnings {
+		if after.TotalWarnings < before.TotalWarnings {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
+// RepairedChanged reports whether the lexical repair phase did
+// anything observable. Either an applied edit OR a skipped-but-
+// attempted edit counts.
+//
+// Osty: toolchain/airepair_decide.osty:125
+func RepairedChanged(changeCount, skipCount int) bool {
+	return changeCount > 0 || skipCount > 0
+}

--- a/internal/runner/airepair_decide_policy_test.go
+++ b/internal/runner/airepair_decide_policy_test.go
@@ -44,6 +44,8 @@ func TestCompareAutoAssist(t *testing.T) {
 		{"check-stage-valued", mkStats(0, 0, 5, 5, 0), mkStats(0, 0, 2, 2, 0), 1},
 		{"resolve-stage-valued", mkStats(0, 3, 0, 3, 0), mkStats(0, 1, 0, 1, 0), 1},
 		{"parse-regression-dominates", mkStats(1, 5, 5, 11, 0), mkStats(2, 0, 0, 2, 0), -1},
+		{"warning-only-improved", mkStats(1, 1, 1, 3, 5), mkStats(1, 1, 1, 3, 2), 1},
+		{"warning-only-regressed", mkStats(1, 1, 1, 3, 2), mkStats(1, 1, 1, 3, 5), -1},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -63,6 +65,11 @@ func TestCompareFrontEndAssist(t *testing.T) {
 	}{
 		{"by-total", mkStats(2, 2, 2, 6, 0), mkStats(3, 1, 1, 5, 0), 1},
 		{"parse-tiebreaker", mkStats(3, 1, 1, 5, 0), mkStats(1, 3, 1, 5, 0), 1},
+		// Parse + totals equal, resolve↔check trade places → neutral
+		// because the front-end scorer aggregates the stages.
+		{"cross-stage-trade-neutral", mkStats(1, 2, 1, 4, 0), mkStats(1, 1, 2, 4, 0), 0},
+		{"warning-only-improved", mkStats(1, 1, 1, 3, 5), mkStats(1, 1, 1, 3, 2), 1},
+		{"warning-only-regressed", mkStats(1, 1, 1, 3, 2), mkStats(1, 1, 1, 3, 5), -1},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/runner/airepair_decide_policy_test.go
+++ b/internal/runner/airepair_decide_policy_test.go
@@ -1,0 +1,89 @@
+package runner
+
+import "testing"
+
+func mkStats(parse, resolve, check, totalErr, totalWarn int) ProbeStats {
+	return ProbeStats{
+		Parse:         ProbeStageStats{Errors: parse},
+		Resolve:       ProbeStageStats{Errors: resolve},
+		Check:         ProbeStageStats{Errors: check},
+		TotalErrors:   totalErr,
+		TotalWarnings: totalWarn,
+	}
+}
+
+func TestCompareParseAssist(t *testing.T) {
+	cases := []struct {
+		name   string
+		before ProbeStats
+		after  ProbeStats
+		want   int
+	}{
+		{"improved", mkStats(3, 1, 1, 5, 0), mkStats(1, 1, 1, 3, 0), 1},
+		{"regressed", mkStats(1, 1, 1, 3, 0), mkStats(2, 1, 1, 4, 0), -1},
+		{"tie-falls-to-total", mkStats(1, 2, 1, 4, 0), mkStats(1, 1, 1, 3, 0), 1},
+		{"all-equal", mkStats(1, 1, 1, 3, 0), mkStats(1, 1, 1, 3, 0), 0},
+		{"warnings-fallback", mkStats(1, 1, 1, 3, 5), mkStats(1, 1, 1, 3, 3), 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := CompareParseAssist(c.before, c.after); got != c.want {
+				t.Errorf("CompareParseAssist = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestCompareAutoAssist(t *testing.T) {
+	cases := []struct {
+		name   string
+		before ProbeStats
+		after  ProbeStats
+		want   int
+	}{
+		{"check-stage-valued", mkStats(0, 0, 5, 5, 0), mkStats(0, 0, 2, 2, 0), 1},
+		{"resolve-stage-valued", mkStats(0, 3, 0, 3, 0), mkStats(0, 1, 0, 1, 0), 1},
+		{"parse-regression-dominates", mkStats(1, 5, 5, 11, 0), mkStats(2, 0, 0, 2, 0), -1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := CompareAutoAssist(c.before, c.after); got != c.want {
+				t.Errorf("CompareAutoAssist = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestCompareFrontEndAssist(t *testing.T) {
+	cases := []struct {
+		name   string
+		before ProbeStats
+		after  ProbeStats
+		want   int
+	}{
+		{"by-total", mkStats(2, 2, 2, 6, 0), mkStats(3, 1, 1, 5, 0), 1},
+		{"parse-tiebreaker", mkStats(3, 1, 1, 5, 0), mkStats(1, 3, 1, 5, 0), 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := CompareFrontEndAssist(c.before, c.after); got != c.want {
+				t.Errorf("CompareFrontEndAssist = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRepairedChanged(t *testing.T) {
+	if RepairedChanged(0, 0) {
+		t.Error("RepairedChanged(0,0) should be false")
+	}
+	if !RepairedChanged(1, 0) {
+		t.Error("RepairedChanged(1,0) should be true")
+	}
+	if !RepairedChanged(0, 1) {
+		t.Error("RepairedChanged(0,1) should be true")
+	}
+	if !RepairedChanged(5, 3) {
+		t.Error("RepairedChanged(5,3) should be true")
+	}
+}

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -37,6 +37,7 @@ import (
 func TestPolicySnapshotParityWithOsty(t *testing.T) {
 	ostySources := []string{
 		"runner.osty",
+		"airepair_decide.osty",
 		"airepair_flags.osty",
 		"airepair_rewrite.osty",
 		"airepair_source.osty",

--- a/toolchain/airepair_decide.osty
+++ b/toolchain/airepair_decide.osty
@@ -1,0 +1,128 @@
+/// Pure decision policy for `osty airepair`'s accept/reject logic.
+/// Host code (internal/airepair) owns lex/parse/check pipeline
+/// execution, diag aggregation, and source-edit application; this
+/// module decides:
+///
+///   - how to rank two `ProbeStats` snapshots under each
+///     scoring mode (parse-assist / auto-assist / front-end-assist),
+///   - whether a `repair.Result`'s edit count + skip count counts
+///     as "the repairer actually did something".
+///
+/// Mirrored by `internal/runner/airepair_decide_policy.go`. The
+/// drift test under internal/runner keeps the two in sync — the
+/// Osty file is the source of truth at review time.
+/// ProbeStageStats summarises diagnostics from one pipeline stage
+/// (parse, resolve, or check). Mirrors the host's `StageStats`.
+pub struct ProbeStageStats {
+    pub errors: Int,
+    pub warnings: Int,
+}
+/// ProbeStats is the per-source pipeline snapshot the accept/reject
+/// scorers compare. Field shapes match the host's `ProbeStats`.
+/// `totalErrors` and `totalWarnings` are pre-computed sums across
+/// the three stages plus any cross-cutting diagnostics — callers
+/// don't recompute them inside the scorers.
+pub struct ProbeStats {
+    pub parse: ProbeStageStats,
+    pub resolve: ProbeStageStats,
+    pub check: ProbeStageStats,
+    pub totalErrors: Int,
+    pub totalWarnings: Int,
+}
+/// compareParseAssist returns `+1` when `after` improves on
+/// `before` for the parse-only assist mode, `-1` when it
+/// regresses, `0` when neither. Priority:
+///
+///   1. parse-stage errors (the mode's namesake).
+///   2. total errors (any stage).
+///   3. total warnings.
+///
+/// Sub-priority differences must individually flip the sign for
+/// the result to change, so a parse improvement at the cost of a
+/// resolve regression still wins.
+pub fn compareParseAssist(before: ProbeStats, after: ProbeStats) -> Int {
+    if after.parse.errors != before.parse.errors {
+        if after.parse.errors < before.parse.errors {
+            return 1
+        }
+        return -1
+    }
+    if after.totalErrors != before.totalErrors {
+        if after.totalErrors < before.totalErrors {
+            return 1
+        }
+        return -1
+    }
+    if after.totalWarnings != before.totalWarnings {
+        if after.totalWarnings < before.totalWarnings {
+            return 1
+        }
+        return -1
+    }
+    0
+}
+/// compareAutoAssist scores the default mode: parse errors first,
+/// then resolve errors, then check errors, then total warnings.
+/// This is the most aggressive ladder — improvements at every
+/// stage are valued, with parser regression as the hard floor.
+pub fn compareAutoAssist(before: ProbeStats, after: ProbeStats) -> Int {
+    if after.parse.errors != before.parse.errors {
+        if after.parse.errors < before.parse.errors {
+            return 1
+        }
+        return -1
+    }
+    if after.resolve.errors != before.resolve.errors {
+        if after.resolve.errors < before.resolve.errors {
+            return 1
+        }
+        return -1
+    }
+    if after.check.errors != before.check.errors {
+        if after.check.errors < before.check.errors {
+            return 1
+        }
+        return -1
+    }
+    if after.totalWarnings != before.totalWarnings {
+        if after.totalWarnings < before.totalWarnings {
+            return 1
+        }
+        return -1
+    }
+    0
+}
+/// compareFrontEndAssist scores the front-end mode: total errors
+/// across all front-end stages first, parse errors as a
+/// tiebreaker, then total warnings. This mode collapses the three
+/// stages into one aggregate so an improvement that trades a
+/// resolve error for a check error still scores neutral.
+pub fn compareFrontEndAssist(before: ProbeStats, after: ProbeStats) -> Int {
+    if after.totalErrors != before.totalErrors {
+        if after.totalErrors < before.totalErrors {
+            return 1
+        }
+        return -1
+    }
+    if after.parse.errors != before.parse.errors {
+        if after.parse.errors < before.parse.errors {
+            return 1
+        }
+        return -1
+    }
+    if after.totalWarnings != before.totalWarnings {
+        if after.totalWarnings < before.totalWarnings {
+            return 1
+        }
+        return -1
+    }
+    0
+}
+/// repairedChanged reports whether the lexical repair phase did
+/// anything observable to the source. Either an applied edit OR a
+/// skipped-but-attempted edit counts — the host uses this to
+/// classify the result as `accepted` vs `already_clean` even
+/// before scoring kicks in.
+pub fn repairedChanged(changeCount: Int, skipCount: Int) -> Bool {
+    changeCount > 0 || skipCount > 0
+}

--- a/toolchain/airepair_decide.osty
+++ b/toolchain/airepair_decide.osty
@@ -19,9 +19,11 @@ pub struct ProbeStageStats {
 }
 /// ProbeStats is the per-source pipeline snapshot the accept/reject
 /// scorers compare. Field shapes match the host's `ProbeStats`.
-/// `totalErrors` and `totalWarnings` are pre-computed sums across
-/// the three stages plus any cross-cutting diagnostics — callers
-/// don't recompute them inside the scorers.
+/// `totalErrors` and `totalWarnings` are pre-computed sums of the
+/// three stage counts (parse + resolve + check) — no cross-cutting
+/// diagnostics are folded in, so `compareAutoAssist`'s deliberate
+/// silence on `totalErrors` keeps the same observational power as
+/// the stage-by-stage check.
 pub struct ProbeStats {
     pub parse: ProbeStageStats,
     pub resolve: ProbeStageStats,

--- a/toolchain/airepair_decide_test.osty
+++ b/toolchain/airepair_decide_test.osty
@@ -64,3 +64,33 @@ fn testRepairedChangedCounts() {
     testing.assert(repairedChanged(0, 1))
     testing.assert(repairedChanged(5, 3))
 }
+fn testCompareFrontEndAssistCrossStageTradeIsNeutral() {
+    // Parse and total errors stay equal; resolve and check trade
+    // places (resolve down 1, check up 1). The front-end scorer
+    // collapses the three stages into a single total + a parse
+    // tiebreaker, so cross-stage trades MUST score neutral.
+    let before = stats(1, 2, 1, 4, 0)
+    let after = stats(1, 1, 2, 4, 0)
+    testing.assertEq(compareFrontEndAssist(before, after), 0)
+}
+fn testCompareAutoAssistWarningOnlyImproved() {
+    // All stage errors equal; only totalWarnings drops.
+    let before = stats(1, 1, 1, 3, 5)
+    let after = stats(1, 1, 1, 3, 2)
+    testing.assertEq(compareAutoAssist(before, after), 1)
+}
+fn testCompareAutoAssistWarningOnlyRegressed() {
+    let before = stats(1, 1, 1, 3, 2)
+    let after = stats(1, 1, 1, 3, 5)
+    testing.assertEq(compareAutoAssist(before, after), -1)
+}
+fn testCompareFrontEndAssistWarningOnlyImproved() {
+    let before = stats(1, 1, 1, 3, 5)
+    let after = stats(1, 1, 1, 3, 2)
+    testing.assertEq(compareFrontEndAssist(before, after), 1)
+}
+fn testCompareFrontEndAssistWarningOnlyRegressed() {
+    let before = stats(1, 1, 1, 3, 2)
+    let after = stats(1, 1, 1, 3, 5)
+    testing.assertEq(compareFrontEndAssist(before, after), -1)
+}

--- a/toolchain/airepair_decide_test.osty
+++ b/toolchain/airepair_decide_test.osty
@@ -1,0 +1,66 @@
+use std.testing
+fn stats(parse: Int, resolve: Int, check: Int, totalErr: Int, totalWarn: Int) -> ProbeStats {
+    ProbeStats {
+        parse: ProbeStageStats {errors: parse, warnings: 0},
+        resolve: ProbeStageStats {errors: resolve, warnings: 0},
+        check: ProbeStageStats {errors: check, warnings: 0},
+        totalErrors: totalErr,
+        totalWarnings: totalWarn,
+    }
+}
+fn testCompareParseAssistImproved() {
+    let before = stats(3, 1, 1, 5, 0)
+    let after = stats(1, 1, 1, 3, 0)
+    testing.assertEq(compareParseAssist(before, after), 1)
+}
+fn testCompareParseAssistRegressed() {
+    let before = stats(1, 1, 1, 3, 0)
+    let after = stats(2, 1, 1, 4, 0)
+    testing.assertEq(compareParseAssist(before, after), -1)
+}
+fn testCompareParseAssistTieFallsToTotal() {
+    let before = stats(1, 2, 1, 4, 0)
+    let after = stats(1, 1, 1, 3, 0)
+    testing.assertEq(compareParseAssist(before, after), 1)
+}
+fn testCompareParseAssistAllEqual() {
+    let s = stats(1, 1, 1, 3, 0)
+    testing.assertEq(compareParseAssist(s, s), 0)
+}
+fn testCompareParseAssistWarningsFallback() {
+    let before = stats(1, 1, 1, 3, 5)
+    let after = stats(1, 1, 1, 3, 3)
+    testing.assertEq(compareParseAssist(before, after), 1)
+}
+fn testCompareAutoAssistAllStagesValued() {
+    let before = stats(0, 0, 5, 5, 0)
+    let after = stats(0, 0, 2, 2, 0)
+    testing.assertEq(compareAutoAssist(before, after), 1)
+    let before2 = stats(0, 3, 0, 3, 0)
+    let after2 = stats(0, 1, 0, 1, 0)
+    testing.assertEq(compareAutoAssist(before2, after2), 1)
+}
+fn testCompareAutoAssistParseRegressionDominates() {
+    let before = stats(1, 5, 5, 11, 0)
+    // parse went up, even though resolve+check dropped.
+    let after = stats(2, 0, 0, 2, 0)
+    testing.assertEq(compareAutoAssist(before, after), -1)
+}
+fn testCompareFrontEndAssistByTotal() {
+    let before = stats(2, 2, 2, 6, 0)
+    // Mixed shift: parse worse but total better.
+    let after = stats(3, 1, 1, 5, 0)
+    testing.assertEq(compareFrontEndAssist(before, after), 1)
+}
+fn testCompareFrontEndAssistParseTiebreaker() {
+    // Equal totals, parse improved → wins.
+    let before = stats(3, 1, 1, 5, 0)
+    let after = stats(1, 3, 1, 5, 0)
+    testing.assertEq(compareFrontEndAssist(before, after), 1)
+}
+fn testRepairedChangedCounts() {
+    testing.assert(!(repairedChanged(0, 0)))
+    testing.assert(repairedChanged(1, 0))
+    testing.assert(repairedChanged(0, 1))
+    testing.assert(repairedChanged(5, 3))
+}


### PR DESCRIPTION
## Summary

`internal/airepair/airepair.go`의 4개 pure 결정 함수를 새
`toolchain/airepair_decide.osty`로 이전. 이미 정책-free 인
`internal/airepair/` 패키지의 마지막 scoring 정책을 toolchain으로
가져옴.

## 이전된 정책 (4 fn + 2 struct)

- `compareParseAssist(before, after) -> Int` — parse-only 어시스트
  스코어 ladder: parse errors → total errors → total warnings
- `compareAutoAssist(before, after) -> Int` — 디폴트 모드 ladder:
  parse → resolve → check → total warnings
- `compareFrontEndAssist(before, after) -> Int` — front-end 모드
  ladder: total errors → parse → total warnings (cross-stage error
  trade는 neutral)
- `repairedChanged(changeCount, skipCount) -> Bool` — repair 단계가
  관찰 가능한 일을 했는지 (edit 또는 skipped attempt)

구조: `ProbeStageStats` + `ProbeStats` Osty 표현.

## Go wrapper 축소

3개 compare fn (~22줄 each = 66줄) → 각 1줄 thin wrapper. 호스트는
한 곳에서 `statsToRunner(s ProbeStats) runner.ProbeStats` 어댑터로
변환:

```go
func compareParseAssist(before, after ProbeStats) int {
    return runner.CompareParseAssist(statsToRunner(before), statsToRunner(after))
}
```

`repairedChanged`도 1줄 wrapper.

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/airepair/... ./internal/runner/...` —
      pass (5.2s + drift, 18개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run TestAIRepair` — pass
      (2.9s, accept/reject 결정 전체 경로 포함)
- [x] 10+ scoring 케이스 (improved/regressed/tie-falls-to-total/
      warnings-fallback/parse-regression-dominates/cross-stage-trade)
      Osty + Go 양측 단위 테스트

## 이번 세션 누적 (22번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1775 | airepair 정책-free + format/scaffold/diag/repair/profile/lockfile/codesdoc 전 영역 self-host | (기존) |
| (this) | airepair accept/reject 스코어링 | 4 fn + 2 struct |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_