### PR TITLE
refactor: diag renderReplacement 템플릿 정책 self-host (toolchain/diag_render.osty 확장)

### DIFF
--- a/internal/diag/format.go
+++ b/internal/diag/format.go
@@ -198,27 +198,22 @@ func (f *Formatter) write(b *bytes.Buffer, d *Diagnostic) {
 }
 
 // renderReplacement resolves a Suggestion into the human-readable text
-// shown after the `→` marker. For plain replacements this is just the
-// literal string. For CopyFrom suggestions it expands the "%s" template
-// using the source bytes covered by CopyFrom — falling back to a
-// placeholder ("<expr>") when Source is unavailable or the span is
-// out of range.
+// shown after the `→` marker. The CopyFrom bounds check + excerpt
+// extraction is host-side; the template substitution and fallback
+// placeholder live in toolchain/diag_render.osty (`diagRenderReplacement`).
 func (f *Formatter) renderReplacement(sug Suggestion) string {
 	if sug.CopyFrom == nil {
 		return sug.Replacement
 	}
 	var excerpt string
+	haveExcerpt := false
 	cs := sug.CopyFrom.Start.Offset
 	ce := sug.CopyFrom.End.Offset
 	if len(f.Source) > 0 && cs >= 0 && ce >= cs && ce <= len(f.Source) {
 		excerpt = string(f.Source[cs:ce])
-	} else {
-		excerpt = "<expr>"
+		haveExcerpt = true
 	}
-	if sug.Replacement == "" || !strings.Contains(sug.Replacement, "%s") {
-		return excerpt
-	}
-	return strings.Replace(sug.Replacement, "%s", excerpt, 1)
+	return runner.DiagRenderReplacement(sug.Replacement, excerpt, haveExcerpt)
 }
 
 // writeSnippet renders the source lines for every span in the diagnostic.

--- a/internal/runner/diag_render_policy.go
+++ b/internal/runner/diag_render_policy.go
@@ -92,3 +92,33 @@ func LineBounds(src []byte, line int) LineBoundsResult {
 	}
 	return LineBoundsResult{Start: -1, End: -1}
 }
+
+// DiagRenderReplacement resolves a Suggestion's replacement
+// template into the human-readable text shown after the `→`
+// marker. The host computes whether the CopyFrom span fits the
+// source (haveExcerpt) and extracts the bytes (excerpt); this
+// helper decides:
+//
+//   - the fallback placeholder ("<expr>") when the excerpt is
+//     unavailable,
+//   - the precedence between literal replacements and the `%s`
+//     template form (empty replacement OR no `%s` → just emit
+//     the excerpt/fallback),
+//   - first-occurrence substitution `%s` → excerpt (matches
+//     Go's `strings.Replace(.., 1)`).
+//
+// Osty: toolchain/diag_render.osty:120
+func DiagRenderReplacement(replacement, excerpt string, haveExcerpt bool) string {
+	body := excerpt
+	if !haveExcerpt {
+		body = "<expr>"
+	}
+	if replacement == "" {
+		return body
+	}
+	idx := strings.Index(replacement, "%s")
+	if idx < 0 {
+		return body
+	}
+	return replacement[:idx] + body + replacement[idx+2:]
+}

--- a/internal/runner/diag_render_policy_test.go
+++ b/internal/runner/diag_render_policy_test.go
@@ -93,3 +93,31 @@ func TestLineBounds(t *testing.T) {
 		})
 	}
 }
+
+func TestDiagRenderReplacement(t *testing.T) {
+	cases := []struct {
+		name         string
+		replacement  string
+		excerpt      string
+		haveExcerpt  bool
+		want         string
+	}{
+		{"empty-replacement-uses-excerpt", "", "foo()", true, "foo()"},
+		{"empty-replacement-fallback", "", "", false, "<expr>"},
+		{"literal-without-template", "replacement-only", "foo()", true, "foo()"},
+		{"template-substitution", "wrap(%s)", "expr", true, "wrap(expr)"},
+		{"template-at-start", "%s.field", "obj", true, "obj.field"},
+		{"template-at-end", "prefix:%s", "tail", true, "prefix:tail"},
+		{"only-first-occurrence", "%s vs %s", "expr", true, "expr vs %s"},
+		{"fallback-with-template", "wrap(%s)", "", false, "wrap(<expr>)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := DiagRenderReplacement(c.replacement, c.excerpt, c.haveExcerpt)
+			if got != c.want {
+				t.Errorf("DiagRenderReplacement(%q, %q, %v) = %q, want %q",
+					c.replacement, c.excerpt, c.haveExcerpt, got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/diag_render.osty
+++ b/toolchain/diag_render.osty
@@ -102,3 +102,36 @@ pub fn lineBounds(src: String, line: Int) -> LineBoundsResult {
     }
     LineBoundsResult {start: -1, end: -1}
 }
+/// diagRenderReplacement resolves a Suggestion's replacement
+/// template into the human-readable text shown after the
+/// `→` marker.
+///
+/// The host computes whether the CopyFrom span fits the source
+/// (`haveExcerpt`) and extracts the bytes (`excerpt`); this
+/// module decides:
+///
+///   - the fallback placeholder ("<expr>") emitted when the
+///     excerpt is unavailable,
+///   - the precedence between literal replacements and the `%s`
+///     template form (empty replacement OR no `%s` → just emit
+///     the excerpt/fallback),
+///   - the first-occurrence substitution `%s` → excerpt (matches
+///     Go's `strings.Replace(.., 1)`).
+pub fn diagRenderReplacement(replacement: String, excerpt: String, haveExcerpt: Bool) -> String {
+    let body = if haveExcerpt {
+        excerpt
+    } else {
+        "<expr>"
+    }
+    if replacement == "" {
+        return body
+    }
+    let idx = strings.indexOf(replacement, "%s")
+    match idx {
+        Some(i) -> {
+            let n = replacement.len()
+            strings.slice(replacement, 0, i) + body + strings.slice(replacement, i + 2, n)
+        },
+        None -> body,
+    }
+}

--- a/toolchain/diag_render_test.osty
+++ b/toolchain/diag_render_test.osty
@@ -85,3 +85,38 @@ fn testLineBoundsEmptySourceLineTwoMisses() {
     testing.assertEq(r.start, -1)
     testing.assertEq(r.end, -1)
 }
+fn testDiagRenderReplacementNoCopyFromUsesExcerpt() {
+    // haveExcerpt=true with empty replacement → just the excerpt.
+    testing.assertEq(diagRenderReplacement("", "foo()", true), "foo()")
+}
+fn testDiagRenderReplacementFallbackWhenNoExcerpt() {
+    testing.assertEq(diagRenderReplacement("", "", false), "<expr>")
+}
+fn testDiagRenderReplacementLiteralWithoutTemplate() {
+    testing.assertEq(diagRenderReplacement("replacement-only", "foo()", true), "foo()")
+}
+fn testDiagRenderReplacementTemplateSubstitution() {
+    testing.assertEq(
+        diagRenderReplacement("wrap(%s)", "expr", true),
+        "wrap(expr)",
+    )
+}
+fn testDiagRenderReplacementTemplateAtStart() {
+    testing.assertEq(diagRenderReplacement("%s.field", "obj", true), "obj.field")
+}
+fn testDiagRenderReplacementTemplateAtEnd() {
+    testing.assertEq(diagRenderReplacement("prefix:%s", "tail", true), "prefix:tail")
+}
+fn testDiagRenderReplacementOnlyFirstOccurrence() {
+    // strings.Replace(.., 1) — second %s stays literal.
+    testing.assertEq(
+        diagRenderReplacement("%s vs %s", "expr", true),
+        "expr vs %s",
+    )
+}
+fn testDiagRenderReplacementFallbackWithTemplate() {
+    testing.assertEq(
+        diagRenderReplacement("wrap(%s)", "", false),
+        "wrap(<expr>)",
+    )
+}


### PR DESCRIPTION
## 요약

`internal/diag/format.go::(*Formatter).renderReplacement` 의 Suggestion replacement 템플릿 정책을 `toolchain/diag_render.osty` 로 self-host.

호스트 측은 CopyFrom span bounds-check + 원본 바이트 추출 (I/O 경계) 만 담당하고, **정책 결정** (`"<expr>"` fallback / `"%s"` 첫 번째 치환 / 빈 replacement 시 excerpt 만 emit) 은 toolchain.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/diag_render.osty`** (확장)
  - `pub fn diagRenderReplacement(replacement, excerpt, haveExcerpt) -> String`
  - haveExcerpt 가 false 면 `"<expr>"` fallback 사용
  - replacement 가 빈 문자열이면 body 만 emit
  - 그 외에는 첫 번째 `"%s"` 를 body 로 치환 (Go `strings.Replace(.., 1)` 시맨틱)
- **`toolchain/diag_render_test.osty`** (확장) — 8 신규 케이스
  - empty replacement + excerpt
  - fallback (no excerpt)
  - literal-without-template
  - template middle / start / end
  - 첫 번째 occurrence 만 치환 (두 번째 `%s` 는 그대로)
  - fallback + template (`wrap(%s)` → `wrap(<expr>)`)

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/diag_render_policy.go`** (확장)
  - `DiagRenderReplacement(replacement, excerpt, haveExcerpt) string` — Osty 와 1:1 미러
- **`internal/runner/diag_render_policy_test.go`** (확장) — 8 row table test
- **`internal/diag/format.go`** (수정)
  - `renderReplacement` 17줄 → 13줄
  - bounds check + excerpt 추출만 호스트 잔존
  - `strings.Contains` / `strings.Replace` 직접 호출 제거 (정책은 runner 위임)

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 8 신규 케이스
  - **Go 스냅샷**: 8 row table test
  - **드리프트 게이트**: 기존 `diag_render.osty` subtest 가 신규 `pub fn` ↔ Go export 1:1 강제
- **호환성**: 기존 diag 골든 스냅샷 + cmd/osty 79초 e2e 통과

## 검증

```
$ .bin/osty check toolchain/diag_render.osty toolchain/diag_render_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/diag/
ok  	github.com/osty/osty/internal/runner    (cached)
?   	github.com/osty/osty/internal/diag      [no test files]

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    79.456s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1787 | format byte/escape 정책 + zero-alloc 스트리밍 | `toolchain/format_escape.osty` |
| 1788 | pkgmgr skipDirEntry | `toolchain/pkg_policy.osty` |
| **이번** | **diag renderReplacement 템플릿 정책** | **`toolchain/diag_render.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/diag_render.osty toolchain/diag_render_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/diag/` 통과 — no test files at package root, downstream consumers exercise it
- [x] `go test ./cmd/osty/` 통과 (79초 e2e) — Suggestion-bearing diagnostics rendering 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_