### PR TITLE
refactor: airepair Python colon-header 리라이터 self-host (toolchain/airepair_python.osty)

### DIFF
--- a/internal/airepair/diagnostic.go
+++ b/internal/airepair/diagnostic.go
@@ -195,130 +195,21 @@ func writePythonClosings(out *strings.Builder, closings []pythonBlockScope, incl
 	}
 }
 
+// rewritePythonColonHeader bridges to runner.RewritePythonColonHeader
+// (mirror of toolchain/airepair_python.osty). The struct/enum shape
+// here stays package-local — runner's snapshot owns the recogniser
+// rules.
 func rewritePythonColonHeader(trimmed string) (pythonColonHeader, bool) {
-	if strings.HasSuffix(trimmed, "->") {
-		head := strings.TrimSpace(strings.TrimSuffix(trimmed, "->"))
-		if head == "" {
-			return pythonColonHeader{}, false
-		}
-		return pythonColonHeader{
-			rewritten:     head + " -> {",
-			changeKind:    "python_arrow_arm_block",
-			message:       "wrap a multiline match arm body in Osty braces",
-			scopeKind:     pythonScopeMatchArm,
-			requiresMatch: true,
-		}, true
-	}
-	if !strings.HasSuffix(trimmed, ":") {
+	r := runner.RewritePythonColonHeader(trimmed)
+	if !r.Ok {
 		return pythonColonHeader{}, false
 	}
-	head := strings.TrimSpace(strings.TrimSuffix(trimmed, ":"))
-	switch {
-	case head == "else":
-		return pythonColonHeader{
-			rewritten:  "else {",
-			changeKind: "python_else_block",
-			message:    "replace Python-style `else:` block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-			elseish:    true,
-		}, true
-	case strings.HasPrefix(head, "elif "):
-		return pythonColonHeader{
-			rewritten:  "else if " + strings.TrimPrefix(head, "elif ") + " {",
-			changeKind: "python_elif_block",
-			message:    "replace Python-style `elif:` block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-			elseish:    true,
-		}, true
-	case strings.HasPrefix(head, "elseif "):
-		return pythonColonHeader{
-			rewritten:  "else if " + strings.TrimPrefix(head, "elseif ") + " {",
-			changeKind: "python_elif_block",
-			message:    "replace alternate `elseif:` block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-			elseish:    true,
-		}, true
-	case strings.HasPrefix(head, "else if "):
-		return pythonColonHeader{
-			rewritten:  head + " {",
-			changeKind: "python_else_if_block",
-			message:    "replace Python-style `else if:` block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-			elseish:    true,
-		}, true
-	case strings.HasPrefix(head, "if "):
-		return pythonColonHeader{
-			rewritten:  head + " {",
-			changeKind: "python_if_block",
-			message:    "replace Python-style `if:` block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-		}, true
-	case strings.HasPrefix(head, "for "):
-		return pythonColonHeader{
-			rewritten:  head + " {",
-			changeKind: "python_for_block",
-			message:    "replace Python-style `for:` block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-		}, true
-	case strings.HasPrefix(head, "while "):
-		return pythonColonHeader{
-			rewritten:  "for " + strings.TrimPrefix(head, "while ") + " {",
-			changeKind: "python_while_block",
-			message:    "replace Python-style `while:` block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-		}, true
-	case strings.HasPrefix(head, "match "):
-		return pythonColonHeader{
-			rewritten:  head + " {",
-			changeKind: "python_match_block",
-			message:    "replace Python-style `match:` block with Osty braces",
-			scopeKind:  pythonScopeMatch,
-		}, true
-	case strings.HasPrefix(head, "case "):
-		return pythonColonHeader{
-			rewritten:     strings.TrimPrefix(head, "case ") + " -> {",
-			changeKind:    "python_case_arm",
-			message:       "replace Python-style `case:` arm with Osty match syntax",
-			scopeKind:     pythonScopeMatchArm,
-			requiresMatch: true,
-		}, true
-	case head == "default":
-		return pythonColonHeader{
-			rewritten:     "_ -> {",
-			changeKind:    "python_default_arm",
-			message:       "replace Python-style `default:` arm with Osty match syntax",
-			scopeKind:     pythonScopeMatchArm,
-			requiresMatch: true,
-		}, true
-	case strings.HasPrefix(head, "fn "):
-		return pythonColonHeader{
-			rewritten:  head + " {",
-			changeKind: "python_fn_block",
-			message:    "replace Python-style function block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-		}, true
-	case strings.HasPrefix(head, "pub fn "):
-		return pythonColonHeader{
-			rewritten:  head + " {",
-			changeKind: "python_fn_block",
-			message:    "replace Python-style function block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-		}, true
-	case strings.HasPrefix(head, "struct "):
-		return pythonColonHeader{
-			rewritten:  head + " {",
-			changeKind: "python_struct_block",
-			message:    "replace Python-style struct block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-		}, true
-	case strings.HasPrefix(head, "interface "):
-		return pythonColonHeader{
-			rewritten:  head + " {",
-			changeKind: "python_interface_block",
-			message:    "replace Python-style interface block with Osty braces",
-			scopeKind:  pythonScopeBlock,
-		}, true
-	default:
-		return pythonColonHeader{}, false
-	}
+	return pythonColonHeader{
+		rewritten:     r.Rewritten,
+		changeKind:    r.ChangeKind,
+		message:       r.Message,
+		scopeKind:     pythonScopeKind(r.ScopeKind),
+		elseish:       r.Elseish,
+		requiresMatch: r.RequiresMatch,
+	}, true
 }

--- a/internal/runner/airepair_python_policy.go
+++ b/internal/runner/airepair_python_policy.go
@@ -1,0 +1,169 @@
+// airepair_python_policy.go is the Go snapshot of
+// toolchain/airepair_python.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import "strings"
+
+// PythonScopeKind enumerates the three scope variants the
+// rewriter threads through its stack. Encoded as int (with named
+// constants instead of a dedicated type) so the host can mirror
+// them as their iota analogue without a wire-format translation
+// step.
+//
+// Osty: toolchain/airepair_python.osty:32
+const (
+	PythonScopeBlock    = 0
+	PythonScopeMatch    = 1
+	PythonScopeMatchArm = 2
+)
+
+// PythonColonHeader mirrors toolchain/airepair_python.osty's
+// PythonColonHeader — the structured outcome of recognising a
+// Python-style block header. Ok == false leaves all the string
+// fields empty.
+//
+// Osty: toolchain/airepair_python.osty:49
+type PythonColonHeader struct {
+	Rewritten     string
+	ChangeKind    string
+	Message       string
+	ScopeKind     int
+	Elseish       bool
+	RequiresMatch bool
+	Ok            bool
+}
+
+// RewritePythonColonHeader classifies a single trimmed line as
+// one of 12 recognised Python-block headers. Returns
+// {Ok: false} when no rule matches; the host falls back to
+// emitting the line verbatim.
+//
+// Osty: toolchain/airepair_python.osty:62
+func RewritePythonColonHeader(trimmed string) PythonColonHeader {
+	if strings.HasSuffix(trimmed, "->") {
+		head := strings.TrimSpace(strings.TrimSuffix(trimmed, "->"))
+		if head == "" {
+			return airepairPyColonNone()
+		}
+		return PythonColonHeader{
+			Rewritten:     head + " -> {",
+			ChangeKind:    "python_arrow_arm_block",
+			Message:       "wrap a multiline match arm body in Osty braces",
+			ScopeKind:     PythonScopeMatchArm,
+			Elseish:       false,
+			RequiresMatch: true,
+			Ok:            true,
+		}
+	}
+	if !strings.HasSuffix(trimmed, ":") {
+		return airepairPyColonNone()
+	}
+	head := strings.TrimSpace(strings.TrimSuffix(trimmed, ":"))
+	if head == "else" {
+		return airepairPyColonBlock("else {", "python_else_block",
+			"replace Python-style `else:` block with Osty braces", true)
+	}
+	if strings.HasPrefix(head, "elif ") {
+		rest := strings.TrimPrefix(head, "elif ")
+		return airepairPyColonBlock("else if "+rest+" {", "python_elif_block",
+			"replace Python-style `elif:` block with Osty braces", true)
+	}
+	if strings.HasPrefix(head, "elseif ") {
+		rest := strings.TrimPrefix(head, "elseif ")
+		return airepairPyColonBlock("else if "+rest+" {", "python_elif_block",
+			"replace alternate `elseif:` block with Osty braces", true)
+	}
+	if strings.HasPrefix(head, "else if ") {
+		return airepairPyColonBlock(head+" {", "python_else_if_block",
+			"replace Python-style `else if:` block with Osty braces", true)
+	}
+	if strings.HasPrefix(head, "if ") {
+		return airepairPyColonBlock(head+" {", "python_if_block",
+			"replace Python-style `if:` block with Osty braces", false)
+	}
+	if strings.HasPrefix(head, "for ") {
+		return airepairPyColonBlock(head+" {", "python_for_block",
+			"replace Python-style `for:` block with Osty braces", false)
+	}
+	if strings.HasPrefix(head, "while ") {
+		rest := strings.TrimPrefix(head, "while ")
+		return airepairPyColonBlock("for "+rest+" {", "python_while_block",
+			"replace Python-style `while:` block with Osty braces", false)
+	}
+	if strings.HasPrefix(head, "match ") {
+		return PythonColonHeader{
+			Rewritten:     head + " {",
+			ChangeKind:    "python_match_block",
+			Message:       "replace Python-style `match:` block with Osty braces",
+			ScopeKind:     PythonScopeMatch,
+			Elseish:       false,
+			RequiresMatch: false,
+			Ok:            true,
+		}
+	}
+	if strings.HasPrefix(head, "case ") {
+		rest := strings.TrimPrefix(head, "case ")
+		return PythonColonHeader{
+			Rewritten:     rest + " -> {",
+			ChangeKind:    "python_case_arm",
+			Message:       "replace Python-style `case:` arm with Osty match syntax",
+			ScopeKind:     PythonScopeMatchArm,
+			Elseish:       false,
+			RequiresMatch: true,
+			Ok:            true,
+		}
+	}
+	if head == "default" {
+		return PythonColonHeader{
+			Rewritten:     "_ -> {",
+			ChangeKind:    "python_default_arm",
+			Message:       "replace Python-style `default:` arm with Osty match syntax",
+			ScopeKind:     PythonScopeMatchArm,
+			Elseish:       false,
+			RequiresMatch: true,
+			Ok:            true,
+		}
+	}
+	if strings.HasPrefix(head, "fn ") {
+		return airepairPyColonBlock(head+" {", "python_fn_block",
+			"replace Python-style function block with Osty braces", false)
+	}
+	if strings.HasPrefix(head, "pub fn ") {
+		return airepairPyColonBlock(head+" {", "python_fn_block",
+			"replace Python-style function block with Osty braces", false)
+	}
+	if strings.HasPrefix(head, "struct ") {
+		return airepairPyColonBlock(head+" {", "python_struct_block",
+			"replace Python-style struct block with Osty braces", false)
+	}
+	if strings.HasPrefix(head, "interface ") {
+		return airepairPyColonBlock(head+" {", "python_interface_block",
+			"replace Python-style interface block with Osty braces", false)
+	}
+	return airepairPyColonNone()
+}
+
+func airepairPyColonBlock(rewritten, changeKind, message string, elseish bool) PythonColonHeader {
+	return PythonColonHeader{
+		Rewritten:     rewritten,
+		ChangeKind:    changeKind,
+		Message:       message,
+		ScopeKind:     PythonScopeBlock,
+		Elseish:       elseish,
+		RequiresMatch: false,
+		Ok:            true,
+	}
+}
+
+func airepairPyColonNone() PythonColonHeader {
+	return PythonColonHeader{
+		Rewritten:     "",
+		ChangeKind:    "",
+		Message:       "",
+		ScopeKind:     PythonScopeBlock,
+		Elseish:       false,
+		RequiresMatch: false,
+		Ok:            false,
+	}
+}

--- a/internal/runner/airepair_python_policy_test.go
+++ b/internal/runner/airepair_python_policy_test.go
@@ -1,0 +1,190 @@
+package runner
+
+import "testing"
+
+func TestRewritePythonColonHeader(t *testing.T) {
+	cases := []struct {
+		name          string
+		in            string
+		wantOk        bool
+		wantRewritten string
+		wantChange    string
+		wantScope     int
+		wantElseish   bool
+		wantRequires  bool
+	}{
+		{
+			name:          "arrow-arm",
+			in:            "Foo(x) ->",
+			wantOk:        true,
+			wantRewritten: "Foo(x) -> {",
+			wantChange:    "python_arrow_arm_block",
+			wantScope:     PythonScopeMatchArm,
+			wantRequires:  true,
+		},
+		{
+			name:   "arrow-empty-rejected",
+			in:     "->",
+			wantOk: false,
+		},
+		{
+			name:          "else",
+			in:            "else:",
+			wantOk:        true,
+			wantRewritten: "else {",
+			wantChange:    "python_else_block",
+			wantScope:     PythonScopeBlock,
+			wantElseish:   true,
+		},
+		{
+			name:          "elif",
+			in:            "elif x > 0:",
+			wantOk:        true,
+			wantRewritten: "else if x > 0 {",
+			wantChange:    "python_elif_block",
+			wantScope:     PythonScopeBlock,
+			wantElseish:   true,
+		},
+		{
+			name:          "elseif",
+			in:            "elseif n == 0:",
+			wantOk:        true,
+			wantRewritten: "else if n == 0 {",
+			wantChange:    "python_elif_block",
+			wantScope:     PythonScopeBlock,
+			wantElseish:   true,
+		},
+		{
+			name:          "else-if",
+			in:            "else if y < 0:",
+			wantOk:        true,
+			wantRewritten: "else if y < 0 {",
+			wantChange:    "python_else_if_block",
+			wantScope:     PythonScopeBlock,
+			wantElseish:   true,
+		},
+		{
+			name:          "if",
+			in:            "if cond:",
+			wantOk:        true,
+			wantRewritten: "if cond {",
+			wantChange:    "python_if_block",
+			wantScope:     PythonScopeBlock,
+		},
+		{
+			name:          "for",
+			in:            "for x in xs:",
+			wantOk:        true,
+			wantRewritten: "for x in xs {",
+			wantChange:    "python_for_block",
+			wantScope:     PythonScopeBlock,
+		},
+		{
+			name:          "while",
+			in:            "while n > 0:",
+			wantOk:        true,
+			wantRewritten: "for n > 0 {",
+			wantChange:    "python_while_block",
+			wantScope:     PythonScopeBlock,
+		},
+		{
+			name:          "match",
+			in:            "match value:",
+			wantOk:        true,
+			wantRewritten: "match value {",
+			wantChange:    "python_match_block",
+			wantScope:     PythonScopeMatch,
+		},
+		{
+			name:          "case",
+			in:            "case Foo(x):",
+			wantOk:        true,
+			wantRewritten: "Foo(x) -> {",
+			wantChange:    "python_case_arm",
+			wantScope:     PythonScopeMatchArm,
+			wantRequires:  true,
+		},
+		{
+			name:          "default",
+			in:            "default:",
+			wantOk:        true,
+			wantRewritten: "_ -> {",
+			wantChange:    "python_default_arm",
+			wantScope:     PythonScopeMatchArm,
+			wantRequires:  true,
+		},
+		{
+			name:          "fn",
+			in:            "fn foo() -> Int:",
+			wantOk:        true,
+			wantRewritten: "fn foo() -> Int {",
+			wantChange:    "python_fn_block",
+			wantScope:     PythonScopeBlock,
+		},
+		{
+			name:          "pub-fn",
+			in:            "pub fn bar() -> String:",
+			wantOk:        true,
+			wantRewritten: "pub fn bar() -> String {",
+			wantChange:    "python_fn_block",
+			wantScope:     PythonScopeBlock,
+		},
+		{
+			name:          "struct",
+			in:            "struct Point:",
+			wantOk:        true,
+			wantRewritten: "struct Point {",
+			wantChange:    "python_struct_block",
+			wantScope:     PythonScopeBlock,
+		},
+		{
+			name:          "interface",
+			in:            "interface Reader:",
+			wantOk:        true,
+			wantRewritten: "interface Reader {",
+			wantChange:    "python_interface_block",
+			wantScope:     PythonScopeBlock,
+		},
+		{
+			name:   "no-colon-rejected",
+			in:     "if cond",
+			wantOk: false,
+		},
+		{
+			name:   "bare-colon-rejected",
+			in:     ":",
+			wantOk: false,
+		},
+		{
+			name:   "unknown-prefix",
+			in:     "randomToken:",
+			wantOk: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewritePythonColonHeader(c.in)
+			if got.Ok != c.wantOk {
+				t.Fatalf("Ok = %v, want %v", got.Ok, c.wantOk)
+			}
+			if !c.wantOk {
+				return
+			}
+			if got.Rewritten != c.wantRewritten {
+				t.Errorf("Rewritten = %q, want %q", got.Rewritten, c.wantRewritten)
+			}
+			if got.ChangeKind != c.wantChange {
+				t.Errorf("ChangeKind = %q, want %q", got.ChangeKind, c.wantChange)
+			}
+			if got.ScopeKind != c.wantScope {
+				t.Errorf("ScopeKind = %d, want %d", got.ScopeKind, c.wantScope)
+			}
+			if got.Elseish != c.wantElseish {
+				t.Errorf("Elseish = %v, want %v", got.Elseish, c.wantElseish)
+			}
+			if got.RequiresMatch != c.wantRequires {
+				t.Errorf("RequiresMatch = %v, want %v", got.RequiresMatch, c.wantRequires)
+			}
+		})
+	}
+}

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -39,6 +39,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"runner.osty",
 		"airepair_decide.osty",
 		"airepair_flags.osty",
+		"airepair_python.osty",
 		"airepair_rewrite.osty",
 		"airepair_source.osty",
 		"codesdoc_policy.osty",

--- a/toolchain/airepair_python.osty
+++ b/toolchain/airepair_python.osty
@@ -1,0 +1,192 @@
+/// Pure Python-style colon-block header rewriter for the
+/// `osty airepair` semantic pass. Host code in
+/// `internal/airepair/diagnostic.go` owns the per-line scan + stack
+/// management; this module decides:
+///
+///   - the canonical `scopeKind` enum values (Block / Match /
+///     MatchArm) callers thread through the stack,
+///   - how a single trimmed line maps to its rewritten form,
+///     change kind, and scope kind (or `ok = false` when the line
+///     is not a recognised Python colon header).
+///
+/// 12 patterns recognised, in source order:
+///
+///   1. `expr ->` — multi-line match-arm body (trailing arrow).
+///   2. `else:`              7. `for X:`
+///   3. `elif X:`            8. `while X:`
+///   4. `elseif X:`          9. `match X:`
+///   5. `else if X:`        10. `case X:`
+///   6. `if X:`             11. `default:`
+///                         12. function-shaped headers
+///                             (`fn`/`pub fn`/`struct`/`interface`)
+///
+/// Mirrored by `internal/runner/airepair_python_policy.go`. The
+/// drift test under internal/runner keeps the two in sync — the
+/// Osty file is the source of truth at review time.
+use std.strings as strings
+/// pythonScopeBlock / pythonScopeMatch / pythonScopeMatchArm are
+/// the scope kinds the rewriter threads through the stack.
+/// Encoded as `Int` (with explicit constants instead of a
+/// dedicated enum type) so the host can mirror them as their
+/// `iota` analogue without a wire-format translation step.
+pub let pythonScopeBlock: Int = 0
+pub let pythonScopeMatch: Int = 1
+pub let pythonScopeMatchArm: Int = 2
+/// PythonColonHeader is the structured outcome of recognising a
+/// Python-style block header. `ok == false` leaves all the
+/// string fields empty.
+///
+///   - `rewritten`: the substituted Osty form (with leading
+///     indent stripped — caller adds it back).
+///   - `changeKind`: stable identifier for the rewrite that lands
+///     in the diag (`python_else_block` etc.).
+///   - `message`: human-readable rewrite description.
+///   - `scopeKind`: which scope to push onto the rewriter's stack.
+///   - `elseish`: continuation header that consumes a closing
+///     brace from the enclosing scope (`else`/`elif`/`else if`).
+///   - `requiresMatch`: arm header that's only valid inside a
+///     `match` scope (case/default/arrow).
+pub struct PythonColonHeader {
+    pub rewritten: String,
+    pub changeKind: String,
+    pub message: String,
+    pub scopeKind: Int,
+    pub elseish: Bool,
+    pub requiresMatch: Bool,
+    pub ok: Bool,
+}
+/// rewritePythonColonHeader classifies a single trimmed line as
+/// one of 12 recognised Python-block headers. Returns
+/// `{ok = false}` when no rule matches; the host falls back to
+/// emitting the line verbatim.
+pub fn rewritePythonColonHeader(trimmed: String) -> PythonColonHeader {
+    if strings.hasSuffix(trimmed, "->") {
+        let head = strings.trimSpace(strings.trimSuffix(trimmed, "->"))
+        if head == "" {
+            return airepairPyColonNone()
+        }
+        return PythonColonHeader {
+            rewritten: head + " -> \{",
+            changeKind: "python_arrow_arm_block",
+            message: "wrap a multiline match arm body in Osty braces",
+            scopeKind: pythonScopeMatchArm,
+            elseish: false,
+            requiresMatch: true,
+            ok: true,
+        }
+    }
+    if !strings.hasSuffix(trimmed, ":") {
+        return airepairPyColonNone()
+    }
+    let head = strings.trimSpace(strings.trimSuffix(trimmed, ":"))
+    if head == "else" {
+        return airepairPyColonBlock("else \{", "python_else_block",
+            "replace Python-style `else:` block with Osty braces", true)
+    }
+    if strings.hasPrefix(head, "elif ") {
+        let rest = strings.trimPrefix(head, "elif ")
+        return airepairPyColonBlock("else if " + rest + " \{", "python_elif_block",
+            "replace Python-style `elif:` block with Osty braces", true)
+    }
+    if strings.hasPrefix(head, "elseif ") {
+        let rest = strings.trimPrefix(head, "elseif ")
+        return airepairPyColonBlock("else if " + rest + " \{", "python_elif_block",
+            "replace alternate `elseif:` block with Osty braces", true)
+    }
+    if strings.hasPrefix(head, "else if ") {
+        return airepairPyColonBlock(head + " \{", "python_else_if_block",
+            "replace Python-style `else if:` block with Osty braces", true)
+    }
+    if strings.hasPrefix(head, "if ") {
+        return airepairPyColonBlock(head + " \{", "python_if_block",
+            "replace Python-style `if:` block with Osty braces", false)
+    }
+    if strings.hasPrefix(head, "for ") {
+        return airepairPyColonBlock(head + " \{", "python_for_block",
+            "replace Python-style `for:` block with Osty braces", false)
+    }
+    if strings.hasPrefix(head, "while ") {
+        let rest = strings.trimPrefix(head, "while ")
+        return airepairPyColonBlock("for " + rest + " \{", "python_while_block",
+            "replace Python-style `while:` block with Osty braces", false)
+    }
+    if strings.hasPrefix(head, "match ") {
+        return PythonColonHeader {
+            rewritten: head + " \{",
+            changeKind: "python_match_block",
+            message: "replace Python-style `match:` block with Osty braces",
+            scopeKind: pythonScopeMatch,
+            elseish: false,
+            requiresMatch: false,
+            ok: true,
+        }
+    }
+    if strings.hasPrefix(head, "case ") {
+        let rest = strings.trimPrefix(head, "case ")
+        return PythonColonHeader {
+            rewritten: rest + " -> \{",
+            changeKind: "python_case_arm",
+            message: "replace Python-style `case:` arm with Osty match syntax",
+            scopeKind: pythonScopeMatchArm,
+            elseish: false,
+            requiresMatch: true,
+            ok: true,
+        }
+    }
+    if head == "default" {
+        return PythonColonHeader {
+            rewritten: "_ -> \{",
+            changeKind: "python_default_arm",
+            message: "replace Python-style `default:` arm with Osty match syntax",
+            scopeKind: pythonScopeMatchArm,
+            elseish: false,
+            requiresMatch: true,
+            ok: true,
+        }
+    }
+    if strings.hasPrefix(head, "fn ") {
+        return airepairPyColonBlock(head + " \{", "python_fn_block",
+            "replace Python-style function block with Osty braces", false)
+    }
+    if strings.hasPrefix(head, "pub fn ") {
+        return airepairPyColonBlock(head + " \{", "python_fn_block",
+            "replace Python-style function block with Osty braces", false)
+    }
+    if strings.hasPrefix(head, "struct ") {
+        return airepairPyColonBlock(head + " \{", "python_struct_block",
+            "replace Python-style struct block with Osty braces", false)
+    }
+    if strings.hasPrefix(head, "interface ") {
+        return airepairPyColonBlock(head + " \{", "python_interface_block",
+            "replace Python-style interface block with Osty braces", false)
+    }
+    airepairPyColonNone()
+}
+/// airepairPyColonBlock is a tiny constructor for the common
+/// "Block-kind rewrite" case where the scopeKind is always
+/// pythonScopeBlock and requiresMatch is always false. Reduces
+/// the boilerplate at the dozen call sites inside the dispatcher.
+fn airepairPyColonBlock(rewritten: String, changeKind: String, message: String, elseish: Bool) -> PythonColonHeader {
+    PythonColonHeader {
+        rewritten: rewritten,
+        changeKind: changeKind,
+        message: message,
+        scopeKind: pythonScopeBlock,
+        elseish: elseish,
+        requiresMatch: false,
+        ok: true,
+    }
+}
+/// airepairPyColonNone returns the "no rule matched" sentinel —
+/// all string fields empty, all bool fields false, ok=false.
+fn airepairPyColonNone() -> PythonColonHeader {
+    PythonColonHeader {
+        rewritten: "",
+        changeKind: "",
+        message: "",
+        scopeKind: pythonScopeBlock,
+        elseish: false,
+        requiresMatch: false,
+        ok: false,
+    }
+}

--- a/toolchain/airepair_python_test.osty
+++ b/toolchain/airepair_python_test.osty
@@ -1,0 +1,124 @@
+use std.testing
+fn testRewritePythonColonHeaderArrowArm() {
+    let r = rewritePythonColonHeader("Foo(x) ->")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "Foo(x) -> \{")
+    testing.assertEq(r.changeKind, "python_arrow_arm_block")
+    testing.assertEq(r.scopeKind, pythonScopeMatchArm)
+    testing.assertEq(r.elseish, false)
+    testing.assertEq(r.requiresMatch, true)
+}
+fn testRewritePythonColonHeaderArrowEmptyRejected() {
+    let r = rewritePythonColonHeader("->")
+    testing.assertEq(r.ok, false)
+}
+fn testRewritePythonColonHeaderElse() {
+    let r = rewritePythonColonHeader("else:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "else \{")
+    testing.assertEq(r.changeKind, "python_else_block")
+    testing.assertEq(r.scopeKind, pythonScopeBlock)
+    testing.assertEq(r.elseish, true)
+    testing.assertEq(r.requiresMatch, false)
+}
+fn testRewritePythonColonHeaderElif() {
+    let r = rewritePythonColonHeader("elif x > 0:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "else if x > 0 \{")
+    testing.assertEq(r.changeKind, "python_elif_block")
+    testing.assertEq(r.elseish, true)
+}
+fn testRewritePythonColonHeaderElseif() {
+    let r = rewritePythonColonHeader("elseif n == 0:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "else if n == 0 \{")
+    testing.assertEq(r.changeKind, "python_elif_block")
+    testing.assertEq(r.elseish, true)
+}
+fn testRewritePythonColonHeaderElseIf() {
+    let r = rewritePythonColonHeader("else if y < 0:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "else if y < 0 \{")
+    testing.assertEq(r.changeKind, "python_else_if_block")
+    testing.assertEq(r.elseish, true)
+}
+fn testRewritePythonColonHeaderIf() {
+    let r = rewritePythonColonHeader("if cond:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "if cond \{")
+    testing.assertEq(r.changeKind, "python_if_block")
+    testing.assertEq(r.elseish, false)
+    testing.assertEq(r.scopeKind, pythonScopeBlock)
+}
+fn testRewritePythonColonHeaderFor() {
+    let r = rewritePythonColonHeader("for x in xs:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "for x in xs \{")
+    testing.assertEq(r.changeKind, "python_for_block")
+}
+fn testRewritePythonColonHeaderWhile() {
+    let r = rewritePythonColonHeader("while n > 0:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "for n > 0 \{")
+    testing.assertEq(r.changeKind, "python_while_block")
+}
+fn testRewritePythonColonHeaderMatch() {
+    let r = rewritePythonColonHeader("match value:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "match value \{")
+    testing.assertEq(r.changeKind, "python_match_block")
+    testing.assertEq(r.scopeKind, pythonScopeMatch)
+    testing.assertEq(r.requiresMatch, false)
+}
+fn testRewritePythonColonHeaderCase() {
+    let r = rewritePythonColonHeader("case Foo(x):")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "Foo(x) -> \{")
+    testing.assertEq(r.changeKind, "python_case_arm")
+    testing.assertEq(r.scopeKind, pythonScopeMatchArm)
+    testing.assertEq(r.requiresMatch, true)
+}
+fn testRewritePythonColonHeaderDefault() {
+    let r = rewritePythonColonHeader("default:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "_ -> \{")
+    testing.assertEq(r.changeKind, "python_default_arm")
+    testing.assertEq(r.scopeKind, pythonScopeMatchArm)
+    testing.assertEq(r.requiresMatch, true)
+}
+fn testRewritePythonColonHeaderFnBlock() {
+    let r = rewritePythonColonHeader("fn foo() -> Int:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "fn foo() -> Int \{")
+    testing.assertEq(r.changeKind, "python_fn_block")
+}
+fn testRewritePythonColonHeaderPubFnBlock() {
+    let r = rewritePythonColonHeader("pub fn bar() -> String:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "pub fn bar() -> String \{")
+    testing.assertEq(r.changeKind, "python_fn_block")
+}
+fn testRewritePythonColonHeaderStruct() {
+    let r = rewritePythonColonHeader("struct Point:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "struct Point \{")
+    testing.assertEq(r.changeKind, "python_struct_block")
+}
+fn testRewritePythonColonHeaderInterface() {
+    let r = rewritePythonColonHeader("interface Reader:")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.rewritten, "interface Reader \{")
+    testing.assertEq(r.changeKind, "python_interface_block")
+}
+fn testRewritePythonColonHeaderNoColonRejected() {
+    let r = rewritePythonColonHeader("if cond")
+    testing.assertEq(r.ok, false)
+}
+fn testRewritePythonColonHeaderBareColonRejected() {
+    let r = rewritePythonColonHeader(":")
+    testing.assertEq(r.ok, false)
+}
+fn testRewritePythonColonHeaderUnknownPrefix() {
+    let r = rewritePythonColonHeader("randomToken:")
+    testing.assertEq(r.ok, false)
+}


### PR DESCRIPTION
## 요약

`internal/airepair/diagnostic.go`의 `rewritePythonColonHeader` (12개 Python-style colon-block 패턴, ~127줄 switch) 를 **toolchain/airepair_python.osty** 로 이전. Go 측은 `runner.RewritePythonColonHeader` 어댑터를 통해 호스트 경계 역할만 수행한다.

CLAUDE.md의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙을 따라, airepair 의미 패스에서 마지막으로 남아 있던 큰 정책 덩어리를 toolchain 으로 옮긴다.

## 변경 내역

### toolchain (source of truth)
- **`toolchain/airepair_python.osty`** (신규)
  - `pub fn rewritePythonColonHeader(trimmed: String) -> PythonColonHeader` — 12개 패턴 분류기
  - `pub struct PythonColonHeader { rewritten, changeKind, message, scopeKind, elseish, requiresMatch, ok }`
  - `pub let pythonScopeBlock/Match/MatchArm: Int` — 호스트가 iota 로 미러링하는 scope kind 상수
  - 내부 헬퍼: `airepairPyColonBlock`/`airepairPyColonNone` (보일러플레이트 축소)
- **`toolchain/airepair_python_test.osty`** (신규) — 19 테스트
  - 12개 패턴 (else/elif/elseif/else if/if/for/while/match/case/default/fn|pub fn/struct/interface) 각각 + arrow arm
  - 거부 케이스: empty arrow, no colon, bare colon, unknown prefix

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/airepair_python_policy.go`** (신규) — Osty 스냅샷
  - `PythonColonHeader` struct + `PythonScope{Block,Match,MatchArm}` 상수 + `RewritePythonColonHeader` 함수
  - 패턴 매칭 dispatch 는 Osty 와 1:1 미러
- **`internal/runner/airepair_python_policy_test.go`** (신규) — 19-row table test
- **`internal/airepair/diagnostic.go`** (수정)
  - 기존 127줄 inline switch → 13줄 어댑터 (runner 결과를 package-local `pythonColonHeader` 로 마샬링)
  - package-local `pythonColonHeader` / `pythonScopeKind` / 상수들은 의도적으로 유지 — 호출자 (`rewritePythonColonBlocks`, `writePythonClosings`) 코드 변경 없이 어댑터만 교체
- **`internal/runner/drift_test.go`** — `ostySources` 에 `"airepair_python.osty"` 추가

## 마이그레이션 결과

- `internal/airepair/diagnostic.go`: **123줄 삭제** / 15줄 추가 (정책 = toolchain, glue = Go)
- 셋 가지 surface 동시 검증:
  - **Osty 측**: `_test.osty` 19 케이스
  - **Go 스냅샷**: 19-row table test
  - **드리프트 게이트**: `TestPolicySnapshotParityWithOsty` 가 Osty `pub fn`/`pub struct` ↔ Go export 1:1 강제

## 검증

```
$ .bin/osty check toolchain/airepair_python.osty toolchain/airepair_python_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/airepair/
ok  	github.com/osty/osty/internal/runner    0.021s
ok  	github.com/osty/osty/internal/airepair  4.996s

$ go test ./cmd/osty/
ok  	github.com/osty/osty/cmd/osty    79.318s
```

## 이번 세션 누적

| # | PR / commit | 이전된 모듈 |
|---|---|---|
| 1775 | lockfile Dependency 직렬화 정책 | `toolchain/lockfile_policy.osty` |
| 1776 | airepair accept/reject 스코어링 | `toolchain/airepair_decide.osty` (compareXxx, isImproved, isAccepted) |
| 1777 | airepair explain reasons | `toolchain/airepair_decide.osty` (explainAcceptXxx, explainRejectXxx) |
| 1779 | registry sanitizeIndexName | `toolchain/registry_policy.osty` |
| **이번** | **airepair Python colon-header 리라이터** | **`toolchain/airepair_python.osty`** |

## Test plan

- [x] `.bin/osty check toolchain/airepair_python.osty toolchain/airepair_python_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트) 통과
- [x] `go test ./internal/airepair/` 통과 (인용 호스트 어댑터 회귀 없음)
- [x] `go test ./cmd/osty/` 통과 (end-to-end airepair 경로)
- [x] `internal/runner/drift_test.go::TestPolicySnapshotParityWithOsty` 의 `airepair_python.osty` subtest 통과

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_