### PR TITLE
refactor: airepair isImproved/isAccepted + explain reasons self-host

### DIFF
--- a/internal/airepair/airepair.go
+++ b/internal/airepair/airepair.go
@@ -230,47 +230,12 @@ func (r Result) JSONReport() Report {
 }
 
 func explainAcceptedReason(mode Mode, before, after ProbeStats, repaired repair.Result, proposed bool) string {
-	if !proposed || (!repairedChanged(repaired) && before == after) {
-		return "already_clean"
-	}
-	if after.Parse.Errors < before.Parse.Errors {
-		return "parse_errors_reduced"
-	}
-	if after.Resolve.Errors < before.Resolve.Errors {
-		return "resolve_errors_reduced"
-	}
-	if after.Check.Errors < before.Check.Errors {
-		return "check_errors_reduced"
-	}
-	if after.TotalWarnings < before.TotalWarnings {
-		return "warnings_reduced"
-	}
-	if mode == ModeRewriteOnly && len(repaired.Changes) > 0 {
-		return "rewrite_mode_applied"
-	}
-	if len(repaired.Changes) > 0 {
-		return "non_regressing_rewrite_accepted"
-	}
-	return "accepted"
+	return runner.ExplainAcceptedReason(string(mode), statsToRunner(before), statsToRunner(after),
+		len(repaired.Changes), proposed)
 }
 
 func explainRejectedReason(mode Mode, before, after ProbeStats) string {
-	if after.Parse.Errors > before.Parse.Errors {
-		return "parse_regression_blocked"
-	}
-	if mode == ModeAutoAssist && after.Resolve.Errors > before.Resolve.Errors {
-		return "resolve_regression_blocked"
-	}
-	if mode == ModeAutoAssist && after.Check.Errors > before.Check.Errors {
-		return "check_regression_blocked"
-	}
-	if after.TotalErrors > before.TotalErrors {
-		return "front_end_regression_blocked"
-	}
-	if after.TotalWarnings > before.TotalWarnings {
-		return "warning_regression_blocked"
-	}
-	return "no_improvement"
+	return runner.ExplainRejectedReason(string(mode), statsToRunner(before), statsToRunner(after))
 }
 
 func repairedChanged(repaired repair.Result) bool {
@@ -405,32 +370,12 @@ func count(diags []*diag.Diagnostic) StageStats {
 }
 
 func isImproved(mode Mode, before, after ProbeStats, repaired repair.Result) bool {
-	switch mode {
-	case ModeRewriteOnly:
-		return len(repaired.Changes) > 0
-	case ModeParseAssist:
-		return compareParseAssist(before, after) > 0
-	case ModeFrontEndAssist:
-		return compareFrontEndAssist(before, after) > 0
-	default:
-		return compareAutoAssist(before, after) > 0
-	}
+	return runner.IsImproved(string(mode), statsToRunner(before), statsToRunner(after), len(repaired.Changes))
 }
 
 func isAccepted(mode Mode, before, after ProbeStats, repaired repair.Result) bool {
-	if len(repaired.Changes) == 0 && repaired.Skipped == 0 {
-		return true
-	}
-	switch mode {
-	case ModeRewriteOnly:
-		return true
-	case ModeParseAssist:
-		return compareParseAssist(before, after) >= 0
-	case ModeFrontEndAssist:
-		return compareFrontEndAssist(before, after) >= 0
-	default:
-		return compareAutoAssist(before, after) >= 0
-	}
+	return runner.IsAccepted(string(mode), statsToRunner(before), statsToRunner(after),
+		len(repaired.Changes), repaired.Skipped)
 }
 
 // compare* returns:

--- a/internal/runner/airepair_decide_policy.go
+++ b/internal/runner/airepair_decide_policy.go
@@ -118,3 +118,113 @@ func CompareFrontEndAssist(before, after ProbeStats) int {
 func RepairedChanged(changeCount, skipCount int) bool {
 	return changeCount > 0 || skipCount > 0
 }
+
+// Airepair mode names — match `--airepair-mode` flag values.
+const (
+	airepairModeRewriteOnly   = "rewrite"
+	airepairModeAutoAssist    = "auto"
+	airepairModeParseAssist   = "parse"
+	airepairModeFrontEndAssist = "frontend"
+)
+
+// IsImproved reports whether `after` is a strict improvement on
+// `before` under the chosen mode. Defaults to auto-assist for
+// unrecognised modes.
+//
+// Osty: toolchain/airepair_decide.osty:138
+func IsImproved(mode string, before, after ProbeStats, repairedChanges int) bool {
+	switch mode {
+	case airepairModeRewriteOnly:
+		return repairedChanges > 0
+	case airepairModeParseAssist:
+		return CompareParseAssist(before, after) > 0
+	case airepairModeFrontEndAssist:
+		return CompareFrontEndAssist(before, after) > 0
+	}
+	return CompareAutoAssist(before, after) > 0
+}
+
+// IsAccepted is the looser sibling of IsImproved. No edits + no
+// skips short-circuits to true (nothing was tried). Rewrite mode
+// always accepts when edits exist. Otherwise the mode's score
+// ladder must be non-negative.
+//
+// Osty: toolchain/airepair_decide.osty:158
+func IsAccepted(mode string, before, after ProbeStats, repairedChanges, repairedSkipped int) bool {
+	if repairedChanges == 0 && repairedSkipped == 0 {
+		return true
+	}
+	switch mode {
+	case airepairModeRewriteOnly:
+		return true
+	case airepairModeParseAssist:
+		return CompareParseAssist(before, after) >= 0
+	case airepairModeFrontEndAssist:
+		return CompareFrontEndAssist(before, after) >= 0
+	}
+	return CompareAutoAssist(before, after) >= 0
+}
+
+// ExplainAcceptedReason returns a stable string tag classifying
+// why the rewriter's output was accepted. Tags are part of the
+// public airepair JSON contract.
+//
+// Osty: toolchain/airepair_decide.osty:179
+func ExplainAcceptedReason(mode string, before, after ProbeStats, repairedChanges int, proposed bool) string {
+	changed := repairedChanges > 0
+	beforeEqAfter := airepairProbeStatsEqual(before, after)
+	if !proposed || (!changed && beforeEqAfter) {
+		return "already_clean"
+	}
+	if after.Parse.Errors < before.Parse.Errors {
+		return "parse_errors_reduced"
+	}
+	if after.Resolve.Errors < before.Resolve.Errors {
+		return "resolve_errors_reduced"
+	}
+	if after.Check.Errors < before.Check.Errors {
+		return "check_errors_reduced"
+	}
+	if after.TotalWarnings < before.TotalWarnings {
+		return "warnings_reduced"
+	}
+	if mode == airepairModeRewriteOnly && repairedChanges > 0 {
+		return "rewrite_mode_applied"
+	}
+	if repairedChanges > 0 {
+		return "non_regressing_rewrite_accepted"
+	}
+	return "accepted"
+}
+
+// ExplainRejectedReason classifies why an output failed isAccepted
+// under the given mode. Tags are part of the public airepair JSON
+// contract.
+//
+// Osty: toolchain/airepair_decide.osty:213
+func ExplainRejectedReason(mode string, before, after ProbeStats) string {
+	if after.Parse.Errors > before.Parse.Errors {
+		return "parse_regression_blocked"
+	}
+	if mode == airepairModeAutoAssist && after.Resolve.Errors > before.Resolve.Errors {
+		return "resolve_regression_blocked"
+	}
+	if mode == airepairModeAutoAssist && after.Check.Errors > before.Check.Errors {
+		return "check_regression_blocked"
+	}
+	if after.TotalErrors > before.TotalErrors {
+		return "front_end_regression_blocked"
+	}
+	if after.TotalWarnings > before.TotalWarnings {
+		return "warning_regression_blocked"
+	}
+	return "no_improvement"
+}
+
+func airepairProbeStatsEqual(a, b ProbeStats) bool {
+	return a.Parse == b.Parse &&
+		a.Resolve == b.Resolve &&
+		a.Check == b.Check &&
+		a.TotalErrors == b.TotalErrors &&
+		a.TotalWarnings == b.TotalWarnings
+}

--- a/internal/runner/airepair_decide_policy_test.go
+++ b/internal/runner/airepair_decide_policy_test.go
@@ -94,3 +94,110 @@ func TestRepairedChanged(t *testing.T) {
 		t.Error("RepairedChanged(5,3) should be true")
 	}
 }
+
+func TestIsImproved(t *testing.T) {
+	s := mkStats(1, 1, 1, 3, 0)
+	if !IsImproved("rewrite", s, s, 1) {
+		t.Error("rewrite + 1 change should be improved")
+	}
+	if IsImproved("rewrite", s, s, 0) {
+		t.Error("rewrite + 0 changes should not be improved")
+	}
+	before := mkStats(3, 1, 1, 5, 0)
+	after := mkStats(1, 1, 1, 3, 0)
+	if !IsImproved("parse", before, after, 1) {
+		t.Error("parse mode improvement missed")
+	}
+	if !IsImproved("frontend", mkStats(2, 2, 2, 6, 0), mkStats(2, 1, 1, 4, 0), 1) {
+		t.Error("frontend mode improvement missed")
+	}
+	// Unknown mode → auto fallback.
+	if !IsImproved("unknown", mkStats(0, 0, 5, 5, 0), mkStats(0, 0, 2, 2, 0), 1) {
+		t.Error("unknown mode should fall back to auto")
+	}
+}
+
+func TestIsAccepted(t *testing.T) {
+	worse := mkStats(5, 5, 5, 15, 0)
+	better := mkStats(1, 1, 1, 3, 0)
+	// No edits + no skips → always accepted.
+	if !IsAccepted("auto", better, worse, 0, 0) {
+		t.Error("no-edits should short-circuit to accepted")
+	}
+	// Rewrite mode → always accepted when edits exist.
+	if !IsAccepted("rewrite", better, worse, 1, 0) {
+		t.Error("rewrite mode should always accept")
+	}
+	// Non-regressing tie → accepted.
+	s := mkStats(1, 1, 1, 3, 0)
+	for _, mode := range []string{"auto", "parse", "frontend"} {
+		if !IsAccepted(mode, s, s, 1, 0) {
+			t.Errorf("%s mode should accept non-regressing tie", mode)
+		}
+	}
+	// Regression → rejected.
+	if IsAccepted("auto", better, worse, 1, 0) {
+		t.Error("auto mode should reject regression with edits")
+	}
+}
+
+func TestExplainAcceptedReason(t *testing.T) {
+	s := mkStats(0, 0, 0, 0, 0)
+	if got := ExplainAcceptedReason("auto", s, s, 0, false); got != "already_clean" {
+		t.Errorf("not-proposed: got %q", got)
+	}
+	if got := ExplainAcceptedReason("auto", s, s, 0, true); got != "already_clean" {
+		t.Errorf("no-changes: got %q", got)
+	}
+	cases := []struct {
+		name       string
+		mode       string
+		before     ProbeStats
+		after      ProbeStats
+		changes    int
+		wantReason string
+	}{
+		{"parse drop", "auto", mkStats(3, 1, 1, 5, 0), mkStats(1, 1, 1, 3, 0), 2, "parse_errors_reduced"},
+		{"resolve drop", "auto", mkStats(0, 3, 0, 3, 0), mkStats(0, 1, 0, 1, 0), 1, "resolve_errors_reduced"},
+		{"check drop", "auto", mkStats(0, 0, 3, 3, 0), mkStats(0, 0, 1, 1, 0), 1, "check_errors_reduced"},
+		{"warnings reduced", "auto", mkStats(1, 1, 1, 3, 5), mkStats(1, 1, 1, 3, 2), 1, "warnings_reduced"},
+		{"rewrite mode applied", "rewrite", mkStats(1, 1, 1, 3, 0), mkStats(1, 1, 1, 3, 0), 1, "rewrite_mode_applied"},
+		{"non-regressing rewrite", "auto", mkStats(1, 1, 1, 3, 0), mkStats(1, 1, 1, 3, 0), 1, "non_regressing_rewrite_accepted"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ExplainAcceptedReason(c.mode, c.before, c.after, c.changes, true)
+			if got != c.wantReason {
+				t.Errorf("got %q, want %q", got, c.wantReason)
+			}
+		})
+	}
+}
+
+func TestExplainRejectedReason(t *testing.T) {
+	cases := []struct {
+		name       string
+		mode       string
+		before     ProbeStats
+		after      ProbeStats
+		wantReason string
+	}{
+		{"parse regression", "auto", mkStats(1, 1, 1, 3, 0), mkStats(2, 1, 1, 4, 0), "parse_regression_blocked"},
+		{"resolve-only-auto", "auto", mkStats(1, 1, 1, 3, 0), mkStats(1, 3, 1, 5, 0), "resolve_regression_blocked"},
+		// In parse mode, the resolve-only branch collapses to the
+		// total-error check.
+		{"resolve-only-parse-falls-to-total", "parse", mkStats(1, 1, 1, 3, 0), mkStats(1, 3, 1, 5, 0), "front_end_regression_blocked"},
+		{"check-only-auto", "auto", mkStats(1, 1, 1, 3, 0), mkStats(1, 1, 3, 5, 0), "check_regression_blocked"},
+		{"front-end aggregate", "frontend", mkStats(1, 1, 1, 3, 0), mkStats(1, 2, 2, 5, 0), "front_end_regression_blocked"},
+		{"warning regression", "auto", mkStats(1, 1, 1, 3, 2), mkStats(1, 1, 1, 3, 5), "warning_regression_blocked"},
+		{"no improvement fallback", "auto", mkStats(1, 1, 1, 3, 0), mkStats(1, 1, 1, 3, 0), "no_improvement"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ExplainRejectedReason(c.mode, c.before, c.after)
+			if got != c.wantReason {
+				t.Errorf("got %q, want %q", got, c.wantReason)
+			}
+		})
+	}
+}

--- a/toolchain/airepair_decide.osty
+++ b/toolchain/airepair_decide.osty
@@ -128,3 +128,146 @@ pub fn compareFrontEndAssist(before: ProbeStats, after: ProbeStats) -> Int {
 pub fn repairedChanged(changeCount: Int, skipCount: Int) -> Bool {
     changeCount > 0 || skipCount > 0
 }
+/// Mode strings the airepair scorers dispatch on. Match
+/// toolchain/airepair_flags.osty's canonical mode names so the
+/// `--airepair-mode` flag and the policy talk in the same alphabet.
+let airepairModeRewriteOnly: String = "rewrite"
+let airepairModeAutoAssist: String = "auto"
+let airepairModeParseAssist: String = "parse"
+let airepairModeFrontEndAssist: String = "frontend"
+/// isImproved reports whether the rewriter's snapshot is a strict
+/// improvement over the pre-repair snapshot under the chosen
+/// mode. The default ("auto" or unrecognised) routes through the
+/// most aggressive ladder.
+///
+/// `rewrite` mode is structurally improved whenever the repair
+/// pass emitted any edits — there's no diagnostic scoring to do.
+pub fn isImproved(mode: String, before: ProbeStats, after: ProbeStats, repairedChanges: Int) -> Bool {
+    if mode == airepairModeRewriteOnly {
+        return repairedChanges > 0
+    }
+    if mode == airepairModeParseAssist {
+        return compareParseAssist(before, after) > 0
+    }
+    if mode == airepairModeFrontEndAssist {
+        return compareFrontEndAssist(before, after) > 0
+    }
+    compareAutoAssist(before, after) > 0
+}
+/// isAccepted is the looser sibling of `isImproved` — it returns
+/// true when the rewriter's output is at least non-regressing.
+/// Two short-circuits:
+///
+///   - No edits + no skips → unconditionally accepted (the source
+///     was already clean and nothing was tried; nothing to undo).
+///   - `rewrite` mode → always accepted when there are edits, since
+///     the mode brackets explicitly opt into the rewrite-only
+///     contract.
+///
+/// Otherwise the mode's score ladder must come out non-negative.
+pub fn isAccepted(mode: String, before: ProbeStats, after: ProbeStats, repairedChanges: Int, repairedSkipped: Int) -> Bool {
+    if repairedChanges == 0 && repairedSkipped == 0 {
+        return true
+    }
+    if mode == airepairModeRewriteOnly {
+        return true
+    }
+    if mode == airepairModeParseAssist {
+        return compareParseAssist(before, after) >= 0
+    }
+    if mode == airepairModeFrontEndAssist {
+        return compareFrontEndAssist(before, after) >= 0
+    }
+    compareAutoAssist(before, after) >= 0
+}
+/// explainAcceptedReason picks a stable string tag that captures
+/// *why* the rewriter's output was accepted. Returned tags travel
+/// untouched into JSON reports (`osty airepair --json`) and the
+/// learning capture corpus, so they're part of the public contract:
+///
+///   - `already_clean`           — repair didn't fire / nothing changed.
+///   - `parse_errors_reduced`    — parse-stage error count dropped.
+///   - `resolve_errors_reduced`  — resolve-stage error count dropped.
+///   - `check_errors_reduced`    — check-stage error count dropped.
+///   - `warnings_reduced`        — only warnings changed (improved).
+///   - `rewrite_mode_applied`    — bracketed rewrite-only mode took
+///                                 the edits without scoring.
+///   - `non_regressing_rewrite_accepted` — edits applied with no
+///                                 measurable improvement but no
+///                                 regression either.
+///   - `accepted`                — fallback (shouldn't fire in
+///                                 practice; kept as a safety net).
+pub fn explainAcceptedReason(
+    mode: String,
+    before: ProbeStats,
+    after: ProbeStats,
+    repairedChanges: Int,
+    proposed: Bool,
+) -> String {
+    let changed = repairedChanges > 0
+    let beforeEqAfter = airepairProbeStatsEqual(before, after)
+    if !proposed || (!changed && beforeEqAfter) {
+        return "already_clean"
+    }
+    if after.parse.errors < before.parse.errors {
+        return "parse_errors_reduced"
+    }
+    if after.resolve.errors < before.resolve.errors {
+        return "resolve_errors_reduced"
+    }
+    if after.check.errors < before.check.errors {
+        return "check_errors_reduced"
+    }
+    if after.totalWarnings < before.totalWarnings {
+        return "warnings_reduced"
+    }
+    if mode == airepairModeRewriteOnly && repairedChanges > 0 {
+        return "rewrite_mode_applied"
+    }
+    if repairedChanges > 0 {
+        return "non_regressing_rewrite_accepted"
+    }
+    "accepted"
+}
+/// explainRejectedReason classifies *why* an output failed the
+/// `isAccepted` ladder under the given mode. Returned tags are
+/// part of the public airepair JSON contract:
+///
+///   - `parse_regression_blocked`     — any mode rejects parse
+///                                      regression.
+///   - `resolve_regression_blocked`   — auto-assist only.
+///   - `check_regression_blocked`     — auto-assist only.
+///   - `front_end_regression_blocked` — total-error regression.
+///   - `warning_regression_blocked`   — warnings up only.
+///   - `no_improvement`               — fallback.
+pub fn explainRejectedReason(mode: String, before: ProbeStats, after: ProbeStats) -> String {
+    if after.parse.errors > before.parse.errors {
+        return "parse_regression_blocked"
+    }
+    if mode == airepairModeAutoAssist && after.resolve.errors > before.resolve.errors {
+        return "resolve_regression_blocked"
+    }
+    if mode == airepairModeAutoAssist && after.check.errors > before.check.errors {
+        return "check_regression_blocked"
+    }
+    if after.totalErrors > before.totalErrors {
+        return "front_end_regression_blocked"
+    }
+    if after.totalWarnings > before.totalWarnings {
+        return "warning_regression_blocked"
+    }
+    "no_improvement"
+}
+/// airepairProbeStatsEqual compares two snapshots field-by-field.
+/// Osty doesn't ship structural equality on user structs yet (no
+/// Equal derive in 0.5 baseline), so the comparison is explicit.
+fn airepairProbeStatsEqual(a: ProbeStats, b: ProbeStats) -> Bool {
+    a.parse.errors == b.parse.errors &&
+        a.parse.warnings == b.parse.warnings &&
+        a.resolve.errors == b.resolve.errors &&
+        a.resolve.warnings == b.resolve.warnings &&
+        a.check.errors == b.check.errors &&
+        a.check.warnings == b.check.warnings &&
+        a.totalErrors == b.totalErrors &&
+        a.totalWarnings == b.totalWarnings
+}

--- a/toolchain/airepair_decide_test.osty
+++ b/toolchain/airepair_decide_test.osty
@@ -94,3 +94,113 @@ fn testCompareFrontEndAssistWarningOnlyRegressed() {
     let after = stats(1, 1, 1, 3, 5)
     testing.assertEq(compareFrontEndAssist(before, after), -1)
 }
+fn testIsImprovedRewriteOnly() {
+    let s = stats(1, 1, 1, 3, 0)
+    testing.assert(isImproved("rewrite", s, s, 1))
+    testing.assert(!(isImproved("rewrite", s, s, 0)))
+}
+fn testIsImprovedParseAssist() {
+    let before = stats(3, 1, 1, 5, 0)
+    let after = stats(1, 1, 1, 3, 0)
+    testing.assert(isImproved("parse", before, after, 1))
+    testing.assert(!(isImproved("parse", after, before, 1)))
+}
+fn testIsImprovedFrontEndAssist() {
+    let before = stats(2, 2, 2, 6, 0)
+    let after = stats(2, 1, 1, 4, 0)
+    testing.assert(isImproved("frontend", before, after, 1))
+}
+fn testIsImprovedDefaultsToAuto() {
+    let before = stats(0, 0, 5, 5, 0)
+    let after = stats(0, 0, 2, 2, 0)
+    testing.assert(isImproved("auto", before, after, 1))
+    testing.assert(isImproved("unknown", before, after, 1))
+}
+fn testIsAcceptedNoEditsNoSkipsShortCircuit() {
+    let before = stats(1, 1, 1, 3, 0)
+    let after = stats(5, 5, 5, 15, 0)
+    // Edits 0 + skipped 0 → unconditionally accepted even though
+    // the after counts are catastrophically worse.
+    testing.assert(isAccepted("auto", before, after, 0, 0))
+}
+fn testIsAcceptedRewriteModeAlwaysAccepts() {
+    let before = stats(1, 1, 1, 3, 0)
+    let after = stats(5, 5, 5, 15, 0)
+    testing.assert(isAccepted("rewrite", before, after, 1, 0))
+}
+fn testIsAcceptedNonRegressingAllowed() {
+    let s = stats(1, 1, 1, 3, 0)
+    testing.assert(isAccepted("auto", s, s, 1, 0))
+    testing.assert(isAccepted("parse", s, s, 1, 0))
+    testing.assert(isAccepted("frontend", s, s, 1, 0))
+}
+fn testIsAcceptedRejectsRegression() {
+    let before = stats(1, 1, 1, 3, 0)
+    let after = stats(2, 1, 1, 4, 0)
+    testing.assert(!(isAccepted("auto", before, after, 1, 0)))
+    testing.assert(!(isAccepted("parse", before, after, 1, 0)))
+}
+fn testExplainAcceptedAlreadyClean() {
+    let s = stats(0, 0, 0, 0, 0)
+    testing.assertEq(explainAcceptedReason("auto", s, s, 0, false), "already_clean")
+    testing.assertEq(explainAcceptedReason("auto", s, s, 0, true), "already_clean")
+}
+fn testExplainAcceptedParseDrop() {
+    let before = stats(3, 1, 1, 5, 0)
+    let after = stats(1, 1, 1, 3, 0)
+    testing.assertEq(explainAcceptedReason("auto", before, after, 2, true), "parse_errors_reduced")
+}
+fn testExplainAcceptedResolveDrop() {
+    let before = stats(0, 3, 0, 3, 0)
+    let after = stats(0, 1, 0, 1, 0)
+    testing.assertEq(explainAcceptedReason("auto", before, after, 1, true), "resolve_errors_reduced")
+}
+fn testExplainAcceptedCheckDrop() {
+    let before = stats(0, 0, 3, 3, 0)
+    let after = stats(0, 0, 1, 1, 0)
+    testing.assertEq(explainAcceptedReason("auto", before, after, 1, true), "check_errors_reduced")
+}
+fn testExplainAcceptedWarningsOnly() {
+    let before = stats(1, 1, 1, 3, 5)
+    let after = stats(1, 1, 1, 3, 2)
+    testing.assertEq(explainAcceptedReason("auto", before, after, 1, true), "warnings_reduced")
+}
+fn testExplainAcceptedRewriteMode() {
+    let s = stats(1, 1, 1, 3, 0)
+    testing.assertEq(explainAcceptedReason("rewrite", s, s, 1, true), "rewrite_mode_applied")
+}
+fn testExplainAcceptedNonRegressingRewrite() {
+    let s = stats(1, 1, 1, 3, 0)
+    testing.assertEq(explainAcceptedReason("auto", s, s, 1, true), "non_regressing_rewrite_accepted")
+}
+fn testExplainRejectedParseRegression() {
+    let before = stats(1, 1, 1, 3, 0)
+    let after = stats(2, 1, 1, 4, 0)
+    testing.assertEq(explainRejectedReason("auto", before, after), "parse_regression_blocked")
+}
+fn testExplainRejectedResolveOnlyAutoMode() {
+    let before = stats(1, 1, 1, 3, 0)
+    let after = stats(1, 3, 1, 5, 0)
+    testing.assertEq(explainRejectedReason("auto", before, after), "resolve_regression_blocked")
+    // parse mode collapses through to front-end regression blocked.
+    testing.assertEq(explainRejectedReason("parse", before, after), "front_end_regression_blocked")
+}
+fn testExplainRejectedCheckOnlyAutoMode() {
+    let before = stats(1, 1, 1, 3, 0)
+    let after = stats(1, 1, 3, 5, 0)
+    testing.assertEq(explainRejectedReason("auto", before, after), "check_regression_blocked")
+}
+fn testExplainRejectedFrontEndAggregate() {
+    let before = stats(1, 1, 1, 3, 0)
+    let after = stats(1, 2, 2, 5, 0)
+    testing.assertEq(explainRejectedReason("frontend", before, after), "front_end_regression_blocked")
+}
+fn testExplainRejectedWarningRegression() {
+    let before = stats(1, 1, 1, 3, 2)
+    let after = stats(1, 1, 1, 3, 5)
+    testing.assertEq(explainRejectedReason("auto", before, after), "warning_regression_blocked")
+}
+fn testExplainRejectedNoImprovementFallback() {
+    let s = stats(1, 1, 1, 3, 0)
+    testing.assertEq(explainRejectedReason("auto", s, s), "no_improvement")
+}


### PR DESCRIPTION
## Summary

PR #1776의 후속. `internal/airepair/airepair.go`의 4개 mode-dispatch
결정 함수를 `toolchain/airepair_decide.osty`로 이전. 이제 airepair의
accept / reject / explain 정책 **전체**가 toolchain의 single
source-of-truth.

## 이전된 정책 (4 fn)

- `isImproved(mode, before, after, repairChanges) -> Bool` — 모드별
  improvement 판정. rewrite는 changes>0만 보고, parse/frontend는
  `compareXxx > 0`, default는 `compareAutoAssist > 0`
- `isAccepted(mode, before, after, repairChanges, repairSkipped) -> Bool`
  — non-regressing 허용. 단축: `changes=0 && skipped=0`이면 무조건
  accepted, `rewrite` 모드면 edits 있으면 무조건 accepted
- `explainAcceptedReason(mode, before, after, repairChanges, proposed) -> String`
  — 8가지 안정 라벨 (`already_clean` / `parse_errors_reduced` /
  `resolve_errors_reduced` / `check_errors_reduced` /
  `warnings_reduced` / `rewrite_mode_applied` /
  `non_regressing_rewrite_accepted` / `accepted`). JSON 리포트의
  public contract
- `explainRejectedReason(mode, before, after) -> String` — 6가지
  라벨 (`parse_regression_blocked` / `resolve_regression_blocked` /
  `check_regression_blocked` / `front_end_regression_blocked` /
  `warning_regression_blocked` / `no_improvement`)

## 설계 노트

- **Mode 이름 통일**: `toolchain/airepair_flags.osty`의 canonical 모드명
  (`"rewrite"`/`"auto"`/`"parse"`/`"frontend"`)을 그대로 사용. Go `Mode`
  enum은 `type Mode string` 그대로라 `string(mode)` 캐스트 한 번이면
  통과
- **struct 동등성**: Osty 0.5 baseline은 user struct에 Equal derive
  미제공이라 `airepairProbeStatsEqual` private helper로 field-by-field
  비교 명시 (host는 Go의 struct equality `before == after` 사용)

## Go wrapper 축소

```go
func isImproved(mode Mode, before, after ProbeStats, repaired repair.Result) bool {
    return runner.IsImproved(string(mode), statsToRunner(before),
        statsToRunner(after), len(repaired.Changes))
}

func isAccepted(mode Mode, before, after ProbeStats, repaired repair.Result) bool {
    return runner.IsAccepted(string(mode), statsToRunner(before),
        statsToRunner(after), len(repaired.Changes), repaired.Skipped)
}
```

`explainAcceptedReason` / `explainRejectedReason`도 동일 패턴 — 모두
1줄 thin wrapper.

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/airepair/... ./internal/runner/...` —
      pass (6.2s + drift, 19개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run TestAIRepair` — pass
      (3.4s, 모든 모드 경로 + JSON 리포트 검증 포함)
- [x] 24개 신규 unit 테스트 (Osty + Go 양쪽): rewrite mode 분기,
      `no edits + no skips` short-circuit, 8가지 accepted reason,
      6가지 rejected reason, 모드별 분기 차이 (resolve-only auto vs
      parse fallback)

## 이번 세션 누적 (24번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1776 | airepair / cmd/codesdoc / profile 정책-free + format/scaffold/diag/repair/lockfile 광범위 self-host | (기존) |
| (this) | airepair isImproved + isAccepted + explain reasons | 4 fn |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_