### PR TITLE
refactor: diag sevColor (Severity → ANSI 색상) self-host (toolchain/diag_render.osty 확장)

### DIFF
--- a/internal/diag/format.go
+++ b/internal/diag/format.go
@@ -117,15 +117,7 @@ func (f *Formatter) col(code, s string) string {
 }
 
 func (f *Formatter) sevColor(sev Severity) string {
-	switch sev {
-	case Error:
-		return ansiRed
-	case Warning:
-		return ansiYellow
-	case Note:
-		return ansiCyan
-	}
-	return ""
+	return runner.DiagSeverityAnsiColor(int(sev))
 }
 
 func (f *Formatter) write(b *bytes.Buffer, d *Diagnostic) {

--- a/internal/runner/diag_render_policy.go
+++ b/internal/runner/diag_render_policy.go
@@ -178,3 +178,20 @@ func DiagShortError(code string, severity, line, column int, message string) str
 	b.WriteString(message)
 	return b.String()
 }
+
+// DiagSeverityAnsiColor maps a Severity int to its terminal ANSI
+// escape sequence — the lead-in code only; callers append the
+// reset themselves. Returns "" for unknown severities.
+//
+// Osty: toolchain/diag_render.osty:176
+func DiagSeverityAnsiColor(sev int) string {
+	switch sev {
+	case DiagSeverityError:
+		return "\x1b[31m"
+	case DiagSeverityWarning:
+		return "\x1b[33m"
+	case DiagSeverityNote:
+		return "\x1b[36m"
+	}
+	return ""
+}

--- a/internal/runner/diag_render_policy_test.go
+++ b/internal/runner/diag_render_policy_test.go
@@ -166,3 +166,24 @@ func TestDiagShortError(t *testing.T) {
 		})
 	}
 }
+
+func TestDiagSeverityAnsiColor(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want string
+	}{
+		{"error", DiagSeverityError, "\x1b[31m"},
+		{"warning", DiagSeverityWarning, "\x1b[33m"},
+		{"note", DiagSeverityNote, "\x1b[36m"},
+		{"unknown-99", 99, ""},
+		{"unknown-neg", -1, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DiagSeverityAnsiColor(c.in); got != c.want {
+				t.Errorf("DiagSeverityAnsiColor(%d) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/toolchain/diag_render.osty
+++ b/toolchain/diag_render.osty
@@ -168,3 +168,20 @@ pub fn diagShortError(code: String, severity: Int, line: Int, column: Int, messa
     }
     code + ": " + head
 }
+/// diagSeverityAnsiColor maps a Severity int to its terminal
+/// ANSI escape sequence — the lead-in code only; callers append
+/// `\x1b[0m` (ansiReset) themselves around the colored text.
+/// Returns the empty string for unknown severities so a stray
+/// value doesn't accidentally tint the rest of the line.
+pub fn diagSeverityAnsiColor(sev: Int) -> String {
+    if sev == diagSeverityError {
+        return "\u{1b}[31m"
+    }
+    if sev == diagSeverityWarning {
+        return "\u{1b}[33m"
+    }
+    if sev == diagSeverityNote {
+        return "\u{1b}[36m"
+    }
+    ""
+}

--- a/toolchain/diag_render_test.osty
+++ b/toolchain/diag_render_test.osty
@@ -151,3 +151,16 @@ fn testDiagShortErrorNoteSeverity() {
         "E0703: note at 42:1: see also",
     )
 }
+fn testDiagSeverityAnsiColorError() {
+    testing.assertEq(diagSeverityAnsiColor(diagSeverityError), "\u{1b}[31m")
+}
+fn testDiagSeverityAnsiColorWarning() {
+    testing.assertEq(diagSeverityAnsiColor(diagSeverityWarning), "\u{1b}[33m")
+}
+fn testDiagSeverityAnsiColorNote() {
+    testing.assertEq(diagSeverityAnsiColor(diagSeverityNote), "\u{1b}[36m")
+}
+fn testDiagSeverityAnsiColorUnknown() {
+    testing.assertEq(diagSeverityAnsiColor(99), "")
+    testing.assertEq(diagSeverityAnsiColor(-1), "")
+}


### PR DESCRIPTION
## 요약

`internal/diag/format.go::(*Formatter).sevColor` (Severity 정수 → 터미널 ANSI 색상 escape 매핑) 을 `toolchain/diag_render.osty` 로 self-host.

| Severity | ANSI escape |
|---|---|
| Error | `\x1b[31m` (red) |
| Warning | `\x1b[33m` (yellow) |
| Note | `\x1b[36m` (cyan) |
| (unknown) | `""` (안전 fallback — 라인이 색으로 오염되지 않도록) |

이번 세션의 `diagSeverityError/Warning/Note` 상수 (#1793) 를 재사용.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/diag_render.osty`** (확장)
  - `pub fn diagSeverityAnsiColor(sev: Int) -> String`
- **`toolchain/diag_render_test.osty`** (확장) — 4 신규 케이스
  - error / warning / note 각 ANSI escape
  - unknown positive (99) / negative (-1) → ""

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/diag_render_policy.go`** (확장) — `DiagSeverityAnsiColor`
- **`internal/runner/diag_render_policy_test.go`** (확장) — 5 row table test
- **`internal/diag/format.go`** (수정) — `sevColor` 10줄 → 3줄 (runner 위임)

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 4 케이스
  - **Go 스냅샷**: 5 row table test
  - **드리프트 게이트**: 기존 `diag_render.osty` subtest 가 신규 `pub fn` ↔ Go export 1:1 강제
- **호환성**: 기존 diag 골든 스냅샷 + cmd/osty 72초 e2e 통과 — 컬러 출력 회귀 없음

## 검증

```
$ .bin/osty check toolchain/diag_render.osty toolchain/diag_render_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/diag/
ok  	github.com/osty/osty/internal/runner    0.024s
?   	github.com/osty/osty/internal/diag      [no test files]

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    72.442s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1793 | diag Severity.String + Diagnostic.Error | `toolchain/diag_render.osty` |
| 1794 | registry checkStatus error message | `toolchain/registry_policy.osty` |
| 1795 | registry validatePackageName | `toolchain/registry_policy.osty` |
| 1796 | validatePackageName log-injection fix (Copilot follow-up) | `toolchain/registry_policy.osty` |
| **이번** | **diag sevColor (Severity → ANSI)** | **`toolchain/diag_render.osty`** (확장) |

## Test plan

- [x] `.bin/osty check toolchain/diag_render.osty toolchain/diag_render_test.osty` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/diag/` 통과
- [x] `go test ./cmd/osty/` 통과 (72초 e2e) — 컬러 출력 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_