### PR TITLE
refactor: manifest field/section emit 헬퍼들 self-host (toolchain/manifest_emit.osty 확장)

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -20,7 +20,6 @@ package manifest
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/osty/osty/internal/runner"
@@ -1074,22 +1073,21 @@ func Marshal(m *Manifest) []byte {
 // header. Short forms (`dep = "1.0"`) are preferred when the
 // dependency has only a version requirement; the long inline-table
 // form is emitted otherwise.
+// writeDeps bridges to runner.RenderManifestDepsSection (mirror of
+// toolchain/manifest_emit.osty). Section header, sort, and per-dep
+// rendering all live in toolchain.
 func writeDeps(b *strings.Builder, section string, deps []Dependency) {
 	if len(deps) == 0 {
 		return
 	}
-	fmt.Fprintf(b, "\n[%s]\n", section)
-	sorted := append([]Dependency(nil), deps...)
-	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
-	for _, d := range sorted {
-		writeDepLine(b, d)
+	specs := make([]runner.ManifestDepEmitSpec, 0, len(deps))
+	for _, d := range deps {
+		specs = append(specs, depEmitSpec(d))
 	}
+	b.WriteString(runner.RenderManifestDepsSection(section, specs))
 }
 
-// writeDepLine bridges to runner.RenderManifestDepLine (mirror of
-// toolchain/manifest_emit.osty). Short-form vs inline-table-form
-// decision, key order, and quoting all live in toolchain.
-func writeDepLine(b *strings.Builder, d Dependency) {
+func depEmitSpec(d Dependency) runner.ManifestDepEmitSpec {
 	git := runner.ManifestGitSpec{}
 	if d.Git != nil {
 		git = runner.ManifestGitSpec{
@@ -1099,7 +1097,7 @@ func writeDepLine(b *strings.Builder, d Dependency) {
 			Rev:    d.Git.Rev,
 		}
 	}
-	b.WriteString(runner.RenderManifestDepLine(runner.ManifestDepEmitSpec{
+	return runner.ManifestDepEmitSpec{
 		Name:         d.Name,
 		VersionReq:   d.VersionReq,
 		Path:         d.Path,
@@ -1109,26 +1107,29 @@ func writeDepLine(b *strings.Builder, d Dependency) {
 		Optional:     d.Optional,
 		Features:     d.Features,
 		DefaultFeats: d.DefaultFeats,
-	}))
+	}
 }
 
+// writeDepLine bridges to runner.RenderManifestDepLine (mirror of
+// toolchain/manifest_emit.osty). Short-form vs inline-table-form
+// decision, key order, and quoting all live in toolchain.
+func writeDepLine(b *strings.Builder, d Dependency) {
+	b.WriteString(runner.RenderManifestDepLine(depEmitSpec(d)))
+}
+
+// writeString, writeStringArray, writeBool bridge to the matching
+// runner.RenderManifest* helpers (mirror of toolchain/manifest_emit.osty).
+// Quoting + array formatting policy lives in toolchain.
 func writeString(b *strings.Builder, key, val string) {
-	fmt.Fprintf(b, "%s = %q\n", key, val)
+	b.WriteString(runner.RenderManifestStringField(key, val))
 }
 
 func writeStringArray(b *strings.Builder, key string, vals []string) {
-	fmt.Fprintf(b, "%s = [", key)
-	for i, v := range vals {
-		if i > 0 {
-			b.WriteString(", ")
-		}
-		fmt.Fprintf(b, "%q", v)
-	}
-	b.WriteString("]\n")
+	b.WriteString(runner.RenderManifestStringArrayField(key, vals))
 }
 
 func writeBool(b *strings.Builder, key string, val bool) {
-	fmt.Fprintf(b, "%s = %t\n", key, val)
+	b.WriteString(runner.RenderManifestBoolField(key, val))
 }
 
 // FindUp searches cwd and each parent directory for osty.toml,

--- a/internal/runner/manifest_emit_policy.go
+++ b/internal/runner/manifest_emit_policy.go
@@ -3,7 +3,10 @@
 // the drift test in this package keeps the two in sync.
 package runner
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // ManifestGitSpec mirrors toolchain/manifest_emit.osty's
 // ManifestGitSpec — the per-dep git source for the emit path.
@@ -94,4 +97,59 @@ func manifestDepCanShortForm(d ManifestDepEmitSpec) bool {
 		!d.Optional &&
 		len(d.Features) == 0 &&
 		d.DefaultFeats
+}
+
+// RenderManifestStringField emits a `key = "value"` line (newline
+// included). Wraps TomlBasicString so callers don't duplicate the
+// quoting policy at every section.
+//
+// Osty: toolchain/manifest_emit.osty:108
+func RenderManifestStringField(key, val string) string {
+	return key + " = " + TomlBasicString(val) + "\n"
+}
+
+// RenderManifestStringArrayField emits a `key = ["a", "b", ...]`
+// line. Empty arrays render as `key = []`; the host suppresses the
+// call when it doesn't want the field at all.
+//
+// Osty: toolchain/manifest_emit.osty:114
+func RenderManifestStringArrayField(key string, vals []string) string {
+	quoted := make([]string, 0, len(vals))
+	for _, v := range vals {
+		quoted = append(quoted, TomlBasicString(v))
+	}
+	return key + " = [" + strings.Join(quoted, ", ") + "]\n"
+}
+
+// RenderManifestBoolField emits `key = true` / `key = false`.
+//
+// Osty: toolchain/manifest_emit.osty:122
+func RenderManifestBoolField(key string, val bool) string {
+	if val {
+		return key + " = true\n"
+	}
+	return key + " = false\n"
+}
+
+// RenderManifestDepsSection emits a `[section]` header followed
+// by one dep line per entry, sorted by Name. Returns the empty
+// string when deps is empty so the host can call it unconditionally
+// without producing an orphan header.
+//
+// Osty: toolchain/manifest_emit.osty:132
+func RenderManifestDepsSection(section string, deps []ManifestDepEmitSpec) string {
+	if len(deps) == 0 {
+		return ""
+	}
+	sorted := make([]ManifestDepEmitSpec, len(deps))
+	copy(sorted, deps)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+	var b strings.Builder
+	b.WriteString("\n[")
+	b.WriteString(section)
+	b.WriteString("]\n")
+	for _, d := range sorted {
+		b.WriteString(RenderManifestDepLine(d))
+	}
+	return b.String()
 }

--- a/internal/runner/manifest_emit_policy_test.go
+++ b/internal/runner/manifest_emit_policy_test.go
@@ -1,6 +1,8 @@
 package runner
 
-import "testing"
+import (
+	"testing"
+)
 
 func defaultManifestDep(name string) ManifestDepEmitSpec {
 	return ManifestDepEmitSpec{
@@ -141,4 +143,87 @@ func TestRenderManifestDepLine(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRenderManifestStringField(t *testing.T) {
+	cases := []struct {
+		name, key, val, want string
+	}{
+		{"plain", "name", "demo", `name = "demo"` + "\n"},
+		{"version", "version", "1.0.0", `version = "1.0.0"` + "\n"},
+		{"quoting-special", "desc", `needs "quotes"`, `desc = "needs \"quotes\""` + "\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestStringField(c.key, c.val); got != c.want {
+				t.Errorf("RenderManifestStringField = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRenderManifestStringArrayField(t *testing.T) {
+	cases := []struct {
+		name, key string
+		vals      []string
+		want      string
+	}{
+		{"two-values", "authors", []string{"Alice", "Bob"}, `authors = ["Alice", "Bob"]` + "\n"},
+		{"empty", "authors", []string{}, "authors = []\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestStringArrayField(c.key, c.vals); got != c.want {
+				t.Errorf("RenderManifestStringArrayField = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRenderManifestBoolField(t *testing.T) {
+	cases := []struct {
+		name, key string
+		val       bool
+		want      string
+	}{
+		{"true", "runtime", true, "runtime = true\n"},
+		{"false", "runtime", false, "runtime = false\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestBoolField(c.key, c.val); got != c.want {
+				t.Errorf("RenderManifestBoolField = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRenderManifestDepsSection(t *testing.T) {
+	t.Run("empty-returns-empty", func(t *testing.T) {
+		if got := RenderManifestDepsSection("dependencies", nil); got != "" {
+			t.Errorf("empty deps must return empty string, got %q", got)
+		}
+	})
+	t.Run("sorts-by-name", func(t *testing.T) {
+		a := defaultManifestDep("alpha")
+		a.VersionReq = "1.0.0"
+		z := defaultManifestDep("zed")
+		z.VersionReq = "2.0.0"
+		got := RenderManifestDepsSection("dependencies", []ManifestDepEmitSpec{z, a})
+		want := "\n[dependencies]\nalpha = \"1.0.0\"\nzed = \"2.0.0\"\n"
+		if got != want {
+			t.Errorf("=\n%q\nwant\n%q", got, want)
+		}
+	})
+	t.Run("mixed-short-long-forms", func(t *testing.T) {
+		s := defaultManifestDep("a")
+		s.VersionReq = "1.0.0"
+		l := defaultManifestDep("b")
+		l.Path = "../b"
+		got := RenderManifestDepsSection("dev-dependencies", []ManifestDepEmitSpec{s, l})
+		want := "\n[dev-dependencies]\na = \"1.0.0\"\nb = { path = \"../b\" }\n"
+		if got != want {
+			t.Errorf("=\n%q\nwant\n%q", got, want)
+		}
+	})
 }

--- a/toolchain/manifest_emit.osty
+++ b/toolchain/manifest_emit.osty
@@ -102,3 +102,42 @@ fn manifestDepCanShortForm(d: ManifestDepEmitSpec) -> Bool {
         && d.features.len() == 0
         && d.defaultFeats
 }
+/// renderManifestStringField emits a `key = "value"` line (newline
+/// included). Wraps `tomlBasicString` so callers don't duplicate the
+/// quoting policy at every section.
+pub fn renderManifestStringField(key: String, val: String) -> String {
+    key + " = " + tomlBasicString(val) + "\n"
+}
+/// renderManifestStringArrayField emits a `key = ["a", "b", ...]`
+/// line. Empty arrays still render the line (e.g. `key = []`); the
+/// host suppresses the call when it doesn't want the field at all.
+pub fn renderManifestStringArrayField(key: String, vals: List<String>) -> String {
+    let mut quoted: List<String> = []
+    for v in vals {
+        quoted.push(tomlBasicString(v))
+    }
+    key + " = [" + strings.join(quoted, ", ") + "]\n"
+}
+/// renderManifestBoolField emits `key = true` / `key = false`.
+pub fn renderManifestBoolField(key: String, val: Bool) -> String {
+    if val {
+        return key + " = true\n"
+    }
+    key + " = false\n"
+}
+/// renderManifestDepsSection emits a `[section]` header followed
+/// by one dep line per entry, sorted by `name`. Returns the empty
+/// string when `deps` is empty so the host can call it
+/// unconditionally without producing an orphan header.
+pub fn renderManifestDepsSection(section: String, deps: List<ManifestDepEmitSpec>) -> String {
+    if deps.len() == 0 {
+        return ""
+    }
+    let sorted = deps.sortedBy(|d| d.name)
+    let mut parts: List<String> = []
+    parts.push("\n[" + section + "]\n")
+    for d in sorted {
+        parts.push(renderManifestDepLine(d))
+    }
+    strings.join(parts, "")
+}

--- a/toolchain/manifest_emit_test.osty
+++ b/toolchain/manifest_emit_test.osty
@@ -139,3 +139,44 @@ fn testRenderManifestDepLineNoFieldsLongForm() {
     let d = defaultDep("x")
     testing.assertEq(renderManifestDepLine(d), "x = {  }\n")
 }
+fn testRenderManifestStringField() {
+    testing.assertEq(renderManifestStringField("name", "demo"), "name = \"demo\"\n")
+    testing.assertEq(renderManifestStringField("version", "1.0.0"), "version = \"1.0.0\"\n")
+}
+fn testRenderManifestStringFieldQuotesSpecial() {
+    testing.assertEq(
+        renderManifestStringField("desc", "needs \"quotes\""),
+        "desc = \"needs \\\"quotes\\\"\"\n",
+    )
+}
+fn testRenderManifestStringArrayField() {
+    testing.assertEq(
+        renderManifestStringArrayField("authors", ["Alice", "Bob"]),
+        "authors = [\"Alice\", \"Bob\"]\n",
+    )
+}
+fn testRenderManifestStringArrayFieldEmpty() {
+    testing.assertEq(renderManifestStringArrayField("authors", []), "authors = []\n")
+}
+fn testRenderManifestBoolField() {
+    testing.assertEq(renderManifestBoolField("runtime", true), "runtime = true\n")
+    testing.assertEq(renderManifestBoolField("runtime", false), "runtime = false\n")
+}
+fn testRenderManifestDepsSectionEmpty() {
+    testing.assertEq(renderManifestDepsSection("dependencies", []), "")
+}
+fn testRenderManifestDepsSectionSortsByName() {
+    let a = ManifestDepEmitSpec {..defaultDep("alpha"), versionReq: "1.0.0"}
+    let b = ManifestDepEmitSpec {..defaultDep("zed"), versionReq: "2.0.0"}
+    let out = renderManifestDepsSection("dependencies", [b, a])
+    let expected = "\n[dependencies]\nalpha = \"1.0.0\"\nzed = \"2.0.0\"\n"
+    testing.assertEq(out, expected)
+}
+fn testRenderManifestDepsSectionHonorsDepLineForm() {
+    // Mixed short + long deps in one section.
+    let short = ManifestDepEmitSpec {..defaultDep("a"), versionReq: "1.0.0"}
+    let long = ManifestDepEmitSpec {..defaultDep("b"), path: "../b"}
+    let out = renderManifestDepsSection("dev-dependencies", [short, long])
+    let expected = "\n[dev-dependencies]\na = \"1.0.0\"\nb = { path = \"../b\" }\n"
+    testing.assertEq(out, expected)
+}


### PR DESCRIPTION
## 요약

지난 PR (#1783) 의 `renderManifestDepLine` 에 이어, **나머지 manifest writer 헬퍼 4개** 를 `toolchain/manifest_emit.osty` 로 이전 — 이제 manifest TOML 출력 전체가 toolchain-owned policy.

`tomlBasicString` (PR #1782) 을 cross-module 재사용해서 쿼팅 정책 일원화.

| Go 함수 (기존) | Osty 함수 (신규) | 정책 |
|---|---|---|
| `writeString` | `renderManifestStringField` | `key = "val"` |
| `writeStringArray` | `renderManifestStringArrayField` | `key = ["a", "b"]` |
| `writeBool` | `renderManifestBoolField` | `key = true/false` |
| `writeDeps` | `renderManifestDepsSection` | `\n[section]\n` 헤더 + name 정렬 + per-dep 라인 |

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/manifest_emit.osty`** (확장)
  - `pub fn renderManifestStringField(key, val)` — tomlBasicString 위임
  - `pub fn renderManifestStringArrayField(key, vals)` — 빈 배열은 `key = []` 로 emission
  - `pub fn renderManifestBoolField(key, val)`
  - `pub fn renderManifestDepsSection(section, deps)` — empty 일 때 "" 반환 (orphan 헤더 방지)
- **`toolchain/manifest_emit_test.osty`** (확장) — 9 신규 케이스
  - string field: plain / quoting-special (`"needs \"quotes\""`)
  - string array: two values / empty
  - bool: true / false
  - deps section: empty (no output) / name 정렬 / mixed short+long form

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/manifest_emit_policy.go`** (확장)
  - `RenderManifestStringField` / `RenderManifestStringArrayField` / `RenderManifestBoolField` / `RenderManifestDepsSection`
  - `sort` import 추가 (deps 섹션 정렬)
- **`internal/runner/manifest_emit_policy_test.go`** (확장) — 4 신규 table test
- **`internal/manifest/manifest.go`** (수정)
  - 4개 writer 모두 1줄 어댑터로 단축
  - `writeDepLine` + `writeDeps` 의 중복 spec 변환을 `depEmitSpec` 헬퍼로 통합 (DRY)
  - `sort` import 제거 (정렬 정책이 toolchain 으로 이동했으므로 더 이상 필요 없음)

## 마이그레이션 결과

- 4개 writer 함수: **~30줄 → 12줄** (각각 1줄 어댑터)
- `internal/manifest/manifest.go`: 더 이상 `sort` / `%q` / `%t` 호출 없음 (TOML 쿼팅 정책 = toolchain 완전 이전)
- 셋 가지 surface 동시 검증:
  - **Osty 측**: 9 신규 케이스
  - **Go 스냅샷**: 4 신규 table test
  - **드리프트 게이트**: 기존 `lockfile_policy.osty` + `manifest_emit.osty` subtest 가 4개 신규 `pub fn` ↔ Go export 1:1 강제
- **호환성**: manifest Marshal/Parse round-trip + e2e (`osty add`, `osty new`) 회귀 없음

## 검증

```
$ .bin/osty check toolchain/manifest_emit.osty toolchain/manifest_emit_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/manifest/ ./internal/pkgmgr/
ok  	github.com/osty/osty/internal/runner    0.019s
ok  	github.com/osty/osty/internal/manifest  0.012s
ok  	github.com/osty/osty/internal/pkgmgr    0.005s

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    70.153s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| 1775 | lockfile Dependency 직렬화 (단일 문자열) | `toolchain/lockfile_policy.osty` |
| 1776 | airepair accept/reject 스코어링 | `toolchain/airepair_decide.osty` |
| 1777 | airepair explain reasons | `toolchain/airepair_decide.osty` |
| 1779 | registry sanitizeIndexName | `toolchain/registry_policy.osty` |
| 1780 | airepair Python colon-header 리라이터 | `toolchain/airepair_python.osty` |
| 1781 | lint Exclude glob 정책 | `toolchain/lint_glob.osty` |
| 1782 | lockfile Marshal + tomlBasicString | `toolchain/lockfile_policy.osty` (확장) |
| 1783 | manifest dep-line emit 정책 | `toolchain/manifest_emit.osty` (신규) |
| **이번** | **manifest field/array/bool/deps 섹션 정책** | **`toolchain/manifest_emit.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/manifest_emit.osty toolchain/manifest_emit_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/manifest/` 통과 — Marshal/Parse round-trip 회귀 없음
- [x] `go test ./cmd/osty/` 통과 — 70초 시나리오 (osty new / add / update / 등) 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_