### PR TITLE
refactor: manifest [bin]/[lib]/[workspace]/[capabilities] 섹션 self-host

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1007,18 +1007,16 @@ func Marshal(m *Manifest) []byte {
 			writeStringArray(&b, "keywords", m.Package.Keywords)
 		}
 	}
-	if m.Bin != nil && (m.Bin.Name != "" || m.Bin.Path != "") {
-		b.WriteString("\n[bin]\n")
-		if m.Bin.Name != "" {
-			writeString(&b, "name", m.Bin.Name)
-		}
-		if m.Bin.Path != "" {
-			writeString(&b, "path", m.Bin.Path)
-		}
+	if m.Bin != nil {
+		b.WriteString(runner.RenderManifestBinSection(runner.ManifestBinEmitSpec{
+			Name: m.Bin.Name,
+			Path: m.Bin.Path,
+		}))
 	}
-	if m.Lib != nil && m.Lib.Path != "" {
-		b.WriteString("\n[lib]\n")
-		writeString(&b, "path", m.Lib.Path)
+	if m.Lib != nil {
+		b.WriteString(runner.RenderManifestLibSection(runner.ManifestLibEmitSpec{
+			Path: m.Lib.Path,
+		}))
 	}
 	writeDeps(&b, "dependencies", m.Dependencies)
 	writeDeps(&b, "dev-dependencies", m.DevDependencies)
@@ -1032,8 +1030,9 @@ func Marshal(m *Manifest) []byte {
 		}
 	}
 	if m.Workspace != nil {
-		b.WriteString("\n[workspace]\n")
-		writeStringArray(&b, "members", m.Workspace.Members)
+		b.WriteString(runner.RenderManifestWorkspaceSection(runner.ManifestWorkspaceEmitSpec{
+			Members: m.Workspace.Members,
+		}))
 	}
 	if m.Lint != nil && (len(m.Lint.Allow) > 0 || len(m.Lint.Deny) > 0) {
 		b.WriteString("\n[lint]\n")
@@ -1045,8 +1044,9 @@ func Marshal(m *Manifest) []byte {
 		}
 	}
 	if m.Capabilities != nil {
-		b.WriteString("\n[capabilities]\n")
-		writeBool(&b, "runtime", m.Capabilities.Runtime)
+		b.WriteString(runner.RenderManifestCapabilitiesSection(runner.ManifestCapabilitiesEmitSpec{
+			Runtime: m.Capabilities.Runtime,
+		}))
 	}
 	if m.GUI != nil {
 		b.WriteString("\n[gui]\n")

--- a/internal/runner/manifest_emit_policy.go
+++ b/internal/runner/manifest_emit_policy.go
@@ -153,3 +153,82 @@ func RenderManifestDepsSection(section string, deps []ManifestDepEmitSpec) strin
 	}
 	return b.String()
 }
+
+// ManifestBinEmitSpec mirrors the host manifest.BinTarget. Empty
+// Name+Path signals "no [bin] section"; the renderer elides the
+// block in that case.
+//
+// Osty: toolchain/manifest_emit.osty:147
+type ManifestBinEmitSpec struct {
+	Name string
+	Path string
+}
+
+// RenderManifestBinSection emits `\n[bin]\n` plus optional name
+// and path lines. Returns "" when both fields are empty so the
+// host can call unconditionally.
+//
+// Osty: toolchain/manifest_emit.osty:156
+func RenderManifestBinSection(bin ManifestBinEmitSpec) string {
+	if bin.Name == "" && bin.Path == "" {
+		return ""
+	}
+	out := "\n[bin]\n"
+	if bin.Name != "" {
+		out += RenderManifestStringField("name", bin.Name)
+	}
+	if bin.Path != "" {
+		out += RenderManifestStringField("path", bin.Path)
+	}
+	return out
+}
+
+// ManifestLibEmitSpec mirrors the host manifest.LibTarget.
+//
+// Osty: toolchain/manifest_emit.osty:171
+type ManifestLibEmitSpec struct {
+	Path string
+}
+
+// RenderManifestLibSection emits `\n[lib]\npath = "..."\n` or the
+// empty string when Path is empty.
+//
+// Osty: toolchain/manifest_emit.osty:176
+func RenderManifestLibSection(lib ManifestLibEmitSpec) string {
+	if lib.Path == "" {
+		return ""
+	}
+	return "\n[lib]\n" + RenderManifestStringField("path", lib.Path)
+}
+
+// ManifestWorkspaceEmitSpec mirrors the host manifest.Workspace.
+//
+// Osty: toolchain/manifest_emit.osty:185
+type ManifestWorkspaceEmitSpec struct {
+	Members []string
+}
+
+// RenderManifestWorkspaceSection emits the [workspace] block;
+// members is always rendered even when empty.
+//
+// Osty: toolchain/manifest_emit.osty:192
+func RenderManifestWorkspaceSection(ws ManifestWorkspaceEmitSpec) string {
+	return "\n[workspace]\n" + RenderManifestStringArrayField("members", ws.Members)
+}
+
+// ManifestCapabilitiesEmitSpec mirrors the host
+// manifest.Capabilities.
+//
+// Osty: toolchain/manifest_emit.osty:199
+type ManifestCapabilitiesEmitSpec struct {
+	Runtime bool
+}
+
+// RenderManifestCapabilitiesSection emits the [capabilities]
+// block. Always emitted by the renderer; the host's nil-check
+// controls presence.
+//
+// Osty: toolchain/manifest_emit.osty:204
+func RenderManifestCapabilitiesSection(caps ManifestCapabilitiesEmitSpec) string {
+	return "\n[capabilities]\n" + RenderManifestBoolField("runtime", caps.Runtime)
+}

--- a/internal/runner/manifest_emit_policy_test.go
+++ b/internal/runner/manifest_emit_policy_test.go
@@ -227,3 +227,77 @@ func TestRenderManifestDepsSection(t *testing.T) {
 		}
 	})
 }
+
+func TestRenderManifestBinSection(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ManifestBinEmitSpec
+		want string
+	}{
+		{"both-empty", ManifestBinEmitSpec{}, ""},
+		{"name-only", ManifestBinEmitSpec{Name: "demo"}, "\n[bin]\nname = \"demo\"\n"},
+		{"path-only", ManifestBinEmitSpec{Path: "src/main.osty"}, "\n[bin]\npath = \"src/main.osty\"\n"},
+		{"both", ManifestBinEmitSpec{Name: "demo", Path: "src/main.osty"}, "\n[bin]\nname = \"demo\"\npath = \"src/main.osty\"\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestBinSection(c.in); got != c.want {
+				t.Errorf("=\n%q\nwant\n%q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRenderManifestLibSection(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ManifestLibEmitSpec
+		want string
+	}{
+		{"empty", ManifestLibEmitSpec{}, ""},
+		{"with-path", ManifestLibEmitSpec{Path: "src/lib.osty"}, "\n[lib]\npath = \"src/lib.osty\"\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestLibSection(c.in); got != c.want {
+				t.Errorf("=\n%q\nwant\n%q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRenderManifestWorkspaceSection(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ManifestWorkspaceEmitSpec
+		want string
+	}{
+		{"two-members", ManifestWorkspaceEmitSpec{Members: []string{"pkg-a", "pkg-b"}}, "\n[workspace]\nmembers = [\"pkg-a\", \"pkg-b\"]\n"},
+		{"empty-members", ManifestWorkspaceEmitSpec{}, "\n[workspace]\nmembers = []\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestWorkspaceSection(c.in); got != c.want {
+				t.Errorf("=\n%q\nwant\n%q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRenderManifestCapabilitiesSection(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ManifestCapabilitiesEmitSpec
+		want string
+	}{
+		{"runtime-true", ManifestCapabilitiesEmitSpec{Runtime: true}, "\n[capabilities]\nruntime = true\n"},
+		{"runtime-false", ManifestCapabilitiesEmitSpec{Runtime: false}, "\n[capabilities]\nruntime = false\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestCapabilitiesSection(c.in); got != c.want {
+				t.Errorf("=\n%q\nwant\n%q", got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/manifest_emit.osty
+++ b/toolchain/manifest_emit.osty
@@ -141,3 +141,66 @@ pub fn renderManifestDepsSection(section: String, deps: List<ManifestDepEmitSpec
     }
     strings.join(parts, "")
 }
+/// ManifestBinEmitSpec mirrors the host `manifest.BinTarget`. Empty
+/// `name`/`path` both signal "no [bin] section"; the renderer
+/// elides the entire block in that case.
+pub struct ManifestBinEmitSpec {
+    pub name: String,
+    pub path: String,
+}
+/// renderManifestBinSection emits `\n[bin]\n` + optional name +
+/// optional path. Returns the empty string when both fields are
+/// empty so the host doesn't have to gate the call (the historical
+/// Go code emitted nothing when the BinTarget pointer was nil OR
+/// both fields were empty).
+pub fn renderManifestBinSection(bin: ManifestBinEmitSpec) -> String {
+    if bin.name == "" && bin.path == "" {
+        return ""
+    }
+    let mut out = "\n[bin]\n"
+    if bin.name != "" {
+        out = out + renderManifestStringField("name", bin.name)
+    }
+    if bin.path != "" {
+        out = out + renderManifestStringField("path", bin.path)
+    }
+    out
+}
+/// ManifestLibEmitSpec mirrors the host `manifest.LibTarget`. Empty
+/// `path` signals "no [lib] section".
+pub struct ManifestLibEmitSpec {
+    pub path: String,
+}
+/// renderManifestLibSection emits `\n[lib]\npath = "..."\n` or
+/// the empty string when `path` is empty.
+pub fn renderManifestLibSection(lib: ManifestLibEmitSpec) -> String {
+    if lib.path == "" {
+        return ""
+    }
+    "\n[lib]\n" + renderManifestStringField("path", lib.path)
+}
+/// ManifestWorkspaceEmitSpec mirrors the host `manifest.Workspace`.
+/// The renderer always emits the section assuming the caller has
+/// decided it's present (the host nil-check is the gate).
+pub struct ManifestWorkspaceEmitSpec {
+    pub members: List<String>,
+}
+/// renderManifestWorkspaceSection emits `\n[workspace]\nmembers =
+/// [...]\n`. Members is always rendered even when empty — that
+/// matches the historical Go output for a present-but-empty
+/// workspace.
+pub fn renderManifestWorkspaceSection(ws: ManifestWorkspaceEmitSpec) -> String {
+    "\n[workspace]\n" + renderManifestStringArrayField("members", ws.members)
+}
+/// ManifestCapabilitiesEmitSpec mirrors the host
+/// `manifest.Capabilities`. Always emitted by the renderer when
+/// the caller passes it through; the host's nil-check controls
+/// presence.
+pub struct ManifestCapabilitiesEmitSpec {
+    pub runtime: Bool,
+}
+/// renderManifestCapabilitiesSection emits
+/// `\n[capabilities]\nruntime = true/false\n`.
+pub fn renderManifestCapabilitiesSection(caps: ManifestCapabilitiesEmitSpec) -> String {
+    "\n[capabilities]\n" + renderManifestBoolField("runtime", caps.runtime)
+}

--- a/toolchain/manifest_emit_test.osty
+++ b/toolchain/manifest_emit_test.osty
@@ -180,3 +180,60 @@ fn testRenderManifestDepsSectionHonorsDepLineForm() {
     let expected = "\n[dev-dependencies]\na = \"1.0.0\"\nb = { path = \"../b\" }\n"
     testing.assertEq(out, expected)
 }
+fn testRenderManifestBinSectionBothEmpty() {
+    testing.assertEq(
+        renderManifestBinSection(ManifestBinEmitSpec {name: "", path: ""}),
+        "",
+    )
+}
+fn testRenderManifestBinSectionNameOnly() {
+    testing.assertEq(
+        renderManifestBinSection(ManifestBinEmitSpec {name: "demo", path: ""}),
+        "\n[bin]\nname = \"demo\"\n",
+    )
+}
+fn testRenderManifestBinSectionPathOnly() {
+    testing.assertEq(
+        renderManifestBinSection(ManifestBinEmitSpec {name: "", path: "src/main.osty"}),
+        "\n[bin]\npath = \"src/main.osty\"\n",
+    )
+}
+fn testRenderManifestBinSectionBoth() {
+    testing.assertEq(
+        renderManifestBinSection(ManifestBinEmitSpec {name: "demo", path: "src/main.osty"}),
+        "\n[bin]\nname = \"demo\"\npath = \"src/main.osty\"\n",
+    )
+}
+fn testRenderManifestLibSectionEmpty() {
+    testing.assertEq(renderManifestLibSection(ManifestLibEmitSpec {path: ""}), "")
+}
+fn testRenderManifestLibSection() {
+    testing.assertEq(
+        renderManifestLibSection(ManifestLibEmitSpec {path: "src/lib.osty"}),
+        "\n[lib]\npath = \"src/lib.osty\"\n",
+    )
+}
+fn testRenderManifestWorkspaceSection() {
+    testing.assertEq(
+        renderManifestWorkspaceSection(ManifestWorkspaceEmitSpec {members: ["pkg-a", "pkg-b"]}),
+        "\n[workspace]\nmembers = [\"pkg-a\", \"pkg-b\"]\n",
+    )
+}
+fn testRenderManifestWorkspaceSectionEmptyMembers() {
+    // Empty members still emits the section — matches the historical
+    // Go output for a present-but-empty workspace.
+    testing.assertEq(
+        renderManifestWorkspaceSection(ManifestWorkspaceEmitSpec {members: []}),
+        "\n[workspace]\nmembers = []\n",
+    )
+}
+fn testRenderManifestCapabilitiesSection() {
+    testing.assertEq(
+        renderManifestCapabilitiesSection(ManifestCapabilitiesEmitSpec {runtime: true}),
+        "\n[capabilities]\nruntime = true\n",
+    )
+    testing.assertEq(
+        renderManifestCapabilitiesSection(ManifestCapabilitiesEmitSpec {runtime: false}),
+        "\n[capabilities]\nruntime = false\n",
+    )
+}


### PR DESCRIPTION
## 요약

지난 PR (#1784) 의 string/array/bool/deps 헬퍼에 이어, 단순한 4개 manifest 섹션의 emission 정책을 `toolchain/manifest_emit.osty` 로 이전.

| Go 섹션 | Osty 함수 (신규) | 정책 |
|---|---|---|
| `[bin]` | `renderManifestBinSection` | optional name + optional path; 둘 다 빈 경우 "" 반환 |
| `[lib]` | `renderManifestLibSection` | path 빈 경우 "" 반환 |
| `[workspace]` | `renderManifestWorkspaceSection` | members 항상 emit (`members = []` 가능) |
| `[capabilities]` | `renderManifestCapabilitiesSection` | runtime bool 항상 emit |

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙 — 정책은 toolchain, glue는 Go.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/manifest_emit.osty`** (확장)
  - `pub struct ManifestBinEmitSpec / ManifestLibEmitSpec / ManifestWorkspaceEmitSpec / ManifestCapabilitiesEmitSpec`
  - `pub fn renderManifestBinSection / renderManifestLibSection / renderManifestWorkspaceSection / renderManifestCapabilitiesSection`
  - **네이밍 주의**: 기존 `manifest_validation.osty` 의 `ManifestWorkspaceSpec` / `ManifestPackageSpec` 와 충돌 방지 위해 `*EmitSpec` 접미사 사용 (`ManifestDepEmitSpec` 와 일관)
- **`toolchain/manifest_emit_test.osty`** (확장) — 11 신규 케이스
  - bin: both-empty (""), name-only, path-only, both
  - lib: empty (""), with-path
  - workspace: 2-members, empty-members (`members = []`)
  - capabilities: runtime=true, runtime=false

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/manifest_emit_policy.go`** (확장)
  - 4개 신규 type (`*EmitSpec`) + 4개 신규 fn (`RenderManifestXSection`)
- **`internal/runner/manifest_emit_policy_test.go`** (확장) — 4 신규 table test
- **`internal/manifest/manifest.go`** (수정)
  - Marshal 의 `[bin]` 분기 8줄 → 5줄 (runner adapter 호출)
  - `[lib]` 분기 3줄 → 4줄
  - `[workspace]` 분기 3줄 → 4줄
  - `[capabilities]` 분기 3줄 → 4줄

## 마이그레이션 결과

- manifest Marshal 의 단순 섹션 emission 정책 모두 toolchain 소유
- 셋 가지 surface 동시 검증:
  - **Osty 측**: 11 신규 케이스
  - **Go 스냅샷**: 4 신규 row table test (총 12 rows)
  - **드리프트 게이트**: `TestPolicySnapshotParityWithOsty/manifest_emit.osty` 가 4개 신규 `pub fn` + 4개 신규 `pub struct` ↔ Go export 1:1 강제
- **호환성**: 기존 manifest Marshal/Parse round-trip + `osty new` / `osty add` e2e 회귀 없음

## 남은 작업

manifest Marshal 의 다음 섹션들은 후속 PR 으로:
- `[package]` (10 필드: name, version, edition, description, authors, license, repository, homepage, keywords)
- `[registries.<name>]` (dynamic header per registry)
- `[gui]` + `[gui.webview2]` (nested optional)
- `[lint]` (allow + deny 배열, 둘 다 빈 경우 skip)

## 검증

```
$ .bin/osty check toolchain/manifest_emit.osty toolchain/manifest_emit_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/manifest/
ok  	github.com/osty/osty/internal/runner    0.020s
ok  	github.com/osty/osty/internal/manifest  0.004s

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    68.881s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| 1775~1779 | (생략 — 이전 PR 참조) | — |
| 1780 | airepair Python colon-header 리라이터 | `toolchain/airepair_python.osty` |
| 1781 | lint Exclude glob 정책 | `toolchain/lint_glob.osty` |
| 1782 | lockfile Marshal + tomlBasicString | `toolchain/lockfile_policy.osty` |
| 1783 | manifest dep-line emit 정책 | `toolchain/manifest_emit.osty` (신규) |
| 1784 | manifest field/array/bool/deps 섹션 정책 | `toolchain/manifest_emit.osty` (확장) |
| **이번** | **manifest [bin]/[lib]/[workspace]/[capabilities] 섹션** | **`toolchain/manifest_emit.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/manifest_emit.osty toolchain/manifest_emit_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/manifest/` 통과 — Marshal/Parse round-trip 회귀 없음
- [x] `go test ./cmd/osty/` 통과 — 4개 섹션을 emit 하는 시나리오 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_