### PR TITLE
refactor: pkgmgr SourceKind.String self-host + iota guard (toolchain/pkg_policy.osty 확장)

### DIFF
--- a/internal/pkgmgr/source.go
+++ b/internal/pkgmgr/source.go
@@ -26,6 +26,7 @@ import (
 	"context"
 
 	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/runner"
 )
 
 // SourceKind selects how a Source materializes its package. Each
@@ -44,16 +45,19 @@ const (
 	SourceRegistry
 )
 
+// Compile-time guard: the SourceKind iota MUST match the int
+// constants in the runner snapshot (toolchain/pkg_policy.osty).
+// A future reorder of the iota above would silently desync the
+// two sources of truth without this; the array length check
+// forces a build failure instead.
+var _ = [1]struct{}{}[int(SourcePath)-runner.PkgSourceKindPath]
+var _ = [1]struct{}{}[int(SourceGit)-runner.PkgSourceKindGit]
+var _ = [1]struct{}{}[int(SourceRegistry)-runner.PkgSourceKindRegistry]
+
+// String bridges to runner.PkgSourceKindString (mirror of
+// toolchain/pkg_policy.osty).
 func (k SourceKind) String() string {
-	switch k {
-	case SourcePath:
-		return "path"
-	case SourceGit:
-		return "git"
-	case SourceRegistry:
-		return "registry"
-	}
-	return "unknown"
+	return runner.PkgSourceKindString(int(k))
 }
 
 // Source is the uniform interface over local, git, and registry

--- a/internal/runner/pkg_policy.go
+++ b/internal/runner/pkg_policy.go
@@ -103,3 +103,27 @@ func pkgPathBase(p string) string {
 	}
 	return p[sep+1 : end]
 }
+
+// PkgSourceKind enum constants. Order matches
+// toolchain/pkg_policy.osty + internal/pkgmgr.SourceKind iota.
+const (
+	PkgSourceKindPath     int = 0
+	PkgSourceKindGit      int = 1
+	PkgSourceKindRegistry int = 2
+)
+
+// PkgSourceKindString maps a SourceKind int back to its
+// human-readable label. Unknown values collapse to "unknown".
+//
+// Osty: toolchain/pkg_policy.osty:118
+func PkgSourceKindString(kind int) string {
+	switch kind {
+	case PkgSourceKindPath:
+		return "path"
+	case PkgSourceKindGit:
+		return "git"
+	case PkgSourceKindRegistry:
+		return "registry"
+	}
+	return "unknown"
+}

--- a/internal/runner/pkg_policy_test.go
+++ b/internal/runner/pkg_policy_test.go
@@ -96,3 +96,24 @@ func TestPkgSkipDirEntry(t *testing.T) {
 		})
 	}
 }
+
+func TestPkgSourceKindString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want string
+	}{
+		{"path", PkgSourceKindPath, "path"},
+		{"git", PkgSourceKindGit, "git"},
+		{"registry", PkgSourceKindRegistry, "registry"},
+		{"unknown-positive", 99, "unknown"},
+		{"unknown-negative", -1, "unknown"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := PkgSourceKindString(c.in); got != c.want {
+				t.Errorf("PkgSourceKindString(%d) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/runner/pkg_policy_test.go
+++ b/internal/runner/pkg_policy_test.go
@@ -117,3 +117,33 @@ func TestPkgSourceKindString(t *testing.T) {
 		})
 	}
 }
+
+func TestPkgSourceKindConstantsLiteralValues(t *testing.T) {
+	// Mirror the literal-value assertion that runs on the Osty side
+	// (toolchain/pkg_policy_test.osty). The compile-time guards in
+	// internal/pkgmgr/source.go would block a build that drifts, but
+	// these run pre-build during `go test` so CI can name the regression.
+	if PkgSourceKindPath != 0 {
+		t.Errorf("PkgSourceKindPath = %d, want 0", PkgSourceKindPath)
+	}
+	if PkgSourceKindGit != 1 {
+		t.Errorf("PkgSourceKindGit = %d, want 1", PkgSourceKindGit)
+	}
+	if PkgSourceKindRegistry != 2 {
+		t.Errorf("PkgSourceKindRegistry = %d, want 2", PkgSourceKindRegistry)
+	}
+}
+
+func TestPkgSourceKindStringByLiteralValue(t *testing.T) {
+	// Hit the mapping with literal ints — independent of the named
+	// constants — so a `PkgSourceKindPath = 1` typo can't hide.
+	if got := PkgSourceKindString(0); got != "path" {
+		t.Errorf("PkgSourceKindString(0) = %q, want %q", got, "path")
+	}
+	if got := PkgSourceKindString(1); got != "git" {
+		t.Errorf("PkgSourceKindString(1) = %q, want %q", got, "git")
+	}
+	if got := PkgSourceKindString(2); got != "registry" {
+		t.Errorf("PkgSourceKindString(2) = %q, want %q", got, "registry")
+	}
+}

--- a/toolchain/pkg_policy.osty
+++ b/toolchain/pkg_policy.osty
@@ -106,3 +106,24 @@ fn pkgPathBase(p: String) -> String {
     }
     strings.slice(p, sep + 1, end)
 }
+/// SourceKind enum constants. Encoded as Int so the host mirrors
+/// them as their iota analogue without a wire-format translation.
+/// Order MUST match `internal/pkgmgr.SourceKind` iota.
+pub let pkgSourceKindPath: Int = 0
+pub let pkgSourceKindGit: Int = 1
+pub let pkgSourceKindRegistry: Int = 2
+/// pkgSourceKindString maps a SourceKind int back to its
+/// human-readable label. Unknown / out-of-range values collapse
+/// to `"unknown"` so log lines never surface a bare number.
+pub fn pkgSourceKindString(kind: Int) -> String {
+    if kind == pkgSourceKindPath {
+        return "path"
+    }
+    if kind == pkgSourceKindGit {
+        return "git"
+    }
+    if kind == pkgSourceKindRegistry {
+        return "registry"
+    }
+    "unknown"
+}

--- a/toolchain/pkg_policy_test.osty
+++ b/toolchain/pkg_policy_test.osty
@@ -91,3 +91,19 @@ fn testPkgSourceKindStringUnknown() {
     testing.assertEq(pkgSourceKindString(99), "unknown")
     testing.assertEq(pkgSourceKindString(-1), "unknown")
 }
+fn testPkgSourceKindConstantsLiteralValues() {
+    // The struct-y constants are part of the wire-format contract
+    // with `internal/pkgmgr.SourceKind` (iota 0/1/2). A regression
+    // would break the host's compile-time guard, but only AFTER
+    // a build — these literal asserts catch the drift in CI tests.
+    testing.assertEq(pkgSourceKindPath, 0)
+    testing.assertEq(pkgSourceKindGit, 1)
+    testing.assertEq(pkgSourceKindRegistry, 2)
+}
+fn testPkgSourceKindStringByLiteralValue() {
+    // Hit the mapping directly with literal ints — bypassing the
+    // named constants — so a `pkgSourceKindPath = 1` typo can't hide.
+    testing.assertEq(pkgSourceKindString(0), "path")
+    testing.assertEq(pkgSourceKindString(1), "git")
+    testing.assertEq(pkgSourceKindString(2), "registry")
+}

--- a/toolchain/pkg_policy_test.osty
+++ b/toolchain/pkg_policy_test.osty
@@ -78,3 +78,16 @@ fn testPkgSkipDirEntryTrailingSeparator() {
     testing.assertEq(pkgSkipDirEntry("sub\\.git\\"), true)
     testing.assertEq(pkgSkipDirEntry(".osty/"), true)
 }
+fn testPkgSourceKindStringPath() {
+    testing.assertEq(pkgSourceKindString(pkgSourceKindPath), "path")
+}
+fn testPkgSourceKindStringGit() {
+    testing.assertEq(pkgSourceKindString(pkgSourceKindGit), "git")
+}
+fn testPkgSourceKindStringRegistry() {
+    testing.assertEq(pkgSourceKindString(pkgSourceKindRegistry), "registry")
+}
+fn testPkgSourceKindStringUnknown() {
+    testing.assertEq(pkgSourceKindString(99), "unknown")
+    testing.assertEq(pkgSourceKindString(-1), "unknown")
+}


### PR DESCRIPTION
## 요약

`internal/pkgmgr/source.go::(SourceKind).String` (`"path"`/`"git"`/`"registry"`/`"unknown"` 매핑) 을 `toolchain/pkg_policy.osty` 로 self-host.

PR #1793 의 Severity 패턴 (enum 상수 `pub let` + `.String` 매핑 + 호스트 컴파일타임 guard) 을 `SourceKind` 에 동일 적용.

CLAUDE.md 의 **"Osty로 작성 가능한 것은 Go로 작성 금지"** 원칙.

## 변경 내역

### toolchain (source of truth, 확장)
- **`toolchain/pkg_policy.osty`** (확장)
  - `pub let pkgSourceKindPath: Int = 0`
  - `pub let pkgSourceKindGit: Int = 1`
  - `pub let pkgSourceKindRegistry: Int = 2`
  - `pub fn pkgSourceKindString(kind: Int) -> String` (unknown 안전 fallback)
- **`toolchain/pkg_policy_test.osty`** (확장) — 4 신규 케이스
  - path / git / registry
  - unknown positive (99) / negative (-1)

### Go 측 (호스트 어댑터 + 스냅샷)
- **`internal/runner/pkg_policy.go`** (확장)
  - 3개 `int` 상수 + `PkgSourceKindString`
- **`internal/runner/pkg_policy_test.go`** (확장) — 5 row table test
- **`internal/pkgmgr/source.go`** (수정)
  - `SourceKind.String` 10줄 → 3줄 (runner 위임)
  - **3개 compile-time array-index assertion** — `var _ = [1]struct{}{}[int(SourcePath)-runner.PkgSourceKindPath]` 등으로 iota 순서 desync 시 빌드 즉시 실패

## 마이그레이션 결과

- 셋 가지 surface 동시 검증:
  - **Osty 측**: 4 케이스
  - **Go 스냅샷**: 5 row table test
  - **드리프트 게이트**: 기존 `pkg_policy.osty` subtest 가 신규 `pub fn` ↔ Go export 1:1 강제
  - **iota 정렬 guard**: 호스트 측 compile-time assertion (Severity 패턴 동일)
- **호환성**: cmd/osty 89초 e2e 통과 — SourceKind 사용 (해시 / 락파일 source URI 등) 회귀 없음

## 검증

```
$ .bin/osty check toolchain/pkg_policy.osty toolchain/pkg_policy_test.osty
exit=0

$ go build ./...
(통과)

$ go test ./internal/runner/ ./internal/pkgmgr/
ok  	github.com/osty/osty/internal/runner    (cached)
ok  	github.com/osty/osty/internal/pkgmgr    0.007s

$ go test ./cmd/osty/ -count=1
ok  	github.com/osty/osty/cmd/osty    89.169s
```

## 이번 세션 누적

| # | PR | 이전된 모듈 |
|---|---|---|
| (생략 — 이전 PR 참조) | — |
| 1798 | diag suggestion + note/help labels | `toolchain/diag_render.osty` |
| 1799 | registry search request normalization | `toolchain/registry_policy.osty` |
| 1800 | registry publish-time dep filtering | `toolchain/registry_policy.osty` |
| **이번** | **pkgmgr SourceKind.String + iota guard** | **`toolchain/pkg_policy.osty`** (확장) |

## Test plan

- [x] `.bin/osty check` 통과
- [x] `go test ./internal/runner/` (스냅샷 + 드리프트 게이트) 통과
- [x] `go test ./internal/pkgmgr/` 통과
- [x] `go test ./cmd/osty/` 통과 (89초 e2e) — SourceKind 사용 경로 회귀 없음

https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwoaqaqLvhwMsvhJ3yjvsf)_