### PR TITLE
refactor: registry sanitizeIndexName self-host (toolchain/registry_policy.osty)

### DIFF
--- a/internal/registry/cache.go
+++ b/internal/registry/cache.go
@@ -2,10 +2,10 @@ package registry
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+
+	"github.com/osty/osty/internal/runner"
 )
 
 // DirIndexCache stores index responses on disk as one JSON file per
@@ -90,25 +90,8 @@ func (c *DirIndexCache) path(name string) string {
 	return filepath.Join(c.Root, sanitizeIndexName(name)+".json")
 }
 
-// sanitizeIndexName produces a filesystem-safe stem from a crate
-// name. Crate names per the manifest validator are restricted to
-// `[A-Za-z0-9_-]`, but defensive sanitization keeps a malicious or
-// future-permissive registry from writing outside Root.
+// sanitizeIndexName delegates to toolchain/registry_policy.osty.
+// Policy lives there; this wrapper just bridges the call.
 func sanitizeIndexName(name string) string {
-	var b strings.Builder
-	for _, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z',
-			r >= 'A' && r <= 'Z',
-			r >= '0' && r <= '9',
-			r == '-' || r == '_' || r == '.':
-			b.WriteRune(r)
-		default:
-			fmt.Fprintf(&b, "_%x", r)
-		}
-	}
-	if b.Len() == 0 {
-		return "_empty"
-	}
-	return b.String()
+	return runner.SanitizeIndexName(name)
 }

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -49,6 +49,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"profile_features.osty",
 		"profile_flags.osty",
 		"profile_pragma.osty",
+		"registry_policy.osty",
 		"repair_policy.osty",
 		"diag_policy.osty",
 		"test_runner.osty",

--- a/internal/runner/registry_policy.go
+++ b/internal/runner/registry_policy.go
@@ -1,0 +1,39 @@
+// registry_policy.go is the Go snapshot of
+// toolchain/registry_policy.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import "fmt"
+
+// SanitizeIndexName lowercases-hex-escapes every char that isn't
+// in the safe alphabet (`[A-Za-z0-9._-]`). Empty input collapses
+// to `"_empty"`.
+//
+// Unicode chars become `_<lowercase-hex-codepoint>` — the result
+// stays ASCII regardless of input.
+//
+// Osty: toolchain/registry_policy.osty:27
+func SanitizeIndexName(name string) string {
+	out := make([]byte, 0, len(name))
+	for _, r := range name {
+		if registrySafeRune(r) {
+			// ASCII safe runes are 1 byte each; non-ASCII can't be
+			// safe per the alphabet so they never reach this branch.
+			out = append(out, byte(r))
+			continue
+		}
+		out = append(out, '_')
+		out = append(out, []byte(fmt.Sprintf("%x", r))...)
+	}
+	if len(out) == 0 {
+		return "_empty"
+	}
+	return string(out)
+}
+
+func registrySafeRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9') ||
+		r == '-' || r == '_' || r == '.'
+}

--- a/internal/runner/registry_policy_test.go
+++ b/internal/runner/registry_policy_test.go
@@ -1,0 +1,35 @@
+package runner
+
+import "testing"
+
+func TestSanitizeIndexName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"all-safe-lower", "serde", "serde"},
+		{"hyphen", "json-ext", "json-ext"},
+		{"underscore", "my_lib", "my_lib"},
+		{"dot", "serde.json", "serde.json"},
+		{"digits", "abc123", "abc123"},
+		{"camel-case", "CamelCase", "CamelCase"},
+		{"empty-collapses", "", "_empty"},
+		{"slash-escaped", "a/b", "a_2fb"},
+		{"space-escaped", "hello world", "hello_20world"},
+		{"colon", "foo:bar", "foo_3abar"},
+		{"at-sign", "a@b", "a_40b"},
+		{"parens", "a()", "a_28_29"},
+		{"korean", "한글", "_d55c_ae00"},
+		{"mixed-ascii-unicode", "a한b", "a_d55cb"},
+		{"existing-underscore-not-doubled", "a_b/c", "a_b_2fc"},
+		{"only-unsafe", "//", "_2f_2f"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := SanitizeIndexName(c.in); got != c.want {
+				t.Errorf("SanitizeIndexName(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/registry_policy.osty
+++ b/toolchain/registry_policy.osty
@@ -1,0 +1,74 @@
+/// Pure registry-client/server policy. Host code in
+/// `internal/registry` owns network/filesystem I/O; this module
+/// decides the small naming/sanitization rules that make registry
+/// state filesystem-safe.
+///
+/// Currently exposed:
+///
+///   - `sanitizeIndexName`: produces a filesystem-safe stem from
+///     a crate name. Crate names per the manifest validator are
+///     restricted to `[A-Za-z0-9_-]`, but defensive sanitization
+///     keeps a malicious or future-permissive registry from
+///     writing index entries outside the cache root.
+///
+/// Mirrored by `internal/runner/registry_policy.go`. The drift
+/// test under internal/runner keeps the two in sync — the Osty
+/// file is the source of truth at review time.
+use std.strings as strings
+/// sanitizeIndexName lowercases-hex-escapes every char that isn't
+/// in the safe alphabet (`[A-Za-z0-9._-]`). Empty input collapses
+/// to `"_empty"` so `os.Stat(path + "")` never operates on the
+/// cache directory itself.
+///
+/// Unicode chars become `_<lowercase-hex-codepoint>` — the result
+/// stays ASCII regardless of the input alphabet.
+pub fn sanitizeIndexName(name: String) -> String {
+    let chars = name.chars()
+    let mut out: List<String> = []
+    for c in chars {
+        if registrySafeChar(c) {
+            out.push(c.toString())
+        } else {
+            out.push("_")
+            out.push(registryLowerHex(c.toInt()))
+        }
+    }
+    if out.len() == 0 {
+        return "_empty"
+    }
+    strings.join(out, "")
+}
+/// registrySafeChar matches the filesystem alphabet
+/// `[A-Za-z0-9._-]`. Dot is allowed because crate names like
+/// `serde.json` aren't in the manifest validator's regex but the
+/// cache shouldn't blow up on them either.
+fn registrySafeChar(c: Char) -> Bool {
+    (c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= '0' && c <= '9') ||
+        c == '-' || c == '_' || c == '.'
+}
+/// registryLowerHex renders `n` (a Unicode codepoint, always
+/// non-negative when reached from `Char.toInt()`) as a
+/// lowercase-hex string with no leading `0x` and no padding. `0`
+/// renders as `"0"` so the output is never empty.
+fn registryLowerHex(n: Int) -> String {
+    if n == 0 {
+        return "0"
+    }
+    let alphabet = "0123456789abcdef"
+    let mut digits: List<String> = []
+    let mut x = n
+    for x > 0 {
+        let d = x % 16
+        digits.push(strings.slice(alphabet, d, d + 1))
+        x = x / 16
+    }
+    let mut out = ""
+    let mut i = digits.len() - 1
+    for i >= 0 {
+        out = out + digits[i]
+        i = i - 1
+    }
+    out
+}

--- a/toolchain/registry_policy_test.osty
+++ b/toolchain/registry_policy_test.osty
@@ -1,0 +1,43 @@
+use std.testing
+fn testSanitizeIndexNameAllSafe() {
+    testing.assertEq(sanitizeIndexName("serde"), "serde")
+    testing.assertEq(sanitizeIndexName("json-ext"), "json-ext")
+    testing.assertEq(sanitizeIndexName("my_lib"), "my_lib")
+    testing.assertEq(sanitizeIndexName("serde.json"), "serde.json")
+    testing.assertEq(sanitizeIndexName("abc123"), "abc123")
+}
+fn testSanitizeIndexNameUppercasePreserved() {
+    testing.assertEq(sanitizeIndexName("CamelCase"), "CamelCase")
+}
+fn testSanitizeIndexNameEmptyCollapses() {
+    testing.assertEq(sanitizeIndexName(""), "_empty")
+}
+fn testSanitizeIndexNameSlashesEscaped() {
+    // `/` is not in the safe alphabet — codepoint 0x2F → "_2f".
+    testing.assertEq(sanitizeIndexName("a/b"), "a_2fb")
+}
+fn testSanitizeIndexNameSpacesEscaped() {
+    // Space = 0x20 → "_20".
+    testing.assertEq(sanitizeIndexName("hello world"), "hello_20world")
+}
+fn testSanitizeIndexNameSpecialChars() {
+    // `:` = 0x3a, `@` = 0x40, `(` = 0x28, `)` = 0x29
+    testing.assertEq(sanitizeIndexName("foo:bar"), "foo_3abar")
+    testing.assertEq(sanitizeIndexName("a@b"), "a_40b")
+    testing.assertEq(sanitizeIndexName("a()"), "a_28_29")
+}
+fn testSanitizeIndexNameUnicodeEscaped() {
+    // `한` = U+D55C, hex `d55c`. `글` = U+AE00, hex `ae00`.
+    testing.assertEq(sanitizeIndexName("한글"), "_d55c_ae00")
+    // Mixed: ASCII pieces stay, Unicode chars escape.
+    testing.assertEq(sanitizeIndexName("a한b"), "a_d55cb")
+}
+fn testSanitizeIndexNameDoesNotDuplicateUnderscore() {
+    // Existing underscore is safe; non-safe chars become `_<hex>` —
+    // they don't get doubly-escaped.
+    testing.assertEq(sanitizeIndexName("a_b/c"), "a_b_2fc")
+}
+fn testSanitizeIndexNameOnlyUnsafe() {
+    // All chars are unsafe → result is purely hex escapes.
+    testing.assertEq(sanitizeIndexName("//"), "_2f_2f")
+}


### PR DESCRIPTION
## Summary

`internal/registry/cache.go`의 파일명 sanitization 정책을 새
`toolchain/registry_policy.osty`로 이전. registry 영역의 첫 self-host
진입.

## 이전된 정책 (1 fn)

`sanitizeIndexName(name) -> String` — 크레이트 이름을 filesystem-safe
stem으로 변환:

- 안전 알파벳 `[A-Za-z0-9._-]`은 통과
- 나머지는 `_<lowercase-hex-codepoint>` 형태로 escape
  (예: `/` → `_2f`, `한` → `_d55c`)
- 빈 입력은 `"_empty"`로 collapse (`os.Stat` 호출 시 cache root 자체를
  건드리지 않도록)

## 설계 노트

Osty 측은 stdlib에 `fmt.Sprintf("%x", n)` 동치가 없어 직접 base-16
인코더 구현:

```osty
fn registryLowerHex(n: Int) -> String {
    if n == 0 { return "0" }
    let alphabet = "0123456789abcdef"
    let mut digits: List<String> = []
    let mut x = n
    for x > 0 {
        digits.push(strings.slice(alphabet, x % 16, x % 16 + 1))
        x = x / 16
    }
    // reverse + join
    ...
}
```

Go wrapper는 1줄 `runner.SanitizeIndexName` 호출. `fmt` import도 제거.

## Test plan

- [x] `.bin/osty check toolchain` — 0 진단
- [x] `go test -count=1 ./internal/registry/... ./internal/runner/...` —
      pass (drift 포함, 20개 ostySources)
- [x] `go test -count=1 -short ./cmd/osty/ -run
      'TestRegistry|TestPublish|TestAdd|TestUpdate|TestSearch'` — pass
- [x] 17개 Osty/Go 유닛 테스트: all-safe / hyphen / underscore / dot /
      camel-case / digits / empty-collapses / slash / space / colon /
      @-sign / parens / korean / mixed-ascii-unicode /
      existing-underscore-not-doubled / only-unsafe

## 이번 세션 누적 (24번째 PR)

| PR | 영역 | self-host 항목 |
|---|---|---|
| #1751–#1777 | airepair / cmd/codesdoc / profile 정책-free 전 영역 self-host | (기존) |
| (this) | registry sanitizeIndexName | 1 fn |

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_