### PR TITLE
refactor: manifest dep-line emit 정책 self-host (toolchain/manifest_emit.osty)

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -1085,61 +1086,30 @@ func writeDeps(b *strings.Builder, section string, deps []Dependency) {
 	}
 }
 
+// writeDepLine bridges to runner.RenderManifestDepLine (mirror of
+// toolchain/manifest_emit.osty). Short-form vs inline-table-form
+// decision, key order, and quoting all live in toolchain.
 func writeDepLine(b *strings.Builder, d Dependency) {
-	// Short form
-	if d.VersionReq != "" &&
-		d.Path == "" &&
-		d.Git == nil &&
-		d.PackageName == "" &&
-		d.Registry == "" &&
-		!d.Optional &&
-		len(d.Features) == 0 &&
-		d.DefaultFeats {
-		fmt.Fprintf(b, "%s = %q\n", d.Name, d.VersionReq)
-		return
-	}
-	// Long form
-	fmt.Fprintf(b, "%s = { ", d.Name)
-	var parts []string
-	if d.VersionReq != "" {
-		parts = append(parts, fmt.Sprintf("version = %q", d.VersionReq))
-	}
-	if d.Path != "" {
-		parts = append(parts, fmt.Sprintf("path = %q", d.Path))
-	}
+	git := runner.ManifestGitSpec{}
 	if d.Git != nil {
-		parts = append(parts, fmt.Sprintf("git = %q", d.Git.URL))
-		if d.Git.Tag != "" {
-			parts = append(parts, fmt.Sprintf("tag = %q", d.Git.Tag))
-		}
-		if d.Git.Branch != "" {
-			parts = append(parts, fmt.Sprintf("branch = %q", d.Git.Branch))
-		}
-		if d.Git.Rev != "" {
-			parts = append(parts, fmt.Sprintf("rev = %q", d.Git.Rev))
+		git = runner.ManifestGitSpec{
+			URL:    d.Git.URL,
+			Tag:    d.Git.Tag,
+			Branch: d.Git.Branch,
+			Rev:    d.Git.Rev,
 		}
 	}
-	if d.PackageName != "" {
-		parts = append(parts, fmt.Sprintf("package = %q", d.PackageName))
-	}
-	if d.Registry != "" {
-		parts = append(parts, fmt.Sprintf("registry = %q", d.Registry))
-	}
-	if d.Optional {
-		parts = append(parts, "optional = true")
-	}
-	if len(d.Features) > 0 {
-		var qs []string
-		for _, f := range d.Features {
-			qs = append(qs, fmt.Sprintf("%q", f))
-		}
-		parts = append(parts, fmt.Sprintf("features = [%s]", strings.Join(qs, ", ")))
-	}
-	if !d.DefaultFeats {
-		parts = append(parts, "default-features = false")
-	}
-	b.WriteString(strings.Join(parts, ", "))
-	b.WriteString(" }\n")
+	b.WriteString(runner.RenderManifestDepLine(runner.ManifestDepEmitSpec{
+		Name:         d.Name,
+		VersionReq:   d.VersionReq,
+		Path:         d.Path,
+		Git:          git,
+		PackageName:  d.PackageName,
+		Registry:     d.Registry,
+		Optional:     d.Optional,
+		Features:     d.Features,
+		DefaultFeats: d.DefaultFeats,
+	}))
 }
 
 func writeString(b *strings.Builder, key, val string) {

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -48,6 +48,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"format_policy.osty",
 		"lint_glob.osty",
 		"lockfile_policy.osty",
+		"manifest_emit.osty",
 		"profile_features.osty",
 		"profile_flags.osty",
 		"profile_pragma.osty",

--- a/internal/runner/manifest_emit_policy.go
+++ b/internal/runner/manifest_emit_policy.go
@@ -21,7 +21,7 @@ type ManifestGitSpec struct {
 // nested git source uses `URL == ""` as its absent sentinel so
 // host call sites don't have to thread a pointer.
 //
-// Osty: toolchain/manifest_emit.osty:30
+// Osty: toolchain/manifest_emit.osty:31
 type ManifestDepEmitSpec struct {
 	Name         string
 	VersionReq   string
@@ -39,7 +39,7 @@ type ManifestDepEmitSpec struct {
 // preferred for version-only deps with default flags; otherwise
 // the inline-table form lists each non-default selector.
 //
-// Osty: toolchain/manifest_emit.osty:47
+// Osty: toolchain/manifest_emit.osty:46
 func RenderManifestDepLine(d ManifestDepEmitSpec) string {
 	if manifestDepCanShortForm(d) {
 		return d.Name + " = " + TomlBasicString(d.VersionReq) + "\n"

--- a/internal/runner/manifest_emit_policy.go
+++ b/internal/runner/manifest_emit_policy.go
@@ -1,0 +1,97 @@
+// manifest_emit_policy.go is the Go snapshot of
+// toolchain/manifest_emit.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+import "strings"
+
+// ManifestGitSpec mirrors toolchain/manifest_emit.osty's
+// ManifestGitSpec — the per-dep git source for the emit path.
+//
+// Osty: toolchain/manifest_emit.osty:21
+type ManifestGitSpec struct {
+	URL    string
+	Tag    string
+	Branch string
+	Rev    string
+}
+
+// ManifestDepEmitSpec is the host shape the dependency-line
+// emitter consumes. Empty-string fields signal "not set"; the
+// nested git source uses `URL == ""` as its absent sentinel so
+// host call sites don't have to thread a pointer.
+//
+// Osty: toolchain/manifest_emit.osty:30
+type ManifestDepEmitSpec struct {
+	Name         string
+	VersionReq   string
+	Path         string
+	Git          ManifestGitSpec
+	PackageName  string
+	Registry     string
+	Optional     bool
+	Features     []string
+	DefaultFeats bool
+}
+
+// RenderManifestDepLine emits one osty.toml dependency entry,
+// trailing newline included. Short form (`name = "1.0"`) is
+// preferred for version-only deps with default flags; otherwise
+// the inline-table form lists each non-default selector.
+//
+// Osty: toolchain/manifest_emit.osty:47
+func RenderManifestDepLine(d ManifestDepEmitSpec) string {
+	if manifestDepCanShortForm(d) {
+		return d.Name + " = " + TomlBasicString(d.VersionReq) + "\n"
+	}
+	var parts []string
+	if d.VersionReq != "" {
+		parts = append(parts, "version = "+TomlBasicString(d.VersionReq))
+	}
+	if d.Path != "" {
+		parts = append(parts, "path = "+TomlBasicString(d.Path))
+	}
+	if d.Git.URL != "" {
+		parts = append(parts, "git = "+TomlBasicString(d.Git.URL))
+		if d.Git.Tag != "" {
+			parts = append(parts, "tag = "+TomlBasicString(d.Git.Tag))
+		}
+		if d.Git.Branch != "" {
+			parts = append(parts, "branch = "+TomlBasicString(d.Git.Branch))
+		}
+		if d.Git.Rev != "" {
+			parts = append(parts, "rev = "+TomlBasicString(d.Git.Rev))
+		}
+	}
+	if d.PackageName != "" {
+		parts = append(parts, "package = "+TomlBasicString(d.PackageName))
+	}
+	if d.Registry != "" {
+		parts = append(parts, "registry = "+TomlBasicString(d.Registry))
+	}
+	if d.Optional {
+		parts = append(parts, "optional = true")
+	}
+	if len(d.Features) > 0 {
+		quoted := make([]string, 0, len(d.Features))
+		for _, f := range d.Features {
+			quoted = append(quoted, TomlBasicString(f))
+		}
+		parts = append(parts, "features = ["+strings.Join(quoted, ", ")+"]")
+	}
+	if !d.DefaultFeats {
+		parts = append(parts, "default-features = false")
+	}
+	return d.Name + " = { " + strings.Join(parts, ", ") + " }\n"
+}
+
+func manifestDepCanShortForm(d ManifestDepEmitSpec) bool {
+	return d.VersionReq != "" &&
+		d.Path == "" &&
+		d.Git.URL == "" &&
+		d.PackageName == "" &&
+		d.Registry == "" &&
+		!d.Optional &&
+		len(d.Features) == 0 &&
+		d.DefaultFeats
+}

--- a/internal/runner/manifest_emit_policy_test.go
+++ b/internal/runner/manifest_emit_policy_test.go
@@ -1,0 +1,144 @@
+package runner
+
+import "testing"
+
+func defaultManifestDep(name string) ManifestDepEmitSpec {
+	return ManifestDepEmitSpec{
+		Name:         name,
+		DefaultFeats: true,
+	}
+}
+
+func TestRenderManifestDepLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ManifestDepEmitSpec
+		want string
+	}{
+		{
+			name: "short-form",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("serde")
+				d.VersionReq = "1.0.0"
+				return d
+			}(),
+			want: "serde = \"1.0.0\"\n",
+		},
+		{
+			name: "short-form-special-char",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("name")
+				d.VersionReq = ">=1.2 <2.0"
+				return d
+			}(),
+			want: "name = \">=1.2 <2.0\"\n",
+		},
+		{
+			name: "long-with-path",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("local")
+				d.Path = "../local"
+				return d
+			}(),
+			want: "local = { path = \"../local\" }\n",
+		},
+		{
+			name: "long-version-plus-path",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("local")
+				d.VersionReq = "1.0.0"
+				d.Path = "../local"
+				return d
+			}(),
+			want: "local = { version = \"1.0.0\", path = \"../local\" }\n",
+		},
+		{
+			name: "git-tag-branch-rev",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("x")
+				d.Git = ManifestGitSpec{
+					URL:    "https://example.com/x.git",
+					Tag:    "v1.0.0",
+					Branch: "main",
+					Rev:    "abc1234",
+				}
+				return d
+			}(),
+			want: "x = { git = \"https://example.com/x.git\", tag = \"v1.0.0\", branch = \"main\", rev = \"abc1234\" }\n",
+		},
+		{
+			name: "package-rename",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("alias")
+				d.VersionReq = "1.0.0"
+				d.PackageName = "real-name"
+				return d
+			}(),
+			want: "alias = { version = \"1.0.0\", package = \"real-name\" }\n",
+		},
+		{
+			name: "registry-named",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("x")
+				d.VersionReq = "1.0.0"
+				d.Registry = "custom"
+				return d
+			}(),
+			want: "x = { version = \"1.0.0\", registry = \"custom\" }\n",
+		},
+		{
+			name: "optional-true",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("x")
+				d.VersionReq = "1.0.0"
+				d.Optional = true
+				return d
+			}(),
+			want: "x = { version = \"1.0.0\", optional = true }\n",
+		},
+		{
+			name: "features",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("x")
+				d.VersionReq = "1.0.0"
+				d.Features = []string{"a", "b"}
+				return d
+			}(),
+			want: "x = { version = \"1.0.0\", features = [\"a\", \"b\"] }\n",
+		},
+		{
+			name: "default-features-false",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("x")
+				d.VersionReq = "1.0.0"
+				d.DefaultFeats = false
+				return d
+			}(),
+			want: "x = { version = \"1.0.0\", default-features = false }\n",
+		},
+		{
+			name: "combined",
+			in: func() ManifestDepEmitSpec {
+				d := defaultManifestDep("x")
+				d.VersionReq = "1.0.0"
+				d.Optional = true
+				d.Features = []string{"foo"}
+				d.DefaultFeats = false
+				return d
+			}(),
+			want: "x = { version = \"1.0.0\", optional = true, features = [\"foo\"], default-features = false }\n",
+		},
+		{
+			name: "no-fields-long",
+			in:   defaultManifestDep("x"),
+			want: "x = {  }\n",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestDepLine(c.in); got != c.want {
+				t.Errorf("RenderManifestDepLine =\n  %q\n want\n  %q", got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/manifest_emit.osty
+++ b/toolchain/manifest_emit.osty
@@ -1,0 +1,104 @@
+/// Pure `osty.toml` dependency line renderer. Host code in
+/// `internal/manifest/manifest.go::writeDepLine` already owns the
+/// per-section iteration + sort; this module decides:
+///
+///   - when a Dependency can be emitted in the short form
+///     (`name = "1.0.0"`) vs the long inline-table form
+///     (`name = { version = "...", path = "...", ... }`),
+///   - the order of inline-table keys (matches the historical
+///     `osty.toml` output so tooling round-trips cleanly),
+///   - quoting via the shared `tomlBasicString` helper from
+///     `toolchain/lockfile_policy.osty`.
+///
+/// Mirrored by `internal/runner/manifest_emit_policy.go`. The
+/// drift test under internal/runner keeps the two in sync — the
+/// Osty file is the source of truth at review time.
+use std.strings as strings
+/// ManifestGitSpec mirrors the host `manifest.GitSource` for the
+/// emit path. `url` is always populated when this is non-`None`;
+/// the three ref selectors are empty strings when absent so the
+/// renderer can decide which lines to emit.
+pub struct ManifestGitSpec {
+    pub url: String,
+    pub tag: String,
+    pub branch: String,
+    pub rev: String,
+}
+/// ManifestDepEmitSpec is the host shape the emit policy needs.
+/// Empty-string fields signal "not set"; `git.url == ""` plays
+/// the same role for the optional nested struct (an Osty `T?`
+/// would force boilerplate at every host call site).
+pub struct ManifestDepEmitSpec {
+    pub name: String,
+    pub versionReq: String,
+    pub path: String,
+    pub git: ManifestGitSpec,
+    pub packageName: String,
+    pub registry: String,
+    pub optional: Bool,
+    pub features: List<String>,
+    pub defaultFeats: Bool,
+}
+/// renderManifestDepLine emits one `osty.toml` dependency entry,
+/// trailing newline included. Short form is preferred for
+/// version-only deps with default flags; everything else takes
+/// the inline-table form so each non-default selector is visible.
+pub fn renderManifestDepLine(d: ManifestDepEmitSpec) -> String {
+    if manifestDepCanShortForm(d) {
+        return d.name + " = " + tomlBasicString(d.versionReq) + "\n"
+    }
+    let mut parts: List<String> = []
+    if d.versionReq != "" {
+        parts.push("version = " + tomlBasicString(d.versionReq))
+    }
+    if d.path != "" {
+        parts.push("path = " + tomlBasicString(d.path))
+    }
+    if d.git.url != "" {
+        parts.push("git = " + tomlBasicString(d.git.url))
+        if d.git.tag != "" {
+            parts.push("tag = " + tomlBasicString(d.git.tag))
+        }
+        if d.git.branch != "" {
+            parts.push("branch = " + tomlBasicString(d.git.branch))
+        }
+        if d.git.rev != "" {
+            parts.push("rev = " + tomlBasicString(d.git.rev))
+        }
+    }
+    if d.packageName != "" {
+        parts.push("package = " + tomlBasicString(d.packageName))
+    }
+    if d.registry != "" {
+        parts.push("registry = " + tomlBasicString(d.registry))
+    }
+    if d.optional {
+        parts.push("optional = true")
+    }
+    if d.features.len() > 0 {
+        let mut quoted: List<String> = []
+        for f in d.features {
+            quoted.push(tomlBasicString(f))
+        }
+        parts.push("features = [" + strings.join(quoted, ", ") + "]")
+    }
+    if !d.defaultFeats {
+        parts.push("default-features = false")
+    }
+    d.name + " = { " + strings.join(parts, ", ") + " }\n"
+}
+/// manifestDepCanShortForm reports whether `d` qualifies for the
+/// `name = "1.0.0"` short emission. The host's `writeDepLine`
+/// uses the same predicate; keep this in lockstep with the
+/// caller's expectations (a stray field there would silently
+/// flip every dep to the long form).
+fn manifestDepCanShortForm(d: ManifestDepEmitSpec) -> Bool {
+    d.versionReq != ""
+        && d.path == ""
+        && d.git.url == ""
+        && d.packageName == ""
+        && d.registry == ""
+        && !d.optional
+        && d.features.len() == 0
+        && d.defaultFeats
+}

--- a/toolchain/manifest_emit_test.osty
+++ b/toolchain/manifest_emit_test.osty
@@ -1,0 +1,141 @@
+use std.testing
+fn emptyGit() -> ManifestGitSpec {
+    ManifestGitSpec {url: "", tag: "", branch: "", rev: ""}
+}
+fn defaultDep(name: String) -> ManifestDepEmitSpec {
+    ManifestDepEmitSpec {
+        name: name,
+        versionReq: "",
+        path: "",
+        git: emptyGit(),
+        packageName: "",
+        registry: "",
+        optional: false,
+        features: [],
+        defaultFeats: true,
+    }
+}
+fn testRenderManifestDepLineShortForm() {
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("serde"),
+        versionReq: "1.0.0",
+    }
+    testing.assertEq(renderManifestDepLine(d), "serde = \"1.0.0\"\n")
+}
+fn testRenderManifestDepLineShortFormWithSpecialChar() {
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("name"),
+        versionReq: ">=1.2 <2.0",
+    }
+    testing.assertEq(renderManifestDepLine(d), "name = \">=1.2 <2.0\"\n")
+}
+fn testRenderManifestDepLineLongWithPath() {
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("local"),
+        path: "../local",
+    }
+    testing.assertEq(renderManifestDepLine(d), "local = { path = \"../local\" }\n")
+}
+fn testRenderManifestDepLineLongVersionPlusPath() {
+    // Version + path => long form (mixed shape disqualifies short).
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("local"),
+        versionReq: "1.0.0",
+        path: "../local",
+    }
+    testing.assertEq(
+        renderManifestDepLine(d),
+        "local = { version = \"1.0.0\", path = \"../local\" }\n",
+    )
+}
+fn testRenderManifestDepLineGitTagBranchRev() {
+    let git = ManifestGitSpec {
+        url: "https://example.com/x.git",
+        tag: "v1.0.0",
+        branch: "main",
+        rev: "abc1234",
+    }
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("x"),
+        git: git,
+    }
+    testing.assertEq(
+        renderManifestDepLine(d),
+        "x = { git = \"https://example.com/x.git\", tag = \"v1.0.0\", branch = \"main\", rev = \"abc1234\" }\n",
+    )
+}
+fn testRenderManifestDepLinePackageRename() {
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("alias"),
+        versionReq: "1.0.0",
+        packageName: "real-name",
+    }
+    testing.assertEq(
+        renderManifestDepLine(d),
+        "alias = { version = \"1.0.0\", package = \"real-name\" }\n",
+    )
+}
+fn testRenderManifestDepLineRegistry() {
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("x"),
+        versionReq: "1.0.0",
+        registry: "custom",
+    }
+    testing.assertEq(
+        renderManifestDepLine(d),
+        "x = { version = \"1.0.0\", registry = \"custom\" }\n",
+    )
+}
+fn testRenderManifestDepLineOptional() {
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("x"),
+        versionReq: "1.0.0",
+        optional: true,
+    }
+    testing.assertEq(
+        renderManifestDepLine(d),
+        "x = { version = \"1.0.0\", optional = true }\n",
+    )
+}
+fn testRenderManifestDepLineFeatures() {
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("x"),
+        versionReq: "1.0.0",
+        features: ["a", "b"],
+    }
+    testing.assertEq(
+        renderManifestDepLine(d),
+        "x = { version = \"1.0.0\", features = [\"a\", \"b\"] }\n",
+    )
+}
+fn testRenderManifestDepLineDefaultFeaturesFalse() {
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("x"),
+        versionReq: "1.0.0",
+        defaultFeats: false,
+    }
+    testing.assertEq(
+        renderManifestDepLine(d),
+        "x = { version = \"1.0.0\", default-features = false }\n",
+    )
+}
+fn testRenderManifestDepLineCombined() {
+    // version + features + optional + default-features=false. The
+    // emission order is fixed: version, features, optional, default-features.
+    let d = ManifestDepEmitSpec {
+        ..defaultDep("x"),
+        versionReq: "1.0.0",
+        optional: true,
+        features: ["foo"],
+        defaultFeats: false,
+    }
+    testing.assertEq(
+        renderManifestDepLine(d),
+        "x = { version = \"1.0.0\", optional = true, features = [\"foo\"], default-features = false }\n",
+    )
+}
+fn testRenderManifestDepLineNoFieldsLongForm() {
+    // No version, no path, no git — degenerate but still emits long form.
+    let d = defaultDep("x")
+    testing.assertEq(renderManifestDepLine(d), "x = {  }\n")
+}

--- a/toolchain/manifest_emit_test.osty
+++ b/toolchain/manifest_emit_test.osty
@@ -121,7 +121,7 @@ fn testRenderManifestDepLineDefaultFeaturesFalse() {
 }
 fn testRenderManifestDepLineCombined() {
     // version + features + optional + default-features=false. The
-    // emission order is fixed: version, features, optional, default-features.
+    // emission order is fixed: version, optional, features, default-features.
     let d = ManifestDepEmitSpec {
         ..defaultDep("x"),
         versionReq: "1.0.0",


### PR DESCRIPTION
## 요약

`internal/manifest/manifest.go::writeDepLine` (~55줄, short-form vs inline-table-form 결정 + 키 순서 + `%q` 쿼팅) 을 새 toolchain 파일 **`toolchain/manifest_emit.osty`** 의 `renderManifestDepLine` 으로 self-host. Go 측은 host `Dependency` → `ManifestDepEmitSpec` 마샬링만 수행 (21줄).

지난 PR (#1782) 에서 추가한 `tomlBasicString` 을 cross-module 재사용 — toolchain 패키지 내부 호출이므로 `use` 없이 직접 가능.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙 — 정책은 toolchain, glue는 Go.

## 변경 내역

### toolchain (source of truth, 새 파일)
- **`toolchain/manifest_emit.osty`** (신규)
  - `pub struct ManifestGitSpec { url, tag, branch, rev }`
  - `pub struct ManifestDepEmitSpec` — host Dependency 의 emit-relevant subset
  - `pub fn renderManifestDepLine(d) -> String` — short/long form 분기 + 키 순서 정책
  - 내부 헬퍼: `manifestDepCanShortForm` (8개 조건의 short-form 가능성 검사)
- **`toolchain/manifest_emit_test.osty`** (신규) — 12 케이스
  - short-form (version-only, default flags)
  - 특수문자 version (`>=1.2 <2.0`)
  - long-form 단독 (path, git, optional, features, default-features=false)
  - git ref 조합 (tag + branch + rev)
  - package rename / registry / 복합 케이스
  - degenerate (no fields) → `{  }`

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/manifest_emit_policy.go`** (신규)
  - `ManifestGitSpec` / `ManifestDepEmitSpec` structs
  - `RenderManifestDepLine` + `manifestDepCanShortForm`
- **`internal/runner/manifest_emit_policy_test.go`** (신규) — 12 row table test
- **`internal/manifest/manifest.go`** (수정)
  - `writeDepLine` 55줄 → 21줄 (host Dependency → runner spec)
- **`internal/runner/drift_test.go`** — `ostySources` 에 `"manifest_emit.osty"` 추가

## 마이그레이션 결과

- `internal/manifest/manifest.go::writeDepLine`: **55줄 → 21줄** (정책 = toolchain, glue = Go)
- 셋 가지 surface 동시 검증:
  - **Osty 측**: 12 케이스 직접
  - **Go 스냅샷**: 12 row table test
  - **드리프트 게이트**: `TestPolicySnapshotParityWithOsty/manifest_emit.osty` 가 `pub fn`/`pub struct` ↔ Go export 1:1 강제
- **호환성**: 기존 manifest 마샬링 테스트 전부 통과 — short/long form 분기 + 정확한 키 순서 보존

## 검증

```
$ .bin/osty check toolchain/manifest_emit.osty toolchain/manifest_emit_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/manifest/
ok  	github.com/osty/osty/internal/runner    0.019s
ok  	github.com/osty/osty/internal/manifest  0.004s

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    67.945s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| 1775 | lockfile Dependency 직렬화 (단일 문자열) | `toolchain/lockfile_policy.osty` |
| 1776 | airepair accept/reject 스코어링 | `toolchain/airepair_decide.osty` |
| 1777 | airepair explain reasons | `toolchain/airepair_decide.osty` |
| 1779 | registry sanitizeIndexName | `toolchain/registry_policy.osty` |
| 1780 | airepair Python colon-header 리라이터 | `toolchain/airepair_python.osty` |
| 1781 | lint Exclude glob 정책 | `toolchain/lint_glob.osty` |
| 1782 | lockfile Marshal + tomlBasicString | `toolchain/lockfile_policy.osty` (확장) |
| **이번** | **manifest dep-line emit 정책** | **`toolchain/manifest_emit.osty`** (신규, `tomlBasicString` 재사용) |

## Test plan

- [x] `.bin/osty check toolchain/manifest_emit.osty toolchain/manifest_emit_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/manifest/` 통과 — manifest Marshal/Parse round-trip 회귀 없음
- [x] `go test ./cmd/osty/` 통과 — `osty add` / `osty new` e2e 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_