### PR TITLE
refactor: diag suggestion display + note/help label 정책 self-host (toolchain/diag_render.osty 확장)

### DIFF
--- a/internal/diag/format.go
+++ b/internal/diag/format.go
@@ -150,42 +150,29 @@ func (f *Formatter) write(b *bytes.Buffer, d *Diagnostic) {
 	for _, note := range d.Notes {
 		fmt.Fprintf(b, " %s %s: %s\n",
 			f.col(ansiBlue+ansiBold, "="),
-			f.col(ansiCyan+ansiBold, "note"),
+			f.col(ansiCyan+ansiBold, runner.DiagNoteLabel()),
 			note)
 	}
 	// Hint.
 	if d.Hint != "" {
 		fmt.Fprintf(b, " %s %s: %s\n",
 			f.col(ansiBlue+ansiBold, "="),
-			f.col(ansiCyan+ansiBold, "help"),
+			f.col(ansiCyan+ansiBold, runner.DiagHelpLabel()),
 			d.Hint)
 	}
 	// Structured suggestions (auto-applicable patches).
 	for _, sug := range d.Suggestions {
-		label := sug.Label
-		if label == "" {
-			label = "suggested fix"
-		}
-		tag := "suggest"
-		if sug.MachineApplicable {
-			tag = "fix"
-		}
+		disp := runner.DiagSuggestionDisplayOf(sug.Label, sug.MachineApplicable, f.renderReplacement(sug))
 		fmt.Fprintf(b, " %s %s: %s\n",
 			f.col(ansiBlue+ansiBold, "="),
-			f.col(ansiGreen+ansiBold, tag),
-			label)
-		// Show the proposed replacement on the next line. An empty
-		// replacement is rendered as "(delete)" for clarity. Suggestions
-		// with a CopyFrom span expand the "%s" placeholder using the
-		// original source when available, so the user sees the concrete
-		// rewrite rather than the raw template.
-		repl := f.renderReplacement(sug)
-		if repl == "" {
-			repl = "(delete)"
-		}
+			f.col(ansiGreen+ansiBold, disp.Tag),
+			disp.Label)
+		// Show the proposed replacement on the next line. The
+		// `(delete)` fallback for an empty rendered replacement is
+		// applied by runner.DiagSuggestionDisplayOf.
 		fmt.Fprintf(b, "   %s %s\n",
 			f.col(ansiGreen, "→"),
-			repl)
+			disp.Replacement)
 	}
 }
 

--- a/internal/runner/diag_render_policy.go
+++ b/internal/runner/diag_render_policy.go
@@ -195,3 +195,48 @@ func DiagSeverityAnsiColor(sev int) string {
 	}
 	return ""
 }
+
+// DiagSuggestionDisplay packages the three labels the formatter
+// emits per Suggestion: the inline tag, the human label, and
+// the rendered replacement.
+//
+// Osty: toolchain/diag_render.osty:193
+type DiagSuggestionDisplay struct {
+	Tag         string
+	Label       string
+	Replacement string
+}
+
+// DiagSuggestionDisplayOf resolves a Suggestion's display
+// strings (see Osty doc for the table). Named `-Of` so the
+// default capitalization rule doesn't collide with the
+// DiagSuggestionDisplay struct in the drift table.
+//
+// Osty: toolchain/diag_render.osty:210
+func DiagSuggestionDisplayOf(userLabel string, machineApplicable bool, rendered string) DiagSuggestionDisplay {
+	tag := "suggest"
+	if machineApplicable {
+		tag = "fix"
+	}
+	label := userLabel
+	if label == "" {
+		label = "suggested fix"
+	}
+	replacement := rendered
+	if replacement == "" {
+		replacement = "(delete)"
+	}
+	return DiagSuggestionDisplay{Tag: tag, Label: label, Replacement: replacement}
+}
+
+// DiagNoteLabel returns the literal "note" used in the formatter's
+// `= note: <text>` line.
+//
+// Osty: toolchain/diag_render.osty:234
+func DiagNoteLabel() string { return "note" }
+
+// DiagHelpLabel returns the literal "help" used in the formatter's
+// `= help: <hint>` line.
+//
+// Osty: toolchain/diag_render.osty:239
+func DiagHelpLabel() string { return "help" }

--- a/internal/runner/diag_render_policy.go
+++ b/internal/runner/diag_render_policy.go
@@ -212,7 +212,7 @@ type DiagSuggestionDisplay struct {
 // default capitalization rule doesn't collide with the
 // DiagSuggestionDisplay struct in the drift table.
 //
-// Osty: toolchain/diag_render.osty:210
+// Osty: toolchain/diag_render.osty:214
 func DiagSuggestionDisplayOf(userLabel string, machineApplicable bool, rendered string) DiagSuggestionDisplay {
 	tag := "suggest"
 	if machineApplicable {
@@ -232,11 +232,11 @@ func DiagSuggestionDisplayOf(userLabel string, machineApplicable bool, rendered 
 // DiagNoteLabel returns the literal "note" used in the formatter's
 // `= note: <text>` line.
 //
-// Osty: toolchain/diag_render.osty:234
+// Osty: toolchain/diag_render.osty:238
 func DiagNoteLabel() string { return "note" }
 
 // DiagHelpLabel returns the literal "help" used in the formatter's
 // `= help: <hint>` line.
 //
-// Osty: toolchain/diag_render.osty:239
+// Osty: toolchain/diag_render.osty:243
 func DiagHelpLabel() string { return "help" }

--- a/internal/runner/diag_render_policy_test.go
+++ b/internal/runner/diag_render_policy_test.go
@@ -187,3 +187,39 @@ func TestDiagSeverityAnsiColor(t *testing.T) {
 		})
 	}
 }
+
+func TestDiagSuggestionDisplayOf(t *testing.T) {
+	cases := []struct {
+		name              string
+		userLabel         string
+		machineApplicable bool
+		rendered          string
+		wantTag           string
+		wantLabel         string
+		wantReplacement   string
+	}{
+		{"fix-applicable", "rename to foo", true, "let foo = 1", "fix", "rename to foo", "let foo = 1"},
+		{"suggest-only", "rename to foo", false, "let foo = 1", "suggest", "rename to foo", "let foo = 1"},
+		{"empty-label", "", true, "x", "fix", "suggested fix", "x"},
+		{"empty-replacement", "rm unused", true, "", "fix", "rm unused", "(delete)"},
+		{"all-defaults", "", false, "", "suggest", "suggested fix", "(delete)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := DiagSuggestionDisplayOf(c.userLabel, c.machineApplicable, c.rendered)
+			if got.Tag != c.wantTag || got.Label != c.wantLabel || got.Replacement != c.wantReplacement {
+				t.Errorf("DiagSuggestionDisplayOf = %+v, want {%q %q %q}",
+					got, c.wantTag, c.wantLabel, c.wantReplacement)
+			}
+		})
+	}
+}
+
+func TestDiagNoteHelpLabels(t *testing.T) {
+	if got := DiagNoteLabel(); got != "note" {
+		t.Errorf("DiagNoteLabel = %q, want %q", got, "note")
+	}
+	if got := DiagHelpLabel(); got != "help" {
+		t.Errorf("DiagHelpLabel = %q, want %q", got, "help")
+	}
+}

--- a/toolchain/diag_render.osty
+++ b/toolchain/diag_render.osty
@@ -185,3 +185,61 @@ pub fn diagSeverityAnsiColor(sev: Int) -> String {
     }
     ""
 }
+/// DiagSuggestionDisplay packages the three labels the formatter
+/// emits per Suggestion: the inline tag (`suggest` vs `fix`),
+/// the human label (Suggestion.Label or its default), and the
+/// rendered replacement (with the empty-string → "(delete)"
+/// fallback applied).
+pub struct DiagSuggestionDisplay {
+    pub tag: String,
+    pub label: String,
+    pub replacement: String,
+}
+/// diagSuggestionDisplayOf resolves a Suggestion's display
+/// strings:
+///
+///   - `tag`         = "fix" when `machineApplicable` else "suggest"
+///   - `label`       = `userLabel` when non-empty else "suggested fix"
+///   - `replacement` = `rendered` when non-empty else "(delete)"
+///
+/// `rendered` is the post-CopyFrom-template expansion (already
+/// produced by `diagRenderReplacement`); the empty-string check
+/// catches the "literal Replacement was the empty string and no
+/// CopyFrom excerpt was substituted" case so the user sees an
+/// explicit "(delete)" hint instead of a bare blank line.
+///
+/// Named `-Of` so the default Go-export capitalization rule
+/// (`DiagSuggestionDisplayOf`) doesn't collide with the
+/// `DiagSuggestionDisplay` struct in the drift parity table.
+pub fn diagSuggestionDisplayOf(userLabel: String, machineApplicable: Bool, rendered: String) -> DiagSuggestionDisplay {
+    let displayTag = if machineApplicable {
+        "fix"
+    } else {
+        "suggest"
+    }
+    let displayLabel = if userLabel == "" {
+        "suggested fix"
+    } else {
+        userLabel
+    }
+    let displayReplacement = if rendered == "" {
+        "(delete)"
+    } else {
+        rendered
+    }
+    DiagSuggestionDisplay {
+        tag: displayTag,
+        label: displayLabel,
+        replacement: displayReplacement,
+    }
+}
+/// diagNoteLabel returns the literal `"note"` used in the
+/// formatter's `= note: <text>` line.
+pub fn diagNoteLabel() -> String {
+    "note"
+}
+/// diagHelpLabel returns the literal `"help"` used in the
+/// formatter's `= help: <hint>` line.
+pub fn diagHelpLabel() -> String {
+    "help"
+}

--- a/toolchain/diag_render_test.osty
+++ b/toolchain/diag_render_test.osty
@@ -171,12 +171,18 @@ fn testDiagSuggestionDisplayFixApplicable() {
     testing.assertEq(r.replacement, "let foo = 1")
 }
 fn testDiagSuggestionDisplaySuggestOnly() {
+    // Non-machine-applicable: only the tag flips to "suggest";
+    // label + replacement still pass-through unchanged.
     let r = diagSuggestionDisplayOf("rename to foo", false, "let foo = 1")
     testing.assertEq(r.tag, "suggest")
+    testing.assertEq(r.label, "rename to foo")
+    testing.assertEq(r.replacement, "let foo = 1")
 }
 fn testDiagSuggestionDisplayEmptyLabel() {
     let r = diagSuggestionDisplayOf("", true, "x")
+    testing.assertEq(r.tag, "fix")
     testing.assertEq(r.label, "suggested fix")
+    testing.assertEq(r.replacement, "x")
 }
 fn testDiagSuggestionDisplayEmptyReplacement() {
     let r = diagSuggestionDisplayOf("rm unused", true, "")

--- a/toolchain/diag_render_test.osty
+++ b/toolchain/diag_render_test.osty
@@ -164,3 +164,33 @@ fn testDiagSeverityAnsiColorUnknown() {
     testing.assertEq(diagSeverityAnsiColor(99), "")
     testing.assertEq(diagSeverityAnsiColor(-1), "")
 }
+fn testDiagSuggestionDisplayFixApplicable() {
+    let r = diagSuggestionDisplayOf("rename to foo", true, "let foo = 1")
+    testing.assertEq(r.tag, "fix")
+    testing.assertEq(r.label, "rename to foo")
+    testing.assertEq(r.replacement, "let foo = 1")
+}
+fn testDiagSuggestionDisplaySuggestOnly() {
+    let r = diagSuggestionDisplayOf("rename to foo", false, "let foo = 1")
+    testing.assertEq(r.tag, "suggest")
+}
+fn testDiagSuggestionDisplayEmptyLabel() {
+    let r = diagSuggestionDisplayOf("", true, "x")
+    testing.assertEq(r.label, "suggested fix")
+}
+fn testDiagSuggestionDisplayEmptyReplacement() {
+    let r = diagSuggestionDisplayOf("rm unused", true, "")
+    testing.assertEq(r.replacement, "(delete)")
+}
+fn testDiagSuggestionDisplayAllDefaults() {
+    let r = diagSuggestionDisplayOf("", false, "")
+    testing.assertEq(r.tag, "suggest")
+    testing.assertEq(r.label, "suggested fix")
+    testing.assertEq(r.replacement, "(delete)")
+}
+fn testDiagNoteLabel() {
+    testing.assertEq(diagNoteLabel(), "note")
+}
+fn testDiagHelpLabel() {
+    testing.assertEq(diagHelpLabel(), "help")
+}


### PR DESCRIPTION
## 요약

`internal/diag/format.go` 의 진단 표시 정책 3가지를 `toolchain/diag_render.osty` 로 self-host:

| 정책 | Osty 함수 (신규) | 결과 |
|---|---|---|
| Suggestion 디스플레이 | `diagSuggestionDisplayOf(label, machineApplicable, rendered)` | `{tag, label, replacement}` 모두 fallback 적용 |
| Note 라벨 | `diagNoteLabel()` | `"note"` |
| Help 라벨 | `diagHelpLabel()` | `"help"` |

Suggestion fallback 규칙:
- `tag` = `"fix"` if `MachineApplicable` else `"suggest"`
- `label` = `sug.Label` if non-empty else `"suggested fix"`
- `replacement` = `rendered` if non-empty else `"(delete)"`

이전 PR (#1793 의 Severity 상수, #1789 의 renderReplacement, #1797 의 sevColor) 와 함께 `(*Formatter).write` 의 텍스트 부분 (헤드라인 라벨 / suggestion display) 이 모두 toolchain-owned. ANSI 코드 적용 및 buffer 출력만 호스트 잔존.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 네이밍 주의

`diagSuggestionDisplayOf` 는 `-Of` 접미사로 struct `DiagSuggestionDisplay` 와의 drift-test 슬롯 충돌 회피 — `registrySearchScoreOf` (PR #1790) 와 동일 패턴.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/diag_render.osty`** (확장)
  - `pub struct DiagSuggestionDisplay { tag, label, replacement }`
  - `pub fn diagSuggestionDisplayOf(userLabel, machineApplicable, rendered) -> DiagSuggestionDisplay`
  - `pub fn diagNoteLabel() / diagHelpLabel()`
- **`toolchain/diag_render_test.osty`** (확장) — 7 신규 케이스
  - fix-applicable / suggest-only / empty-label / empty-replacement / all-defaults
  - note label / help label

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/diag_render_policy.go`** (확장)
  - `DiagSuggestionDisplay` struct + `DiagSuggestionDisplayOf` + `DiagNoteLabel` + `DiagHelpLabel`
- **`internal/runner/diag_render_policy_test.go`** (확장) — 5 + 1 row table test
- **`internal/diag/format.go`** (수정)
  - Notes 분기: hardcoded `"note"` → `runner.DiagNoteLabel()`
  - Hint 분기: hardcoded `"help"` → `runner.DiagHelpLabel()`
  - Suggestions 분기: label/tag/replacement fallback 직접 처리 → `runner.DiagSuggestionDisplayOf(...)` 한 줄
  - 약 15줄의 조건 분기 제거

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 7 신규 케이스
  - **Go 스냅샷**: 5 + 1 row table test (총 6 신규 row)
  - **드리프트 게이트**: 기존 `diag_render.osty` subtest 가 3개 신규 `pub fn` + 1 신규 `pub struct` ↔ Go export 1:1 강제 (Of 패턴으로 collision 회피)
- **호환성**: 기존 diag 골든 스냅샷 + cmd/osty 69초 e2e 통과 — note / help / suggestion 표시 회귀 없음

## 검증

```
$ .bin/osty check toolchain/diag_render.osty toolchain/diag_render_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/diag/
ok  	github.com/osty/osty/internal/runner    0.026s
?   	github.com/osty/osty/internal/diag      [no test files]

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    69.054s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1795 | registry validatePackageName | `toolchain/registry_policy.osty` |
| 1796 | validatePackageName log-injection fix | `toolchain/registry_policy.osty` |
| 1797 | diag sevColor (Severity → ANSI) | `toolchain/diag_render.osty` |
| **이번** | **diag suggestion display + note/help labels** | **`toolchain/diag_render.osty`** (확장) |

## Test plan

- [x] `.bin/osty check` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/diag/` 통과
- [x] `go test ./cmd/osty/` 통과 (69초 e2e) — 진단 출력 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_