### PR TITLE
selfhost mir generator phase 3 fn attrs + entry safepoint

### DIFF
--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -456,6 +456,46 @@ func TestPhase0SelfHostWiringExists(t *testing.T) {
 				// i64 raw lane narrowing as handle.join.
 				"return out + mirEmitNarrowPayloadLine(dest, raw, destLLVM)",
 				"TODO taskGroup dest type",
+				// Phase 3a/3b — function-level attribute string +
+				// param noalias threaded into the `define` header.
+				// `mirEmitFunctionStub` was passing `""` for attrs
+				// even though `mirFormatFnAttrs` was already
+				// implemented; Phase 3a wires A8/A9/A10/A13 through
+				// `mirEmitFnAttrsFromMir`, and Phase 3b extends
+				// `mirEmitParamListJoined` with the `noalias` param
+				// attribute decided by `mirParamIsNoalias`. Loss of
+				// any of these needles would silently regress the
+				// emitter back to attribute-free + alias-able
+				// signatures.
+				"pub fn mirInlineModeDiscriminant(",
+				"mirEmitFnAttrsFromMir(",
+				"mirEmitParamLocalName(",
+				"let attrs = mirEmitFnAttrsFromMir(func)",
+				"mirFunctionDefineHeader(\"\", func.returnType, func.name, paramListJoined, attrs)",
+				"mirParamIsNoalias(ty, nameStr, func.noaliasAll, func.noaliasParams)",
+				"MirInlineNone -> 0",
+				"MirInlineSoft -> 1",
+				"MirInlineAlways -> 2",
+				"MirInlineNever -> 3",
+				// Phase 3c — function-entry GC safepoint. Every
+				// emitted `define` block opens with
+				// `call void @osty.gc.safepoint_v1(i64 <entry-id>,
+				// ptr null, i64 0)` (encoded `1 << 56 =
+				// 72057594037927936` per lir_proto_plan.md Phase 5),
+				// matching the production Go emitter so the GC can
+				// observe entered functions regardless of which MIR
+				// block was tagged as `fn_.entry`. The matching
+				// runtime decl is threaded into
+				// `mirEmitRuntimeDeclarationsSection` via
+				// `mirRuntimeDeclareSafepointV1`. Loss of any of
+				// these needles silently regresses the emit to
+				// safepoint-free bodies that miss the GC observation
+				// window and produce a dangling call.
+				"pub fn mirEntrySafepointIdString(",
+				"pub fn mirEmitEntryGcSafepoint(",
+				"\"72057594037927936\"",
+				"mirEmitEntryGcSafepoint()",
+				"mirRuntimeDeclareSafepointV1()",
 			},
 		},
 		{

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -531,6 +531,20 @@ pub fn mirFormatFnAttrs(inlineMode: Int, hot: Bool, cold: Bool, pureFn: Bool, ta
 // we always prepend `+` after stripping any user-typed `+`.
 // Space-join the parts list. Empty list → "" so caller emits
 // the attribute-free define/declare shape.
+/// mirInlineModeDiscriminant translates a MirInlineMode enum value
+/// into the integer discriminant that `mirFormatFnAttrs` expects:
+/// 0 none / 1 soft / 2 always / 3 never. Mirrors the
+/// `ir.FnDecl.InlineMode` ordering used by the Go-side production
+/// emitter so the LLVM `inlinehint` / `alwaysinline` / `noinline`
+/// translation stays byte-stable across both ports.
+pub fn mirInlineModeDiscriminant(mode: MirInlineMode) -> Int {
+    match mode {
+        MirInlineNone -> 0,
+        MirInlineSoft -> 1,
+        MirInlineAlways -> 2,
+        MirInlineNever -> 3,
+    }
+}
 /// mirLlvmTypeHeadName strips the optional `pkg.` prefix and the
 /// `<...>` argument list from a hirTypeString-style named type
 /// text, returning just the head identifier. For `Map<String, Int>`
@@ -16781,6 +16795,28 @@ pub fn mirGcAllocBytesCallLine(dst: String, size: String) -> String {
 pub fn mirSafepointPollEmitLine(kind: String) -> String {
     "  call void @osty.gc.safepoint_v1(i64 " + kind + ", ptr null, i64 0)\n"
 }
+/// mirEntrySafepointIdString returns the safepoint-id literal for a
+/// function-entry safepoint as a decimal string. The production emit
+/// encodes the kind in the high 8 bits and a per-function serial in
+/// the low 56 bits (see lir_proto_plan.md Phase 5); for an entry
+/// safepoint the kind byte is `1` and the serial starts at `0`, so
+/// the id collapses to `1 << 56 = 72057594037927936`. Hard-coding the
+/// literal keeps the emit byte-stable against
+/// `internal/llvmgen/mir_generator_test.go:3469` which pins the same
+/// value on the Go side.
+pub fn mirEntrySafepointIdString() -> String {
+    "72057594037927936"
+}
+/// mirEmitEntryGcSafepoint renders the function-entry GC safepoint
+/// call that every emitted `define` opens with. Sits at the very
+/// front of the entry block — before parameter-binding copies, alloca
+/// preambles, and any projection stores — so the GC can observe an
+/// entered function regardless of which MIR block was tagged as
+/// `fn_.entry`. Pair with `mirRuntimeDeclareSafepointV1` in the
+/// module's runtime-decls section so the call resolves.
+pub fn mirEmitEntryGcSafepoint() -> String {
+    mirSafepointPollEmitLine(mirEntrySafepointIdString())
+}
 /// mirRegisterFromIntLiteral renders the register text form of a
 /// numeric literal: `<reg>` for non-numeric strings, returns the
 /// integer or float text directly so it can flow into a typed-arg
@@ -17038,9 +17074,11 @@ pub fn mirEmitModule(m: MirModule, opts: MirEmitOpts) -> String {
 /// a body), falls back to the Phase 0 single-`entry:`+stub form.
 fn mirEmitFunctionStub(func: MirFunction) -> String {
     let paramListJoined = mirEmitParamListJoined(func)
-    let mut out = mirFunctionDefineHeader("", func.returnType, func.name, paramListJoined, "")
+    let attrs = mirEmitFnAttrsFromMir(func)
+    let mut out = mirFunctionDefineHeader("", func.returnType, func.name, paramListJoined, attrs)
     if func.blocks.len() == 0 {
         out = out + "entry:\n"
+        out = out + mirEmitEntryGcSafepoint()
         out = out + mirEmitReturnStub(func.returnType)
         return out + mirFunctionDefineFooter()
     }
@@ -17049,6 +17087,7 @@ fn mirEmitFunctionStub(func: MirFunction) -> String {
         let label = mirBlockLabelName(isEntry, mirGenIntToString(block.id))
         out = out + mirBlockHeaderLine(label)
         if isEntry {
+            out = out + mirEmitEntryGcSafepoint()
             out = out + mirEmitParamBindingPrologue(func)
         }
         let mut instrIdx = 0
@@ -17195,10 +17234,39 @@ fn mirEmitParamListJoined(func: MirFunction) -> String {
             out = out + ", "
         }
         let ty = mirEmitParamType(func, paramLocal)
-        out = out + ty + " %p" + mirGenIntToString(i)
+        let nameStr = mirEmitParamLocalName(func, paramLocal)
+        let isNoalias = mirParamIsNoalias(ty, nameStr, func.noaliasAll, func.noaliasParams)
+        let noaliasTag = if isNoalias {
+            " noalias"
+        } else {
+            ""
+        }
+        out = out + ty + noaliasTag + " %p" + mirGenIntToString(i)
         i = i + 1
     }
     out
+}
+/// mirEmitParamLocalName returns the source-level name of the
+/// parameter local, or `""` when the index is out of range. Phase 3b
+/// uses this to feed `mirParamIsNoalias` so per-name `#[noalias(p1,
+/// p2)]` selectors can match against the original Osty parameter
+/// names — the emitted LLVM register stays `%p<i>` either way.
+fn mirEmitParamLocalName(func: MirFunction, paramLocal: Int) -> String {
+    if paramLocal < 0 || paramLocal >= func.locals.len() {
+        return ""
+    }
+    func.locals[paramLocal].name
+}
+/// mirEmitFnAttrsFromMir derives the LLVM function-header attribute
+/// string from a `MirFunction`'s A8/A9/A10/A13 annotation fields and
+/// hands it to `mirFunctionDefineHeader`. Returns `""` when no
+/// attribute applies so the caller emits the attribute-free `define`
+/// shape. Phase 3a wires `#[inline(...)]` / `#[hot]` / `#[cold]` /
+/// `#[pure]` / `#[target_feature]` through this adapter; bodies are
+/// still stubbed at Phase 1+ TODO sites elsewhere in this file.
+fn mirEmitFnAttrsFromMir(func: MirFunction) -> String {
+    let disc = mirInlineModeDiscriminant(func.inlineMode)
+    mirFormatFnAttrs(disc, func.hot, func.cold, func.pure, func.targetFeatures)
 }
 fn mirEmitParamType(func: MirFunction, paramLocal: Int) -> String {
     if paramLocal < 0 || paramLocal >= func.locals.len() {
@@ -18539,6 +18607,7 @@ fn mirEmitStringPredicateIntrinsic(func: MirFunction, instr: MirInstr, runtimeSy
 /// new runtime calls land here in the same PR that adds them.
 pub fn mirEmitRuntimeDeclarationsSection() -> String {
     let mut out = mirModuleSectionDirective("runtime declarations")
+    out = out + mirRuntimeDeclareSafepointV1() + "\n"
     out = out + "declare void @osty_rt_io_write(ptr, i1, i1)\n"
     out = out + "declare void @osty_rt_abort(ptr)\n"
     out = out + "declare void @osty_rt_panic(ptr)\n"


### PR DESCRIPTION
## Summary
- Phase 3a wires `#[inline(...)]` / `#[hot]` / `#[cold]` / `#[pure]` / `#[target_feature]` into the `define` header via `mirEmitFnAttrsFromMir` + `mirInlineModeDiscriminant`.
- Phase 3b threads `noalias` param attribute through `mirEmitParamListJoined` using the existing `mirParamIsNoalias` predicate.
- Phase 3c emits `call void @osty.gc.safepoint_v1(i64 72057594037927936, ptr null, i64 0)` at every define's entry block (matches the Go-side pin per `lir_proto_plan.md` Phase 5). Runtime decl threaded through `mirEmitRuntimeDeclarationsSection` via `mirRuntimeDeclareSafepointV1`.
- Adds 14 structural needles to `TestPhase0SelfHostWiringExists` so a future revert fails the wiring gate.

## Test plan
- [x] `go test ./internal/selfhost/ -run TestPhase0SelfHostWiringExists` 통과
- [x] `osty check toolchain/mir_generator.osty` exit 0
- [x] `just ci` PASS (0 warnings)
- [x] `just vet` 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)