### PR TITLE
refactor: diag Severity.String + Diagnostic.Error 정책 self-host (toolchain/diag_render.osty 확장)

### DIFF
--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -12,6 +12,7 @@
 package diag
 
 import (
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
 )
@@ -32,15 +33,7 @@ const (
 )
 
 func (s Severity) String() string {
-	switch s {
-	case Error:
-		return "error"
-	case Warning:
-		return "warning"
-	case Note:
-		return "note"
-	}
-	return "unknown"
+	return runner.DiagSeverityString(int(s))
 }
 
 // Span is a half-open range [Start, End) within a single source file.
@@ -155,10 +148,7 @@ func (d *Diagnostic) PrimarySpan() (Span, bool) {
 // from functions that conventionally return error.
 func (d *Diagnostic) Error() string {
 	pos := d.PrimaryPos()
-	if d.Code != "" {
-		return d.Code + ": " + d.Severity.String() + " at " + pos.String() + ": " + d.Message
-	}
-	return d.Severity.String() + " at " + pos.String() + ": " + d.Message
+	return runner.DiagShortError(d.Code, int(d.Severity), pos.Line, pos.Column, d.Message)
 }
 
 // Builder offers a fluent API for assembling a Diagnostic.

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -32,6 +32,15 @@ const (
 	Note
 )
 
+// Compile-time guard: the Severity iota MUST match the int
+// constants the runner snapshot (toolchain/diag_render.osty)
+// uses. A future reorder of the iota declaration above would
+// silently desync the two sources of truth without this; the
+// array length check forces a build failure instead.
+var _ = [1]struct{}{}[int(Error)-runner.DiagSeverityError]
+var _ = [1]struct{}{}[int(Warning)-runner.DiagSeverityWarning]
+var _ = [1]struct{}{}[int(Note)-runner.DiagSeverityNote]
+
 func (s Severity) String() string {
 	return runner.DiagSeverityString(int(s))
 }

--- a/internal/runner/diag_render_policy.go
+++ b/internal/runner/diag_render_policy.go
@@ -126,10 +126,12 @@ func DiagRenderReplacement(replacement, excerpt string, haveExcerpt bool) string
 
 // DiagSeverity enum constants. Order matches
 // toolchain/diag_render.osty + internal/diag.Severity iota.
+// The diag package guards against drift via a compile-time
+// assertion in init() — see internal/diag/diag.go.
 const (
-	DiagSeverityError   = 0
-	DiagSeverityWarning = 1
-	DiagSeverityNote    = 2
+	DiagSeverityError   int = 0
+	DiagSeverityWarning int = 1
+	DiagSeverityNote    int = 2
 )
 
 // DiagSeverityString maps a Severity int back to its
@@ -152,11 +154,27 @@ func DiagSeverityString(sev int) string {
 // `<code>: <severity> at <line>:<col>: <message>` when code is
 // set, otherwise the prefix is dropped.
 //
+// Hot path — (*Diagnostic).Error() is called from any code that
+// treats a diagnostic as an `error`, including logging. Uses a
+// single strings.Builder to avoid the intermediate string
+// allocations a `+` chain would produce.
+//
 // Osty: toolchain/diag_render.osty:164
 func DiagShortError(code string, severity, line, column int, message string) string {
-	head := DiagSeverityString(severity) + " at " + strconv.Itoa(line) + ":" + strconv.Itoa(column) + ": " + message
-	if code == "" {
-		return head
+	var b strings.Builder
+	if code != "" {
+		b.Grow(len(code) + len(message) + 24)
+		b.WriteString(code)
+		b.WriteString(": ")
+	} else {
+		b.Grow(len(message) + 24)
 	}
-	return code + ": " + head
+	b.WriteString(DiagSeverityString(severity))
+	b.WriteString(" at ")
+	b.WriteString(strconv.Itoa(line))
+	b.WriteByte(':')
+	b.WriteString(strconv.Itoa(column))
+	b.WriteString(": ")
+	b.WriteString(message)
+	return b.String()
 }

--- a/internal/runner/diag_render_policy.go
+++ b/internal/runner/diag_render_policy.go
@@ -5,6 +5,7 @@ package runner
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -121,4 +122,41 @@ func DiagRenderReplacement(replacement, excerpt string, haveExcerpt bool) string
 		return body
 	}
 	return replacement[:idx] + body + replacement[idx+2:]
+}
+
+// DiagSeverity enum constants. Order matches
+// toolchain/diag_render.osty + internal/diag.Severity iota.
+const (
+	DiagSeverityError   = 0
+	DiagSeverityWarning = 1
+	DiagSeverityNote    = 2
+)
+
+// DiagSeverityString maps a Severity int back to its
+// human-readable label. Unknown values collapse to "unknown".
+//
+// Osty: toolchain/diag_render.osty:148
+func DiagSeverityString(sev int) string {
+	switch sev {
+	case DiagSeverityError:
+		return "error"
+	case DiagSeverityWarning:
+		return "warning"
+	case DiagSeverityNote:
+		return "note"
+	}
+	return "unknown"
+}
+
+// DiagShortError renders the compact (*Diagnostic).Error() form:
+// `<code>: <severity> at <line>:<col>: <message>` when code is
+// set, otherwise the prefix is dropped.
+//
+// Osty: toolchain/diag_render.osty:164
+func DiagShortError(code string, severity, line, column int, message string) string {
+	head := DiagSeverityString(severity) + " at " + strconv.Itoa(line) + ":" + strconv.Itoa(column) + ": " + message
+	if code == "" {
+		return head
+	}
+	return code + ": " + head
 }

--- a/internal/runner/diag_render_policy_test.go
+++ b/internal/runner/diag_render_policy_test.go
@@ -121,3 +121,48 @@ func TestDiagRenderReplacement(t *testing.T) {
 		})
 	}
 }
+
+func TestDiagSeverityString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want string
+	}{
+		{"error", DiagSeverityError, "error"},
+		{"warning", DiagSeverityWarning, "warning"},
+		{"note", DiagSeverityNote, "note"},
+		{"unknown-positive", 99, "unknown"},
+		{"unknown-negative", -1, "unknown"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DiagSeverityString(c.in); got != c.want {
+				t.Errorf("DiagSeverityString(%d) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDiagShortError(t *testing.T) {
+	cases := []struct {
+		name     string
+		code     string
+		severity int
+		line     int
+		column   int
+		message  string
+		want     string
+	}{
+		{"with-code", "E0500", DiagSeverityError, 12, 3, "name not found", "E0500: error at 12:3: name not found"},
+		{"without-code", "", DiagSeverityWarning, 1, 5, "unused let", "warning at 1:5: unused let"},
+		{"note-severity", "E0703", DiagSeverityNote, 42, 1, "see also", "E0703: note at 42:1: see also"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := DiagShortError(c.code, c.severity, c.line, c.column, c.message)
+			if got != c.want {
+				t.Errorf("DiagShortError = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/diag_render.osty
+++ b/toolchain/diag_render.osty
@@ -135,3 +135,36 @@ pub fn diagRenderReplacement(replacement: String, excerpt: String, haveExcerpt: 
         None -> body,
     }
 }
+/// Severity enum constants. Encoded as Int (not a dedicated
+/// enum type) so the host mirrors them as their `iota` analogue
+/// without a wire-format translation step. Order MUST match
+/// `internal/diag.Severity` 's iota declaration.
+pub let diagSeverityError: Int = 0
+pub let diagSeverityWarning: Int = 1
+pub let diagSeverityNote: Int = 2
+/// diagSeverityString maps a `Severity` int back to its
+/// human-readable label. Unknown / out-of-range values collapse
+/// to `"unknown"` so log lines never surface a bare number.
+pub fn diagSeverityString(sev: Int) -> String {
+    if sev == diagSeverityError {
+        return "error"
+    }
+    if sev == diagSeverityWarning {
+        return "warning"
+    }
+    if sev == diagSeverityNote {
+        return "note"
+    }
+    "unknown"
+}
+/// diagShortError renders the compact `(*Diagnostic).Error()`
+/// form: `<code>: <severity> at <line>:<col>: <message>` when
+/// `code` is set, otherwise the prefix is dropped. Line/col come
+/// from the host (`PrimaryPos()`).
+pub fn diagShortError(code: String, severity: Int, line: Int, column: Int, message: String) -> String {
+    let head = diagSeverityString(severity) + " at " + "{line}" + ":" + "{column}" + ": " + message
+    if code == "" {
+        return head
+    }
+    code + ": " + head
+}

--- a/toolchain/diag_render_test.osty
+++ b/toolchain/diag_render_test.osty
@@ -120,3 +120,34 @@ fn testDiagRenderReplacementFallbackWithTemplate() {
         "wrap(<expr>)",
     )
 }
+fn testDiagSeverityStringError() {
+    testing.assertEq(diagSeverityString(diagSeverityError), "error")
+}
+fn testDiagSeverityStringWarning() {
+    testing.assertEq(diagSeverityString(diagSeverityWarning), "warning")
+}
+fn testDiagSeverityStringNote() {
+    testing.assertEq(diagSeverityString(diagSeverityNote), "note")
+}
+fn testDiagSeverityStringUnknown() {
+    testing.assertEq(diagSeverityString(99), "unknown")
+    testing.assertEq(diagSeverityString(-1), "unknown")
+}
+fn testDiagShortErrorWithCode() {
+    testing.assertEq(
+        diagShortError("E0500", diagSeverityError, 12, 3, "name not found"),
+        "E0500: error at 12:3: name not found",
+    )
+}
+fn testDiagShortErrorWithoutCode() {
+    testing.assertEq(
+        diagShortError("", diagSeverityWarning, 1, 5, "unused let"),
+        "warning at 1:5: unused let",
+    )
+}
+fn testDiagShortErrorNoteSeverity() {
+    testing.assertEq(
+        diagShortError("E0703", diagSeverityNote, 42, 1, "see also"),
+        "E0703: note at 42:1: see also",
+    )
+}


### PR DESCRIPTION
## 요약

`internal/diag/diag.go` 의 두 작은 렌더링 정책을 `toolchain/diag_render.osty` 로 self-host:

| Go | Osty (신규) | 정책 |
|---|---|---|
| `Severity.String()` | `diagSeverityString(sev: Int)` | 정수 → `"error"`/`"warning"`/`"note"`/`"unknown"` 매핑 |
| `(*Diagnostic).Error()` | `diagShortError(code, severity, line, column, message)` | `<code>: <severity> at <line>:<col>: <message>` 컴팩트 form (code 없으면 prefix 생략) |

작은 함수들이지만 `error` 인터페이스 구현 + 로그 출력 + 진단 컬렉터에서 공유되는 핵심 텍스트. Severity enum 상수 3개도 `pub let` 으로 추가해 호스트가 iota 값으로 미러링.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/diag_render.osty`** (확장)
  - `pub let diagSeverityError: Int = 0`
  - `pub let diagSeverityWarning: Int = 1`
  - `pub let diagSeverityNote: Int = 2`
  - `pub fn diagSeverityString(sev: Int) -> String`
  - `pub fn diagShortError(code, severity, line, column, message) -> String`
- **`toolchain/diag_render_test.osty`** (확장) — 8 신규 케이스
  - 각 severity (error/warning/note) + unknown (positive / negative)
  - with-code / without-code / note-severity

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/diag_render_policy.go`** (확장)
  - 3개 상수 (`DiagSeverityError`/`Warning`/`Note`)
  - `DiagSeverityString` / `DiagShortError`
  - `strconv` import 추가
- **`internal/runner/diag_render_policy_test.go`** (확장) — 8 row table test
- **`internal/diag/diag.go`** (수정)
  - `Severity.String()` 10줄 → 3줄 (runner 위임)
  - `(*Diagnostic).Error()` 5줄 → 4줄
  - `runner` import 추가

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 8 신규 케이스
  - **Go 스냅샷**: 8 row table test
  - **드리프트 게이트**: 기존 `diag_render.osty` subtest 가 2개 신규 `pub fn` ↔ Go export 1:1 강제
- **호환성**: 기존 diag 골든 스냅샷 + cmd/osty 75초 e2e 통과 — `error` 인터페이스 / 진단 텍스트 출력 회귀 없음

## 검증

```
$ .bin/osty check toolchain/diag_render.osty toolchain/diag_render_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/diag/
ok  	github.com/osty/osty/internal/runner    (cached)
?   	github.com/osty/osty/internal/diag      [no test files]

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    75.964s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1789 | diag renderReplacement 템플릿 | `toolchain/diag_render.osty` |
| 1790 | registry searchScore 순위 정책 | `toolchain/registry_policy.osty` |
| 1791 | lint isLintCode (Lxxxx 판정) | `toolchain/lint_codes.osty` |
| **이번** | **diag Severity.String + Diagnostic.Error** | **`toolchain/diag_render.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/diag_render.osty toolchain/diag_render_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/diag/` 통과
- [x] `go test ./cmd/osty/` 통과 (75초 e2e) — 에러 출력 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_