### PR TITLE
refactor: registry publish-time dep filtering 정책 self-host (toolchain/registry_policy.osty 확장)

### DIFF
--- a/internal/registry/server.go
+++ b/internal/registry/server.go
@@ -723,35 +723,35 @@ func manifestFromTarball(tarPath string) (*manifest.Manifest, error) {
 	}
 }
 
+// versionDependencies bridges to runner.ClassifyPublishDeps
+// (mirror of toolchain/registry_policy.osty). The host turns
+// manifest.Dependency lists into the runner spec; the policy
+// decides which deps are recorded and which trigger publish
+// rejection (path deps).
 func versionDependencies(m *manifest.Manifest) ([]VersionDependency, error) {
-	var out []VersionDependency
-	add := func(kind string, deps []manifest.Dependency) error {
-		for _, d := range deps {
-			if d.Path != "" {
-				return fmt.Errorf("dependency %q uses path=%q; path dependencies cannot be published", d.Name, d.Path)
-			}
-			if d.Git != nil {
-				continue
-			}
-			name := d.PackageName
-			if name == "" {
-				name = d.Name
-			}
-			req := d.VersionReq
-			if req == "" {
-				req = "*"
-			}
-			out = append(out, VersionDependency{Name: name, Req: req, Kind: kind})
-		}
-		return nil
+	r := runner.ClassifyPublishDeps(publishDepSpecs(m.Dependencies), publishDepSpecs(m.DevDependencies))
+	if r.ErrorMessage != "" {
+		return nil, errors.New(r.ErrorMessage)
 	}
-	if err := add("normal", m.Dependencies); err != nil {
-		return nil, err
-	}
-	if err := add("dev", m.DevDependencies); err != nil {
-		return nil, err
+	out := make([]VersionDependency, 0, len(r.Deps))
+	for _, d := range r.Deps {
+		out = append(out, VersionDependency{Name: d.Name, Req: d.Req, Kind: d.Kind})
 	}
 	return out, nil
+}
+
+func publishDepSpecs(deps []manifest.Dependency) []runner.PublishDepSpec {
+	specs := make([]runner.PublishDepSpec, 0, len(deps))
+	for _, d := range deps {
+		specs = append(specs, runner.PublishDepSpec{
+			Name:        d.Name,
+			PackageName: d.PackageName,
+			VersionReq:  d.VersionReq,
+			Path:        d.Path,
+			IsGit:       d.Git != nil,
+		})
+	}
+	return specs
 }
 
 func copyFeatures(m *manifest.Manifest) map[string][]string {

--- a/internal/runner/registry_policy.go
+++ b/internal/runner/registry_policy.go
@@ -159,3 +159,73 @@ func RegistrySearchRequestNormalize(rawQuery string, rawLimit int) RegistrySearc
 	}
 	return RegistrySearchRequest{Query: q, Limit: limit}
 }
+
+// PublishDepSpec is the host-side dependency shape the publish
+// filter operates on.
+//
+// Osty: toolchain/registry_policy.osty:246
+type PublishDepSpec struct {
+	Name        string
+	PackageName string
+	VersionReq  string
+	Path        string
+	IsGit       bool
+}
+
+// PublishVersionDep is the structured output the registry's
+// store records on each published version. Kind is "normal" or
+// "dev".
+//
+// Osty: toolchain/registry_policy.osty:256
+type PublishVersionDep struct {
+	Name string
+	Req  string
+	Kind string
+}
+
+// PublishDepsResult bundles the filtered dep list + an optional
+// rejection message.
+//
+// Osty: toolchain/registry_policy.osty:265
+type PublishDepsResult struct {
+	Deps         []PublishVersionDep
+	ErrorMessage string
+}
+
+// ClassifyPublishDeps applies per-publish dep policy:
+//   - path dep → reject the publish
+//   - git dep → silently skip
+//   - else → record with effective name + version req
+//
+// Osty: toolchain/registry_policy.osty:280
+func ClassifyPublishDeps(normal, dev []PublishDepSpec) PublishDepsResult {
+	var out []PublishVersionDep
+	if msg := appendPublishDeps(&out, normal, "normal"); msg != "" {
+		return PublishDepsResult{ErrorMessage: msg}
+	}
+	if msg := appendPublishDeps(&out, dev, "dev"); msg != "" {
+		return PublishDepsResult{ErrorMessage: msg}
+	}
+	return PublishDepsResult{Deps: out}
+}
+
+func appendPublishDeps(out *[]PublishVersionDep, section []PublishDepSpec, kind string) string {
+	for _, d := range section {
+		if d.Path != "" {
+			return "dependency " + TomlBasicString(d.Name) + " uses path=" + TomlBasicString(d.Path) + "; path dependencies cannot be published"
+		}
+		if d.IsGit {
+			continue
+		}
+		name := d.PackageName
+		if name == "" {
+			name = d.Name
+		}
+		req := d.VersionReq
+		if req == "" {
+			req = "*"
+		}
+		*out = append(*out, PublishVersionDep{Name: name, Req: req, Kind: kind})
+	}
+	return ""
+}

--- a/internal/runner/registry_policy_test.go
+++ b/internal/runner/registry_policy_test.go
@@ -187,3 +187,86 @@ func TestRegistrySearchRequestNormalize(t *testing.T) {
 		})
 	}
 }
+
+func TestClassifyPublishDeps(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		normal := []PublishDepSpec{
+			{Name: "serde", VersionReq: "1.0"},
+			{Name: "log", VersionReq: "0.4"},
+		}
+		r := ClassifyPublishDeps(normal, nil)
+		if r.ErrorMessage != "" {
+			t.Fatalf("unexpected err: %q", r.ErrorMessage)
+		}
+		if len(r.Deps) != 2 || r.Deps[0].Name != "serde" || r.Deps[0].Req != "1.0" || r.Deps[0].Kind != "normal" {
+			t.Errorf("unexpected: %+v", r.Deps)
+		}
+	})
+	t.Run("dev-kind", func(t *testing.T) {
+		dev := []PublishDepSpec{{Name: "testing", VersionReq: "0.1"}}
+		r := ClassifyPublishDeps(nil, dev)
+		if len(r.Deps) != 1 || r.Deps[0].Kind != "dev" {
+			t.Errorf("unexpected: %+v", r.Deps)
+		}
+	})
+	t.Run("package-rename", func(t *testing.T) {
+		normal := []PublishDepSpec{{Name: "alias", PackageName: "real-name", VersionReq: "1.0"}}
+		r := ClassifyPublishDeps(normal, nil)
+		if r.Deps[0].Name != "real-name" {
+			t.Errorf("name = %q, want real-name", r.Deps[0].Name)
+		}
+	})
+	t.Run("default-req-star", func(t *testing.T) {
+		normal := []PublishDepSpec{{Name: "anything"}}
+		r := ClassifyPublishDeps(normal, nil)
+		if r.Deps[0].Req != "*" {
+			t.Errorf("req = %q, want *", r.Deps[0].Req)
+		}
+	})
+	t.Run("skips-git", func(t *testing.T) {
+		normal := []PublishDepSpec{
+			{Name: "serde", VersionReq: "1.0"},
+			{Name: "git-dep", IsGit: true},
+		}
+		r := ClassifyPublishDeps(normal, nil)
+		if r.ErrorMessage != "" {
+			t.Fatalf("unexpected err: %q", r.ErrorMessage)
+		}
+		if len(r.Deps) != 1 || r.Deps[0].Name != "serde" {
+			t.Errorf("unexpected: %+v", r.Deps)
+		}
+	})
+	t.Run("rejects-path", func(t *testing.T) {
+		normal := []PublishDepSpec{{Name: "local", Path: "../local"}}
+		r := ClassifyPublishDeps(normal, nil)
+		want := `dependency "local" uses path="../local"; path dependencies cannot be published`
+		if r.ErrorMessage != want {
+			t.Errorf("err = %q, want %q", r.ErrorMessage, want)
+		}
+		if len(r.Deps) != 0 {
+			t.Errorf("deps must be empty on rejection, got %+v", r.Deps)
+		}
+	})
+	t.Run("rejects-path-in-dev", func(t *testing.T) {
+		dev := []PublishDepSpec{{Name: "local", Path: "../local"}}
+		r := ClassifyPublishDeps(nil, dev)
+		want := `dependency "local" uses path="../local"; path dependencies cannot be published`
+		if r.ErrorMessage != want {
+			t.Errorf("err = %q, want %q", r.ErrorMessage, want)
+		}
+	})
+	t.Run("both-sections", func(t *testing.T) {
+		normal := []PublishDepSpec{{Name: "a", VersionReq: "1.0"}}
+		dev := []PublishDepSpec{{Name: "b", VersionReq: "2.0"}}
+		r := ClassifyPublishDeps(normal, dev)
+		if len(r.Deps) != 2 || r.Deps[0].Kind != "normal" || r.Deps[1].Kind != "dev" {
+			t.Errorf("unexpected: %+v", r.Deps)
+		}
+	})
+	t.Run("empty", func(t *testing.T) {
+		r := ClassifyPublishDeps(nil, nil)
+		if r.ErrorMessage != "" || len(r.Deps) != 0 {
+			t.Errorf("unexpected: %+v", r)
+		}
+	})
+}

--- a/toolchain/registry_policy.osty
+++ b/toolchain/registry_policy.osty
@@ -277,40 +277,60 @@ pub struct PublishDepsResult {
 ///   - Otherwise the dep is recorded with the effective name
 ///     (`packageName` else `name`) and version req (`"*"` when
 ///     blank).
+///
+/// Both sections share the same scan body but the accumulator
+/// lives in this function's frame — no helper takes `out` as a
+/// parameter. Keeps the policy independent of Osty's
+/// `List<T>` pass-by-reference semantics (the Go snapshot uses
+/// `*[]...` for the same logic).
 pub fn classifyPublishDeps(normal: List<PublishDepSpec>, dev: List<PublishDepSpec>) -> PublishDepsResult {
     let mut out: List<PublishVersionDep> = []
-    let normalErr = appendPublishDeps(out, normal, "normal")
-    if normalErr != "" {
-        return PublishDepsResult {deps: [], errorMessage: normalErr}
+    let mut i = 0
+    let normalLen = normal.len()
+    for i < normalLen {
+        let d = normal[i]
+        if d.path != "" {
+            return PublishDepsResult {deps: [], errorMessage: pathDepRejectMessage(d.name, d.path)}
+        }
+        if !d.isGit {
+            out.push(classifiedPublishDep(d, "normal"))
+        }
+        i = i + 1
     }
-    let devErr = appendPublishDeps(out, dev, "dev")
-    if devErr != "" {
-        return PublishDepsResult {deps: [], errorMessage: devErr}
+    let mut j = 0
+    let devLen = dev.len()
+    for j < devLen {
+        let d = dev[j]
+        if d.path != "" {
+            return PublishDepsResult {deps: [], errorMessage: pathDepRejectMessage(d.name, d.path)}
+        }
+        if !d.isGit {
+            out.push(classifiedPublishDep(d, "dev"))
+        }
+        j = j + 1
     }
     PublishDepsResult {deps: out, errorMessage: ""}
 }
-/// appendPublishDeps mutates `out` in place with the classified
-/// entries for one section. Returns `""` on success; the path-dep
-/// rejection message otherwise.
-fn appendPublishDeps(out: List<PublishVersionDep>, section: List<PublishDepSpec>, kind: String) -> String {
-    for d in section {
-        if d.path != "" {
-            return "dependency " + tomlBasicString(d.name) + " uses path=" + tomlBasicString(d.path) + "; path dependencies cannot be published"
-        }
-        if d.isGit {
-            continue
-        }
-        let outName = if d.packageName == "" {
-            d.name
-        } else {
-            d.packageName
-        }
-        let outReq = if d.versionReq == "" {
-            "*"
-        } else {
-            d.versionReq
-        }
-        out.push(PublishVersionDep {name: outName, req: outReq, kind: kind})
+/// classifiedPublishDep builds one `PublishVersionDep` from a
+/// non-path / non-git spec, applying the empty-string fallbacks
+/// (`packageName` → `name`, `versionReq` → `"*"`).
+fn classifiedPublishDep(d: PublishDepSpec, kind: String) -> PublishVersionDep {
+    let outName = if d.packageName == "" {
+        d.name
+    } else {
+        d.packageName
     }
-    ""
+    let outReq = if d.versionReq == "" {
+        "*"
+    } else {
+        d.versionReq
+    }
+    PublishVersionDep {name: outName, req: outReq, kind: kind}
+}
+/// pathDepRejectMessage formats the publish-blocking error when a
+/// path dependency is seen. Name + path are run through
+/// `tomlBasicString` so embedded quotes / control characters get
+/// escaped (log-injection prevention — see PR #1796 pattern).
+fn pathDepRejectMessage(name: String, path: String) -> String {
+    "dependency " + tomlBasicString(name) + " uses path=" + tomlBasicString(path) + "; path dependencies cannot be published"
 }

--- a/toolchain/registry_policy.osty
+++ b/toolchain/registry_policy.osty
@@ -230,3 +230,87 @@ pub fn registrySearchRequestNormalize(rawQuery: String, rawLimit: Int) -> Regist
         errorMessage: "",
     }
 }
+/// PublishDepSpec is the host-side dependency shape the publish
+/// filter operates on. Mirrors a subset of manifest.Dependency:
+///
+///   - `name`: alias used in the manifest (`[dependencies]` key).
+///   - `packageName`: explicit `package = "..."` override; empty
+///     falls back to `name`.
+///   - `versionReq`: the `version = "..."` constraint; empty
+///     becomes the wildcard `"*"`.
+///   - `path`: non-empty marks the dep as a path source — those
+///     get rejected at publish time.
+///   - `isGit`: true marks a git source — silently dropped from
+///     the published metadata (the registry has no way to honour
+///     git deps after the fact).
+pub struct PublishDepSpec {
+    pub name: String,
+    pub packageName: String,
+    pub versionReq: String,
+    pub path: String,
+    pub isGit: Bool,
+}
+/// PublishVersionDep is the structured output the registry's
+/// store records on each published version. `kind` is "normal"
+/// or "dev" — the labels the historical Go code used.
+pub struct PublishVersionDep {
+    pub name: String,
+    pub req: String,
+    pub kind: String,
+}
+/// PublishDepsResult bundles the filtered dep list + an
+/// optional rejection message. `errorMessage != ""` blocks the
+/// publish; the message is the user-facing string the HTTP
+/// handler wraps in `badRequest`.
+pub struct PublishDepsResult {
+    pub deps: List<PublishVersionDep>,
+    pub errorMessage: String,
+}
+/// classifyPublishDeps applies the per-publish dep policy to a
+/// manifest's `[dependencies]` (normal) and `[dev-dependencies]`
+/// (dev) lists. Rules:
+///
+///   - A path dependency (`d.path != ""`) blocks the publish —
+///     the registry can't honour file-system pointers.
+///   - A git dependency (`d.isGit`) is silently dropped — the
+///     registry only records registry-resolvable deps.
+///   - Otherwise the dep is recorded with the effective name
+///     (`packageName` else `name`) and version req (`"*"` when
+///     blank).
+pub fn classifyPublishDeps(normal: List<PublishDepSpec>, dev: List<PublishDepSpec>) -> PublishDepsResult {
+    let mut out: List<PublishVersionDep> = []
+    let normalErr = appendPublishDeps(out, normal, "normal")
+    if normalErr != "" {
+        return PublishDepsResult {deps: [], errorMessage: normalErr}
+    }
+    let devErr = appendPublishDeps(out, dev, "dev")
+    if devErr != "" {
+        return PublishDepsResult {deps: [], errorMessage: devErr}
+    }
+    PublishDepsResult {deps: out, errorMessage: ""}
+}
+/// appendPublishDeps mutates `out` in place with the classified
+/// entries for one section. Returns `""` on success; the path-dep
+/// rejection message otherwise.
+fn appendPublishDeps(out: List<PublishVersionDep>, section: List<PublishDepSpec>, kind: String) -> String {
+    for d in section {
+        if d.path != "" {
+            return "dependency " + tomlBasicString(d.name) + " uses path=" + tomlBasicString(d.path) + "; path dependencies cannot be published"
+        }
+        if d.isGit {
+            continue
+        }
+        let outName = if d.packageName == "" {
+            d.name
+        } else {
+            d.packageName
+        }
+        let outReq = if d.versionReq == "" {
+            "*"
+        } else {
+            d.versionReq
+        }
+        out.push(PublishVersionDep {name: outName, req: outReq, kind: kind})
+    }
+    ""
+}

--- a/toolchain/registry_policy_test.osty
+++ b/toolchain/registry_policy_test.osty
@@ -209,3 +209,71 @@ fn testRegistrySearchRequestNormalizeNegativeLimit() {
     testing.assertEq(r.errorMessage, "")
     testing.assertEq(r.limit, 20)
 }
+fn pubDep(name: String) -> PublishDepSpec {
+    PublishDepSpec {name: name, packageName: "", versionReq: "", path: "", isGit: false}
+}
+fn testClassifyPublishDepsBasic() {
+    let normal = [
+        PublishDepSpec {..pubDep("serde"), versionReq: "1.0"},
+        PublishDepSpec {..pubDep("log"), versionReq: "0.4"},
+    ]
+    let r = classifyPublishDeps(normal, [])
+    testing.assertEq(r.errorMessage, "")
+    testing.assertEq(r.deps.len(), 2)
+    testing.assertEq(r.deps[0].name, "serde")
+    testing.assertEq(r.deps[0].req, "1.0")
+    testing.assertEq(r.deps[0].kind, "normal")
+    testing.assertEq(r.deps[1].name, "log")
+}
+fn testClassifyPublishDepsDevKind() {
+    let dev = [PublishDepSpec {..pubDep("testing"), versionReq: "0.1"}]
+    let r = classifyPublishDeps([], dev)
+    testing.assertEq(r.deps.len(), 1)
+    testing.assertEq(r.deps[0].kind, "dev")
+}
+fn testClassifyPublishDepsPackageRename() {
+    // packageName overrides name for the published manifest.
+    let normal = [PublishDepSpec {..pubDep("alias"), packageName: "real-name", versionReq: "1.0"}]
+    let r = classifyPublishDeps(normal, [])
+    testing.assertEq(r.deps[0].name, "real-name")
+}
+fn testClassifyPublishDepsDefaultReq() {
+    // Empty versionReq defaults to `"*"`.
+    let normal = [pubDep("anything")]
+    let r = classifyPublishDeps(normal, [])
+    testing.assertEq(r.deps[0].req, "*")
+}
+fn testClassifyPublishDepsSkipsGit() {
+    let normal = [
+        PublishDepSpec {..pubDep("serde"), versionReq: "1.0"},
+        PublishDepSpec {..pubDep("git-dep"), isGit: true},
+    ]
+    let r = classifyPublishDeps(normal, [])
+    testing.assertEq(r.errorMessage, "")
+    testing.assertEq(r.deps.len(), 1)
+    testing.assertEq(r.deps[0].name, "serde")
+}
+fn testClassifyPublishDepsRejectsPath() {
+    let normal = [PublishDepSpec {..pubDep("local"), path: "../local"}]
+    let r = classifyPublishDeps(normal, [])
+    testing.assertEq(r.errorMessage, "dependency \"local\" uses path=\"../local\"; path dependencies cannot be published")
+    testing.assertEq(r.deps.len(), 0)
+}
+fn testClassifyPublishDepsRejectsPathInDev() {
+    let dev = [PublishDepSpec {..pubDep("local"), path: "../local"}]
+    let r = classifyPublishDeps([], dev)
+    testing.assertEq(r.errorMessage, "dependency \"local\" uses path=\"../local\"; path dependencies cannot be published")
+}
+fn testClassifyPublishDepsBothSections() {
+    let normal = [PublishDepSpec {..pubDep("a"), versionReq: "1.0"}]
+    let dev = [PublishDepSpec {..pubDep("b"), versionReq: "2.0"}]
+    let r = classifyPublishDeps(normal, dev)
+    testing.assertEq(r.deps.len(), 2)
+    testing.assertEq(r.deps[0].kind, "normal")
+    testing.assertEq(r.deps[1].kind, "dev")
+}
+fn testClassifyPublishDepsEmpty() {
+    let r = classifyPublishDeps([], [])
+    testing.assertEq(r.errorMessage, "")
+    testing.assertEq(r.deps.len(), 0)
+}


### PR DESCRIPTION
## 요약

`internal/registry/server.go::versionDependencies` (`osty publish` 요청에서 manifest 의 normal/dev 의존성을 published metadata 로 변환) 정책을 `toolchain/registry_policy.osty` 로 self-host.

| 입력 dep 종류 | 정책 |
|---|---|
| `path = "..."` | **publish 거부** — `dependency "NAME" uses path="PATH"; path dependencies cannot be published` |
| `git = { ... }` | **조용히 skip** — registry 는 git URL resolve 못 함 |
| 그 외 (registry dep) | **기록** — effective name (`packageName` else `name`) + req (`versionReq` else `"*"`) + kind |

호스트 측은 `manifest.Dependency` → runner spec 변환 + 결과 wrap 만 담당. 오류 메시지의 echoed name/path 는 `tomlBasicString` 으로 escape (log injection 방지 — PR #1796 와 동일 패턴).

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/registry_policy.osty`** (확장)
  - `pub struct PublishDepSpec { name, packageName, versionReq, path, isGit }`
  - `pub struct PublishVersionDep { name, req, kind }`
  - `pub struct PublishDepsResult { deps, errorMessage }`
  - `pub fn classifyPublishDeps(normal, dev) -> PublishDepsResult`
  - 내부 helper `appendPublishDeps`
- **`toolchain/registry_policy_test.osty`** (확장) — 9 신규 케이스
  - basic / dev kind / package rename / default req
  - skip git / reject path (normal + dev)
  - both sections / empty

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/registry_policy.go`** (확장)
  - 3 신규 type + `ClassifyPublishDeps` + 내부 `appendPublishDeps`
- **`internal/runner/registry_policy_test.go`** (확장) — 9 sub-test
- **`internal/registry/server.go`** (수정)
  - `versionDependencies` 28줄 → 26줄 (host 는 spec 변환 + `errors.New` 래핑만)
  - 신규 `publishDepSpecs` helper (manifest.Dependency → runner.PublishDepSpec)

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 9 신규 케이스
  - **Go 스냅샷**: 9 sub-test
  - **드리프트 게이트**: 기존 `registry_policy.osty` subtest 가 3 신규 `pub struct` + 1 신규 `pub fn` ↔ Go export 1:1 강제
- **호환성**: cmd/osty 90초 e2e 통과 — `osty publish` path/git/registry dep 처리 회귀 없음

## 검증

```
$ .bin/osty check toolchain/registry_policy.osty toolchain/registry_policy_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/registry/
ok  	github.com/osty/osty/internal/runner    0.028s
?   	github.com/osty/osty/internal/registry  [no test files]

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    90.142s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1797 | diag sevColor | `toolchain/diag_render.osty` |
| 1798 | diag suggestion + note/help labels | `toolchain/diag_render.osty` |
| 1799 | registry search request normalization | `toolchain/registry_policy.osty` |
| **이번** | **registry publish-time dep filtering** | **`toolchain/registry_policy.osty`** (확장) |

## Test plan

- [x] `.bin/osty check` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/registry/` 통과
- [x] `go test ./cmd/osty/` 통과 (90초 e2e) — `osty publish` 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_