### PR TITLE
fix: validatePackageName log-injection 안전성 + Copilot 후속 정리 (#1795 후속)

### DIFF
--- a/internal/registry/server.go
+++ b/internal/registry/server.go
@@ -781,7 +781,7 @@ func copyStringSliceMap(in map[string][]string) map[string][]string {
 // rejection text.
 func validatePackageName(name string) error {
 	if msg := runner.ValidateRegistryPackageName(name); msg != "" {
-		return fmt.Errorf("%s", msg)
+		return errors.New(msg)
 	}
 	return nil
 }

--- a/internal/runner/registry_policy.go
+++ b/internal/runner/registry_policy.go
@@ -100,8 +100,11 @@ func RegistryStatusErrorMessage(url string, statusCode int, body, statusText str
 // accepted name alphabet. Returns the empty string on success;
 // otherwise an error message the host wraps in badRequest:
 //
-//   - empty input → "package name is empty"
-//   - any other rejection → `invalid package name "<name>"`
+//   - empty input → `package name is empty`
+//   - any other rejection → `invalid package name <quoted>` where
+//     <quoted> is TomlBasicString(name) — Go `%q`-style escapes
+//     keep embedded quotes / backslashes / control characters from
+//     breaking log lines or HTTP error responses.
 //
 // Rules: [A-Za-z_] everywhere, [0-9-] for non-first positions.
 //
@@ -120,7 +123,7 @@ func ValidateRegistryPackageName(name string) string {
 		always := isUpper || isLower || isUnderscore
 		nonFirst := i > 0 && (isDigit || isDash)
 		if !(always || nonFirst) {
-			return "invalid package name \"" + name + "\""
+			return "invalid package name " + TomlBasicString(name)
 		}
 	}
 	return ""

--- a/internal/runner/registry_policy_test.go
+++ b/internal/runner/registry_policy_test.go
@@ -133,3 +133,28 @@ func TestValidateRegistryPackageName(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRegistryPackageNameEscapesEchoedName(t *testing.T) {
+	// Embedded characters that commonly cause ambiguity in logs/strings
+	// (`"`, `\`, control chars) MUST be echoed back escaped — otherwise
+	// a malicious name could break log lines or HTTP responses.
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"embedded-quote", "a\"b", `invalid package name "a\"b"`},
+		{"embedded-backslash", "a\\b", `invalid package name "a\\b"`},
+		{"embedded-newline", "a\nb", `invalid package name "a\nb"`},
+		{"embedded-tab", "a\tb", `invalid package name "a\tb"`},
+		{"embedded-cr", "a\rb", `invalid package name "a\rb"`},
+		{"low-control", "a\x01b", `invalid package name "a\x01b"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ValidateRegistryPackageName(c.in); got != c.want {
+				t.Errorf("ValidateRegistryPackageName(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/registry_policy.osty
+++ b/toolchain/registry_policy.osty
@@ -147,8 +147,11 @@ pub fn registryStatusErrorMessage(url: String, statusCode: Int, body: String, st
 /// accepted name alphabet. Returns the empty string on success;
 /// otherwise an error message the host wraps in `badRequest`:
 ///
-///   - empty input → `"package name is empty"`
-///   - any other rejection → `"invalid package name \"<name>\""`
+///   - empty input → `package name is empty`
+///   - any other rejection → `invalid package name <quoted>` where
+///     `<quoted>` is `tomlBasicString(name)` — embedded quotes,
+///     backslashes, and control characters are escaped so the
+///     echoed name cannot break log lines or HTTP error responses.
 ///
 /// Rules:
 ///
@@ -172,7 +175,7 @@ pub fn validateRegistryPackageName(name: String) -> String {
         let always = isUpper || isLower || isUnderscore
         let nonFirst = i > 0 && (isDigit || isDash)
         if !(always || nonFirst) {
-            return "invalid package name \"" + name + "\""
+            return "invalid package name " + tomlBasicString(name)
         }
         i = i + 1
     }

--- a/toolchain/registry_policy_test.osty
+++ b/toolchain/registry_policy_test.osty
@@ -142,3 +142,29 @@ fn testValidateRegistryPackageNameUnicode() {
 fn testValidateRegistryPackageNameUnderscoreFirst() {
     testing.assertEq(validateRegistryPackageName("_foo"), "")
 }
+fn testValidateRegistryPackageNameEmbeddedQuote() {
+    // `a"b` echoes with the embedded quote escaped — `tomlBasicString`
+    // adds outer quotes and `\"` for the embedded one.
+    testing.assertEq(
+        validateRegistryPackageName("a\"b"),
+        "invalid package name \"a\\\"b\"",
+    )
+}
+fn testValidateRegistryPackageNameEmbeddedBackslash() {
+    testing.assertEq(
+        validateRegistryPackageName("a\\b"),
+        "invalid package name \"a\\\\b\"",
+    )
+}
+fn testValidateRegistryPackageNameEmbeddedNewline() {
+    testing.assertEq(
+        validateRegistryPackageName("a\nb"),
+        "invalid package name \"a\\nb\"",
+    )
+}
+fn testValidateRegistryPackageNameEmbeddedTab() {
+    testing.assertEq(
+        validateRegistryPackageName("a\tb"),
+        "invalid package name \"a\\tb\"",
+    )
+}


### PR DESCRIPTION
## 요약

PR #1795 (registry validatePackageName self-host) 머지 후 Copilot 리뷰 4건 처리 — 후속 보안 + 정리 PR.

가장 중요한 변경: **로그 인젝션 방어**. `invalid package name "<name>"` 메시지가 원본 name 을 verbatim echo 해서 embedded `"`, 줄바꿈, 탭 등이 로그 라인이나 HTTP 응답을 깰 수 있었다.

## 변경 내역

### 1. 로그 인젝션 방어 (Copilot review_comment_id=3242309247)
`tomlBasicString` (PR #1782 도입, Go `%q` 시맨틱) 으로 echoed name 을 escape:
- `a"b` → `invalid package name "a\"b"`
- `a\nb` (literal newline) → `invalid package name "a\nb"`
- control chars → `\xNN`

- **`toolchain/registry_policy.osty`**: `"\"" + name + "\""` → `tomlBasicString(name)`
- **`internal/runner/registry_policy.go`**: 동일 변경, `TomlBasicString` 사용

### 2. `errors.New` 우선 (Copilot review_comment_id=3242309204)
`fmt.Errorf("%s", msg)` → `errors.New(msg)`. format 머시너리 불필요 호출 제거.

- **`internal/registry/server.go`**: `validatePackageName` 의 wrap 한 줄 변경

### 3. doc 일관성 (Copilot review_comment_id=3242309324)
Osty + Go 양쪽 doc 코멘트가 동일한 byte-for-byte 출력 형식 (`invalid package name <quoted>`) 을 명시. 이전 docs 는 backtick / escape mix 로 혼란 가능했음.

### 4. Escape 회귀 테스트 (Copilot review_comment_id=3242309292)
- **`toolchain/registry_policy_test.osty`**: 4 신규 케이스 (quote / backslash / newline / tab)
- **`internal/runner/registry_policy_test.go`**: 6 row 신규 table test (위 4 + CR + low-control char `\x01`)

## 회귀 안전성

기존 8 케이스 (정상명 / empty / leading-digit / leading-dash / dot / space / unicode / underscore-first) 모두 ASCII-safe 입력 — `tomlBasicString` 출력이 기존 `"name"` 형식과 동일하므로 모두 통과.

`unicode` 케이스 (`한글`) 의 출력도 unchanged: `tomlBasicString` 은 0x80+ UTF-8 byte 를 verbatim 통과시킴 (PR #1782 의 byte-faithful 패턴) → `"한글"` 그대로 emit.

## 검증

```
$ .bin/osty check toolchain/registry_policy.osty toolchain/registry_policy_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/registry/
ok  	github.com/osty/osty/internal/runner    0.032s
?   	github.com/osty/osty/internal/registry  [no test files]

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    94.185s
```

## Test plan

- [x] `.bin/osty check` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 + 6 신규 escape 케이스) 통과
- [x] `go test ./cmd/osty/` 통과 (94초 e2e) — `osty publish` validation 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_