### PR TITLE
refactor: registry validatePackageName self-host (toolchain/registry_policy.osty 확장)

### DIFF
--- a/internal/registry/server.go
+++ b/internal/registry/server.go
@@ -775,22 +775,13 @@ func copyStringSliceMap(in map[string][]string) map[string][]string {
 	return out
 }
 
+// validatePackageName bridges to runner.ValidateRegistryPackageName
+// (mirror of toolchain/registry_policy.osty). Returns nil on
+// success; otherwise an error whose message matches the policy's
+// rejection text.
 func validatePackageName(name string) error {
-	if name == "" {
-		return fmt.Errorf("package name is empty")
-	}
-	for i, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z',
-			r >= 'A' && r <= 'Z',
-			r == '_':
-			continue
-		case i > 0 && r >= '0' && r <= '9',
-			i > 0 && r == '-':
-			continue
-		default:
-			return fmt.Errorf("invalid package name %q", name)
-		}
+	if msg := runner.ValidateRegistryPackageName(name); msg != "" {
+		return fmt.Errorf("%s", msg)
 	}
 	return nil
 }

--- a/internal/runner/registry_policy.go
+++ b/internal/runner/registry_policy.go
@@ -95,3 +95,33 @@ func RegistryStatusErrorMessage(url string, statusCode int, body, statusText str
 	}
 	return "registry " + url + ": HTTP " + strconv.Itoa(statusCode) + ": " + msg
 }
+
+// ValidateRegistryPackageName checks `name` against the registry's
+// accepted name alphabet. Returns the empty string on success;
+// otherwise an error message the host wraps in badRequest:
+//
+//   - empty input → "package name is empty"
+//   - any other rejection → `invalid package name "<name>"`
+//
+// Rules: [A-Za-z_] everywhere, [0-9-] for non-first positions.
+//
+// Osty: toolchain/registry_policy.osty:158
+func ValidateRegistryPackageName(name string) string {
+	if name == "" {
+		return "package name is empty"
+	}
+	for i := 0; i < len(name); i++ {
+		b := name[i]
+		isUpper := b >= 'A' && b <= 'Z'
+		isLower := b >= 'a' && b <= 'z'
+		isUnderscore := b == '_'
+		isDigit := b >= '0' && b <= '9'
+		isDash := b == '-'
+		always := isUpper || isLower || isUnderscore
+		nonFirst := i > 0 && (isDigit || isDash)
+		if !(always || nonFirst) {
+			return "invalid package name \"" + name + "\""
+		}
+	}
+	return ""
+}

--- a/internal/runner/registry_policy_test.go
+++ b/internal/runner/registry_policy_test.go
@@ -105,3 +105,31 @@ func TestRegistryStatusErrorMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRegistryPackageName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"valid-serde", "serde", ""},
+		{"valid-underscore-mid", "my_lib", ""},
+		{"valid-dash-mid", "json-ext", ""},
+		{"valid-digits", "abc123", ""},
+		{"valid-camel", "CamelCase", ""},
+		{"valid-leading-underscore", "_foo", ""},
+		{"empty", "", "package name is empty"},
+		{"leading-digit", "1abc", "invalid package name \"1abc\""},
+		{"leading-dash", "-abc", "invalid package name \"-abc\""},
+		{"dot-rejected", "serde.json", "invalid package name \"serde.json\""},
+		{"space-rejected", "hello world", "invalid package name \"hello world\""},
+		{"unicode-rejected", "한글", "invalid package name \"한글\""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ValidateRegistryPackageName(c.in); got != c.want {
+				t.Errorf("ValidateRegistryPackageName(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/registry_policy.osty
+++ b/toolchain/registry_policy.osty
@@ -143,3 +143,38 @@ pub fn registryStatusErrorMessage(url: String, statusCode: Int, body: String, st
     }
     "registry " + url + ": HTTP " + "{statusCode}" + ": " + msg
 }
+/// validateRegistryPackageName checks `name` against the registry's
+/// accepted name alphabet. Returns the empty string on success;
+/// otherwise an error message the host wraps in `badRequest`:
+///
+///   - empty input → `"package name is empty"`
+///   - any other rejection → `"invalid package name \"<name>\""`
+///
+/// Rules:
+///
+///   - All positions: `[A-Za-z_]` ok.
+///   - All positions except the first: `[0-9-]` also ok.
+///   - Anything else (including any non-ASCII) is rejected.
+pub fn validateRegistryPackageName(name: String) -> String {
+    if name == "" {
+        return "package name is empty"
+    }
+    let bs = name.bytes()
+    let n = bs.len()
+    let mut i = 0
+    for i < n {
+        let b = bs[i].toInt()
+        let isUpper = b >= 0x41 && b <= 0x5A
+        let isLower = b >= 0x61 && b <= 0x7A
+        let isUnderscore = b == 0x5F
+        let isDigit = b >= 0x30 && b <= 0x39
+        let isDash = b == 0x2D
+        let always = isUpper || isLower || isUnderscore
+        let nonFirst = i > 0 && (isDigit || isDash)
+        if !(always || nonFirst) {
+            return "invalid package name \"" + name + "\""
+        }
+        i = i + 1
+    }
+    ""
+}

--- a/toolchain/registry_policy_test.osty
+++ b/toolchain/registry_policy_test.osty
@@ -113,3 +113,32 @@ fn testRegistryStatusErrorMessageTrimsBody() {
         "registry https://r.dev/x: HTTP 403: not allowed",
     )
 }
+fn testValidateRegistryPackageNameValid() {
+    testing.assertEq(validateRegistryPackageName("serde"), "")
+    testing.assertEq(validateRegistryPackageName("my_lib"), "")
+    testing.assertEq(validateRegistryPackageName("json-ext"), "")
+    testing.assertEq(validateRegistryPackageName("abc123"), "")
+    testing.assertEq(validateRegistryPackageName("CamelCase"), "")
+}
+fn testValidateRegistryPackageNameEmpty() {
+    testing.assertEq(validateRegistryPackageName(""), "package name is empty")
+}
+fn testValidateRegistryPackageNameLeadingDigit() {
+    testing.assertEq(validateRegistryPackageName("1abc"), "invalid package name \"1abc\"")
+}
+fn testValidateRegistryPackageNameLeadingDash() {
+    testing.assertEq(validateRegistryPackageName("-abc"), "invalid package name \"-abc\"")
+}
+fn testValidateRegistryPackageNameDot() {
+    // Dot is not in the registry's accepted alphabet (only in cache sanitizer's).
+    testing.assertEq(validateRegistryPackageName("serde.json"), "invalid package name \"serde.json\"")
+}
+fn testValidateRegistryPackageNameSpace() {
+    testing.assertEq(validateRegistryPackageName("hello world"), "invalid package name \"hello world\"")
+}
+fn testValidateRegistryPackageNameUnicode() {
+    testing.assertEq(validateRegistryPackageName("한글"), "invalid package name \"한글\"")
+}
+fn testValidateRegistryPackageNameUnderscoreFirst() {
+    testing.assertEq(validateRegistryPackageName("_foo"), "")
+}


### PR DESCRIPTION
## 요약

`internal/registry/server.go::validatePackageName` 의 패키지명 검증 정책 (`[A-Za-z_]` everywhere + `[0-9-]` non-first) + 오류 메시지를 `toolchain/registry_policy.osty` 로 self-host. `osty publish` 진입점에서 사용.

호스트 측은 `fmt.Errorf` 로 에러 래핑만 담당, 정책 본문 + 에러 문구는 toolchain 소유.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/registry_policy.osty`** (확장)
  - `pub fn validateRegistryPackageName(name: String) -> String`
  - 성공 시 빈 문자열, 실패 시 `"package name is empty"` 또는 `"invalid package name \"<name>\""`
- **`toolchain/registry_policy_test.osty`** (확장) — 8 신규 케이스
  - valid (다양한 정상명)
  - empty
  - leading-digit (`1abc`)
  - leading-dash (`-abc`)
  - dot (`serde.json` — cache sanitizer 와 달리 publish 검증은 dot 거부)
  - space, unicode 거부
  - underscore-first 허용

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/registry_policy.go`** (확장)
  - `ValidateRegistryPackageName(name string) string`
- **`internal/runner/registry_policy_test.go`** (확장) — 12 row table test
- **`internal/registry/server.go`** (수정)
  - `validatePackageName` 17줄 → 6줄 (runner 위임 후 nil/`fmt.Errorf` 래핑)

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 8 케이스
  - **Go 스냅샷**: 12 row table test
  - **드리프트 게이트**: 기존 `registry_policy.osty` subtest 가 신규 `pub fn` ↔ Go export 1:1 강제
- **호환성**: cmd/osty 94초 e2e 통과 — `osty publish` validation 경로 회귀 없음

## 검증

```
$ .bin/osty check toolchain/registry_policy.osty toolchain/registry_policy_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/
ok  	github.com/osty/osty/internal/runner    0.034s

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    94.093s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1791 | lint isLintCode | `toolchain/lint_codes.osty` |
| 1793 | diag Severity.String + Diagnostic.Error | `toolchain/diag_render.osty` |
| 1794 | registry checkStatus error message | `toolchain/registry_policy.osty` |
| **이번** | **registry validatePackageName** | **`toolchain/registry_policy.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/registry_policy.osty toolchain/registry_policy_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./cmd/osty/` 통과 (94초 e2e) — `osty publish` validation 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_