### PR TITLE
refactor: registry checkStatus error message 정책 self-host (toolchain/registry_policy.osty 확장)

### DIFF
--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -31,6 +31,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/osty/osty/internal/runner"
 )
 
 // DefaultTimeout bounds how long any single request may take. Tuned
@@ -407,7 +409,8 @@ func (c *Client) addHeaders(req *http.Request) {
 
 // checkStatus returns nil iff resp.StatusCode is in allowed.
 // Consumes a portion of the body for the error message so the user
-// sees the registry's own diagnostic.
+// sees the registry's own diagnostic. The error text format lives
+// in toolchain/registry_policy.osty (`registryStatusErrorMessage`).
 func checkStatus(resp *http.Response, allowed ...int) error {
 	for _, code := range allowed {
 		if resp.StatusCode == code {
@@ -415,9 +418,7 @@ func checkStatus(resp *http.Response, allowed ...int) error {
 		}
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<14))
-	msg := strings.TrimSpace(string(body))
-	if msg == "" {
-		msg = resp.Status
-	}
-	return fmt.Errorf("registry %s: HTTP %d: %s", resp.Request.URL, resp.StatusCode, msg)
+	return fmt.Errorf("%s", runner.RegistryStatusErrorMessage(
+		resp.Request.URL.String(), resp.StatusCode, string(body), resp.Status,
+	))
 }

--- a/internal/runner/registry_policy.go
+++ b/internal/runner/registry_policy.go
@@ -5,6 +5,7 @@ package runner
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -77,4 +78,20 @@ func RegistrySearchScoreOf(name, description string, keywords []string, q string
 		}
 	}
 	return RegistrySearchScore{Score: 0, Ok: false}
+}
+
+// RegistryStatusErrorMessage builds the error string emitted
+// when an HTTP response from the registry has an unexpected
+// status code. Format: `registry <url>: HTTP <code>: <msg>`.
+// When the trimmed body is empty, statusText (typically
+// `resp.Status`) is used as the message.
+//
+// Osty: toolchain/registry_policy.osty:137
+func RegistryStatusErrorMessage(url string, statusCode int, body, statusText string) string {
+	trimmed := strings.TrimSpace(body)
+	msg := trimmed
+	if msg == "" {
+		msg = statusText
+	}
+	return "registry " + url + ": HTTP " + strconv.Itoa(statusCode) + ": " + msg
 }

--- a/internal/runner/registry_policy_test.go
+++ b/internal/runner/registry_policy_test.go
@@ -65,3 +65,43 @@ func TestRegistrySearchScoreOf(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistryStatusErrorMessage(t *testing.T) {
+	cases := []struct {
+		name       string
+		url        string
+		statusCode int
+		body       string
+		statusText string
+		want       string
+	}{
+		{
+			"with-body",
+			"https://r.dev/v1/crates/serde", 500, "internal error", "500 Internal Server Error",
+			"registry https://r.dev/v1/crates/serde: HTTP 500: internal error",
+		},
+		{
+			"empty-body-uses-status",
+			"https://r.dev/x", 404, "", "404 Not Found",
+			"registry https://r.dev/x: HTTP 404: 404 Not Found",
+		},
+		{
+			"whitespace-body-uses-status",
+			"https://r.dev/x", 404, "   \n\t  ", "404 Not Found",
+			"registry https://r.dev/x: HTTP 404: 404 Not Found",
+		},
+		{
+			"trims-body",
+			"https://r.dev/x", 403, "  not allowed  ", "403 Forbidden",
+			"registry https://r.dev/x: HTTP 403: not allowed",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RegistryStatusErrorMessage(c.url, c.statusCode, c.body, c.statusText)
+			if got != c.want {
+				t.Errorf("RegistryStatusErrorMessage =\n%q\nwant\n%q", got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/registry_policy.osty
+++ b/toolchain/registry_policy.osty
@@ -116,3 +116,30 @@ pub fn registrySearchScoreOf(name: String, description: String, keywords: List<S
     }
     RegistrySearchScore {score: 0, ok: false}
 }
+/// registryStatusErrorMessage builds the error string emitted
+/// when an HTTP response from the registry has an unexpected
+/// status code. Format mirrors the existing host code:
+///
+///   `registry <url>: HTTP <code>: <msg>`
+///
+/// Inputs:
+///
+///   - `url`: the request's URL (typically the package endpoint).
+///   - `statusCode`: numeric HTTP status (e.g. 500, 404).
+///   - `body`: the response body, host-trimmed to a sane upper
+///     bound (the historical limit is 16 KiB).
+///   - `statusText`: `resp.Status` (e.g. "500 Internal Server
+///     Error") — used as the fallback message when `body` is
+///     empty or whitespace-only.
+///
+/// The body is trimmed (whitespace at both ends) before use;
+/// an empty trim triggers the statusText fallback.
+pub fn registryStatusErrorMessage(url: String, statusCode: Int, body: String, statusText: String) -> String {
+    let trimmed = strings.trimSpace(body)
+    let msg = if trimmed == "" {
+        statusText
+    } else {
+        trimmed
+    }
+    "registry " + url + ": HTTP " + "{statusCode}" + ": " + msg
+}

--- a/toolchain/registry_policy_test.osty
+++ b/toolchain/registry_policy_test.osty
@@ -85,3 +85,31 @@ fn testRegistrySearchScoreKeywordCaseInsensitive() {
     testing.assertEq(r.ok, true)
     testing.assertEq(r.score, 4)
 }
+fn testRegistryStatusErrorMessageWithBody() {
+    testing.assertEq(
+        registryStatusErrorMessage(
+            "https://r.dev/v1/crates/serde", 500, "internal error", "500 Internal Server Error",
+        ),
+        "registry https://r.dev/v1/crates/serde: HTTP 500: internal error",
+    )
+}
+fn testRegistryStatusErrorMessageEmptyBodyUsesStatus() {
+    testing.assertEq(
+        registryStatusErrorMessage("https://r.dev/x", 404, "", "404 Not Found"),
+        "registry https://r.dev/x: HTTP 404: 404 Not Found",
+    )
+}
+fn testRegistryStatusErrorMessageWhitespaceBodyUsesStatus() {
+    testing.assertEq(
+        registryStatusErrorMessage("https://r.dev/x", 404, "   \n\t  ", "404 Not Found"),
+        "registry https://r.dev/x: HTTP 404: 404 Not Found",
+    )
+}
+fn testRegistryStatusErrorMessageTrimsBody() {
+    testing.assertEq(
+        registryStatusErrorMessage(
+            "https://r.dev/x", 403, "  not allowed  ", "403 Forbidden",
+        ),
+        "registry https://r.dev/x: HTTP 403: not allowed",
+    )
+}


### PR DESCRIPTION
## 요약

`internal/registry/client.go::checkStatus` 의 HTTP non-2xx 응답 시 사용자에게 보여줄 에러 메시지 포맷 + body-trim/statusText-fallback 정책을 `toolchain/registry_policy.osty` 로 self-host.

호스트 측은 HTTP 응답 / body 읽기 / URL 추출만 담당, 정책 (trim + fallback + format) 은 toolchain.

```
registry <url>: HTTP <code>: <msg>
```
- `msg` = trimmed body if non-empty, else `resp.Status` ("404 Not Found" 류)

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/registry_policy.osty`** (확장)
  - `pub fn registryStatusErrorMessage(url, statusCode, body, statusText) -> String`
- **`toolchain/registry_policy_test.osty`** (확장) — 4 신규 케이스
  - with-body (body 그대로 표시)
  - empty-body → statusText fallback
  - whitespace-only body → statusText fallback
  - body trim (앞뒤 공백 제거)

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/registry_policy.go`** (확장)
  - `RegistryStatusErrorMessage` + `strconv` import
- **`internal/runner/registry_policy_test.go`** (확장) — 4 row table test
- **`internal/registry/client.go`** (수정)
  - `checkStatus` 11줄 → 12줄 (정책 본문 = runner 위임)
  - `runner` import 추가

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 4 신규 케이스
  - **Go 스냅샷**: 4 row table test
  - **드리프트 게이트**: 기존 `registry_policy.osty` subtest 가 신규 `pub fn` ↔ Go export 1:1 강제
- **호환성**: cmd/osty 91초 e2e 통과 — `osty fetch` / `osty add` / `osty publish` 의 registry 오류 경로 회귀 없음

## 검증

```
$ .bin/osty check toolchain/registry_policy.osty toolchain/registry_policy_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/registry/
ok  	github.com/osty/osty/internal/runner    0.035s
?   	github.com/osty/osty/internal/registry  [no test files]

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    91.822s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1791 | lint isLintCode | `toolchain/lint_codes.osty` |
| 1793 | diag Severity.String + Diagnostic.Error | `toolchain/diag_render.osty` |
| **이번** | **registry checkStatus error message** | **`toolchain/registry_policy.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/registry_policy.osty toolchain/registry_policy_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/registry/` 통과 (no test files at package root)
- [x] `go test ./cmd/osty/` 통과 (91초 e2e) — registry 오류 표시 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_