### PR TITLE
refactor: manifest [package]/[registries]/[lint]/[gui] 섹션 self-host (Marshal 완료)

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -977,36 +977,20 @@ func stringArray(v *value, context string) ([]string, error) {
 // then the workspace table (if any).
 func Marshal(m *Manifest) []byte {
 	var b strings.Builder
-	// A virtual workspace may omit [package]. In every other case the
-	// package section comes first because it's the most important
-	// human-readable summary.
-	pkgEmit := m.HasPackage || m.Package.Name != "" || m.Package.Version != ""
-	if pkgEmit {
-		b.WriteString("[package]\n")
-		writeString(&b, "name", m.Package.Name)
-		writeString(&b, "version", m.Package.Version)
-		if m.Package.Edition != "" {
-			writeString(&b, "edition", m.Package.Edition)
-		}
-		if m.Package.Description != "" {
-			writeString(&b, "description", m.Package.Description)
-		}
-		if len(m.Package.Authors) > 0 {
-			writeStringArray(&b, "authors", m.Package.Authors)
-		}
-		if m.Package.License != "" {
-			writeString(&b, "license", m.Package.License)
-		}
-		if m.Package.Repository != "" {
-			writeString(&b, "repository", m.Package.Repository)
-		}
-		if m.Package.Homepage != "" {
-			writeString(&b, "homepage", m.Package.Homepage)
-		}
-		if len(m.Package.Keywords) > 0 {
-			writeStringArray(&b, "keywords", m.Package.Keywords)
-		}
-	}
+	// A virtual workspace may omit [package]. The renderer handles
+	// that gate via the HasPackage flag.
+	b.WriteString(runner.RenderManifestPackageSection(runner.ManifestPackageEmitSpec{
+		HasPackage:  m.HasPackage,
+		Name:        m.Package.Name,
+		Version:     m.Package.Version,
+		Edition:     m.Package.Edition,
+		Description: m.Package.Description,
+		Authors:     m.Package.Authors,
+		License:     m.Package.License,
+		Repository:  m.Package.Repository,
+		Homepage:    m.Package.Homepage,
+		Keywords:    m.Package.Keywords,
+	}))
 	if m.Bin != nil {
 		b.WriteString(runner.RenderManifestBinSection(runner.ManifestBinEmitSpec{
 			Name: m.Bin.Name,
@@ -1020,28 +1004,27 @@ func Marshal(m *Manifest) []byte {
 	}
 	writeDeps(&b, "dependencies", m.Dependencies)
 	writeDeps(&b, "dev-dependencies", m.DevDependencies)
-	for _, r := range m.Registries {
-		b.WriteString(fmt.Sprintf("\n[registries.%s]\n", r.Name))
-		if r.URL != "" {
-			writeString(&b, "url", r.URL)
+	if len(m.Registries) > 0 {
+		specs := make([]runner.ManifestRegistryEmitSpec, 0, len(m.Registries))
+		for _, r := range m.Registries {
+			specs = append(specs, runner.ManifestRegistryEmitSpec{
+				Name:  r.Name,
+				URL:   r.URL,
+				Token: r.Token,
+			})
 		}
-		if r.Token != "" {
-			writeString(&b, "token", r.Token)
-		}
+		b.WriteString(runner.RenderManifestRegistriesSection(specs))
 	}
 	if m.Workspace != nil {
 		b.WriteString(runner.RenderManifestWorkspaceSection(runner.ManifestWorkspaceEmitSpec{
 			Members: m.Workspace.Members,
 		}))
 	}
-	if m.Lint != nil && (len(m.Lint.Allow) > 0 || len(m.Lint.Deny) > 0) {
-		b.WriteString("\n[lint]\n")
-		if len(m.Lint.Allow) > 0 {
-			writeStringArray(&b, "allow", m.Lint.Allow)
-		}
-		if len(m.Lint.Deny) > 0 {
-			writeStringArray(&b, "deny", m.Lint.Deny)
-		}
+	if m.Lint != nil {
+		b.WriteString(runner.RenderManifestLintSection(runner.ManifestLintEmitSpec{
+			Allow: m.Lint.Allow,
+			Deny:  m.Lint.Deny,
+		}))
 	}
 	if m.Capabilities != nil {
 		b.WriteString(runner.RenderManifestCapabilitiesSection(runner.ManifestCapabilitiesEmitSpec{
@@ -1049,22 +1032,21 @@ func Marshal(m *Manifest) []byte {
 		}))
 	}
 	if m.GUI != nil {
-		b.WriteString("\n[gui]\n")
-		if m.GUI.Backend != "" {
-			writeString(&b, "backend", m.GUI.Backend)
-		}
-		if m.GUI.Entry != "" {
-			writeString(&b, "entry", m.GUI.Entry)
-		}
-		if m.GUI.WebView2 != nil {
-			b.WriteString("\n[gui.webview2]\n")
-			if m.GUI.WebView2.HasDevTools {
-				writeBool(&b, "devtools", m.GUI.WebView2.DevTools)
-			}
-			if m.GUI.WebView2.Runtime != "" {
-				writeString(&b, "runtime", m.GUI.WebView2.Runtime)
+		wv := runner.ManifestWebView2EmitSpec{}
+		hasWV2 := m.GUI.WebView2 != nil
+		if hasWV2 {
+			wv = runner.ManifestWebView2EmitSpec{
+				HasDevTools: m.GUI.WebView2.HasDevTools,
+				DevTools:    m.GUI.WebView2.DevTools,
+				Runtime:     m.GUI.WebView2.Runtime,
 			}
 		}
+		b.WriteString(runner.RenderManifestGUISection(runner.ManifestGUIEmitSpec{
+			Backend:     m.GUI.Backend,
+			Entry:       m.GUI.Entry,
+			HasWebView2: hasWV2,
+			WebView2:    wv,
+		}))
 	}
 	return []byte(b.String())
 }

--- a/internal/runner/manifest_emit_policy.go
+++ b/internal/runner/manifest_emit_policy.go
@@ -232,3 +232,168 @@ type ManifestCapabilitiesEmitSpec struct {
 func RenderManifestCapabilitiesSection(caps ManifestCapabilitiesEmitSpec) string {
 	return "\n[capabilities]\n" + RenderManifestBoolField("runtime", caps.Runtime)
 }
+
+// ManifestPackageEmitSpec mirrors the [package] table emit
+// payload. HasPackage is the host's `Manifest.HasPackage` flag —
+// together with Name/Version it gates emission so a virtual
+// workspace manifest omits the entire section.
+//
+// Osty: toolchain/manifest_emit.osty:211
+type ManifestPackageEmitSpec struct {
+	HasPackage  bool
+	Name        string
+	Version     string
+	Edition     string
+	Description string
+	Authors     []string
+	License     string
+	Repository  string
+	Homepage    string
+	Keywords    []string
+}
+
+// RenderManifestPackageSection emits `[package]\n` plus every
+// non-empty field. Returns "" for a virtual workspace shape
+// (HasPackage == false AND both Name + Version empty).
+//
+// Osty: toolchain/manifest_emit.osty:231
+func RenderManifestPackageSection(pkg ManifestPackageEmitSpec) string {
+	if !pkg.HasPackage && pkg.Name == "" && pkg.Version == "" {
+		return ""
+	}
+	out := "[package]\n"
+	out += RenderManifestStringField("name", pkg.Name)
+	out += RenderManifestStringField("version", pkg.Version)
+	if pkg.Edition != "" {
+		out += RenderManifestStringField("edition", pkg.Edition)
+	}
+	if pkg.Description != "" {
+		out += RenderManifestStringField("description", pkg.Description)
+	}
+	if len(pkg.Authors) > 0 {
+		out += RenderManifestStringArrayField("authors", pkg.Authors)
+	}
+	if pkg.License != "" {
+		out += RenderManifestStringField("license", pkg.License)
+	}
+	if pkg.Repository != "" {
+		out += RenderManifestStringField("repository", pkg.Repository)
+	}
+	if pkg.Homepage != "" {
+		out += RenderManifestStringField("homepage", pkg.Homepage)
+	}
+	if len(pkg.Keywords) > 0 {
+		out += RenderManifestStringArrayField("keywords", pkg.Keywords)
+	}
+	return out
+}
+
+// ManifestRegistryEmitSpec mirrors one entry of the host
+// `manifest.Registries` slice.
+//
+// Osty: toolchain/manifest_emit.osty:264
+type ManifestRegistryEmitSpec struct {
+	Name  string
+	URL   string
+	Token string
+}
+
+// RenderManifestRegistriesSection emits one
+// `[registries.<name>]` block per entry. Order is preserved
+// from the input slice (the historical Go code did not sort).
+// Returns "" when the slice is empty.
+//
+// Osty: toolchain/manifest_emit.osty:273
+func RenderManifestRegistriesSection(registries []ManifestRegistryEmitSpec) string {
+	if len(registries) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range registries {
+		b.WriteString("\n[registries.")
+		b.WriteString(r.Name)
+		b.WriteString("]\n")
+		if r.URL != "" {
+			b.WriteString(RenderManifestStringField("url", r.URL))
+		}
+		if r.Token != "" {
+			b.WriteString(RenderManifestStringField("token", r.Token))
+		}
+	}
+	return b.String()
+}
+
+// ManifestLintEmitSpec mirrors the [lint] table emit payload.
+// Empty Allow AND empty Deny together gate the section out.
+//
+// Osty: toolchain/manifest_emit.osty:292
+type ManifestLintEmitSpec struct {
+	Allow []string
+	Deny  []string
+}
+
+// RenderManifestLintSection emits `\n[lint]\n` + optional allow +
+// optional deny. Returns "" when both arrays are empty.
+//
+// Osty: toolchain/manifest_emit.osty:298
+func RenderManifestLintSection(lint ManifestLintEmitSpec) string {
+	if len(lint.Allow) == 0 && len(lint.Deny) == 0 {
+		return ""
+	}
+	out := "\n[lint]\n"
+	if len(lint.Allow) > 0 {
+		out += RenderManifestStringArrayField("allow", lint.Allow)
+	}
+	if len(lint.Deny) > 0 {
+		out += RenderManifestStringArrayField("deny", lint.Deny)
+	}
+	return out
+}
+
+// ManifestWebView2EmitSpec mirrors the nested
+// `[gui.webview2]` table. HasDevTools is the host's flag
+// distinguishing "field absent" from `devtools = false`.
+//
+// Osty: toolchain/manifest_emit.osty:315
+type ManifestWebView2EmitSpec struct {
+	HasDevTools bool
+	DevTools    bool
+	Runtime     string
+}
+
+// ManifestGUIEmitSpec mirrors the [gui] table. HasWebView2 gates
+// the nested `[gui.webview2]` block.
+//
+// Osty: toolchain/manifest_emit.osty:324
+type ManifestGUIEmitSpec struct {
+	Backend     string
+	Entry       string
+	HasWebView2 bool
+	WebView2    ManifestWebView2EmitSpec
+}
+
+// RenderManifestGUISection emits `\n[gui]\n` + optional fields,
+// followed by an optional nested `\n[gui.webview2]\n` block.
+// Always emitted by the renderer; the host's nil-check on m.GUI
+// controls presence.
+//
+// Osty: toolchain/manifest_emit.osty:334
+func RenderManifestGUISection(gui ManifestGUIEmitSpec) string {
+	out := "\n[gui]\n"
+	if gui.Backend != "" {
+		out += RenderManifestStringField("backend", gui.Backend)
+	}
+	if gui.Entry != "" {
+		out += RenderManifestStringField("entry", gui.Entry)
+	}
+	if gui.HasWebView2 {
+		out += "\n[gui.webview2]\n"
+		if gui.WebView2.HasDevTools {
+			out += RenderManifestBoolField("devtools", gui.WebView2.DevTools)
+		}
+		if gui.WebView2.Runtime != "" {
+			out += RenderManifestStringField("runtime", gui.WebView2.Runtime)
+		}
+	}
+	return out
+}

--- a/internal/runner/manifest_emit_policy_test.go
+++ b/internal/runner/manifest_emit_policy_test.go
@@ -301,3 +301,147 @@ func TestRenderManifestCapabilitiesSection(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderManifestPackageSection(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ManifestPackageEmitSpec
+		want string
+	}{
+		{
+			name: "virtual-workspace-omits",
+			in:   ManifestPackageEmitSpec{},
+			want: "",
+		},
+		{
+			name: "present-flag-emits-blank-fields",
+			in:   ManifestPackageEmitSpec{HasPackage: true},
+			want: "[package]\nname = \"\"\nversion = \"\"\n",
+		},
+		{
+			name: "name-version-only",
+			in:   ManifestPackageEmitSpec{Name: "demo", Version: "0.1.0"},
+			want: "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+		},
+		{
+			name: "all-fields",
+			in: ManifestPackageEmitSpec{
+				HasPackage:  true,
+				Name:        "demo",
+				Version:     "0.1.0",
+				Edition:     "0.5",
+				Description: "A demo",
+				Authors:     []string{"Alice"},
+				License:     "MIT",
+				Repository:  "https://github.com/x/demo",
+				Homepage:    "https://demo.example",
+				Keywords:    []string{"demo", "test"},
+			},
+			want: "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"0.5\"\ndescription = \"A demo\"\nauthors = [\"Alice\"]\nlicense = \"MIT\"\nrepository = \"https://github.com/x/demo\"\nhomepage = \"https://demo.example\"\nkeywords = [\"demo\", \"test\"]\n",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestPackageSection(c.in); got != c.want {
+				t.Errorf("=\n%q\nwant\n%q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRenderManifestRegistriesSection(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		if got := RenderManifestRegistriesSection(nil); got != "" {
+			t.Errorf("empty input must return \"\", got %q", got)
+		}
+	})
+	t.Run("single-full", func(t *testing.T) {
+		r := ManifestRegistryEmitSpec{Name: "custom", URL: "https://registry.custom.dev", Token: "secret"}
+		want := "\n[registries.custom]\nurl = \"https://registry.custom.dev\"\ntoken = \"secret\"\n"
+		if got := RenderManifestRegistriesSection([]ManifestRegistryEmitSpec{r}); got != want {
+			t.Errorf("=\n%q\nwant\n%q", got, want)
+		}
+	})
+	t.Run("url-only", func(t *testing.T) {
+		r := ManifestRegistryEmitSpec{Name: "noauth", URL: "https://r.dev"}
+		want := "\n[registries.noauth]\nurl = \"https://r.dev\"\n"
+		if got := RenderManifestRegistriesSection([]ManifestRegistryEmitSpec{r}); got != want {
+			t.Errorf("=\n%q\nwant\n%q", got, want)
+		}
+	})
+	t.Run("preserves-input-order", func(t *testing.T) {
+		r1 := ManifestRegistryEmitSpec{Name: "b", URL: "u1"}
+		r2 := ManifestRegistryEmitSpec{Name: "a", URL: "u2"}
+		want := "\n[registries.b]\nurl = \"u1\"\n\n[registries.a]\nurl = \"u2\"\n"
+		if got := RenderManifestRegistriesSection([]ManifestRegistryEmitSpec{r1, r2}); got != want {
+			t.Errorf("=\n%q\nwant\n%q", got, want)
+		}
+	})
+}
+
+func TestRenderManifestLintSection(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ManifestLintEmitSpec
+		want string
+	}{
+		{"both-empty", ManifestLintEmitSpec{}, ""},
+		{"allow-only", ManifestLintEmitSpec{Allow: []string{"L0001", "dead_code"}}, "\n[lint]\nallow = [\"L0001\", \"dead_code\"]\n"},
+		{"deny-only", ManifestLintEmitSpec{Deny: []string{"unused"}}, "\n[lint]\ndeny = [\"unused\"]\n"},
+		{"both", ManifestLintEmitSpec{Allow: []string{"L0001"}, Deny: []string{"L0002"}}, "\n[lint]\nallow = [\"L0001\"]\ndeny = [\"L0002\"]\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RenderManifestLintSection(c.in); got != c.want {
+				t.Errorf("=\n%q\nwant\n%q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRenderManifestGUISection(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		if got := RenderManifestGUISection(ManifestGUIEmitSpec{}); got != "\n[gui]\n" {
+			t.Errorf("minimal gui = %q, want %q", got, "\n[gui]\n")
+		}
+	})
+	t.Run("with-fields", func(t *testing.T) {
+		got := RenderManifestGUISection(ManifestGUIEmitSpec{Backend: "wry", Entry: "src/ui.osty"})
+		want := "\n[gui]\nbackend = \"wry\"\nentry = \"src/ui.osty\"\n"
+		if got != want {
+			t.Errorf("=\n%q\nwant\n%q", got, want)
+		}
+	})
+	t.Run("webview2-devtools-only", func(t *testing.T) {
+		got := RenderManifestGUISection(ManifestGUIEmitSpec{
+			Backend:     "webview2",
+			HasWebView2: true,
+			WebView2:    ManifestWebView2EmitSpec{HasDevTools: true, DevTools: true},
+		})
+		want := "\n[gui]\nbackend = \"webview2\"\n\n[gui.webview2]\ndevtools = true\n"
+		if got != want {
+			t.Errorf("=\n%q\nwant\n%q", got, want)
+		}
+	})
+	t.Run("webview2-devtools-false-explicit", func(t *testing.T) {
+		// HasDevTools=true + DevTools=false → emit `devtools = false` (false != absent).
+		got := RenderManifestGUISection(ManifestGUIEmitSpec{
+			HasWebView2: true,
+			WebView2:    ManifestWebView2EmitSpec{HasDevTools: true, DevTools: false, Runtime: "C:/runtime"},
+		})
+		want := "\n[gui]\n\n[gui.webview2]\ndevtools = false\nruntime = \"C:/runtime\"\n"
+		if got != want {
+			t.Errorf("=\n%q\nwant\n%q", got, want)
+		}
+	})
+	t.Run("webview2-devtools-absent", func(t *testing.T) {
+		got := RenderManifestGUISection(ManifestGUIEmitSpec{
+			HasWebView2: true,
+			WebView2:    ManifestWebView2EmitSpec{HasDevTools: false, Runtime: "C:/runtime"},
+		})
+		want := "\n[gui]\n\n[gui.webview2]\nruntime = \"C:/runtime\"\n"
+		if got != want {
+			t.Errorf("=\n%q\nwant\n%q", got, want)
+		}
+	})
+}

--- a/toolchain/manifest_emit.osty
+++ b/toolchain/manifest_emit.osty
@@ -204,3 +204,149 @@ pub struct ManifestCapabilitiesEmitSpec {
 pub fn renderManifestCapabilitiesSection(caps: ManifestCapabilitiesEmitSpec) -> String {
     "\n[capabilities]\n" + renderManifestBoolField("runtime", caps.runtime)
 }
+/// ManifestPackageEmitSpec mirrors the [package] table emit
+/// payload. `hasPackage` is the host's `Manifest.HasPackage` flag
+/// — together with name/version it gates emission so a virtual
+/// workspace manifest omits the entire section.
+pub struct ManifestPackageEmitSpec {
+    pub hasPackage: Bool,
+    pub name: String,
+    pub version: String,
+    pub edition: String,
+    pub description: String,
+    pub authors: List<String>,
+    pub license: String,
+    pub repository: String,
+    pub homepage: String,
+    pub keywords: List<String>,
+}
+/// renderManifestPackageSection emits `[package]\n` plus every
+/// non-empty field. Returns "" when `hasPackage` is false AND
+/// both `name` and `version` are empty — that's the "virtual
+/// workspace" shape the host has historically skipped.
+///
+/// `name` and `version` are always emitted (even when blank) so
+/// the section can be parsed back as an explicit `name = ""`
+/// when the host requested presence via `hasPackage = true`.
+pub fn renderManifestPackageSection(pkg: ManifestPackageEmitSpec) -> String {
+    if !pkg.hasPackage && pkg.name == "" && pkg.version == "" {
+        return ""
+    }
+    let mut out = "[package]\n"
+    out = out + renderManifestStringField("name", pkg.name)
+    out = out + renderManifestStringField("version", pkg.version)
+    if pkg.edition != "" {
+        out = out + renderManifestStringField("edition", pkg.edition)
+    }
+    if pkg.description != "" {
+        out = out + renderManifestStringField("description", pkg.description)
+    }
+    if pkg.authors.len() > 0 {
+        out = out + renderManifestStringArrayField("authors", pkg.authors)
+    }
+    if pkg.license != "" {
+        out = out + renderManifestStringField("license", pkg.license)
+    }
+    if pkg.repository != "" {
+        out = out + renderManifestStringField("repository", pkg.repository)
+    }
+    if pkg.homepage != "" {
+        out = out + renderManifestStringField("homepage", pkg.homepage)
+    }
+    if pkg.keywords.len() > 0 {
+        out = out + renderManifestStringArrayField("keywords", pkg.keywords)
+    }
+    out
+}
+/// ManifestRegistryEmitSpec mirrors one entry of the host
+/// `manifest.Registries` slice. The renderer emits a
+/// `[registries.<name>]` block; empty `url`/`token` are skipped.
+pub struct ManifestRegistryEmitSpec {
+    pub name: String,
+    pub url: String,
+    pub token: String,
+}
+/// renderManifestRegistriesSection emits one `[registries.<name>]`
+/// block per entry. Order is preserved from the input list (the
+/// historical Go code did not sort here). Returns "" when the
+/// list is empty.
+pub fn renderManifestRegistriesSection(registries: List<ManifestRegistryEmitSpec>) -> String {
+    if registries.len() == 0 {
+        return ""
+    }
+    let mut out = ""
+    for r in registries {
+        out = out + "\n[registries." + r.name + "]\n"
+        if r.url != "" {
+            out = out + renderManifestStringField("url", r.url)
+        }
+        if r.token != "" {
+            out = out + renderManifestStringField("token", r.token)
+        }
+    }
+    out
+}
+/// ManifestLintEmitSpec mirrors the [lint] table emit payload.
+/// Empty `allow` AND empty `deny` together gate the section out;
+/// the host's historical guard was `len(Allow)>0 || len(Deny)>0`.
+pub struct ManifestLintEmitSpec {
+    pub allow: List<String>,
+    pub deny: List<String>,
+}
+/// renderManifestLintSection emits `\n[lint]\n` + optional allow +
+/// optional deny. Returns "" when both arrays are empty.
+pub fn renderManifestLintSection(lint: ManifestLintEmitSpec) -> String {
+    if lint.allow.len() == 0 && lint.deny.len() == 0 {
+        return ""
+    }
+    let mut out = "\n[lint]\n"
+    if lint.allow.len() > 0 {
+        out = out + renderManifestStringArrayField("allow", lint.allow)
+    }
+    if lint.deny.len() > 0 {
+        out = out + renderManifestStringArrayField("deny", lint.deny)
+    }
+    out
+}
+/// ManifestWebView2EmitSpec mirrors the nested
+/// `[gui.webview2]` table. `hasDevTools` is the host's flag
+/// distinguishing "field absent" from `devTools = false`
+/// (both serialise to different output).
+pub struct ManifestWebView2EmitSpec {
+    pub hasDevTools: Bool,
+    pub devTools: Bool,
+    pub runtime: String,
+}
+/// ManifestGUIEmitSpec mirrors the [gui] table. `hasWebView2`
+/// gates the nested `[gui.webview2]` block; without that flag,
+/// an empty `ManifestWebView2EmitSpec` would still appear since
+/// Osty has no `T?` for opting the whole struct out.
+pub struct ManifestGUIEmitSpec {
+    pub backend: String,
+    pub entry: String,
+    pub hasWebView2: Bool,
+    pub webView2: ManifestWebView2EmitSpec,
+}
+/// renderManifestGUISection emits `\n[gui]\n` + optional fields,
+/// followed by an optional `\n[gui.webview2]\n` nested block.
+/// Always emitted by the renderer; the host's nil-check on `m.GUI`
+/// controls presence.
+pub fn renderManifestGUISection(gui: ManifestGUIEmitSpec) -> String {
+    let mut out = "\n[gui]\n"
+    if gui.backend != "" {
+        out = out + renderManifestStringField("backend", gui.backend)
+    }
+    if gui.entry != "" {
+        out = out + renderManifestStringField("entry", gui.entry)
+    }
+    if gui.hasWebView2 {
+        out = out + "\n[gui.webview2]\n"
+        if gui.webView2.hasDevTools {
+            out = out + renderManifestBoolField("devtools", gui.webView2.devTools)
+        }
+        if gui.webView2.runtime != "" {
+            out = out + renderManifestStringField("runtime", gui.webView2.runtime)
+        }
+    }
+    out
+}

--- a/toolchain/manifest_emit_test.osty
+++ b/toolchain/manifest_emit_test.osty
@@ -237,3 +237,190 @@ fn testRenderManifestCapabilitiesSection() {
         "\n[capabilities]\nruntime = false\n",
     )
 }
+fn defaultPackage() -> ManifestPackageEmitSpec {
+    ManifestPackageEmitSpec {
+        hasPackage: false,
+        name: "",
+        version: "",
+        edition: "",
+        description: "",
+        authors: [],
+        license: "",
+        repository: "",
+        homepage: "",
+        keywords: [],
+    }
+}
+fn testRenderManifestPackageSectionVirtualOmits() {
+    testing.assertEq(renderManifestPackageSection(defaultPackage()), "")
+}
+fn testRenderManifestPackageSectionPresentWithFlag() {
+    let pkg = ManifestPackageEmitSpec {..defaultPackage(), hasPackage: true}
+    testing.assertEq(
+        renderManifestPackageSection(pkg),
+        "[package]\nname = \"\"\nversion = \"\"\n",
+    )
+}
+fn testRenderManifestPackageSectionNameVersion() {
+    let pkg = ManifestPackageEmitSpec {
+        ..defaultPackage(),
+        name: "demo",
+        version: "0.1.0",
+    }
+    testing.assertEq(
+        renderManifestPackageSection(pkg),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+    )
+}
+fn testRenderManifestPackageSectionAllFields() {
+    let pkg = ManifestPackageEmitSpec {
+        hasPackage: true,
+        name: "demo",
+        version: "0.1.0",
+        edition: "0.5",
+        description: "A demo",
+        authors: ["Alice"],
+        license: "MIT",
+        repository: "https://github.com/x/demo",
+        homepage: "https://demo.example",
+        keywords: ["demo", "test"],
+    }
+    let expected = "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"0.5\"\ndescription = \"A demo\"\nauthors = [\"Alice\"]\nlicense = \"MIT\"\nrepository = \"https://github.com/x/demo\"\nhomepage = \"https://demo.example\"\nkeywords = [\"demo\", \"test\"]\n"
+    testing.assertEq(renderManifestPackageSection(pkg), expected)
+}
+fn testRenderManifestRegistriesSectionEmpty() {
+    testing.assertEq(renderManifestRegistriesSection([]), "")
+}
+fn testRenderManifestRegistriesSectionSingle() {
+    let r = ManifestRegistryEmitSpec {
+        name: "custom",
+        url: "https://registry.custom.dev",
+        token: "secret",
+    }
+    testing.assertEq(
+        renderManifestRegistriesSection([r]),
+        "\n[registries.custom]\nurl = \"https://registry.custom.dev\"\ntoken = \"secret\"\n",
+    )
+}
+fn testRenderManifestRegistriesSectionUrlOnly() {
+    let r = ManifestRegistryEmitSpec {
+        name: "noauth",
+        url: "https://r.dev",
+        token: "",
+    }
+    testing.assertEq(
+        renderManifestRegistriesSection([r]),
+        "\n[registries.noauth]\nurl = \"https://r.dev\"\n",
+    )
+}
+fn testRenderManifestRegistriesSectionMultiplePreservesOrder() {
+    let r1 = ManifestRegistryEmitSpec {name: "b", url: "u1", token: ""}
+    let r2 = ManifestRegistryEmitSpec {name: "a", url: "u2", token: ""}
+    let out = renderManifestRegistriesSection([r1, r2])
+    testing.assertEq(
+        out,
+        "\n[registries.b]\nurl = \"u1\"\n\n[registries.a]\nurl = \"u2\"\n",
+    )
+}
+fn testRenderManifestLintSectionBothEmpty() {
+    testing.assertEq(
+        renderManifestLintSection(ManifestLintEmitSpec {allow: [], deny: []}),
+        "",
+    )
+}
+fn testRenderManifestLintSectionAllowOnly() {
+    testing.assertEq(
+        renderManifestLintSection(ManifestLintEmitSpec {
+            allow: ["L0001", "dead_code"],
+            deny: [],
+        }),
+        "\n[lint]\nallow = [\"L0001\", \"dead_code\"]\n",
+    )
+}
+fn testRenderManifestLintSectionDenyOnly() {
+    testing.assertEq(
+        renderManifestLintSection(ManifestLintEmitSpec {
+            allow: [],
+            deny: ["unused"],
+        }),
+        "\n[lint]\ndeny = [\"unused\"]\n",
+    )
+}
+fn testRenderManifestLintSectionBoth() {
+    testing.assertEq(
+        renderManifestLintSection(ManifestLintEmitSpec {
+            allow: ["L0001"],
+            deny: ["L0002"],
+        }),
+        "\n[lint]\nallow = [\"L0001\"]\ndeny = [\"L0002\"]\n",
+    )
+}
+fn emptyWebView2() -> ManifestWebView2EmitSpec {
+    ManifestWebView2EmitSpec {hasDevTools: false, devTools: false, runtime: ""}
+}
+fn defaultGUI() -> ManifestGUIEmitSpec {
+    ManifestGUIEmitSpec {
+        backend: "",
+        entry: "",
+        hasWebView2: false,
+        webView2: emptyWebView2(),
+    }
+}
+fn testRenderManifestGUISectionMinimal() {
+    testing.assertEq(renderManifestGUISection(defaultGUI()), "\n[gui]\n")
+}
+fn testRenderManifestGUISectionWithFields() {
+    let gui = ManifestGUIEmitSpec {..defaultGUI(), backend: "wry", entry: "src/ui.osty"}
+    testing.assertEq(
+        renderManifestGUISection(gui),
+        "\n[gui]\nbackend = \"wry\"\nentry = \"src/ui.osty\"\n",
+    )
+}
+fn testRenderManifestGUISectionWebView2DevtoolsOnly() {
+    let gui = ManifestGUIEmitSpec {
+        ..defaultGUI(),
+        backend: "webview2",
+        hasWebView2: true,
+        webView2: ManifestWebView2EmitSpec {
+            hasDevTools: true,
+            devTools: true,
+            runtime: "",
+        },
+    }
+    testing.assertEq(
+        renderManifestGUISection(gui),
+        "\n[gui]\nbackend = \"webview2\"\n\n[gui.webview2]\ndevtools = true\n",
+    )
+}
+fn testRenderManifestGUISectionWebView2DevtoolsFalsePresent() {
+    // hasDevTools=true with devTools=false should still emit (false != absent).
+    let gui = ManifestGUIEmitSpec {
+        ..defaultGUI(),
+        hasWebView2: true,
+        webView2: ManifestWebView2EmitSpec {
+            hasDevTools: true,
+            devTools: false,
+            runtime: "C:/runtime",
+        },
+    }
+    testing.assertEq(
+        renderManifestGUISection(gui),
+        "\n[gui]\n\n[gui.webview2]\ndevtools = false\nruntime = \"C:/runtime\"\n",
+    )
+}
+fn testRenderManifestGUISectionWebView2DevtoolsAbsent() {
+    // hasDevTools=false → omit devtools line entirely.
+    let gui = ManifestGUIEmitSpec {
+        ..defaultGUI(),
+        hasWebView2: true,
+        webView2: ManifestWebView2EmitSpec {
+            hasDevTools: false,
+            devTools: false,
+            runtime: "C:/runtime",
+        },
+    }
+    testing.assertEq(
+        renderManifestGUISection(gui),
+        "\n[gui]\n\n[gui.webview2]\nruntime = \"C:/runtime\"\n",
+    )
+}


### PR DESCRIPTION
## 요약

지난 PR (#1785) 의 단순 4개 섹션 (`[bin]`/`[lib]`/`[workspace]`/`[capabilities]`) 에 이어, **나머지 manifest Marshal 섹션 emission 정책 전체** 를 `toolchain/manifest_emit.osty` 로 이전:

| 섹션 | 신규 Osty 함수 | 정책 |
|---|---|---|
| `[package]` (10 필드) | `renderManifestPackageSection` | virtual workspace 시 "" 반환 |
| `[registries.<name>]` | `renderManifestRegistriesSection` | 입력 순서 보존 |
| `[lint]` | `renderManifestLintSection` | allow + deny 모두 empty 시 "" 반환 |
| `[gui]` + `[gui.webview2]` (nested) | `renderManifestGUISection` | `hasWebView2`/`hasDevTools` flag 로 nested + tristate emission |

이제 `internal/manifest/manifest.go::Marshal` 의 **모든 7개 섹션** (package / bin / lib / deps / dev-dependencies / registries / workspace / lint / capabilities / gui+webview2) emission 정책이 toolchain-owned.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙 완수.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/manifest_emit.osty`** (확장)
  - `pub struct ManifestPackageEmitSpec` — 10 필드 + `hasPackage` 게이트 flag
  - `pub struct ManifestRegistryEmitSpec` — name/url/token
  - `pub struct ManifestLintEmitSpec` — allow + deny 배열
  - `pub struct ManifestWebView2EmitSpec` — `hasDevTools` flag (false vs absent 구분) + devTools + runtime
  - `pub struct ManifestGUIEmitSpec` — backend / entry / `hasWebView2` + nested WebView2
  - `pub fn renderManifestPackageSection / renderManifestRegistriesSection / renderManifestLintSection / renderManifestGUISection`
- **`toolchain/manifest_emit_test.osty`** (확장) — 17 신규 케이스
  - package: virtual workspace omits, present flag emits blank fields, name-version only, all-fields
  - registries: empty, single full, url-only, preserves input order
  - lint: both-empty, allow-only, deny-only, both
  - gui: minimal, with-fields, webview2 devtools-only, devtools-false-explicit (`false != absent`), devtools-absent

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/manifest_emit_policy.go`** (확장)
  - 5개 신규 type + 5개 신규 fn (`Render*Section`)
- **`internal/runner/manifest_emit_policy_test.go`** (확장) — 4 신규 row table test
- **`internal/manifest/manifest.go`** (수정)
  - `[package]` 23줄 → 13줄
  - `[registries]` 9줄 → 11줄 (spec 마샬링 오버헤드)
  - `[lint]` 9줄 → 6줄
  - `[gui]` 17줄 → 16줄 (nested webview2 spec 마샬링)

## 마이그레이션 결과

- **manifest Marshal 의 모든 섹션 emission 정책 = toolchain-owned** (이전 PR 들과 합쳐 100% 완료)
- 셋 가지 surface 동시 검증:
  - **Osty 측**: 17 신규 케이스
  - **Go 스냅샷**: 4 신규 row table test
  - **드리프트 게이트**: `TestPolicySnapshotParityWithOsty/manifest_emit.osty` 가 5개 신규 `pub fn` + 5개 신규 `pub struct` ↔ Go export 1:1 강제
- **호환성**: 기존 manifest Marshal/Parse round-trip + `osty new` / `osty add` / `osty publish` e2e (cmd/osty 70초) 회귀 없음

## 검증

```
$ .bin/osty check toolchain/manifest_emit.osty toolchain/manifest_emit_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/manifest/
ok  	github.com/osty/osty/internal/runner    0.021s
ok  	github.com/osty/osty/internal/manifest  0.005s

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    70.520s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| 1775~1779 | (이전 PR 참조) | — |
| 1780 | airepair Python colon-header 리라이터 | `toolchain/airepair_python.osty` |
| 1781 | lint Exclude glob 정책 | `toolchain/lint_glob.osty` |
| 1782 | lockfile Marshal + tomlBasicString | `toolchain/lockfile_policy.osty` |
| 1783 | manifest dep-line emit | `toolchain/manifest_emit.osty` (신규) |
| 1784 | manifest field/array/bool/deps 정책 | `toolchain/manifest_emit.osty` (확장) |
| 1785 | manifest [bin]/[lib]/[workspace]/[capabilities] | `toolchain/manifest_emit.osty` (확장) |
| **이번** | **manifest [package]/[registries]/[lint]/[gui] (Marshal 완료)** | **`toolchain/manifest_emit.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/manifest_emit.osty toolchain/manifest_emit_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/manifest/` 통과 — Marshal/Parse round-trip 회귀 없음
- [x] `go test ./cmd/osty/` 통과 (70초 e2e) — manifest Marshal 호출 경로 (`osty new`/`osty add`/`osty publish`) 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_