### PR TITLE
refactor: registry searchScore 순위 정책 self-host (toolchain/registry_policy.osty 확장)

### DIFF
--- a/internal/registry/server.go
+++ b/internal/registry/server.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr/semver"
+	"github.com/osty/osty/internal/runner"
 )
 
 // DefaultMaxUploadBytes is the default upper bound for one published
@@ -673,24 +674,8 @@ func totalDownloads(rec *PackageRecord) int64 {
 }
 
 func searchScore(name string, meta PublishMetadata, q string) (int, bool) {
-	lowerName := strings.ToLower(name)
-	switch {
-	case lowerName == q:
-		return 0, true
-	case strings.HasPrefix(lowerName, q):
-		return 1, true
-	case strings.Contains(lowerName, q):
-		return 2, true
-	}
-	if strings.Contains(strings.ToLower(meta.Description), q) {
-		return 3, true
-	}
-	for _, kw := range meta.Keywords {
-		if strings.Contains(strings.ToLower(kw), q) {
-			return 4, true
-		}
-	}
-	return 0, false
+	r := runner.RegistrySearchScoreOf(name, meta.Description, meta.Keywords, q)
+	return r.Score, r.Ok
 }
 
 func manifestFromTarball(tarPath string) (*manifest.Manifest, error) {

--- a/internal/runner/registry_policy.go
+++ b/internal/runner/registry_policy.go
@@ -3,7 +3,10 @@
 // the drift test in this package keeps the two in sync.
 package runner
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // SanitizeIndexName lowercases-hex-escapes every char that isn't
 // in the safe alphabet (`[A-Za-z0-9._-]`). Empty input collapses
@@ -36,4 +39,42 @@ func registrySafeRune(r rune) bool {
 		(r >= 'A' && r <= 'Z') ||
 		(r >= '0' && r <= '9') ||
 		r == '-' || r == '_' || r == '.'
+}
+
+// RegistrySearchScore is the structured outcome of ranking one
+// package against the user's search query. Ok=false means
+// "no match"; lower Score ranks better.
+//
+// Osty: toolchain/registry_policy.osty:79
+type RegistrySearchScore struct {
+	Score int
+	Ok    bool
+}
+
+// RegistrySearchScoreOf ranks one package against query q.
+// Tiered match: 0 exact-name / 1 prefix / 2 contains-name /
+// 3 contains-description / 4 contains-keyword. Callers
+// pre-lowercase q so the host doesn't re-pay trim cost.
+//
+// Osty: toolchain/registry_policy.osty:95
+func RegistrySearchScoreOf(name, description string, keywords []string, q string) RegistrySearchScore {
+	lowerName := strings.ToLower(name)
+	if lowerName == q {
+		return RegistrySearchScore{Score: 0, Ok: true}
+	}
+	if strings.HasPrefix(lowerName, q) {
+		return RegistrySearchScore{Score: 1, Ok: true}
+	}
+	if strings.Contains(lowerName, q) {
+		return RegistrySearchScore{Score: 2, Ok: true}
+	}
+	if strings.Contains(strings.ToLower(description), q) {
+		return RegistrySearchScore{Score: 3, Ok: true}
+	}
+	for _, kw := range keywords {
+		if strings.Contains(strings.ToLower(kw), q) {
+			return RegistrySearchScore{Score: 4, Ok: true}
+		}
+	}
+	return RegistrySearchScore{Score: 0, Ok: false}
 }

--- a/internal/runner/registry_policy_test.go
+++ b/internal/runner/registry_policy_test.go
@@ -33,3 +33,35 @@ func TestSanitizeIndexName(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistrySearchScoreOf(t *testing.T) {
+	cases := []struct {
+		name        string
+		pkgName     string
+		description string
+		keywords    []string
+		query       string
+		wantOk      bool
+		wantScore   int
+	}{
+		{"exact-name", "serde", "JSON lib", nil, "serde", true, 0},
+		{"case-insensitive-exact", "Serde", "", nil, "serde", true, 0},
+		{"prefix", "serdex", "", nil, "serde", true, 1},
+		{"contains-name", "my-serde-helper", "", nil, "serde", true, 2},
+		{"description", "foo", "A JSON serde library", nil, "serde", true, 3},
+		{"keyword", "foo", "bar", []string{"serialization", "serde"}, "serde", true, 4},
+		{"keyword-case-insensitive", "foo", "", []string{"JSON"}, "json", true, 4},
+		{"no-match", "foo", "bar", []string{"baz"}, "serde", false, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RegistrySearchScoreOf(c.pkgName, c.description, c.keywords, c.query)
+			if got.Ok != c.wantOk {
+				t.Fatalf("Ok = %v, want %v", got.Ok, c.wantOk)
+			}
+			if c.wantOk && got.Score != c.wantScore {
+				t.Errorf("Score = %d, want %d", got.Score, c.wantScore)
+			}
+		})
+	}
+}

--- a/toolchain/registry_policy.osty
+++ b/toolchain/registry_policy.osty
@@ -72,3 +72,44 @@ fn registryLowerHex(n: Int) -> String {
     }
     out
 }
+/// RegistrySearchScore is the structured outcome of ranking one
+/// package against the user's search query. `ok == false` means
+/// "no match" — the host drops the entry; lower `score` ranks
+/// better (0 = exact name match).
+pub struct RegistrySearchScore {
+    pub score: Int,
+    pub ok: Bool,
+}
+/// registrySearchScore ranks one package against query `q`.
+/// Tiered match — lower score wins:
+///
+///   0  name (case-insensitive) equals q
+///   1  name has q as a prefix
+///   2  name contains q
+///   3  description contains q
+///   4  any keyword contains q
+///
+/// All comparisons use case-insensitive containment; the caller
+/// pre-lowercases `q` so the host doesn't re-pay the trim cost
+/// for every record.
+pub fn registrySearchScore(name: String, description: String, keywords: List<String>, q: String) -> RegistrySearchScore {
+    let lowerName = strings.toLower(name)
+    if lowerName == q {
+        return RegistrySearchScore {score: 0, ok: true}
+    }
+    if strings.hasPrefix(lowerName, q) {
+        return RegistrySearchScore {score: 1, ok: true}
+    }
+    if strings.contains(lowerName, q) {
+        return RegistrySearchScore {score: 2, ok: true}
+    }
+    if strings.contains(strings.toLower(description), q) {
+        return RegistrySearchScore {score: 3, ok: true}
+    }
+    for kw in keywords {
+        if strings.contains(strings.toLower(kw), q) {
+            return RegistrySearchScore {score: 4, ok: true}
+        }
+    }
+    RegistrySearchScore {score: 0, ok: false}
+}

--- a/toolchain/registry_policy.osty
+++ b/toolchain/registry_policy.osty
@@ -80,7 +80,7 @@ pub struct RegistrySearchScore {
     pub score: Int,
     pub ok: Bool,
 }
-/// registrySearchScore ranks one package against query `q`.
+/// registrySearchScoreOf ranks one package against query `q`.
 /// Tiered match — lower score wins:
 ///
 ///   0  name (case-insensitive) equals q
@@ -91,8 +91,11 @@ pub struct RegistrySearchScore {
 ///
 /// All comparisons use case-insensitive containment; the caller
 /// pre-lowercases `q` so the host doesn't re-pay the trim cost
-/// for every record.
-pub fn registrySearchScore(name: String, description: String, keywords: List<String>, q: String) -> RegistrySearchScore {
+/// for every record. Named `-Of` (rather than dropping the suffix)
+/// so the default Go-export capitalization rule
+/// (`RegistrySearchScoreOf`) doesn't collide with the
+/// `RegistrySearchScore` struct in the drift parity table.
+pub fn registrySearchScoreOf(name: String, description: String, keywords: List<String>, q: String) -> RegistrySearchScore {
     let lowerName = strings.toLower(name)
     if lowerName == q {
         return RegistrySearchScore {score: 0, ok: true}

--- a/toolchain/registry_policy_test.osty
+++ b/toolchain/registry_policy_test.osty
@@ -41,3 +41,47 @@ fn testSanitizeIndexNameOnlyUnsafe() {
     // All chars are unsafe → result is purely hex escapes.
     testing.assertEq(sanitizeIndexName("//"), "_2f_2f")
 }
+fn testRegistrySearchScoreExactName() {
+    let r = registrySearchScore("serde", "JSON lib", [], "serde")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.score, 0)
+}
+fn testRegistrySearchScoreCaseInsensitiveExact() {
+    let r = registrySearchScore("Serde", "", [], "serde")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.score, 0)
+}
+fn testRegistrySearchScorePrefix() {
+    let r = registrySearchScore("serdex", "", [], "serde")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.score, 1)
+}
+fn testRegistrySearchScoreContainsName() {
+    let r = registrySearchScore("my-serde-helper", "", [], "serde")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.score, 2)
+}
+fn testRegistrySearchScoreDescription() {
+    let r = registrySearchScore("foo", "A JSON serde library", [], "serde")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.score, 3)
+}
+fn testRegistrySearchScoreKeyword() {
+    let r = registrySearchScore("foo", "bar", ["serialization", "serde"], "serde")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.score, 4)
+}
+fn testRegistrySearchScoreNoMatch() {
+    let r = registrySearchScore("foo", "bar", ["baz"], "serde")
+    testing.assertEq(r.ok, false)
+}
+fn testRegistrySearchScorePrefersExactOverPrefix() {
+    // Same string matches both rules; exact (0) wins over prefix (1).
+    let r = registrySearchScore("serde", "", [], "serde")
+    testing.assertEq(r.score, 0)
+}
+fn testRegistrySearchScoreKeywordCaseInsensitive() {
+    let r = registrySearchScore("foo", "", ["JSON"], "json")
+    testing.assertEq(r.ok, true)
+    testing.assertEq(r.score, 4)
+}

--- a/toolchain/registry_policy_test.osty
+++ b/toolchain/registry_policy_test.osty
@@ -42,46 +42,46 @@ fn testSanitizeIndexNameOnlyUnsafe() {
     testing.assertEq(sanitizeIndexName("//"), "_2f_2f")
 }
 fn testRegistrySearchScoreExactName() {
-    let r = registrySearchScore("serde", "JSON lib", [], "serde")
+    let r = registrySearchScoreOf("serde", "JSON lib", [], "serde")
     testing.assertEq(r.ok, true)
     testing.assertEq(r.score, 0)
 }
 fn testRegistrySearchScoreCaseInsensitiveExact() {
-    let r = registrySearchScore("Serde", "", [], "serde")
+    let r = registrySearchScoreOf("Serde", "", [], "serde")
     testing.assertEq(r.ok, true)
     testing.assertEq(r.score, 0)
 }
 fn testRegistrySearchScorePrefix() {
-    let r = registrySearchScore("serdex", "", [], "serde")
+    let r = registrySearchScoreOf("serdex", "", [], "serde")
     testing.assertEq(r.ok, true)
     testing.assertEq(r.score, 1)
 }
 fn testRegistrySearchScoreContainsName() {
-    let r = registrySearchScore("my-serde-helper", "", [], "serde")
+    let r = registrySearchScoreOf("my-serde-helper", "", [], "serde")
     testing.assertEq(r.ok, true)
     testing.assertEq(r.score, 2)
 }
 fn testRegistrySearchScoreDescription() {
-    let r = registrySearchScore("foo", "A JSON serde library", [], "serde")
+    let r = registrySearchScoreOf("foo", "A JSON serde library", [], "serde")
     testing.assertEq(r.ok, true)
     testing.assertEq(r.score, 3)
 }
 fn testRegistrySearchScoreKeyword() {
-    let r = registrySearchScore("foo", "bar", ["serialization", "serde"], "serde")
+    let r = registrySearchScoreOf("foo", "bar", ["serialization", "serde"], "serde")
     testing.assertEq(r.ok, true)
     testing.assertEq(r.score, 4)
 }
 fn testRegistrySearchScoreNoMatch() {
-    let r = registrySearchScore("foo", "bar", ["baz"], "serde")
+    let r = registrySearchScoreOf("foo", "bar", ["baz"], "serde")
     testing.assertEq(r.ok, false)
 }
 fn testRegistrySearchScorePrefersExactOverPrefix() {
     // Same string matches both rules; exact (0) wins over prefix (1).
-    let r = registrySearchScore("serde", "", [], "serde")
+    let r = registrySearchScoreOf("serde", "", [], "serde")
     testing.assertEq(r.score, 0)
 }
 fn testRegistrySearchScoreKeywordCaseInsensitive() {
-    let r = registrySearchScore("foo", "", ["JSON"], "json")
+    let r = registrySearchScoreOf("foo", "", ["JSON"], "json")
     testing.assertEq(r.ok, true)
     testing.assertEq(r.score, 4)
 }


### PR DESCRIPTION
## 요약

`internal/registry/server.go::searchScore` — `osty search` 의 relevance 순위 매기는 정책 (이름 / prefix / contains-name / description / keyword 5단계, case-insensitive 매칭) 을 `toolchain/registry_policy.osty` 로 self-host.

호스트는 trim + lowercase 처리한 query 와 stored metadata 만 넘기고, 정책 자체 (5단계 score + ok 판정) 는 toolchain 소유.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

| Score | 매칭 규칙 |
|---|---|
| 0 | name (case-insensitive) == query (최우선) |
| 1 | name has query as prefix |
| 2 | name contains query |
| 3 | description contains query |
| 4 | any keyword contains query |
| ok=false | 아무 매칭 없음 |

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/registry_policy.osty`** (확장)
  - `pub struct RegistrySearchScore { score, ok }`
  - `pub fn registrySearchScore(name, description, keywords, q) -> RegistrySearchScore`
- **`toolchain/registry_policy_test.osty`** (확장) — 9 신규 케이스
  - exact / case-insensitive exact / prefix / contains-name
  - description / keyword 매칭
  - no-match (`ok=false`)
  - prefers-exact-over-prefix
  - keyword-case-insensitive

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/registry_policy.go`** (확장)
  - `RegistrySearchScore` struct + `RegistrySearchScoreOf` fn
  - `strings` import 추가
- **`internal/runner/registry_policy_test.go`** (확장) — 8 row table test
- **`internal/registry/server.go`** (수정)
  - `searchScore` 22줄 → 4줄 (runner 위임)
  - `runner` import 추가

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 9 신규 케이스
  - **Go 스냅샷**: 8 row table test
  - **드리프트 게이트**: 기존 `registry_policy.osty` subtest 가 신규 `pub fn` + `pub struct` ↔ Go export 1:1 강제
- **호환성**: cmd/osty 78초 e2e 통과 — `osty search` 시나리오 회귀 없음

## 검증

```
$ .bin/osty check toolchain/registry_policy.osty toolchain/registry_policy_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/registry/
ok  	github.com/osty/osty/internal/runner    (cached)
?   	github.com/osty/osty/internal/registry  [no test files]

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    78.084s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1787 | format byte/escape 정책 | `toolchain/format_escape.osty` |
| 1788 | pkgmgr skipDirEntry | `toolchain/pkg_policy.osty` |
| 1789 | diag renderReplacement 템플릿 | `toolchain/diag_render.osty` |
| **이번** | **registry searchScore 순위 정책** | **`toolchain/registry_policy.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/registry_policy.osty toolchain/registry_policy_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/registry/` 통과 — no test files at package root, downstream consumers exercise it
- [x] `go test ./cmd/osty/` 통과 (78초 e2e) — `osty search` 호출 경로 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_