### PR TITLE
refactor: lint isLintCode (Lxxxx 네임스페이스 판정) self-host (toolchain/lint_codes.osty)

### DIFF
--- a/internal/lint/allow.go
+++ b/internal/lint/allow.go
@@ -1,5 +1,9 @@
 package lint
 
+import (
+	"github.com/osty/osty/internal/runner"
+)
+
 // Lint name expansion shared by project-level config. Declaration-level
 // #[allow(...)] suppression is implemented by the self-hosted lint pass.
 //
@@ -44,17 +48,9 @@ func resolveAllowName(name string) []string {
 	return nil
 }
 
-// isLintCode reports whether a code string belongs to the L-prefixed
-// lint namespace.
+// isLintCode bridges to runner.IsLintCode (mirror of
+// toolchain/lint_codes.osty). The Lxxxx namespace rule lives in
+// toolchain.
 func isLintCode(code string) bool {
-	if len(code) < 2 || code[0] != 'L' {
-		return false
-	}
-	for i := 1; i < len(code); i++ {
-		c := code[i]
-		if c < '0' || c > '9' {
-			return false
-		}
-	}
-	return true
+	return runner.IsLintCode(code)
 }

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -47,6 +47,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"diag_render.osty",
 		"format_escape.osty",
 		"format_policy.osty",
+		"lint_codes.osty",
 		"lint_glob.osty",
 		"lockfile_policy.osty",
 		"manifest_emit.osty",

--- a/internal/runner/lint_codes_policy.go
+++ b/internal/runner/lint_codes_policy.go
@@ -1,0 +1,22 @@
+// lint_codes_policy.go is the Go snapshot of
+// toolchain/lint_codes.osty. Osty is the source of truth;
+// the drift test in this package keeps the two in sync.
+package runner
+
+// IsLintCode reports whether `code` belongs to the Lxxxx
+// namespace — exactly one `L` followed by one or more ASCII
+// digits. Empty strings and short tokens are rejected.
+//
+// Osty: toolchain/lint_codes.osty:25
+func IsLintCode(code string) bool {
+	if len(code) < 2 || code[0] != 'L' {
+		return false
+	}
+	for i := 1; i < len(code); i++ {
+		c := code[i]
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runner/lint_codes_policy_test.go
+++ b/internal/runner/lint_codes_policy_test.go
@@ -1,0 +1,38 @@
+package runner
+
+import "testing"
+
+func TestIsLintCode(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"basic-L0001", "L0001", true},
+		{"basic-L0040", "L0040", true},
+		{"basic-L9999", "L9999", true},
+		{"single-digit-L1", "L1", true},
+		{"single-digit-L0", "L0", true},
+		{"reject-bare-L", "L", false},
+		{"reject-empty", "", false},
+		{"reject-E-prefix", "E0001", false},
+		{"reject-W-prefix", "W0750", false},
+		{"reject-lower-l", "l0001", false},
+		{"reject-X-prefix", "X0001", false},
+		{"reject-alpha-tail", "L00aa", false},
+		{"reject-all-alpha", "LABC", false},
+		{"reject-underscore", "L_1", false},
+		{"reject-alias-unused", "unused", false},
+		{"reject-alias-dead_code", "dead_code", false},
+		{"reject-alias-all", "all", false},
+		{"reject-trailing-space", "L0001 ", false},
+		{"reject-leading-space", " L0001", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsLintCode(c.in); got != c.want {
+				t.Errorf("IsLintCode(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/lint_codes.osty
+++ b/toolchain/lint_codes.osty
@@ -1,0 +1,43 @@
+/// Pure policy for the lint code namespace (`Lxxxx`). Host code
+/// in `internal/lint` shares one validator across:
+///
+///   - `osty.toml`'s `[lint] allow = [...]` / `deny = [...]`
+///     entries (project-level config),
+///   - `#[allow(...)]` annotations on declarations (decl-level
+///     suppression — already self-hosted via the lint pass),
+///   - `Config.Apply` 's per-diagnostic dispatch — see
+///     `internal/lint/config.go`.
+///
+/// Mirrored by `internal/runner/lint_codes_policy.go`. The drift
+/// test under internal/runner keeps the two in sync — the Osty
+/// file is the source of truth at review time.
+use std.strings as strings
+/// isLintCode reports whether `code` belongs to the `Lxxxx`
+/// namespace — exactly one `L` followed by one or more ASCII
+/// digits. Empty strings and short tokens are rejected.
+///
+/// Used to:
+///
+///   - short-circuit `resolveAllowName` for entries like
+///     `L0001` so the alias scan doesn't have to consider them,
+///   - gate which diagnostics `Config.Apply` mutates (it leaves
+///     non-`L` codes untouched).
+pub fn isLintCode(code: String) -> Bool {
+    let bs = code.bytes()
+    let n = bs.len()
+    if n < 2 {
+        return false
+    }
+    if bs[0].toInt() != 0x4C {
+        return false
+    }
+    let mut i = 1
+    for i < n {
+        let b = bs[i].toInt()
+        if b < 0x30 || b > 0x39 {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}

--- a/toolchain/lint_codes.osty
+++ b/toolchain/lint_codes.osty
@@ -11,7 +11,6 @@
 /// Mirrored by `internal/runner/lint_codes_policy.go`. The drift
 /// test under internal/runner keeps the two in sync — the Osty
 /// file is the source of truth at review time.
-use std.strings as strings
 /// isLintCode reports whether `code` belongs to the `Lxxxx`
 /// namespace — exactly one `L` followed by one or more ASCII
 /// digits. Empty strings and short tokens are rejected.

--- a/toolchain/lint_codes_test.osty
+++ b/toolchain/lint_codes_test.osty
@@ -1,0 +1,36 @@
+use std.testing
+fn testIsLintCodeBasic() {
+    testing.assertEq(isLintCode("L0001"), true)
+    testing.assertEq(isLintCode("L0040"), true)
+    testing.assertEq(isLintCode("L9999"), true)
+}
+fn testIsLintCodeSingleDigit() {
+    testing.assertEq(isLintCode("L1"), true)
+    testing.assertEq(isLintCode("L0"), true)
+}
+fn testIsLintCodeRejectsBareL() {
+    testing.assertEq(isLintCode("L"), false)
+}
+fn testIsLintCodeRejectsEmpty() {
+    testing.assertEq(isLintCode(""), false)
+}
+fn testIsLintCodeRejectsNonLPrefix() {
+    testing.assertEq(isLintCode("E0001"), false)
+    testing.assertEq(isLintCode("W0750"), false)
+    testing.assertEq(isLintCode("l0001"), false)
+    testing.assertEq(isLintCode("X0001"), false)
+}
+fn testIsLintCodeRejectsAlphaTail() {
+    testing.assertEq(isLintCode("L00aa"), false)
+    testing.assertEq(isLintCode("LABC"), false)
+    testing.assertEq(isLintCode("L_1"), false)
+}
+fn testIsLintCodeRejectsAlias() {
+    testing.assertEq(isLintCode("unused"), false)
+    testing.assertEq(isLintCode("dead_code"), false)
+    testing.assertEq(isLintCode("all"), false)
+}
+fn testIsLintCodeRejectsTrailingSpace() {
+    testing.assertEq(isLintCode("L0001 "), false)
+    testing.assertEq(isLintCode(" L0001"), false)
+}


### PR DESCRIPTION
## 요약

`internal/lint/allow.go::isLintCode` (코드 문자열이 `Lxxxx` 형식인지 체크 — `L` + 1+ ASCII 숫자) 를 새 toolchain 파일 **`toolchain/lint_codes.osty`** 로 self-host.

작은 함수지만 `[lint] allow`/`deny` 와 `Config.Apply` 두 곳에서 공유되는 중심 정책 — toolchain 으로 옮겨 lint 코드 네임스페이스 규칙을 단일 source of truth 로 만든다.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 신규 파일)
- **`toolchain/lint_codes.osty`** (신규)
  - `pub fn isLintCode(code: String) -> Bool` — byte-level scan
- **`toolchain/lint_codes_test.osty`** (신규) — 8 케이스
  - basic L0001/L0040/L9999
  - single-digit L1/L0
  - bare `L` 거부, empty 거부
  - E·W·lowercase l·X prefix 거부
  - alpha tail 거부, alias (`unused`/`dead_code`/`all`) 거부
  - leading/trailing space 거부

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/lint_codes_policy.go`** (신규) — `IsLintCode`
- **`internal/runner/lint_codes_policy_test.go`** (신규) — 19 row table test
- **`internal/runner/drift_test.go`** — `ostySources` 에 `"lint_codes.osty"` 등록
- **`internal/lint/allow.go`** (수정)
  - `isLintCode` 11줄 → 3줄 (runner 위임)
  - `runner` import 추가

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 8 케이스
  - **Go 스냅샷**: 19 row table test
  - **드리프트 게이트**: `TestPolicySnapshotParityWithOsty/lint_codes.osty` 가 `pub fn` ↔ Go export 1:1 강제
- **호환성**: cmd/osty 76초 e2e 통과 — `osty lint` + `osty.toml [lint]` 시나리오 회귀 없음

## 검증

```
$ .bin/osty check toolchain/lint_codes.osty toolchain/lint_codes_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/lint/
ok  	github.com/osty/osty/internal/runner    0.038s
?   	github.com/osty/osty/internal/lint      [no test files]

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    76.098s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1788 | pkgmgr skipDirEntry | `toolchain/pkg_policy.osty` |
| 1789 | diag renderReplacement 템플릿 | `toolchain/diag_render.osty` |
| 1790 | registry searchScore 순위 정책 | `toolchain/registry_policy.osty` |
| **이번** | **lint isLintCode (Lxxxx 네임스페이스 판정)** | **`toolchain/lint_codes.osty`** (신규) |

## Test plan

- [x] `.bin/osty check toolchain/lint_codes.osty toolchain/lint_codes_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/lint/` 통과 (no test files at package root)
- [x] `go test ./cmd/osty/` 통과 (76초 e2e) — lint 호출 경로 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_