### PR TITLE
refactor: pkgmgr skipDirEntry self-host (toolchain/pkg_policy.osty)

### DIFF
--- a/internal/pkgmgr/hash.go
+++ b/internal/pkgmgr/hash.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/osty/osty/internal/runner"
 )
 
 // HashPrefix is the algorithm tag used in lockfile `checksum` fields.
@@ -105,15 +107,10 @@ func VerifyChecksum(want, got string) error {
 }
 
 // skipDirEntry returns true for filesystem entries the packager
-// should ignore: our own cache, version-control metadata, OS cruft.
-func skipDirEntry(rel string, info os.FileInfo) bool {
-	base := filepath.Base(rel)
-	if rel == "." {
-		return false
-	}
-	switch base {
-	case ".osty", ".git", ".hg", ".svn", ".DS_Store":
-		return true
-	}
-	return false
+// should ignore. Decision policy lives in
+// toolchain/pkg_policy.osty::pkgSkipDirEntry; this wrapper just
+// drops the unused FileInfo so existing filepath.Walk call sites
+// don't have to change.
+func skipDirEntry(rel string, _ os.FileInfo) bool {
+	return runner.PkgSkipDirEntry(rel)
 }

--- a/internal/runner/pkg_policy.go
+++ b/internal/runner/pkg_policy.go
@@ -61,3 +61,35 @@ func LockedDiffMessage(lockfileName string, changes []string) string {
 	b.WriteString("rerun without --locked to update the lockfile.")
 	return b.String()
 }
+
+// PkgSkipDirEntry reports whether a filesystem entry should be
+// excluded when hashing a path-source directory or packing a
+// publish tarball. Pure basename match; `rel == "."` (the walk
+// root itself) is never skipped.
+//
+// Osty: toolchain/pkg_policy.osty:64
+func PkgSkipDirEntry(rel string) bool {
+	if rel == "." {
+		return false
+	}
+	base := pkgPathBase(rel)
+	switch base {
+	case ".osty", ".git", ".hg", ".svn", ".DS_Store":
+		return true
+	}
+	return false
+}
+
+func pkgPathBase(p string) string {
+	last := -1
+	for i := 0; i < len(p); i++ {
+		b := p[i]
+		if b == '/' || b == '\\' {
+			last = i
+		}
+	}
+	if last < 0 {
+		return p
+	}
+	return p[last+1:]
+}

--- a/internal/runner/pkg_policy.go
+++ b/internal/runner/pkg_policy.go
@@ -80,16 +80,26 @@ func PkgSkipDirEntry(rel string) bool {
 	return false
 }
 
+// pkgPathBase mirrors filepath.Base on forward-slash and backslash
+// paths, including trimming trailing separators (`sub/.git/` →
+// `.git`).
 func pkgPathBase(p string) string {
-	last := -1
-	for i := 0; i < len(p); i++ {
-		b := p[i]
-		if b == '/' || b == '\\' {
-			last = i
-		}
+	end := len(p)
+	for end > 0 && (p[end-1] == '/' || p[end-1] == '\\') {
+		end--
 	}
-	if last < 0 {
+	if end == 0 {
 		return p
 	}
-	return p[last+1:]
+	sep := -1
+	for i := 0; i < end; i++ {
+		b := p[i]
+		if b == '/' || b == '\\' {
+			sep = i
+		}
+	}
+	if sep < 0 {
+		return p[:end]
+	}
+	return p[sep+1 : end]
 }

--- a/internal/runner/pkg_policy_test.go
+++ b/internal/runner/pkg_policy_test.go
@@ -64,3 +64,32 @@ func TestLockedDiffMessageFormatsChanges(t *testing.T) {
 		t.Errorf("LockedDiffMessage =\n%q\nwant\n%q", got, want)
 	}
 }
+
+func TestPkgSkipDirEntry(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"dot-kept", ".", false},
+		{"osty-cache-root", ".osty", true},
+		{"osty-cache-nested", "sub/.osty", true},
+		{"path-inside-osty-not-skipped", ".osty/cache/x", false},
+		{"git", ".git", true},
+		{"hg", ".hg", true},
+		{"svn", ".svn", true},
+		{"ds-store", ".DS_Store", true},
+		{"ds-store-nested", "sub/.DS_Store", true},
+		{"normal-source", "src/main.osty", false},
+		{"normal-readme", "README.md", false},
+		{"backslash-git", "sub\\.git", true},
+		{"backslash-normal", "sub\\src\\main.osty", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := PkgSkipDirEntry(c.in); got != c.want {
+				t.Errorf("PkgSkipDirEntry(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/runner/pkg_policy_test.go
+++ b/internal/runner/pkg_policy_test.go
@@ -84,6 +84,9 @@ func TestPkgSkipDirEntry(t *testing.T) {
 		{"normal-readme", "README.md", false},
 		{"backslash-git", "sub\\.git", true},
 		{"backslash-normal", "sub\\src\\main.osty", false},
+		{"trailing-slash-git", "sub/.git/", true},
+		{"trailing-backslash-git", "sub\\.git\\", true},
+		{"trailing-slash-osty", ".osty/", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/toolchain/pkg_policy.osty
+++ b/toolchain/pkg_policy.osty
@@ -75,21 +75,34 @@ pub fn pkgSkipDirEntry(rel: String) -> Bool {
 /// pkgPathBase mirrors Go's `filepath.Base` on forward-slash and
 /// backslash paths. `pkgmgr` passes platform-native paths through
 /// `filepath.Rel`, which yields `\\`-separated relatives on Windows;
-/// the matcher must agree there too, so we split on both.
+/// the matcher must agree there too, so we split on both. Trailing
+/// separators are stripped first so `sub/.git/` still resolves
+/// `.git` as the base (matches `filepath.Base` semantics).
 fn pkgPathBase(p: String) -> String {
+    let mut end = p.bytes().len()
     let bs = p.bytes()
-    let n = bs.len()
-    let mut last = -1
+    for end > 0 {
+        let last = bs[end - 1].toInt()
+        if last == 0x2F || last == 0x5C {
+            end = end - 1
+        } else {
+            break
+        }
+    }
+    if end == 0 {
+        return p
+    }
+    let mut sep = -1
     let mut i = 0
-    for i < n {
+    for i < end {
         let b = bs[i].toInt()
         if b == 0x2F || b == 0x5C {
-            last = i
+            sep = i
         }
         i = i + 1
     }
-    if last < 0 {
-        return p
+    if sep < 0 {
+        return strings.slice(p, 0, end)
     }
-    strings.slice(p, last + 1, n)
+    strings.slice(p, sep + 1, end)
 }

--- a/toolchain/pkg_policy.osty
+++ b/toolchain/pkg_policy.osty
@@ -52,3 +52,44 @@ pub fn lockedDiffMessage(lockfileName: String, changes: List<String>) -> String?
     lines.push("rerun without --locked to update the lockfile.")
     Some(strings.join(lines, "\n"))
 }
+/// pkgSkipDirEntry reports whether a filesystem entry should be
+/// excluded when hashing a path-source directory or packing a
+/// publish tarball. Used by both `internal/pkgmgr/hash.go::HashDir`
+/// and `internal/pkgmgr/tarball.go::CreateTarGz`.
+///
+/// The decision is purely a basename match — `info.IsDir()` is
+/// ignored by the Go caller too, so this policy only takes the
+/// relative path. `rel == "."` (the walk root itself) is never
+/// skipped.
+pub fn pkgSkipDirEntry(rel: String) -> Bool {
+    if rel == "." {
+        return false
+    }
+    let base = pkgPathBase(rel)
+    base == ".osty"
+        || base == ".git"
+        || base == ".hg"
+        || base == ".svn"
+        || base == ".DS_Store"
+}
+/// pkgPathBase mirrors Go's `filepath.Base` on forward-slash and
+/// backslash paths. `pkgmgr` passes platform-native paths through
+/// `filepath.Rel`, which yields `\\`-separated relatives on Windows;
+/// the matcher must agree there too, so we split on both.
+fn pkgPathBase(p: String) -> String {
+    let bs = p.bytes()
+    let n = bs.len()
+    let mut last = -1
+    let mut i = 0
+    for i < n {
+        let b = bs[i].toInt()
+        if b == 0x2F || b == 0x5C {
+            last = i
+        }
+        i = i + 1
+    }
+    if last < 0 {
+        return p
+    }
+    strings.slice(p, last + 1, n)
+}

--- a/toolchain/pkg_policy_test.osty
+++ b/toolchain/pkg_policy_test.osty
@@ -44,3 +44,30 @@ fn testLockedDiffMessageFormatsChanges() {
         None -> testing.assert(false),
     }
 }
+fn testPkgSkipDirEntryDotKept() {
+    testing.assertEq(pkgSkipDirEntry("."), false)
+}
+fn testPkgSkipDirEntryOstyCache() {
+    testing.assertEq(pkgSkipDirEntry(".osty"), true)
+    testing.assertEq(pkgSkipDirEntry("sub/.osty"), true)
+    testing.assertEq(pkgSkipDirEntry(".osty/cache/x"), false)
+}
+fn testPkgSkipDirEntryVcsDirs() {
+    testing.assertEq(pkgSkipDirEntry(".git"), true)
+    testing.assertEq(pkgSkipDirEntry(".hg"), true)
+    testing.assertEq(pkgSkipDirEntry(".svn"), true)
+}
+fn testPkgSkipDirEntryMacosFile() {
+    testing.assertEq(pkgSkipDirEntry(".DS_Store"), true)
+    testing.assertEq(pkgSkipDirEntry("sub/.DS_Store"), true)
+}
+fn testPkgSkipDirEntryNormalFile() {
+    testing.assertEq(pkgSkipDirEntry("src/main.osty"), false)
+    testing.assertEq(pkgSkipDirEntry("README.md"), false)
+}
+fn testPkgSkipDirEntryWindowsSeparator() {
+    // pkgmgr passes filepath.Rel output which is backslash-separated
+    // on Windows. The basename matcher must agree on either separator.
+    testing.assertEq(pkgSkipDirEntry("sub\\.git"), true)
+    testing.assertEq(pkgSkipDirEntry("sub\\src\\main.osty"), false)
+}

--- a/toolchain/pkg_policy_test.osty
+++ b/toolchain/pkg_policy_test.osty
@@ -71,3 +71,10 @@ fn testPkgSkipDirEntryWindowsSeparator() {
     testing.assertEq(pkgSkipDirEntry("sub\\.git"), true)
     testing.assertEq(pkgSkipDirEntry("sub\\src\\main.osty"), false)
 }
+fn testPkgSkipDirEntryTrailingSeparator() {
+    // filepath.Walk doesn't pass trailing separators in practice, but the
+    // contract says we mirror filepath.Base which DOES trim them.
+    testing.assertEq(pkgSkipDirEntry("sub/.git/"), true)
+    testing.assertEq(pkgSkipDirEntry("sub\\.git\\"), true)
+    testing.assertEq(pkgSkipDirEntry(".osty/"), true)
+}


### PR DESCRIPTION
## 요약

`internal/pkgmgr/hash.go::skipDirEntry` (path-source 해싱 / 타르볼 패킹 시 제외할 파일 이름 정책) 을 `toolchain/pkg_policy.osty` 로 self-host.

기존 Go 함수는 `info os.FileInfo` 를 받지만 실제로는 **basename 체크만 수행** (info 미사용). Runner adapter 가 그 unused parameter 를 떨구고 `filepath.Walk` 호출 사이트의 signature 는 유지.

`tarball.go::CreateTarGz` 도 동일 `skipDirEntry` 를 공유하므로 자동으로 toolchain 정책을 따른다.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/pkg_policy.osty`** (확장)
  - `pub fn pkgSkipDirEntry(rel: String) -> Bool` — basename 매칭 (`.osty` / `.git` / `.hg` / `.svn` / `.DS_Store`)
  - 내부 `pkgPathBase` helper — `/` 와 `\\` 둘 다 separator 로 인식 (Windows `filepath.Rel` 결과 호환)
- **`toolchain/pkg_policy_test.osty`** (확장) — 6 신규 케이스
  - `.` (walk root) kept
  - `.osty` / `.git` / `.hg` / `.svn` cache+VCS 스킵
  - nested `.DS_Store` 스킵
  - 정상 소스 파일 / README 유지
  - Windows backslash separator 매칭

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/pkg_policy.go`** (확장)
  - `PkgSkipDirEntry(rel)` + `pkgPathBase` 헬퍼
- **`internal/runner/pkg_policy_test.go`** (확장) — 13 row table test
- **`internal/pkgmgr/hash.go`** (수정)
  - `skipDirEntry` 12줄 → 4줄 (runner adapter, unused `os.FileInfo` 는 `_` 로 폐기)

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 6 신규 케이스
  - **Go 스냅샷**: 13 row table test
  - **드리프트 게이트**: 기존 `pkg_policy.osty` subtest 가 신규 `pub fn` ↔ Go export 1:1 강제
- **호환성**: 기존 hash + tarball 시나리오 통과 — `osty publish` 경로 회귀 없음

## 검증

```
$ .bin/osty check toolchain/pkg_policy.osty toolchain/pkg_policy_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/pkgmgr/
ok  	github.com/osty/osty/internal/runner    (cached)
ok  	github.com/osty/osty/internal/pkgmgr    0.008s

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    93.496s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1786 | manifest [package]/[registries]/[lint]/[gui] (Marshal 완료) | `toolchain/manifest_emit.osty` |
| 1787 | format byte/escape 정책 + zero-alloc 스트리밍 | `toolchain/format_escape.osty` |
| **이번** | **pkgmgr skipDirEntry** | **`toolchain/pkg_policy.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/pkg_policy.osty toolchain/pkg_policy_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/pkgmgr/` 통과
- [x] `go test ./cmd/osty/` 통과 (93초 e2e) — `osty publish` / path source 해시 시나리오 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_