### PR TITLE
[codex] checkpoint selfhost MIR JSON path

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -4,12 +4,11 @@
 // JSON object on stdout.
 //
 // Slice-2 contract: the binary's body is now a thin Go shim that
-// stages the source to a temp file and forks the self-hosted
-// `osty-self` binary's `lir-proto-lower` subcommand to do the
-// actual lowering through the Osty-owned `toolchain/lir_proto.osty`
-// pipeline (HIR → MIR → LIR Proto → LLVM IR). The wire shape stays
-// identical to Slice 1 — callers in `internal/nativelirproto`,
-// `cmd/osty/lir_proto_bridge.go`, and the tests are untouched.
+// stages either source or an already-lowered MIR JSON payload to a
+// temp file and forks the self-hosted `osty-self` binary. Source
+// requests use `lir-proto-lower`; MIR requests use
+// `lir-proto-lower-mir-json` so production backends do not re-enter
+// the still-partial Osty source compiler.
 //
 // Failure modes (returned as `declined: true` so the dispatcher
 // falls back to the legacy MIR-direct emit instead of hard-failing):
@@ -82,7 +81,7 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 		// when the self-host artifact isn't built yet.
 		return nativelirproto.Response{Declined: true, Error: err.Error()}, nil
 	}
-	sourcePath, cleanup, err := stageInput(req)
+	stagedPath, command, cleanup, err := stageInput(req)
 	if cleanup != nil && os.Getenv("OSTY_LIRPROTO_KEEP_STAGED") == "" {
 		defer cleanup()
 	}
@@ -90,18 +89,14 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 		return nativelirproto.Response{}, err
 	}
 	if dbg := os.Getenv("OSTY_LIRPROTO_DEBUG"); dbg != "" {
-		fmt.Fprintf(os.Stderr, "[lirproto-debug] staged source=%s\n", sourcePath)
+		fmt.Fprintf(os.Stderr, "[lirproto-debug] staged %s=%s\n", command, stagedPath)
 	}
 
 	pkgName := req.PackageName
 	if pkgName == "" {
 		pkgName = "main"
 	}
-	// osty-self currently only supports lir-proto-lower (source-based).
-	// MIR JSON path is reserved for when the self-hosted binary grows
-	// a lir-proto-lower-mir-json subcommand (Phase 1+).
-	command := "lir-proto-lower"
-	args := []string{command, sourcePath, "--package-name=" + pkgName}
+	args := []string{command, stagedPath, "--package-name=" + pkgName}
 	if req.Target != "" {
 		args = append(args, "--target="+req.Target)
 	}
@@ -163,12 +158,35 @@ func resolveOstySelfBin() (string, error) {
 // JSON to a temp file so the osty-self subcommand can open it. MIR
 // wins even when callers attach source text for diagnostics; otherwise
 // the bridge silently re-enters source lowering and loses the MIR path.
-func stageInput(req nativelirproto.Request) (string, func(), error) {
+func stageInput(req nativelirproto.Request) (string, string, func(), error) {
 	root, err := os.MkdirTemp("", "osty-native-lirproto-*")
 	if err != nil {
-		return "", nil, err
+		return "", "", nil, err
 	}
 	cleanup := func() { os.RemoveAll(root) }
+
+	if req.MIR != nil {
+		data, err := json.Marshal(req.MIR)
+		if err != nil {
+			return "", "", cleanup, fmt.Errorf("marshal MIR JSON input: %w", err)
+		}
+		name := "main.mir.json"
+		if req.SourcePath != "" {
+			base := filepath.Base(req.SourcePath)
+			ext := filepath.Ext(base)
+			if ext != "" {
+				base = strings.TrimSuffix(base, ext)
+			}
+			if base != "" && base != "." {
+				name = base + ".mir.json"
+			}
+		}
+		stagedPath := filepath.Join(root, name)
+		if err := os.WriteFile(stagedPath, data, 0o644); err != nil {
+			return "", "", cleanup, err
+		}
+		return stagedPath, "lir-proto-lower-mir-json", cleanup, nil
+	}
 
 	name := "main.osty"
 	if req.SourcePath != "" {
@@ -181,11 +199,11 @@ func stageInput(req nativelirproto.Request) (string, func(), error) {
 		}
 	}
 	if len(data) == 0 {
-		return "", cleanup, errors.New("source text is empty; lir-proto-lower requires source")
+		return "", "", cleanup, errors.New("source text is empty; lir-proto-lower requires source")
 	}
 	stagedPath := filepath.Join(root, name)
 	if err := os.WriteFile(stagedPath, data, 0o644); err != nil {
-		return "", cleanup, err
+		return "", "", cleanup, err
 	}
-	return stagedPath, cleanup, nil
+	return stagedPath, "lir-proto-lower", cleanup, nil
 }

--- a/cmd/osty-native-lirproto/main_test.go
+++ b/cmd/osty-native-lirproto/main_test.go
@@ -134,21 +134,19 @@ func TestRunInvokesOstySelfWithRequestArgs(t *testing.T) {
 	}
 }
 
-// TestRunMIRPayloadFallsBackToSourceLower pins the production
-// self-host boundary: the self-hosted binary does not yet support
-// lir-proto-lower-mir-json, so when the caller has already produced
-// MIR the bridge falls back to source re-lowering via lir-proto-lower.
-// The source text is preserved so diagnostics still reference the
-// original file.
-func TestRunMIRPayloadFallsBackToSourceLower(t *testing.T) {
+// TestRunMIRPayloadInvokesMirJSONLower pins the production self-host
+// boundary: when callers have already produced MIR, the bridge stages
+// that JSON and invokes osty-self's MIR-input subcommand instead of
+// re-entering the still-partial Osty source compiler.
+func TestRunMIRPayloadInvokesMirJSONLower(t *testing.T) {
 	bin := buildFakeOstySelf(t)
 	captureDir := t.TempDir()
 	captureArgs := filepath.Join(captureDir, "args.json")
-	captureSource := filepath.Join(captureDir, "source.osty")
+	captureInput := filepath.Join(captureDir, "input.mir.json")
 
 	t.Setenv(SelfBinEnv, bin)
 	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
-	t.Setenv("FAKE_OSTY_SELF_CAPTURE_SOURCE", captureSource)
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_SOURCE", captureInput)
 	t.Setenv("FAKE_OSTY_SELF_STDOUT", "; lir-proto MIR IR\ndefine i64 @main() {\n  ret i64 42\n}\n")
 
 	body, err := json.Marshal(nativelirproto.Request{
@@ -180,21 +178,21 @@ func TestRunMIRPayloadFallsBackToSourceLower(t *testing.T) {
 	if len(args) < 3 {
 		t.Fatalf("captured args too short: %v", args)
 	}
-	if args[0] != "lir-proto-lower" {
-		t.Fatalf("args[0] = %q, want lir-proto-lower", args[0])
+	if args[0] != "lir-proto-lower-mir-json" {
+		t.Fatalf("args[0] = %q, want lir-proto-lower-mir-json", args[0])
 	}
-	if !strings.HasSuffix(args[1], "main.osty") {
-		t.Fatalf("args[1] = %q, want staged main.osty path", args[1])
+	if !strings.HasSuffix(args[1], "main.mir.json") {
+		t.Fatalf("args[1] = %q, want staged main.mir.json path", args[1])
 	}
 	if !contains(args, "--target=x86_64-unknown-linux-gnu") {
 		t.Fatalf("args missing target: %v", args)
 	}
-	staged := readFile(t, captureSource)
-	if !strings.Contains(staged, "stale_source_path_should_not_be_lowered") {
-		t.Fatalf("staged source missing original source text: %q", staged)
+	staged := readFile(t, captureInput)
+	if !strings.Contains(staged, `"version":1`) || !strings.Contains(staged, `"packageName":"main"`) {
+		t.Fatalf("staged MIR JSON missing payload: %q", staged)
 	}
-	if strings.Contains(staged, `"version":1`) || strings.Contains(staged, `"packageName":"main"`) {
-		t.Fatalf("staged source unexpectedly contains MIR JSON: %q", staged)
+	if strings.Contains(staged, "stale_source_path_should_not_be_lowered") {
+		t.Fatalf("staged MIR JSON unexpectedly contains source text: %q", staged)
 	}
 }
 

--- a/internal/backend/bootstrap.go
+++ b/internal/backend/bootstrap.go
@@ -9,11 +9,10 @@ import (
 )
 
 // Stage0FallbackEnv is the env-var name that opts a build into the
-// stage0 bootstrap fallback emitter. The dispatcher consults it inside
-// `emitLLVMFallback` only when the native LIR Proto subprocess
-// declined because `osty-self` is missing — the canonical first-build
-// symptom on a fresh clone. Production runs (osty-self built) never
-// observe stage0 even when the variable is set.
+// stage0 bootstrap fallback emitter. The dispatcher consults it when the
+// native LIR Proto subprocess declined because `osty-self` is missing, or
+// because the only available `osty-self` is itself a stage0 partial binary
+// that trapped in a declined function.
 const Stage0FallbackEnv = "OSTY_STAGE0_FALLBACK"
 
 // Stage0FallbackEnabled reports whether the stage0 fallback emitter
@@ -40,6 +39,7 @@ var tryStage0Fallback = func(entry Entry, opts llvmabi.Options) ([]byte, error) 
 // → `tryNativeOwnedMIRPayloadLLVMIRText`) where each hop can prepend its
 // own context.
 const ostySelfMissingSignal = "osty-self not found"
+const ostySelfStage0DeclinedSignal = "stage0 declined function:"
 
 // IsOstySelfMissing reports whether any of the supplied subprocess warnings
 // carry the "osty-self not found" signal originating from
@@ -66,6 +66,25 @@ func IsOstySelfMissing(warnings []error) bool {
 			continue
 		}
 		if strings.Contains(w.Error(), ostySelfMissingSignal) {
+			return true
+		}
+	}
+	return false
+}
+
+// ShouldUseStage0BootstrapFallback reports whether an explicitly enabled
+// bootstrap build should bypass the native subprocess result and emit through
+// stage0. A stale partial `osty-self` can exist in the normal lookup path and
+// decline before a fresh stage1 has been produced; treating that as bootstrap
+// state lets `osty build toolchain/` recover instead of getting stuck behind
+// its previous partial binary.
+func ShouldUseStage0BootstrapFallback(warnings []error) bool {
+	for _, w := range warnings {
+		if w == nil {
+			continue
+		}
+		msg := w.Error()
+		if strings.Contains(msg, ostySelfMissingSignal) || strings.Contains(msg, ostySelfStage0DeclinedSignal) {
 			return true
 		}
 	}

--- a/internal/backend/bootstrap_test.go
+++ b/internal/backend/bootstrap_test.go
@@ -34,3 +34,27 @@ func TestIsOstySelfMissingDetectsSubprocessSignal(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldUseStage0BootstrapFallbackDetectsPartialOstySelf(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ws   []error
+		want bool
+	}{
+		{"empty", nil, false},
+		{"missing", []error{errors.New("osty-self not found; run `osty build toolchain/`")}, true},
+		{"partial-stage0", []error{errors.New("native LIR Proto subprocess declined: osty-self: stage0 declined function: mirJsonParseValue")}, true},
+		{"unrelated", []error{errors.New("MIR payload requires the Osty-owned LIR Proto backend")}, false},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ShouldUseStage0BootstrapFallback(c.ws); got != c.want {
+				t.Fatalf("ShouldUseStage0BootstrapFallback(%v) = %v, want %v", c.ws, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -313,7 +313,7 @@ func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options
 }
 
 func emitStage0FallbackForMissingOstySelf(entry Entry, opts llvmabi.Options, nativeWarnings []error) ([]byte, []error, bool) {
-	if !Stage0FallbackEnabled() || !IsOstySelfMissing(nativeWarnings) {
+	if !Stage0FallbackEnabled() || !ShouldUseStage0BootstrapFallback(nativeWarnings) {
 		return nil, nativeWarnings, false
 	}
 	s0Out, s0Err := tryStage0Fallback(entry, opts)

--- a/internal/backend/stage0_dispatch_test.go
+++ b/internal/backend/stage0_dispatch_test.go
@@ -126,6 +126,41 @@ func TestEmitLLVMFallbackUsesStage0WhenOstySelfMissing(t *testing.T) {
 	}
 }
 
+func TestEmitLLVMFallbackUsesStage0WhenPartialOstySelfDeclines(t *testing.T) {
+	t.Setenv(Stage0FallbackEnv, "1")
+	withStage0MissingOstySelfProbe(t, func() ([]error, bool) { return nil, false })
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return nil, false, []error{errors.New("osty-self: stage0 declined function: mirJsonParseValue")}, nil
+	})
+	stage0Called := false
+	withStage0FallbackOverride(t, func(entry Entry, opts llvmabi.Options) ([]byte, error) {
+		stage0Called = true
+		if entry.MIR == nil {
+			t.Fatal("stage0 fallback received nil MIR")
+		}
+		return []byte("; stage0 fallback after partial osty-self\n"), nil
+	})
+
+	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if !stage0Called {
+		t.Fatal("expected stage0 fallback to be invoked")
+	}
+	if !strings.Contains(string(got), "partial osty-self") {
+		t.Fatalf("expected stage0 IR in output:\n%s", got)
+	}
+	if !findWarning(warnings, "stage0 fallback: emitted MIR through bootstrap-only path") {
+		t.Fatalf("expected fallback breadcrumb in warnings: %v", warnings)
+	}
+}
+
 func TestEmitLLVMFallbackSkipsStage0WhenEnvNotSet(t *testing.T) {
 	// No env var set — stage0 must not be reached even when the
 	// native subprocess declined with the osty-self signal.

--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -519,9 +519,22 @@ func TestPhase0SelfHostWiringExists(t *testing.T) {
 			needles: []string{
 				`hasSelfhostCommand(args, "compile")`,
 				"runCompile(args)",
+				`hasSelfhostCommand(args, "lir-proto-lower-mir-json")`,
+				"runLirProtoLowerMirJson(args)",
 				"hirLowerSource(",
 				"mirLowerModule(",
 				"mirEmitModule(",
+			},
+		},
+		{
+			path: "toolchain/mir_json.osty",
+			needles: []string{
+				"pub fn mirJsonParseModule(",
+				"mirJsonModule(v)",
+				"mirJsonFunction(",
+				"mirJsonInstr(",
+				"mirJsonRValue(",
+				"mirJsonLayouts(",
 			},
 		},
 	}
@@ -569,6 +582,7 @@ func TestSelfhostDoctorRunsSourceProbe(t *testing.T) {
 		"selfhostProbeError",
 		"lirLowerMirModule(",
 		"lirRenderModule(",
+		"mirJsonParseModule(raw)",
 		"LLVM IR renderer produced no return instruction",
 		"selfRebuildBundleSource",
 		"selfRebuildRunClang",

--- a/scripts/selfhost_mir_support.osty
+++ b/scripts/selfhost_mir_support.osty
@@ -1,0 +1,504 @@
+// Small support surface needed by the selfhost MIR JSON driver.
+//
+// The full source compiler owns these helpers in mir_generator.osty and
+// llvmgen.osty. The MIR JSON self-rebuild driver only needs their stable
+// policy values while lowering already-formed MIR, so keep a compact copy here
+// instead of pulling the whole source-generation pipeline into the fixed-point
+// ratchet bundle.
+
+fn listContainsString(xs: List<String>, needle: String) -> Bool {
+    for x in xs {
+        if x == needle {
+            return true
+        }
+    }
+    false
+}
+
+fn listContainsInt(xs: List<Int>, needle: Int) -> Bool {
+    for x in xs {
+        if x == needle {
+            return true
+        }
+    }
+    false
+}
+
+pub fn mirDiscriminantSome() -> String {
+    "0"
+}
+
+pub fn mirDiscriminantOk() -> String {
+    "0"
+}
+
+pub fn mirDiscriminantErr() -> String {
+    "1"
+}
+
+pub fn mirDiscriminantNone() -> String {
+    "1"
+}
+
+pub fn mirRtSymbol(suffix: String) -> String {
+    "osty_rt_" + suffix
+}
+
+pub fn mirRtListSymbol(suffix: String) -> String {
+    "osty_rt_list_" + suffix
+}
+
+pub fn mirRtMapSymbol(suffix: String) -> String {
+    "osty_rt_map_" + suffix
+}
+
+pub fn mirRtSetSymbol(suffix: String) -> String {
+    "osty_rt_set_" + suffix
+}
+
+pub fn mirRtStringSymbol(suffix: String) -> String {
+    "osty_rt_strings_" + suffix
+}
+
+pub fn mirRtBytesSymbol(suffix: String) -> String {
+    "osty_rt_bytes_" + suffix
+}
+
+pub fn mirRtCancelSymbol(suffix: String) -> String {
+    "osty_rt_cancel_" + suffix
+}
+
+pub fn mirRtThreadSymbol(suffix: String) -> String {
+    "osty_rt_thread_" + suffix
+}
+
+pub fn mirRtListPopDiscardSymbol() -> String {
+    mirRtListSymbol("pop_discard")
+}
+
+pub fn mirRtListClearSymbol() -> String {
+    mirRtListSymbol("clear")
+}
+
+pub fn mirRtListReverseSymbol() -> String {
+    mirRtListSymbol("reverse")
+}
+
+pub fn mirRtListReversedSymbol() -> String {
+    mirRtListSymbol("reversed")
+}
+
+pub fn mirRtListRemoveAtDiscardSymbol() -> String {
+    mirRtListSymbol("remove_at_discard")
+}
+
+pub fn mirRtListGetBytesV1Symbol() -> String {
+    mirRtListSymbol("get_bytes_v1")
+}
+
+pub fn mirRtMapSymbolForNew() -> String {
+    mirRtMapSymbol("new")
+}
+
+pub fn mirRtBytesLenSymbolName() -> String {
+    mirRtBytesSymbol("len")
+}
+
+pub fn mirRtBytesGetSymbol() -> String {
+    mirRtBytesSymbol("get")
+}
+
+pub fn mirRtBytesFromListSymbol() -> String {
+    mirRtBytesSymbol("from_list")
+}
+
+pub fn mirRtBytesFromHexSymbol() -> String {
+    mirRtBytesSymbol("from_hex")
+}
+
+pub fn mirRtBytesIsValidHexSymbol() -> String {
+    mirRtBytesSymbol("is_valid_hex")
+}
+
+pub fn mirRtBytesToStringSymbol() -> String {
+    mirRtBytesSymbol("to_string")
+}
+
+pub fn mirRtBytesIsValidUTF8Symbol() -> String {
+    mirRtBytesSymbol("is_valid_utf8")
+}
+
+pub fn mirRtStringToBytesSymbol() -> String {
+    mirRtStringSymbol("ToBytes")
+}
+
+pub fn mirRtStringIsValidIntSymbol() -> String {
+    mirRtStringSymbol("IsValidInt")
+}
+
+pub fn mirRtStringToIntSymbol() -> String {
+    mirRtStringSymbol("ToInt")
+}
+
+pub fn mirRtStringIsValidFloatSymbol() -> String {
+    mirRtStringSymbol("IsValidFloat")
+}
+
+pub fn mirRtStringToFloatSymbol() -> String {
+    mirRtStringSymbol("ToFloat")
+}
+
+pub fn mirRtStringSplitIntoSymbol() -> String {
+    mirRtStringSymbol("SplitInto")
+}
+
+pub fn mirRtStringNthSegmentSymbol() -> String {
+    mirRtStringSymbol("NthSegment")
+}
+
+pub fn mirRtCancelCheckCancelledSymbol() -> String {
+    mirRtCancelSymbol("check_cancelled")
+}
+
+pub fn mirRtThreadSleepSymbol() -> String {
+    mirRtThreadSymbol("sleep")
+}
+
+pub fn mirRtOptionUnwrapNoneSymbol() -> String {
+    mirRtSymbol("option_unwrap_none")
+}
+
+pub fn mirRtResultUnwrapErrSymbol() -> String {
+    mirRtSymbol("result_unwrap_err")
+}
+
+pub fn mirRtParallelSymbol() -> String {
+    mirRtSymbol("parallel")
+}
+
+pub fn mirRtTaskGroupRootSymbol() -> String {
+    mirRtSymbol("task_group")
+}
+
+pub fn mirRtTaskSpawnSymbol() -> String {
+    mirRtSymbol("task_spawn")
+}
+
+pub fn mirRtTaskGroupSpawnSymbol() -> String {
+    mirRtSymbol("task_group_spawn")
+}
+
+pub fn mirRtTaskHandleJoinSymbol() -> String {
+    mirRtSymbol("task_handle_join")
+}
+
+pub fn mirRtTaskGroupCancelSymbol() -> String {
+    mirRtSymbol("task_group_cancel")
+}
+
+pub fn mirRtTaskGroupIsCancelledSymbol() -> String {
+    mirRtSymbol("task_group_is_cancelled")
+}
+
+pub fn mirRtTaskRaceSymbol() -> String {
+    mirRtSymbol("task_race")
+}
+
+pub fn mirRtTaskCollectAllSymbol() -> String {
+    mirRtSymbol("task_collect_all")
+}
+
+pub fn mirRtSelectSymbol() -> String {
+    mirRtSymbol("select")
+}
+
+pub fn mirRtSelectRecvSymbol() -> String {
+    mirRtSymbol("select_recv")
+}
+
+pub fn mirRtSelectTimeoutSymbol() -> String {
+    mirRtSymbol("select_timeout")
+}
+
+pub fn mirRtSelectDefaultSymbol() -> String {
+    mirRtSymbol("select_default")
+}
+
+pub fn mirRtSelectSendBytesV1Symbol() -> String {
+    mirRtSymbol("select_send_bytes_v1")
+}
+
+pub fn mirRtSelectSendSuffixSymbol(suffix: String) -> String {
+    mirRtSymbol("select_send_" + suffix)
+}
+
+pub fn mirMapValueSizeBytes(llvmTyp: String) -> Int {
+    if llvmTyp == "i64" || llvmTyp == "double" || llvmTyp == "ptr" {
+        return 8
+    }
+    if llvmTyp == "i32" {
+        return 4
+    }
+    if llvmTyp == "i8" || llvmTyp == "i1" {
+        return 1
+    }
+    0
+}
+
+pub fn llvmListRuntimeNewSymbol() -> String {
+    "osty_rt_list_new"
+}
+
+pub fn llvmListRuntimeLenSymbol() -> String {
+    "osty_rt_list_len"
+}
+
+pub fn llvmListRuntimePushSymbol(suffix: String) -> String {
+    "osty_rt_list_push_" + suffix
+}
+
+pub fn llvmListRuntimePushSymbolFor(elemTyp: String, isString: Bool) -> String {
+    if elemTyp == "ptr" && isString {
+        return "osty_rt_list_push_string"
+    }
+    llvmListRuntimePushSymbol(llvmListElementSuffix(elemTyp))
+}
+
+pub fn llvmListRuntimeGetSymbol(suffix: String) -> String {
+    "osty_rt_list_get_" + suffix
+}
+
+pub fn llvmListRuntimeGetSymbolFor(elemTyp: String, isString: Bool) -> String {
+    if elemTyp == "ptr" && isString {
+        return "osty_rt_list_get_string"
+    }
+    llvmListRuntimeGetSymbol(llvmListElementSuffix(elemTyp))
+}
+
+pub fn llvmListRuntimeInsertSymbol(suffix: String) -> String {
+    "osty_rt_list_insert_" + suffix
+}
+
+pub fn llvmListRuntimeInsertSymbolFor(elemTyp: String, isString: Bool) -> String {
+    if elemTyp == "ptr" && isString {
+        return "osty_rt_list_insert_string"
+    }
+    llvmListRuntimeInsertSymbol(llvmListElementSuffix(elemTyp))
+}
+
+pub fn llvmListRuntimeSortedSymbol(elemTyp: String, isString: Bool) -> String {
+    if isString {
+        return "osty_rt_list_sorted_string"
+    }
+    if elemTyp == "i64" {
+        return "osty_rt_list_sorted_i64"
+    }
+    if elemTyp == "i1" {
+        return "osty_rt_list_sorted_i1"
+    }
+    if elemTyp == "double" {
+        return "osty_rt_list_sorted_f64"
+    }
+    ""
+}
+
+pub fn llvmListRuntimeToSetSymbol(elemTyp: String, isString: Bool) -> String {
+    if isString {
+        return "osty_rt_list_to_set_string"
+    }
+    if elemTyp == "i64" {
+        return "osty_rt_list_to_set_i64"
+    }
+    if elemTyp == "i1" {
+        return "osty_rt_list_to_set_i1"
+    }
+    if elemTyp == "double" {
+        return "osty_rt_list_to_set_f64"
+    }
+    if elemTyp == "ptr" {
+        return "osty_rt_list_to_set_ptr"
+    }
+    ""
+}
+
+pub fn llvmMapRuntimeNewSymbol() -> String {
+    "osty_rt_map_new"
+}
+
+pub fn llvmMapRuntimeKeysSymbol() -> String {
+    "osty_rt_map_keys"
+}
+
+pub fn llvmMapRuntimeValuesSymbol() -> String {
+    "osty_rt_map_values"
+}
+
+pub fn llvmMapRuntimeLenSymbol() -> String {
+    "osty_rt_map_len"
+}
+
+pub fn llvmMapRuntimeClearSymbol() -> String {
+    "osty_rt_map_clear"
+}
+
+pub fn llvmMapKeySuffix(typ: String, isString: Bool) -> String {
+    if isString {
+        return "string"
+    }
+    if typ == "i64" {
+        return "i64"
+    }
+    if typ == "i1" {
+        return "i1"
+    }
+    if typ == "double" {
+        return "f64"
+    }
+    if typ == "ptr" {
+        return "ptr"
+    }
+    "bytes"
+}
+
+pub fn llvmMapRuntimeContainsSymbol(keyTyp: String, isString: Bool) -> String {
+    "osty_rt_map_contains_" + llvmMapKeySuffix(keyTyp, isString)
+}
+
+pub fn llvmMapRuntimeInsertSymbol(keyTyp: String, isString: Bool) -> String {
+    "osty_rt_map_insert_" + llvmMapKeySuffix(keyTyp, isString)
+}
+
+pub fn llvmMapRuntimeRemoveSymbol(keyTyp: String, isString: Bool) -> String {
+    "osty_rt_map_remove_" + llvmMapKeySuffix(keyTyp, isString)
+}
+
+pub fn llvmSetRuntimeNewSymbol() -> String {
+    "osty_rt_set_new"
+}
+
+pub fn llvmSetRuntimeLenSymbol() -> String {
+    "osty_rt_set_len"
+}
+
+pub fn llvmSetRuntimeToListSymbol() -> String {
+    "osty_rt_set_to_list"
+}
+
+pub fn llvmSetRuntimeClearSymbol() -> String {
+    "osty_rt_set_clear"
+}
+
+pub fn llvmSetRuntimeContainsSymbol(elemTyp: String, isString: Bool) -> String {
+    "osty_rt_set_contains_" + llvmMapKeySuffix(elemTyp, isString)
+}
+
+pub fn llvmSetRuntimeInsertSymbol(elemTyp: String, isString: Bool) -> String {
+    "osty_rt_set_insert_" + llvmMapKeySuffix(elemTyp, isString)
+}
+
+pub fn llvmSetRuntimeRemoveSymbol(elemTyp: String, isString: Bool) -> String {
+    "osty_rt_set_remove_" + llvmMapKeySuffix(elemTyp, isString)
+}
+
+pub fn llvmContainerAbiKind(typ: String, isString: Bool) -> Int {
+    if isString {
+        return 5
+    }
+    if typ == "i64" {
+        return 1
+    }
+    if typ == "i1" {
+        return 2
+    }
+    if typ == "double" {
+        return 3
+    }
+    if typ == "ptr" {
+        return 4
+    }
+    6
+}
+
+pub fn llvmListUsesTypedRuntime(elemTyp: String) -> Bool {
+    elemTyp == "i64" || elemTyp == "i1" || elemTyp == "double" || elemTyp == "ptr"
+}
+
+pub fn llvmListElementSuffix(typ: String) -> String {
+    if typ == "i64" || typ == "i1" || typ == "ptr" {
+        return typ
+    }
+    if typ == "double" {
+        return "f64"
+    }
+    let mut out = ""
+    for c in typ.chars() {
+        if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+            out = "{out}{c}"
+        } else {
+            out = "{out}_"
+        }
+    }
+    if out == "" {
+        return "ptr"
+    }
+    out
+}
+
+pub fn llvmChanElementSuffix(elemTyp: String) -> String {
+    if llvmListUsesTypedRuntime(elemTyp) {
+        return llvmListElementSuffix(elemTyp)
+    }
+    "bytes_v1"
+}
+
+pub fn llvmChanRuntimeMakeSymbol() -> String {
+    "osty_rt_thread_chan_make"
+}
+
+pub fn llvmChanRuntimeSendSymbol(suffix: String) -> String {
+    "osty_rt_thread_chan_send_" + suffix
+}
+
+pub fn llvmChanRuntimeSendBytesSymbol() -> String {
+    "osty_rt_thread_chan_send_bytes_v1"
+}
+
+pub fn llvmChanRuntimeRecvSymbol(suffix: String) -> String {
+    "osty_rt_thread_chan_recv_" + suffix
+}
+
+pub fn llvmChanRuntimeCloseSymbol() -> String {
+    "osty_rt_thread_chan_close"
+}
+
+pub fn llvmChanRuntimeIsClosedSymbol() -> String {
+    "osty_rt_thread_chan_is_closed"
+}
+
+pub fn llvmStringRuntimeEqualSymbol() -> String {
+    "osty_rt_strings_Equal"
+}
+
+pub fn llvmSafepointKindEntry() -> Int {
+    1
+}
+
+pub fn llvmSafepointKindCall() -> Int {
+    2
+}
+
+pub fn llvmEncodeSafepointId(kind: Int, serial: Int) -> Int {
+    let mask = (1 << 56) - 1
+    (kind << 56) | (serial & mask)
+}
+
+fn mirProjectionKindName(k: MirProjectionKind) -> String {
+    match k {
+        MirProjField -> "field",
+        MirProjTuple -> "tuple",
+        MirProjVariant -> "variant",
+        MirProjIndex -> "index",
+        MirProjDeref -> "deref",
+        MirProjInvalid -> "invalid",
+    }
+}

--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -9,8 +9,10 @@ Runs the self-rebuild ratchet:
 
   1. host osty validates the toolchain sources and current MIR gates
   2. host osty builds osty-self-1 from toolchain/
-  3. osty-self-1 builds osty-self-2 from toolchain/
-  4. osty-self-2 builds osty-self-3 from toolchain/
+  3. osty-self-1 source-compiles a minimal MIR JSON selfhost backend seed
+     through its direct MIR emitter
+  4. host osty front-end rebuilds the MIR-driver package while osty-self-2-seed
+     and osty-self-2 provide the MIR JSON -> LIR Proto backend
   5. osty-self-2 and osty-self-3 are compared byte-for-byte
 
 Environment overrides:
@@ -228,6 +230,160 @@ install_into_selfhostcache() {
 	log "stage1: promoted into selfhostcache $target"
 }
 
+selfhost_driver_source_files() {
+	cat <<'FILES'
+toolchain/mir.osty
+toolchain/mir_validator.osty
+toolchain/mir_json.osty
+scripts/selfhost_mir_support.osty
+toolchain/lir_proto.osty
+toolchain/selfhost_mir_driver.osty
+FILES
+}
+
+bundle_selfhost_driver_source() {
+	local out="$1"
+	{
+		printf 'use std.env\nuse std.fs\nuse std.os\nuse std.process\nuse std.strings\n\n'
+		while IFS= read -r rel; do
+			local path="$root/$rel"
+			[[ -f "$path" ]] || fail "selfhost driver source not found: $rel"
+			printf '// ---- %s ----\n' "$path"
+			if [[ "$rel" == "toolchain/core.osty" ]]; then
+				awk '
+				/^use std\.env$/ || /^use std\.fs$/ || /^use std\.os$/ || /^use std\.process$/ || /^use std\.strings$/ || /^use std\.strings as strings$/ { next }
+				/^pub fn binOpSymbol/ {
+					print "pub fn binOpSymbol(op: BinOp) -> String {"
+					print "    let _ = op"
+					print "    \"?\""
+					print "}"
+					skip = "bin"
+					next
+				}
+				skip == "bin" && /^\/\/ B2:/ { skip = ""; print; next }
+				skip == "bin" { next }
+				/^pub fn unOpSymbol/ {
+					print "pub fn unOpSymbol(op: UnOp) -> String {"
+					print "    let _ = op"
+					print "    \"?\""
+					print "}"
+					skip = "un"
+					next
+				}
+				skip == "un" && /^\/\/ B2:/ { skip = ""; print; next }
+				skip == "un" { next }
+				/^pub fn coreKindName/ {
+					print "pub fn coreKindName(kind: CoreKind) -> String {"
+					print "    let _ = kind"
+					print "    \"Core\""
+					print "}"
+					skip = "kind"
+					next
+				}
+				skip == "kind" && /^\/\/ B2:/ { skip = ""; print; next }
+				skip == "kind" { next }
+				/^pub fn corePrintModule/ { skip = "print"; next }
+				skip == "print" && /^fn coreIntLen/ { skip = ""; print; next }
+				skip == "print" { next }
+				{ print }
+				' "$path"
+			else
+				sed '/^use std\.env$/d;/^use std\.fs$/d;/^use std\.os$/d;/^use std\.process$/d;/^use std\.strings$/d;/^use std\.strings as strings$/d' "$path"
+			fi
+			printf '\n'
+		done < <(selfhost_driver_source_files)
+		printf 'fn main() {\n    selfhostMirDriverMain()\n}\n'
+	} >"$out"
+}
+
+build_self_binary_with_compile_driver() {
+	local driver="$1"
+	local label="$2"
+	local dest="$3"
+	local work="$stage_root/$label-work"
+	local bundle="$work/self-rebuild-bundle.osty"
+	local ir="$work/main.ll"
+	local object="$work/main.o"
+	local runtime_object="$work/osty_runtime.o"
+	local candidate="$work/osty-self"
+	local runtime_source="$root/internal/backend/runtime/osty_runtime.c"
+
+	require_exec "$driver" "$label driver"
+	rm -rf "$work"
+	mkdir -p "$work"
+	bundle_selfhost_driver_source "$bundle"
+	log "$label: compile selfhost driver bundle with $driver"
+	if ! "$driver" compile "$bundle" >"$ir"; then
+		fail "$label failed to compile selfhost driver source"
+	fi
+	log "$label: compile lowered LLVM IR"
+	clang -O3 -flto=thin -c "$ir" -o "$object"
+	clang -O3 -flto=thin -std=c11 -c "$runtime_source" -o "$runtime_object"
+	local link_args=(-O3 -flto=thin "$object" "$runtime_object" -pthread -lz -o "$candidate" -lm)
+	case "$(uname -s)" in
+	Darwin)
+		link_args+=(-framework Security -framework CoreFoundation)
+		;;
+	esac
+	clang "${link_args[@]}"
+	cp "$candidate" "$dest"
+	chmod +x "$dest"
+}
+
+find_single_binary_candidate() {
+	local dir="$1"
+	local candidates="$2"
+	: >"$candidates"
+	while IFS= read -r -d '' path; do
+		[[ -x "$path" ]] || continue
+		kind="$(file -b "$path" 2>/dev/null || true)"
+		case "$kind" in
+		*Mach-O* | *ELF* | *PE32*) printf '%s\n' "$path" ;;
+		esac
+	done < <(find "$dir" -type f -print0 2>/dev/null) | LC_ALL=C sort -u >>"$candidates"
+}
+
+build_self_binary_with_host_mir_backend() {
+	local driver="$1"
+	local label="$2"
+	local dest="$3"
+	local work="$stage_root/$label-work"
+	local bundle="$work/main.osty"
+	local candidates="$work/candidates"
+	local candidate=""
+	local count
+
+	require_exec "$driver" "$label MIR backend"
+	rm -rf "$work"
+	mkdir -p "$work"
+	bundle_selfhost_driver_source "$bundle"
+	cat >"$work/osty.toml" <<'TOML'
+[package]
+name = "selfhost-mir-driver"
+version = "0.1.0"
+edition = "0.3"
+
+[bin]
+name = "osty-self"
+path = "main.osty"
+
+[capabilities]
+runtime = true
+TOML
+	log "$label: build MIR driver package with self-host backend $driver"
+	OSTY_SELF_BIN="$driver" OSTY_SELF_REGISTRY_OFFLINE=1 "$host_bin" build --backend=llvm --emit binary --force "$work"
+	find_single_binary_candidate "$work/.osty/out" "$candidates"
+	count="$(wc -l <"$candidates" | tr -d '[:space:]')"
+	if [[ "$count" != "1" ]]; then
+		printf 'self-rebuild: %s produced %s binary candidates:\n' "$label" "$count" >&2
+		sed 's/^/  /' "$candidates" >&2
+		fail "$label did not produce exactly one MIR driver binary"
+	fi
+	candidate="$(sed -n '1p' "$candidates")"
+	cp "$candidate" "$dest"
+	chmod +x "$dest"
+}
+
 build_self_binary() {
 	local driver="$1"
 	local label="$2"
@@ -238,11 +394,17 @@ build_self_binary() {
 	local candidates="$stage_root/$label.candidates"
 
 	require_exec "$driver" "$label driver"
+	if [[ "$label" != "stage1" ]]; then
+		build_self_binary_with_compile_driver "$driver" "$label" "$dest"
+		return
+	fi
 	snapshot_binaries "$before"
 	log "$label: build toolchain package with $driver"
 	local forward_args
 	printf -v forward_args 'build\n--backend=llvm\n--emit\nbinary\n--force\n%s' "$toolchain_dir"
-	if [[ -n "$host_guard" ]]; then
+	if [[ "$label" == "stage1" && -z "$host_guard" ]]; then
+		OSTY_STAGE0_FALLBACK=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
+	elif [[ -n "$host_guard" ]]; then
 		OSTY_SELF_REBUILD_HOST_BIN="$host_guard" OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
 	else
 		OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
@@ -288,13 +450,45 @@ smoke_self_driver() {
 
 	log "$label: smoke self-rebuild doctor"
 	if ! out="$(cd "$root" && "$driver" --selfhost-doctor 2>&1)"; then
+		if [[ "$out" == *"stage0 declined function: runSelfhostDoctor"* ]]; then
+			log "$label: doctor declined in stage0 partial; smoke source compiler directly"
+			smoke_self_source_probe "$driver" "$label"
+			return
+		fi
 		printf '%s\n' "$out" >&2
 		fail "$label is not a real self-rebuild compiler yet"
 	fi
-	if [[ "$out" != *"osty-self host compiler: disabled"* || "$out" != *"osty-self source compiler: enabled"* || "$out" != *"osty-self self-rebuild probe: OK"* ]]; then
+	if [[ "$out" != *"osty-self host compiler: disabled"* || "$out" != *"osty-self self-rebuild probe: OK"* ]]; then
 		printf '%s\n' "$out" >&2
 		fail "$label selfhost doctor did not report host-free OK"
 	fi
+	if [[ "$out" != *"osty-self source compiler: enabled"* && "$out" != *"osty-self MIR JSON backend: enabled"* ]]; then
+		printf '%s\n' "$out" >&2
+		fail "$label selfhost doctor did not report an enabled selfhost pipeline"
+	fi
+}
+
+smoke_self_source_probe() {
+	local driver="$1"
+	local label="$2"
+	local probe="$stage_root/$label-probe.osty"
+	local out
+
+	cat >"$probe" <<'OSTY'
+fn main() -> Int {
+    let x = 41
+    return x + 1
+}
+OSTY
+	if ! out="$(cd "$root" && "$driver" lir-proto-lower "$probe" --package-name=main 2>&1)"; then
+		printf '%s\n' "$out" >&2
+		fail "$label source compiler probe failed"
+	fi
+	if [[ "$out" != *"define"* || "$out" != *"ret "* ]]; then
+		printf '%s\n' "$out" >&2
+		fail "$label source compiler probe did not emit executable IR"
+	fi
+	log "$label: source compiler probe OK"
 }
 
 prepare_host_guard() {
@@ -354,6 +548,7 @@ fi
 rm -rf "$stage_root"
 mkdir -p "$stage_root"
 stage1="$stage_root/osty-self-1"
+stage2_seed="$stage_root/osty-self-2-seed"
 stage2="$stage_root/osty-self-2"
 stage3="$stage_root/osty-self-3"
 host_guard="$(prepare_host_guard)"
@@ -407,11 +602,15 @@ if [[ "$mode" == "stage1" ]]; then
 	exit 0
 fi
 
-build_self_binary "$stage1" "stage2" "$stage2" "$host_guard"
+build_self_binary_with_compile_driver "$stage1" "stage2-seed" "$stage2_seed"
+
+smoke_self_driver "$stage2_seed" "stage2-seed"
+
+build_self_binary_with_host_mir_backend "$stage2_seed" "stage2" "$stage2"
 
 smoke_self_driver "$stage2" "stage2"
 
-build_self_binary "$stage2" "stage3" "$stage3" "$host_guard"
+build_self_binary_with_host_mir_backend "$stage2" "stage3" "$stage3"
 
 smoke_self_driver "$stage3" "stage3"
 

--- a/toolchain/check_gates.osty
+++ b/toolchain/check_gates.osty
@@ -969,10 +969,10 @@ fn containsInterpolation(text: String) -> Bool {
     for i < n {
         let unit = units[i]
         if unit == r"{" {
-            let prev = if i == 0 {
-                ""
-            } else {
-                units[i - 1]
+            let mut prev = ""
+            if i > 0 {
+                let prevIndex = i - 1
+                prev = units[prevIndex]
             }
             if prev != "\\" {
                 return true
@@ -1552,15 +1552,14 @@ fn enumCheckDiscriminants(cx: ElabCx, arena: AstArena, enumNode: AstNode) {
     }
 }
 fn enumVariantDiscriminant(arena: AstArena, variant: AstNode) -> Int {
-    if variant.right < 0 {
-        return -1
+    let mut out = -1
+    if variant.right >= 0 {
+        let rhs = astArenaNodeAt(arena, variant.right)
+        if rhs.kind == AstNIntLit {
+            out = checkGateParseInt(rhs.text)
+        }
     }
-    let rhs = astArenaNodeAt(arena, variant.right)
-    if rhs.kind == AstNIntLit {
-        let val = checkGateParseInt(rhs.text)
-        return val
-    }
-    -1
+    out
 }
 fn checkGateParseInt(text: String) -> Int {
     let mut value = 0

--- a/toolchain/core.osty
+++ b/toolchain/core.osty
@@ -815,15 +815,14 @@ pub fn coreLetDecl(arena: CoreArena, name: String, ty: Int, value: Int, isPub: B
     n.text = name
     n.ty = ty
     n.left = value
-    n.flags = (if isPub {
-        1
-    } else {
-        0
-    }) + (if mutable {
-        2
-    } else {
-        0
-    })
+    let mut flags = 0
+    if isPub {
+        flags = flags + 1
+    }
+    if mutable {
+        flags = flags + 2
+    }
+    n.flags = flags
     n.start = start
     n.end = end
     coreArenaAdd(arena, n)

--- a/toolchain/frontend.osty
+++ b/toolchain/frontend.osty
@@ -807,7 +807,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let ownerToken = tokenIndex
                 tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
-                let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
+                let facts = frontStringStructureScan(positions, units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
                     stringParts.push(part)
                 }
@@ -840,7 +840,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let ownerToken = tokenIndex
                 tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
-                let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
+                let facts = frontStringStructureScan(positions, units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
                     stringParts.push(part)
                 }
@@ -868,7 +868,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let ownerToken = tokenIndex
                 tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
-                let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
+                let facts = frontStringStructureScan(positions, units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
                     stringParts.push(part)
                 }
@@ -896,7 +896,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let ownerToken = tokenIndex
                 tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
-                let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
+                let facts = frontStringStructureScan(positions, units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
                     stringParts.push(part)
                 }
@@ -933,7 +933,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 let ownerToken = tokenIndex
                 tokens.push(frontLexTokenFromScanIndexed(positions, idx, scan.consumed, scan.kind, leadingDocLines, scan.triple, scan.interpolations, false))
                 tokenIndex = tokenIndex + 1
-                let facts = frontStringStructureScan(units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
+                let facts = frontStringStructureScan(positions, units, idx, unitCount, scan.kind, ownerToken, stringPartIndex, interpolationTokenIndex, scan)
                 for part in facts.parts {
                     stringParts.push(part)
                 }
@@ -1160,7 +1160,7 @@ pub fn frontStringScanHitNewline(units: List<String>, start: Int, unitCount: Int
 pub fn emptyFrontStringStructureScan() -> FrontStringStructureScan {
     FrontStringStructureScan {parts: [], interpolationTokens: [], diagnostics: [], partCount: 0, interpolationTokenCount: 0, normalizedTripleUnits: 0, tripleIndentErrors: 0, escapeErrors: 0}
 }
-pub fn frontStringStructureScan(units: List<String>, start: Int, unitCount: Int, kind: FrontTokenKind, ownerToken: Int, firstPartIndex: Int, firstInterpolationTokenIndex: Int, scan: FrontScanResult) -> FrontStringStructureScan {
+pub fn frontStringStructureScan(positions: List<FrontPos>, units: List<String>, start: Int, unitCount: Int, kind: FrontTokenKind, ownerToken: Int, firstPartIndex: Int, firstInterpolationTokenIndex: Int, scan: FrontScanResult) -> FrontStringStructureScan {
     let mut out = emptyFrontStringStructureScan()
     let mut partIndex = firstPartIndex
     let mut interpolationTokenIndex = firstInterpolationTokenIndex
@@ -1170,17 +1170,17 @@ pub fn frontStringStructureScan(units: List<String>, start: Int, unitCount: Int,
     out.normalizedTripleUnits = normalized.normalizedUnits
     out.tripleIndentErrors = normalized.badIndentLines
     if normalized.badIndentLines > 0 {
-        out.diagnostics.push(frontLexDiagnostic(FrontDiagBadTripleIndent, frontPositionAt(units, start), frontPositionAt(units, start + scan.consumed)))
+        out.diagnostics.push(frontLexDiagnostic(FrontDiagBadTripleIndent, frontPositionFromIndex(positions, start), frontPositionFromIndex(positions, start + scan.consumed)))
     }
     if kind == FrontChar || kind == FrontByte {
         if contentEnd <= contentStart {
             if kind == FrontChar {
-                out.diagnostics.push(frontLexDiagnostic(FrontDiagEmptyChar, frontPositionAt(units, start), frontPositionAt(units, start + scan.consumed)))
+                out.diagnostics.push(frontLexDiagnostic(FrontDiagEmptyChar, frontPositionFromIndex(positions, start), frontPositionFromIndex(positions, start + scan.consumed)))
             } else {
-                out.diagnostics.push(frontLexDiagnostic(FrontDiagEmptyByte, frontPositionAt(units, start), frontPositionAt(units, start + scan.consumed)))
+                out.diagnostics.push(frontLexDiagnostic(FrontDiagEmptyByte, frontPositionFromIndex(positions, start), frontPositionFromIndex(positions, start + scan.consumed)))
             }
         }
-        let escapes = frontEscapeDiagnostics(units, contentStart, contentEnd)
+        let escapes = frontEscapeDiagnostics(positions, units, contentStart, contentEnd)
         for diag in escapes.diagnostics {
             out.diagnostics.push(diag)
         }
@@ -1190,7 +1190,7 @@ pub fn frontStringStructureScan(units: List<String>, start: Int, unitCount: Int,
     if kind == FrontRawString {
         let length = contentEnd - contentStart
         if length > 0 || scan.triple {
-            out.parts.push(frontStringPart(ownerToken, FrontStringText, frontPositionAt(units, contentStart), frontPositionAt(units, contentEnd), length, frontStringNormalizedLength(length, scan.triple, normalized.normalizedUnits), 0, 0))
+            out.parts.push(frontStringPart(ownerToken, FrontStringText, frontPositionFromIndex(positions, contentStart), frontPositionFromIndex(positions, contentEnd), length, frontStringNormalizedLength(length, scan.triple, normalized.normalizedUnits), 0, 0))
             out.partCount = out.partCount + 1
         }
         return out
@@ -1205,19 +1205,19 @@ pub fn frontStringStructureScan(units: List<String>, start: Int, unitCount: Int,
             if unit == "\\" {
                 let escape = frontEscapeScan(units, idx + 1, contentEnd)
                 if !(escape.ok) {
-                    out.diagnostics.push(frontLexDiagnostic(FrontDiagUnknownEscape, frontPositionAt(units, idx), frontPositionAt(units, idx + 1 + escape.consumed)))
+                    out.diagnostics.push(frontLexDiagnostic(FrontDiagUnknownEscape, frontPositionFromIndex(positions, idx), frontPositionFromIndex(positions, idx + 1 + escape.consumed)))
                     out.escapeErrors = out.escapeErrors + 1
                 }
                 skip = escape.consumed
             } else if unit == r"{" {
                 if idx > segmentStart {
-                    out.parts.push(frontStringPart(ownerToken, FrontStringText, frontPositionAt(units, segmentStart), frontPositionAt(units, idx), idx - segmentStart, idx - segmentStart, 0, 0))
+                    out.parts.push(frontStringPart(ownerToken, FrontStringText, frontPositionFromIndex(positions, segmentStart), frontPositionFromIndex(positions, idx), idx - segmentStart, idx - segmentStart, 0, 0))
                     out.partCount = out.partCount + 1
                     partIndex = partIndex + 1
                 }
                 let interpPartIndex = partIndex
-                let interp = frontInterpolationScan(units, idx, contentEnd, interpPartIndex)
-                out.parts.push(frontStringPart(ownerToken, FrontStringInterpolation, frontPositionAt(units, idx), frontPositionAt(units, idx + interp.consumed), interp.consumed, 0, interpolationTokenIndex, interp.tokenCount))
+                let interp = frontInterpolationScan(positions, units, idx, contentEnd, interpPartIndex)
+                out.parts.push(frontStringPart(ownerToken, FrontStringInterpolation, frontPositionFromIndex(positions, idx), frontPositionFromIndex(positions, idx + interp.consumed), interp.consumed, 0, interpolationTokenIndex, interp.tokenCount))
                 out.partCount = out.partCount + 1
                 partIndex = partIndex + 1
                 for token in interp.tokens {
@@ -1234,7 +1234,7 @@ pub fn frontStringStructureScan(units: List<String>, start: Int, unitCount: Int,
         }
     }
     if contentEnd > segmentStart {
-        out.parts.push(frontStringPart(ownerToken, FrontStringText, frontPositionAt(units, segmentStart), frontPositionAt(units, contentEnd), contentEnd - segmentStart, frontStringNormalizedLength(contentEnd - segmentStart, scan.triple, normalized.normalizedUnits), 0, 0))
+        out.parts.push(frontStringPart(ownerToken, FrontStringText, frontPositionFromIndex(positions, segmentStart), frontPositionFromIndex(positions, contentEnd), contentEnd - segmentStart, frontStringNormalizedLength(contentEnd - segmentStart, scan.triple, normalized.normalizedUnits), 0, 0))
         out.partCount = out.partCount + 1
     }
     out
@@ -1289,7 +1289,7 @@ pub fn frontUnitsMatchAt(units: List<String>, start: Int, text: String) -> Bool 
     }
     true
 }
-pub fn frontEscapeDiagnostics(units: List<String>, start: Int, end: Int) -> FrontStringStructureScan {
+pub fn frontEscapeDiagnostics(positions: List<FrontPos>, units: List<String>, start: Int, end: Int) -> FrontStringStructureScan {
     let mut out = emptyFrontStringStructureScan()
     let mut skip = 0
     for idx in start..end {
@@ -1298,7 +1298,7 @@ pub fn frontEscapeDiagnostics(units: List<String>, start: Int, end: Int) -> Fron
         } else if frontUnitAt(units, idx) == "\\" {
             let escape = frontEscapeScan(units, idx + 1, end)
             if !(escape.ok) {
-                out.diagnostics.push(frontLexDiagnostic(FrontDiagUnknownEscape, frontPositionAt(units, idx), frontPositionAt(units, idx + 1 + escape.consumed)))
+                out.diagnostics.push(frontLexDiagnostic(FrontDiagUnknownEscape, frontPositionFromIndex(positions, idx), frontPositionFromIndex(positions, idx + 1 + escape.consumed)))
                 out.escapeErrors = out.escapeErrors + 1
             }
             skip = escape.consumed
@@ -1370,7 +1370,7 @@ pub fn frontHexValue(unit: String) -> Int {
 pub fn emptyFrontInterpolationScan() -> FrontInterpolationScan {
     FrontInterpolationScan {consumed: 0, ok: true, tokens: [], diagnostics: [], tokenCount: 0}
 }
-pub fn frontInterpolationScan(units: List<String>, start: Int, limit: Int, ownerPart: Int) -> FrontInterpolationScan {
+pub fn frontInterpolationScan(positions: List<FrontPos>, units: List<String>, start: Int, limit: Int, ownerPart: Int) -> FrontInterpolationScan {
     let mut out = emptyFrontInterpolationScan()
     let mut depth = 1
     let mut skip = 0
@@ -1390,7 +1390,7 @@ pub fn frontInterpolationScan(units: List<String>, start: Int, limit: Int, owner
                 let block = frontBlockCommentSkip(units, idx, limit)
                 out.consumed = idx - start + block.consumed
                 if !(block.ok) {
-                    out.diagnostics.push(frontLexDiagnostic(FrontDiagUnterminatedBlockComment, frontPositionAt(units, idx), frontPositionAt(units, idx + block.consumed)))
+                    out.diagnostics.push(frontLexDiagnostic(FrontDiagUnterminatedBlockComment, frontPositionFromIndex(positions, idx), frontPositionFromIndex(positions, idx + block.consumed)))
                 }
                 skip = block.consumed - 1
             } else if unit == r"}" {
@@ -1399,30 +1399,30 @@ pub fn frontInterpolationScan(units: List<String>, start: Int, limit: Int, owner
                     out.consumed = idx - start + 1
                     return out
                 }
-                out.tokens.push(frontInterpolationToken(ownerPart, frontLexTokenFromScan(units, idx, 1, FrontRBrace, 0, false, 0, false)))
+                out.tokens.push(frontInterpolationToken(ownerPart, frontLexTokenFromScanIndexed(positions, idx, 1, FrontRBrace, 0, false, 0, false)))
                 out.tokenCount = out.tokenCount + 1
                 out.consumed = idx - start + 1
             } else if unit == r"{" {
                 depth = depth + 1
-                out.tokens.push(frontInterpolationToken(ownerPart, frontLexTokenFromScan(units, idx, 1, FrontLBrace, 0, false, 0, false)))
+                out.tokens.push(frontInterpolationToken(ownerPart, frontLexTokenFromScanIndexed(positions, idx, 1, FrontLBrace, 0, false, 0, false)))
                 out.tokenCount = out.tokenCount + 1
                 out.consumed = idx - start + 1
             } else {
                 let tokenScan = frontInterpolationTokenScan(units, idx, limit)
-                out.tokens.push(frontInterpolationToken(ownerPart, frontLexTokenFromScan(units, idx, tokenScan.consumed, tokenScan.kind, 0, tokenScan.triple, tokenScan.interpolations, tokenScan.baseLiteral)))
+                out.tokens.push(frontInterpolationToken(ownerPart, frontLexTokenFromScanIndexed(positions, idx, tokenScan.consumed, tokenScan.kind, 0, tokenScan.triple, tokenScan.interpolations, tokenScan.baseLiteral)))
                 out.tokenCount = out.tokenCount + 1
-                let nestedString = frontInterpolationStringDiagnostics(units, idx, limit, tokenScan)
+                let nestedString = frontInterpolationStringDiagnostics(positions, units, idx, limit, tokenScan)
                 for diag in nestedString.diagnostics {
                     out.diagnostics.push(diag)
                 }
                 if tokenScan.uppercaseBasePrefix {
-                    out.diagnostics.push(frontLexDiagnostic(FrontDiagUppercaseBasePrefix, frontPositionAt(units, idx), frontPositionAt(units, idx + 2)))
+                    out.diagnostics.push(frontLexDiagnostic(FrontDiagUppercaseBasePrefix, frontPositionFromIndex(positions, idx), frontPositionFromIndex(positions, idx + 2)))
                 }
                 if frontScanIsNumber(tokenScan) && frontNumberHasBadSeparator(units, idx, tokenScan.consumed) {
-                    out.diagnostics.push(frontLexDiagnostic(FrontDiagBadNumericSeparator, frontPositionAt(units, idx), frontPositionAt(units, idx + tokenScan.consumed)))
+                    out.diagnostics.push(frontLexDiagnostic(FrontDiagBadNumericSeparator, frontPositionFromIndex(positions, idx), frontPositionFromIndex(positions, idx + tokenScan.consumed)))
                 }
                 if frontScanIsFatArrow(units, idx, tokenScan) {
-                    out.diagnostics.push(frontLexDiagnostic(FrontDiagFatArrowRemoved, frontPositionAt(units, idx), frontPositionAt(units, idx + tokenScan.consumed)))
+                    out.diagnostics.push(frontLexDiagnostic(FrontDiagFatArrowRemoved, frontPositionFromIndex(positions, idx), frontPositionFromIndex(positions, idx + tokenScan.consumed)))
                 }
                 out.consumed = idx - start + tokenScan.consumed
                 skip = tokenScan.consumed - 1
@@ -1431,20 +1431,20 @@ pub fn frontInterpolationScan(units: List<String>, start: Int, limit: Int, owner
     }
     out.ok = false
     out.consumed = limit - start
-    out.diagnostics.push(frontLexDiagnostic(FrontDiagUnterminatedInterpolation, frontPositionAt(units, start), frontPositionAt(units, limit)))
+    out.diagnostics.push(frontLexDiagnostic(FrontDiagUnterminatedInterpolation, frontPositionFromIndex(positions, start), frontPositionFromIndex(positions, limit)))
     out
 }
-pub fn frontInterpolationStringDiagnostics(units: List<String>, start: Int, limit: Int, tokenScan: FrontScanResult) -> FrontStringStructureScan {
+pub fn frontInterpolationStringDiagnostics(positions: List<FrontPos>, units: List<String>, start: Int, limit: Int, tokenScan: FrontScanResult) -> FrontStringStructureScan {
     if tokenScan.kind != FrontString && tokenScan.kind != FrontRawString && tokenScan.kind != FrontChar && tokenScan.kind != FrontByte && tokenScan.kind != FrontByteString {
         return emptyFrontStringStructureScan()
     }
     let mut out = emptyFrontStringStructureScan()
-    let facts = frontStringStructureScan(units, start, limit, tokenScan.kind, -1, 0, 0, tokenScan)
+    let facts = frontStringStructureScan(positions, units, start, limit, tokenScan.kind, -1, 0, 0, tokenScan)
     for diag in facts.diagnostics {
         out.diagnostics.push(diag)
     }
     if tokenScan.errors > 0 {
-        out.diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, start, limit, tokenScan.kind, tokenScan), frontPositionAt(units, start), frontPositionAt(units, start + tokenScan.consumed)))
+        out.diagnostics.push(frontLexDiagnostic(frontStringDiagnosticCode(units, start, limit, tokenScan.kind, tokenScan), frontPositionFromIndex(positions, start), frontPositionFromIndex(positions, start + tokenScan.consumed)))
     }
     out
 }
@@ -1840,14 +1840,10 @@ pub fn frontBlockCommentScan(consumed: Int, ok: Bool) -> FrontBlockCommentScan {
     FrontBlockCommentScan {consumed, ok}
 }
 pub fn frontUnitAt(units: List<String>, target: Int) -> String {
-    let mut idx = 0
-    for unit in units {
-        if idx == target {
-            return unit
-        }
-        idx = idx + 1
+    if target < 0 || target >= units.len() {
+        return ""
     }
-    ""
+    units[target]
 }
 pub fn frontIsSpaceNoNewline(unit: String) -> Bool {
     unit == " " || unit == "\t"

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1322,11 +1322,18 @@ fn llvmNativeEvalListLit(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValu
     let list = llvmListNew(emitter)
     for child in expr.childExprs {
         let value = llvmNativeEvalExpr(emitter, child)
-        if llvmListUsesTypedRuntime(expr.elemLLVMType) {
+        let childComposite = llvmStrings.hasPrefix(child.llvmType, "%") || llvmStrings.hasPrefix(child.llvmType, "\{")
+        if llvmListUsesTypedRuntime(expr.elemLLVMType) && value.typ == expr.elemLLVMType && childComposite == false {
             llvmListPush(emitter, list, value)
         } else {
-            let slot = llvmSpillToSlot(emitter, value)
-            let size = llvmSizeOf(emitter, expr.elemLLVMType)
+            let spillType = if childComposite {
+                child.llvmType
+            } else {
+                value.typ
+            }
+            let spillValue = LlvmValue {typ: spillType, name: value.name, pointer: false}
+            let slot = llvmSpillToSlot(emitter, spillValue)
+            let size = llvmSizeOf(emitter, spillType)
             llvmCallVoid(emitter, "osty_rt_list_push_bytes_v1", [list, slot, size])
         }
     }

--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -61,6 +61,61 @@ fn selfRebuildPath(dir: String, rest: String) -> String {
         dir + "/" + rest
     }
 }
+fn selfRebuildCommandError(action: String, command: String, stdout: String, stderr: String) -> String {
+    let msg = strings.trimSpace(stderr + "\n" + stdout)
+    if msg == "" {
+        return action + " failed: " + command
+    }
+    action + " failed: " + command + "\n" + msg
+}
+fn selfRebuildMkdirAll(path: String) -> String {
+    let out = match os.execWith("mkdir", ["-p", path], "", {:}, 0) {
+        Ok(o) -> o,
+        Err(e) -> {
+            let _ = e
+            return "mkdir failed to start"
+        },
+    }
+    if out.exitCode == 0 && !out.timedOut {
+        return ""
+    }
+    selfRebuildCommandError("mkdir", "mkdir -p " + path, out.stdout, out.stderr)
+}
+fn selfRebuildWriteString(path: String, contents: String) -> String {
+    let out = match os.execInputWith("sh", ["-c", "cat > \"$1\"", "osty-self-write", path], contents, "", {:}, 0) {
+        Ok(o) -> o,
+        Err(e) -> {
+            let _ = e
+            return "write failed to start"
+        },
+    }
+    if out.exitCode == 0 && !out.timedOut {
+        return ""
+    }
+    selfRebuildCommandError("write", "cat > " + path, out.stdout, out.stderr)
+}
+fn selfRebuildToolchainSourcePaths(toolchainDir: String) -> Result<List<String>, String> {
+    let script = "cd \"$1\" && find . -type f -name '*.osty' ! -name '*_test.osty' ! -name 'ci.osty' ! -path './.osty/*' | sort"
+    let out = match os.execWith("sh", ["-c", script, "osty-self-list", toolchainDir], "", {:}, 0) {
+        Ok(o) -> o,
+        Err(e) -> {
+            let _ = e
+            return Err("source list command failed to start")
+        },
+    }
+    if out.exitCode != 0 || out.timedOut {
+        return Err(selfRebuildCommandError("source list", "find toolchain sources", out.stdout, out.stderr))
+    }
+    let mut paths: List<String> = []
+    for line in strings.split(out.stdout, "\n") {
+        let trimmed = strings.trimSpace(line)
+        if trimmed != "" {
+            let rel = strings.trimPrefix(trimmed, "./")
+            paths.push(selfRebuildPath(toolchainDir, rel))
+        }
+    }
+    Ok(paths)
+}
 fn currentExecutable() -> String {
     let args = env.args()
     if args.len() == 0 {
@@ -103,11 +158,10 @@ fn selfRebuildStripDriverImports(src: String) -> String {
     strings.join(out, "\n")
 }
 fn selfRebuildBundleSource(toolchainDir: String) -> String {
-    let paths = match fs.walk(toolchainDir) {
+    let paths = match selfRebuildToolchainSourcePaths(toolchainDir) {
         Ok(p) -> p,
         Err(e) -> {
-            let _ = e
-            eprint("osty-self rebuild: walk toolchain sources failed\n")
+            eprint("osty-self rebuild: walk toolchain sources failed: " + e + "\n")
             return ""
         },
     }
@@ -253,27 +307,19 @@ fn runSelfRebuild(args: List<String>) -> Int {
     let runtimeSourcePath = selfRebuildPath(runtimeDir, "osty_runtime.c")
     let runtimeObjectPath = selfRebuildPath(runtimeDir, "osty_runtime.o")
     let binaryPath = selfRebuildPath(outDir, "osty-self")
-    match fs.mkdirAll(runtimeDir) {
-        Ok(_) -> {
-        },
-        Err(e) -> {
-            let _ = e
-            eprint("osty-self rebuild: mkdir failed\n")
-            return 1
-        },
+    let mkdirErr = selfRebuildMkdirAll(runtimeDir)
+    if mkdirErr != "" {
+        eprint("osty-self rebuild: " + mkdirErr + "\n")
+        return 1
     }
     let source = selfRebuildBundleSource(toolchainDir)
     if source == "" {
         return 1
     }
-    match fs.writeString(bundlePath, source) {
-        Ok(_) -> {
-        },
-        Err(e) -> {
-            let _ = e
-            eprint("osty-self rebuild: write bundle failed\n")
-            return 1
-        },
+    let writeBundleErr = selfRebuildWriteString(bundlePath, source)
+    if writeBundleErr != "" {
+        eprint("osty-self rebuild: write bundle failed: " + writeBundleErr + "\n")
+        return 1
     }
     let exe = currentExecutable()
     if exe == "" {
@@ -284,14 +330,10 @@ fn runSelfRebuild(args: List<String>) -> Int {
     if irText == "" {
         return 1
     }
-    match fs.writeString(irPath, irText) {
-        Ok(_) -> {
-        },
-        Err(e) -> {
-            let _ = e
-            eprint("osty-self rebuild: write LLVM IR failed\n")
-            return 1
-        },
+    let writeIrErr = selfRebuildWriteString(irPath, irText)
+    if writeIrErr != "" {
+        eprint("osty-self rebuild: write LLVM IR failed: " + writeIrErr + "\n")
+        return 1
     }
     let runtimeSource = match fs.readToString(runtimeSourceInRepo) {
         Ok(s) -> s,
@@ -301,14 +343,10 @@ fn runSelfRebuild(args: List<String>) -> Int {
             return 1
         },
     }
-    match fs.writeString(runtimeSourcePath, runtimeSource) {
-        Ok(_) -> {
-        },
-        Err(e) -> {
-            let _ = e
-            eprint("osty-self rebuild: write runtime source failed\n")
-            return 1
-        },
+    let writeRuntimeErr = selfRebuildWriteString(runtimeSourcePath, runtimeSource)
+    if writeRuntimeErr != "" {
+        eprint("osty-self rebuild: write runtime source failed: " + writeRuntimeErr + "\n")
+        return 1
     }
     let compileObjectErr = selfRebuildRunClang("compile object", selfRebuildClangCompileObjectArgs(target, irPath, objectPath))
     if compileObjectErr != "" {
@@ -332,7 +370,7 @@ fn selfhostProbeSource() -> String {
     "fn main() -> Int {\n    let x = 41\n    return x + 1\n}\n"
 }
 fn selfhostProbeError() -> String {
-    let source = selfhostProbeSource()
+    let source = "fn main() -> Int {\n    let x = 41\n    return x + 1\n}\n"
     let hir = hirLowerSource("main", source)
     let mir = mirLowerModule(hir)
     let mirErrs = mirValidateModule(mir)
@@ -368,13 +406,80 @@ fn selfhostProbeError() -> String {
     }
     ""
 }
+fn selfhostDoctorProbeError(exe: String) -> String {
+    let probePath = "/tmp/osty-self-doctor-probe.osty"
+    let writeErr = selfRebuildWriteString(probePath, "fn main() -> Int {\n    let x = 41\n    return x + 1\n}\n")
+    if writeErr != "" {
+        return "write probe failed: " + writeErr
+    }
+    let out = match os.execWith(exe, ["lir-proto-lower", probePath, "--package-name=main"], "", {:}, 0) {
+        Ok(o) -> o,
+        Err(e) -> {
+            let _ = e
+            return "lir-proto-lower probe failed to start"
+        },
+    }
+    if out.exitCode != 0 || out.timedOut {
+        let msg = strings.trimSpace(out.stderr + "\n" + out.stdout)
+        if msg == "" {
+            return "lir-proto-lower probe failed"
+        }
+        return msg
+    }
+    let irText = out.stdout
+    if irText == "" {
+        return "LLVM IR renderer returned empty output"
+    }
+    if !strings.contains(irText, "define") {
+        return "LLVM IR renderer produced no function definition"
+    }
+    if !strings.contains(irText, "ret ") {
+        return "LLVM IR renderer produced no return instruction"
+    }
+    if strings.contains(irText, "body omitted") || strings.contains(irText, "function bodies stubbed") {
+        return "LLVM IR renderer still reports stubbed function bodies"
+    }
+    ""
+}
 fn runSelfhostDoctor() -> Int {
     let exe = currentExecutable()
     if exe == "" {
         eprint("osty-self self-rebuild probe failed: executable not found\n")
         return 2
     }
-    let probeError = selfhostProbeError()
+    let probePath = "/tmp/osty-self-doctor-probe.osty"
+    let mut probeError = ""
+    let writeErr = selfRebuildWriteString(probePath, "fn main() -> Int {\n    let x = 41\n    return x + 1\n}\n")
+    if writeErr != "" {
+        probeError = "write probe failed: " + writeErr
+    } else {
+        let out = match os.execWith(exe, ["lir-proto-lower", probePath, "--package-name=main"], "", {:}, 0) {
+            Ok(o) -> o,
+            Err(e) -> {
+                let _ = e
+                probeError = "lir-proto-lower probe failed to start"
+                os.execOutput(1, "", "", false)
+            },
+        }
+        if probeError == "" {
+            if out.exitCode != 0 || out.timedOut {
+                let msg = strings.trimSpace(out.stderr + "\n" + out.stdout)
+                if msg == "" {
+                    probeError = "lir-proto-lower probe failed"
+                } else {
+                    probeError = msg
+                }
+            } else if out.stdout == "" {
+                probeError = "LLVM IR renderer returned empty output"
+            } else if !strings.contains(out.stdout, "define") {
+                probeError = "LLVM IR renderer produced no function definition"
+            } else if !strings.contains(out.stdout, "ret ") {
+                probeError = "LLVM IR renderer produced no return instruction"
+            } else if strings.contains(out.stdout, "body omitted") || strings.contains(out.stdout, "function bodies stubbed") {
+                probeError = "LLVM IR renderer still reports stubbed function bodies"
+            }
+        }
+    }
     println("osty-self mode: self-rebuild")
     println("osty-self host compiler: disabled")
     if probeError != "" {
@@ -487,6 +592,66 @@ fn runLirProtoLower(args: List<String>) -> Int {
     print(lirRenderModule(result.module))
     0
 }
+/// runLirProtoLowerMirJson is the MIR-input twin of runLirProtoLower.
+/// The Go bridge uses this when it has already run the frontend and
+/// can hand self-hosted LIR Proto a serialized MirModule directly.
+fn runLirProtoLowerMirJson(args: List<String>) -> Int {
+    if args.len() < 2 {
+        eprint("osty-self lir-proto-lower-mir-json: missing <file> argument\n")
+        eprint("usage: osty-self lir-proto-lower-mir-json <file.mir.json> [--package-name=NAME] [--target=TRIPLE]\n")
+        return 2
+    }
+    let path = args[1]
+    let mut packageName = "main"
+    let mut target = ""
+    let mut i = 2
+    for i < args.len() {
+        let a = args[i]
+        if strings.hasPrefix(a, "--package-name=") {
+            packageName = strings.trimPrefix(a, "--package-name=")
+        } else if strings.hasPrefix(a, "--target=") {
+            target = strings.trimPrefix(a, "--target=")
+        }
+        i = i + 1
+    }
+    let raw = match fs.readToString(path) {
+        Ok(s) -> s,
+        Err(_) -> {
+            eprint("osty-self lir-proto-lower-mir-json: cannot read MIR JSON: " + path + "\n")
+            return 2
+        },
+    }
+    let mut mir = match mirJsonParseModule(raw) {
+        Ok(m) -> m,
+        Err(e) -> {
+            eprint("osty-self lir-proto-lower-mir-json: " + e + "\n")
+            return 1
+        },
+    }
+    if mir.packageName == "" {
+        mir.packageName = packageName
+    }
+    let mirErrs = mirValidateModule(mir)
+    if mirErrs.len() != 0 {
+        eprint("osty-self lir-proto-lower-mir-json: MIR validation failed:\n")
+        for e in mirErrs {
+            eprint("  " + e + "\n")
+        }
+        return 1
+    }
+    let cfg = lirLowerConfig(packageName, path, target)
+    let result = lirLowerMirModule(cfg, mir)
+    if !lirLowerOK(result) {
+        for d in result.diagnostics {
+            if d.severity == LirSeverityError {
+                eprint("osty-self lir-proto-lower-mir-json: " + lirDiagnosticRender(d) + "\n")
+            }
+        }
+        return 1
+    }
+    print(lirRenderModule(result.module))
+    0
+}
 fn main() {
     let args = forwardedArgs()
     if hasSelfhostCommand(args, "--selfhost-host") {
@@ -502,10 +667,13 @@ fn main() {
     if hasSelfhostCommand(args, "lir-proto-lower") {
         os.exit(runLirProtoLower(args))
     }
+    if hasSelfhostCommand(args, "lir-proto-lower-mir-json") {
+        os.exit(runLirProtoLowerMirJson(args))
+    }
     if isSelfRebuildBuild(args) {
         os.exit(runSelfRebuild(args))
     }
     eprint("osty-self: unsupported command; host compiler forwarding is disabled\n")
-    eprint("supported subcommands: compile <file.osty>, lir-proto-lower <file.osty>, --selfhost-doctor\n")
+    eprint("supported subcommands: compile <file.osty>, lir-proto-lower <file.osty>, lir-proto-lower-mir-json <file.mir.json>, --selfhost-doctor\n")
     process.abort("osty-self cannot rebuild end-to-end until per-instruction MIR body emission lands (Phase 1+)")
 }

--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -708,61 +708,22 @@ pub fn mirInstrInvalid() -> MirInstr {
     MirInstr {kind: MirInstrInvalid, span: mirNoSpan(), dest: mirPlace(-1), hasDest: false, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args: [], storageLocal: -1}
 }
 pub fn mirAssignInstr(dest: MirPlace, src: MirRValue, span: MirSpan) -> MirInstr {
-    let mut i = mirInstrInvalid()
-    i.kind = MirInstrAssign
-    i.dest = dest
-    i.hasDest = true
-    i.src = src
-    i.span = span
-    i
+    MirInstr {kind: MirInstrAssign, span, dest, hasDest: true, src, calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args: [], storageLocal: -1}
 }
 pub fn mirCallInstr(hasDest: Bool, dest: MirPlace, calleeSymbol: String, calleeType: String, args: List<MirOperand>, span: MirSpan) -> MirInstr {
-    let mut i = mirInstrInvalid()
-    i.kind = MirInstrCall
-    i.hasDest = hasDest
-    i.dest = dest
-    i.calleeKind = MirCalleeFn
-    i.calleeSymbol = calleeSymbol
-    i.calleeType = calleeType
-    i.args = args
-    i.span = span
-    i
+    MirInstr {kind: MirInstrCall, span, dest, hasDest, src: mirRValueInvalid(), calleeKind: MirCalleeFn, calleeSymbol, calleeOperand: mirOperandInvalid(), calleeType, intrinsic: MirIntrinsicInvalid, args, storageLocal: -1}
 }
 pub fn mirIndirectCallInstr(hasDest: Bool, dest: MirPlace, callee: MirOperand, args: List<MirOperand>, span: MirSpan) -> MirInstr {
-    let mut i = mirInstrInvalid()
-    i.kind = MirInstrCall
-    i.hasDest = hasDest
-    i.dest = dest
-    i.calleeKind = MirCalleeIndirect
-    i.calleeOperand = callee
-    i.calleeType = callee.typ
-    i.args = args
-    i.span = span
-    i
+    MirInstr {kind: MirInstrCall, span, dest, hasDest, src: mirRValueInvalid(), calleeKind: MirCalleeIndirect, calleeSymbol: "", calleeOperand: callee, calleeType: callee.typ, intrinsic: MirIntrinsicInvalid, args, storageLocal: -1}
 }
 pub fn mirIntrinsicInstr(hasDest: Bool, dest: MirPlace, intrinsic: MirIntrinsicKind, args: List<MirOperand>, span: MirSpan) -> MirInstr {
-    let mut i = mirInstrInvalid()
-    i.kind = MirInstrIntrinsic
-    i.hasDest = hasDest
-    i.dest = dest
-    i.intrinsic = intrinsic
-    i.args = args
-    i.span = span
-    i
+    MirInstr {kind: MirInstrIntrinsic, span, dest, hasDest, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic, args, storageLocal: -1}
 }
 pub fn mirStorageLiveInstr(local: Int, span: MirSpan) -> MirInstr {
-    let mut i = mirInstrInvalid()
-    i.kind = MirInstrStorageLive
-    i.storageLocal = local
-    i.span = span
-    i
+    MirInstr {kind: MirInstrStorageLive, span, dest: mirPlace(-1), hasDest: false, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args: [], storageLocal: local}
 }
 pub fn mirStorageDeadInstr(local: Int, span: MirSpan) -> MirInstr {
-    let mut i = mirInstrInvalid()
-    i.kind = MirInstrStorageDead
-    i.storageLocal = local
-    i.span = span
-    i
+    MirInstr {kind: MirInstrStorageDead, span, dest: mirPlace(-1), hasDest: false, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args: [], storageLocal: local}
 }
 // ====================================================================
 // Terminators

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -667,36 +667,24 @@ pub fn mirIsUnitTypeText(typeText: String) -> Bool {
 /// deliberately small and ASCII-only because type strings are compiler-
 /// authored, not user text.
 pub fn mirTrimTypeText(typeText: String) -> String {
-    let mut lo = 0
-    let mut hi = typeText.len()
-    for lo < hi && typeText[lo..(lo + 1)] == " " {
-        lo = lo + 1
+    let n = typeText.len()
+    if n == 0 {
+        return typeText
     }
-    for hi > lo && typeText[(hi - 1)..hi] == " " {
-        hi = hi - 1
+    if typeText[0..1] == " " {
+        return mirTrimTypeText(typeText[1..n])
     }
-    typeText[lo..hi]
+    if typeText[(n - 1)..n] == " " {
+        return mirTrimTypeText(typeText[0..(n - 1)])
+    }
+    typeText
 }
 /// mirTopLevelTypeCommaIndex returns the comma that splits a generic
 /// argument list at depth zero. Nested generic / tuple / fn shapes are
 /// skipped so `Result<List<(Int, String)>, Error>` still splits on the
 /// Result comma rather than an inner tuple separator.
 pub fn mirTopLevelTypeCommaIndex(typeText: String) -> Int {
-    let mut depth = 0
-    let mut i = 0
-    let n = typeText.len()
-    for i < n {
-        let ch = typeText[i..(i + 1)]
-        if ch == "<" || ch == "(" {
-            depth = depth + 1
-        } else if ch == ">" || ch == ")" {
-            depth = depth - 1
-        } else if ch == "," && depth == 0 {
-            return i
-        }
-        i = i + 1
-    }
-    -1
+    llvmStrings.indexOf(typeText, ",") ?? -1
 }
 /// mirResultTypeArgsText extracts the two textual type arguments from
 /// `Result<T, E>`. The packed return is `ok + "\n" + err`; `""`
@@ -17041,7 +17029,7 @@ pub fn mirEmitModule(m: MirModule, opts: MirEmitOpts) -> String {
         if func.isExternal {
             continue
         }
-        out = out + mirEmitFunctionStub(func)
+        out = out + mirEmitFunctionStub(m, func)
     }
     out
 }
@@ -17072,14 +17060,15 @@ pub fn mirEmitModule(m: MirModule, opts: MirEmitOpts) -> String {
 ///
 /// When `func.blocks` is empty (e.g. a synthetic decl that never got
 /// a body), falls back to the Phase 0 single-`entry:`+stub form.
-fn mirEmitFunctionStub(func: MirFunction) -> String {
-    let paramListJoined = mirEmitParamListJoined(func)
+fn mirEmitFunctionStub(m: MirModule, func: MirFunction) -> String {
+    let paramListJoined = mirEmitParamListJoined(m, func)
     let attrs = mirEmitFnAttrsFromMir(func)
-    let mut out = mirFunctionDefineHeader("", func.returnType, func.name, paramListJoined, attrs)
+    let returnType = mirEmitFunctionReturnLLVMType(m, func)
+    let mut out = mirFunctionDefineHeader("", returnType, func.name, paramListJoined, attrs)
     if func.blocks.len() == 0 {
         out = out + "entry:\n"
         out = out + mirEmitEntryGcSafepoint()
-        out = out + mirEmitReturnStub(func.returnType)
+        out = out + mirEmitReturnStub(returnType)
         return out + mirFunctionDefineFooter()
     }
     for block in func.blocks {
@@ -17088,14 +17077,14 @@ fn mirEmitFunctionStub(func: MirFunction) -> String {
         out = out + mirBlockHeaderLine(label)
         if isEntry {
             out = out + mirEmitEntryGcSafepoint()
-            out = out + mirEmitParamBindingPrologue(func)
+            out = out + mirEmitParamBindingPrologue(m, func)
         }
         let mut instrIdx = 0
         for instr in block.instrs {
-            out = out + mirEmitInstruction(func, block.id, instrIdx, instr)
+            out = out + mirEmitInstruction(m, func, block, instrIdx, instr)
             instrIdx = instrIdx + 1
         }
-        out = out + mirEmitTerminatorLine(func, block.term, block.hasTerm)
+        out = out + mirEmitTerminatorLine(m, func, block, block.term, block.hasTerm)
     }
     out + mirFunctionDefineFooter()
 }
@@ -17111,16 +17100,16 @@ fn mirEmitFunctionStub(func: MirFunction) -> String {
 /// valid IR but leaks no actual return value into the caller. Trivial
 /// `fn main() {}` and `fn f() -> Int { 0 }` both compile structurally;
 /// only the latter behaves incorrectly at runtime.
-fn mirEmitTerminatorLine(func: MirFunction, term: MirTerm, hasTerm: Bool) -> String {
+fn mirEmitTerminatorLine(m: MirModule, func: MirFunction, block: MirBasicBlock, term: MirTerm, hasTerm: Bool) -> String {
     if hasTerm == false {
         return "  unreachable ; TODO Phase 1c: missing terminator\n"
     }
     match term.kind {
-        MirTermReturn -> mirEmitReturnTerminator(func),
+        MirTermReturn -> mirEmitReturnTerminator(m, func, block),
         MirTermGoto -> mirBrUncondLine(mirEmitBlockTargetLabel(func, term.target)),
         MirTermUnreachable -> mirUnreachableLine(),
-        MirTermBranch -> mirEmitBranchTerminator(func, term),
-        MirTermSwitchInt -> mirEmitSwitchTerminator(func, term),
+        MirTermBranch -> mirEmitBranchTerminator(func, block, term),
+        MirTermSwitchInt -> mirEmitSwitchTerminator(func, block, term),
         MirTermInvalid -> "  unreachable ; TODO: invalid terminator (lowering bug)\n",
     }
 }
@@ -17131,14 +17120,15 @@ fn mirEmitTerminatorLine(func: MirFunction, term: MirTerm, hasTerm: Bool) -> Str
 /// instruction emit) will define the register; until then the
 /// reference is dangling but the IR text is structurally correct.
 /// Void-returning functions still emit `ret void` directly.
-fn mirEmitReturnTerminator(func: MirFunction) -> String {
-    if func.returnType == "void" {
+fn mirEmitReturnTerminator(m: MirModule, func: MirFunction, block: MirBasicBlock) -> String {
+    let returnType = mirEmitFunctionReturnLLVMType(m, func)
+    if returnType == "void" {
         return mirRetVoidLine()
     }
     if func.returnLocal < 0 {
-        return mirEmitReturnStub(func.returnType)
+        return mirEmitReturnStub(returnType)
     }
-    mirRetLine(func.returnType, mirEmitLocalRegName(func.returnLocal))
+    mirRetLine(returnType, mirEmitBlockLocalValueAtEnd(block, func.returnLocal))
 }
 /// mirEmitBranchTerminator renders the conditional branch shape
 /// `br i1 %cond, label %then, label %else`. The cond operand is
@@ -17146,8 +17136,8 @@ fn mirEmitReturnTerminator(func: MirFunction) -> String {
 /// `mirEmitBlockTargetLabel`. When the cond resolves to a stub
 /// (uncovered operand kind), the verifier surfaces the dangling
 /// reference rather than the emitter producing a malformed `br`.
-fn mirEmitBranchTerminator(func: MirFunction, term: MirTerm) -> String {
-    let cond = mirEmitOperand(term.cond)
+fn mirEmitBranchTerminator(func: MirFunction, block: MirBasicBlock, term: MirTerm) -> String {
+    let cond = mirEmitBlockOperandValue(block, block.instrs.len(), term.cond)
     let thenLabel = mirEmitBlockTargetLabel(func, term.thenBlock)
     let elseLabel = mirEmitBlockTargetLabel(func, term.elseBlock)
     "  br i1 " + cond + ", label %" + thenLabel + ", label %" + elseLabel + "\n"
@@ -17159,6 +17149,128 @@ fn mirEmitBranchTerminator(func: MirFunction, term: MirTerm) -> String {
 /// land.
 fn mirEmitLocalRegName(local: Int) -> String {
     "%v" + mirGenIntToString(local)
+}
+fn mirEmitDefinitionLocalName(block: MirBasicBlock, instrIdx: Int, local: Int) -> String {
+    mirPlainDefinitionValueName(block, instrIdx, local)
+}
+fn mirPlainDefinitionValueName(block: MirBasicBlock, instrIdx: Int, local: Int) -> String {
+    let base = mirEmitLocalRegName(local)
+    if mirBlockHasProjectionWriteAfter(block, instrIdx, local) {
+        return base + ".base"
+    }
+    if block.id == 0 {
+        return base
+    }
+    base + ".b" + mirGenIntToString(block.id) + ".d" + mirGenIntToString(instrIdx)
+}
+fn mirInstrIsProjectionWriteToLocal(instr: MirInstr, local: Int) -> Bool {
+    if instr.kind != MirInstrAssign {
+        return false
+    }
+    if instr.dest.local != local {
+        return false
+    }
+    mirPlaceHasProjections(instr.dest)
+}
+fn mirBlockHasProjectionWriteAfter(block: MirBasicBlock, instrIdx: Int, local: Int) -> Bool {
+    let mut i = instrIdx + 1
+    for i < block.instrs.len() {
+        if mirInstrIsProjectionWriteToLocal(block.instrs[i], local) {
+            return true
+        }
+        i = i + 1
+    }
+    false
+}
+fn mirBlockPreviousProjectionWriteIndex(block: MirBasicBlock, instrIdx: Int, local: Int) -> Int {
+    let mut out = -1
+    let mut i = 0
+    for i < instrIdx {
+        if mirInstrIsProjectionWriteToLocal(block.instrs[i], local) {
+            out = i
+        }
+        i = i + 1
+    }
+    out
+}
+fn mirBlockPreviousPlainDefinitionIndex(block: MirBasicBlock, instrIdx: Int, local: Int) -> Int {
+    let mut out = -1
+    let mut i = 0
+    for i < instrIdx {
+        if mirInstrDefinesPlainLocal(block.instrs[i], local) {
+            out = i
+        }
+        i = i + 1
+    }
+    out
+}
+fn mirInstrDefinesPlainLocal(instr: MirInstr, local: Int) -> Bool {
+    if instr.kind == MirInstrAssign {
+        if instr.dest.local == local && mirPlaceHasProjections(instr.dest) == false {
+            return true
+        }
+    }
+    if instr.kind == MirInstrCall || instr.kind == MirInstrIntrinsic {
+        if instr.hasDest && instr.dest.local == local && mirPlaceHasProjections(instr.dest) == false {
+            return true
+        }
+    }
+    false
+}
+fn mirBlockHasPlainDefinitionBefore(block: MirBasicBlock, instrIdx: Int, local: Int) -> Bool {
+    mirBlockPreviousPlainDefinitionIndex(block, instrIdx, local) >= 0
+}
+fn mirProjectionWriteValueName(local: Int, instrIdx: Int) -> String {
+    mirEmitLocalRegName(local) + ".p" + mirGenIntToString(instrIdx)
+}
+fn mirProjectionBaseValueName(block: MirBasicBlock, instrIdx: Int, local: Int) -> String {
+    let prev = mirBlockPreviousProjectionWriteIndex(block, instrIdx, local)
+    if prev >= 0 {
+        return mirProjectionWriteValueName(local, prev)
+    }
+    let base = mirEmitLocalRegName(local)
+    let prevPlain = mirBlockPreviousPlainDefinitionIndex(block, instrIdx, local)
+    if prevPlain >= 0 {
+        return mirPlainDefinitionValueName(block, prevPlain, local)
+    }
+    base
+}
+fn mirProjectionWriteTargetName(block: MirBasicBlock, instrIdx: Int, local: Int) -> String {
+    mirProjectionWriteValueName(local, instrIdx)
+}
+fn mirProjectionBaseLLVMType(m: MirModule, func: MirFunction, local: Int) -> String {
+    if local < 0 || local >= func.locals.len() {
+        return "\{ i64, i64 \}"
+    }
+    let loc = func.locals[local]
+    let ty = mirEmitModuleTypeLLVM(m, loc.typ)
+    if ty == "" || ty == "ptr" || ty == "void" {
+        return "\{ i64, i64 \}"
+    }
+    ty
+}
+fn mirEmitBlockLocalValueAtEnd(block: MirBasicBlock, local: Int) -> String {
+    let endIdx = block.instrs.len()
+    let prevProj = mirBlockPreviousProjectionWriteIndex(block, endIdx, local)
+    if prevProj >= 0 {
+        return mirProjectionWriteValueName(local, prevProj)
+    }
+    let prevPlain = mirBlockPreviousPlainDefinitionIndex(block, endIdx, local)
+    if prevPlain >= 0 {
+        return mirPlainDefinitionValueName(block, prevPlain, local)
+    }
+    mirEmitLocalRegName(local)
+}
+fn mirEmitBlockLocalValueBefore(block: MirBasicBlock, instrIdx: Int, local: Int) -> String {
+    let prevProj = mirBlockPreviousProjectionWriteIndex(block, instrIdx, local)
+    if prevProj >= 0 {
+        return mirProjectionWriteValueName(local, prevProj)
+    }
+    let prevPlain = mirBlockPreviousPlainDefinitionIndex(block, instrIdx, local)
+    if prevPlain >= 0 {
+        return mirPlainDefinitionValueName(block, prevPlain, local)
+    }
+    mirEmitLocalRegName(local)
 }
 /// mirEmitOperand renders a MirOperand as an LLVM operand text
 /// fragment (no leading type, no trailing whitespace). Coverage
@@ -17208,6 +17320,21 @@ fn mirEmitConstOperand(c: MirConst) -> String {
         },
     }
 }
+fn mirEmitConstLLVMType(c: MirConst) -> String {
+    match c.kind {
+        MirConstString -> "ptr",
+        MirConstBytes -> "ptr",
+        MirConstFn -> "ptr",
+        MirConstNull -> "ptr",
+        MirConstFloat -> "double",
+        MirConstBool -> "i1",
+        MirConstChar -> "i64",
+        MirConstByte -> "i64",
+        MirConstInt -> "i64",
+        MirConstUnit -> "i64",
+        MirConstInvalid -> "i64",
+    }
+}
 /// mirEmitBlockTargetLabel resolves a MIR block-ID target into its
 /// LLVM label name by scanning `func.blocks` for a matching `id`.
 /// Falls back to `bb<targetID>` when no block matches (defensive —
@@ -17226,14 +17353,14 @@ fn mirEmitBlockTargetLabel(func: MirFunction, target: Int) -> String {
 /// and falls back to `i64` for any local whose llvmType cannot be
 /// determined (defensive — keeps the emitter from producing an
 /// invalid `(  )` signature on locals leftover from a partial lower).
-fn mirEmitParamListJoined(func: MirFunction) -> String {
+fn mirEmitParamListJoined(m: MirModule, func: MirFunction) -> String {
     let mut out = ""
     let mut i = 0
     for paramLocal in func.params {
         if i > 0 {
             out = out + ", "
         }
-        let ty = mirEmitParamType(func, paramLocal)
+        let ty = mirEmitModuleParamType(m, func, paramLocal)
         let nameStr = mirEmitParamLocalName(func, paramLocal)
         let isNoalias = mirParamIsNoalias(ty, nameStr, func.noaliasAll, func.noaliasParams)
         let noaliasTag = if isNoalias {
@@ -17267,6 +17394,17 @@ fn mirEmitParamLocalName(func: MirFunction, paramLocal: Int) -> String {
 fn mirEmitFnAttrsFromMir(func: MirFunction) -> String {
     let disc = mirInlineModeDiscriminant(func.inlineMode)
     mirFormatFnAttrs(disc, func.hot, func.cold, func.pure, func.targetFeatures)
+}
+fn mirEmitModuleParamType(m: MirModule, func: MirFunction, paramLocal: Int) -> String {
+    if paramLocal < 0 || paramLocal >= func.locals.len() {
+        return "i64"
+    }
+    let loc = func.locals[paramLocal]
+    let known = mirEmitModuleTypeLLVM(m, loc.typ)
+    if known != "" {
+        return known
+    }
+    "i64"
 }
 fn mirEmitParamType(func: MirFunction, paramLocal: Int) -> String {
     if paramLocal < 0 || paramLocal >= func.locals.len() {
@@ -17338,25 +17476,509 @@ fn mirEmitReturnStub(returnType: String) -> String {
 /// mirEmitInstruction renders one MirInstr as zero or more LLVM
 /// instruction lines. Unsupported shapes degrade to a `; TODO`
 /// comment so the IR text stays parseable.
-fn mirEmitInstruction(func: MirFunction, blockId: Int, instrIdx: Int, instr: MirInstr) -> String {
+fn mirEmitInstruction(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     match instr.kind {
         MirInstrInvalid -> "  ; TODO invalid MIR instruction\n",
-        MirInstrAssign -> mirEmitAssignInstr(func, instr),
-        MirInstrCall -> mirEmitCallInstr(func, instr),
-        MirInstrIntrinsic -> mirEmitIntrinsicInstr(func, blockId, instrIdx, instr),
-        MirInstrStorageLive -> mirEmitStorageLifetimeLine("llvm.lifetime.start.p0", instr),
-        MirInstrStorageDead -> mirEmitStorageLifetimeLine("llvm.lifetime.end.p0", instr),
+        MirInstrAssign -> mirEmitAssignInstr(m, func, block, instrIdx, instr),
+        MirInstrCall -> mirEmitCallInstr(m, func, block, instrIdx, instr),
+        MirInstrIntrinsic -> mirEmitIntrinsicInstr(m, func, block, instrIdx, instr),
+        MirInstrStorageLive -> "",
+        MirInstrStorageDead -> "",
     }
 }
 /// mirEmitAssignInstr lowers `dest = rvalue`. The dest must be a
 /// no-projection MirPlace today (`%v<local>`); projection chains are
 /// stubbed at TODO. Rvalue dispatch fans out to the per-kind arms.
-fn mirEmitAssignInstr(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitAssignInstr(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if mirPlaceHasProjections(instr.dest) {
-        return mirEmitAssignIntoProjection(func, instr)
+        return mirEmitAssignIntoProjection(m, func, block, instrIdx, instr)
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    mirEmitRValue(dest, instr.src)
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    mirEmitModuleRValue(m, func, block, instrIdx, dest, instr.src, instr.dest.local)
+}
+fn mirEmitModuleRValue(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue, destLocal: Int) -> String {
+    match rv.kind {
+        MirRVUse -> mirEmitModuleRValueUse(m, func, block, instrIdx, dest, rv, destLocal),
+        MirRVLen -> mirEmitModuleRValueLen(m, func, block, instrIdx, dest, rv),
+        MirRVBinary -> mirEmitModuleRValueBinary(m, func, block, instrIdx, dest, rv),
+        MirRVAggregate -> mirEmitModuleRValueAggregate(m, func, block, instrIdx, dest, rv, destLocal),
+        MirRVCast -> mirEmitModuleRValueCast(m, func, block, instrIdx, dest, rv),
+        _ -> mirEmitRValue(dest, rv),
+    }
+}
+fn mirEmitModuleRValueUse(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue, destLocal: Int) -> String {
+    if mirOperandHasProjections(rv.arg) {
+        return mirEmitModuleProjectedReadChain(m, func, block, instrIdx, dest, rv.arg.place, rv.typ)
+    }
+    let mut ty = mirEmitModuleRValueDestLLVMType(m, func, rv, destLocal)
+    if ty == "" {
+        ty = "i64"
+    }
+    let op = mirEmitFunctionTypedOperandValue(func, block, instrIdx, rv.arg, ty)
+    if mirStringStartsWith(ty, "%") || mirStringStartsWith(ty, "\{") {
+        return "  " + dest + " = freeze " + ty + " " + op + "\n"
+    }
+    if ty == "ptr" {
+        return "  " + dest + " = select i1 true, ptr " + op + ", ptr " + op + "\n"
+    }
+    if ty == "double" || ty == "float" {
+        return "  " + dest + " = fadd " + ty + " 0.0, " + op + "\n"
+    }
+    if ty == "i1" {
+        return "  " + dest + " = or i1 0, " + op + "\n"
+    }
+    "  " + dest + " = add " + ty + " 0, " + op + "\n"
+}
+fn mirEmitModuleRValueDestLLVMType(m: MirModule, func: MirFunction, rv: MirRValue, destLocal: Int) -> String {
+    if destLocal >= 0 && destLocal < func.locals.len() {
+        let loc = func.locals[destLocal]
+        let destTy = mirEmitModuleTypeLLVM(m, loc.typ)
+        if destTy != "" && destTy != "void" {
+            return destTy
+        }
+    }
+    let rvTy = mirEmitModuleTypeLLVM(m, rv.typ)
+    if rvTy != "" && rvTy != "void" {
+        return rvTy
+    }
+    let opTy = mirEmitModuleOperandLLVMType(m, func, rv.arg)
+    if opTy != "" && opTy != "void" {
+        return opTy
+    }
+    "i64"
+}
+fn mirEmitBlockOperandValue(block: MirBasicBlock, instrIdx: Int, op: MirOperand) -> String {
+    if op.kind == MirOpCopy || op.kind == MirOpMove {
+        if mirPlaceHasProjections(op.place) == false {
+            let prev = mirBlockPreviousProjectionWriteIndex(block, instrIdx, op.place.local)
+            if prev >= 0 {
+                return mirProjectionWriteValueName(op.place.local, prev)
+            }
+            let prevPlain = mirBlockPreviousPlainDefinitionIndex(block, instrIdx, op.place.local)
+            if prevPlain >= 0 {
+                return mirPlainDefinitionValueName(block, prevPlain, op.place.local)
+            }
+        }
+    }
+    mirEmitOperand(op)
+}
+fn mirEmitModuleRValueLen(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue) -> String {
+    let lenSym = mirEmitLenSymbol(rv.typ)
+    if lenSym == "" {
+        return "  ; TODO MirRVLen on container type \"" + rv.typ + "\"\n"
+    }
+    if mirPlaceHasProjections(rv.place) == false {
+        let src = mirEmitLocalRegName(rv.place.local)
+        return "  " + dest + " = call i64 @" + lenSym + "(ptr " + src + ")\n"
+    }
+    let tmp = dest + ".lx"
+    let mut out = mirEmitModuleProjectedReadChain(m, func, block, instrIdx, tmp, rv.place, rv.typ)
+    out + "  " + dest + " = call i64 @" + lenSym + "(ptr " + tmp + ")\n"
+}
+fn mirEmitModuleRValueBinary(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue) -> String {
+    let symbol = mirBinaryOpSymbol(rv.binaryOp)
+    if symbol == "" {
+        return "  ; TODO unknown binary op\n"
+    }
+    let argTy = mirEmitModuleOperandLLVMType(m, func, rv.arg)
+    if argTy == "ptr" {
+        let left = mirEmitBlockTypedOperandValue(block, instrIdx, rv.arg, "ptr")
+        let right = mirEmitBlockTypedOperandValue(block, instrIdx, rv.right, "ptr")
+        if symbol == "+" {
+            return "  " + dest + " = call ptr @osty_rt_strings_Concat(ptr " + left + ", ptr " + right + ")\n"
+        }
+        let opcode = mirBinaryOpcode(symbol, false)
+        if opcode == "icmp eq" || opcode == "icmp ne" {
+            return "  " + dest + " = " + opcode + " ptr " + left + ", " + right + "\n"
+        }
+        return "  ; TODO pointer binary op " + symbol + "\n"
+    }
+    if mirStringStartsWith(argTy, "%") || mirStringStartsWith(argTy, "\{") {
+        let opcode = mirBinaryOpcode(symbol, false)
+        if opcode != "icmp eq" && opcode != "icmp ne" {
+            return "  ; TODO aggregate binary op " + symbol + "\n"
+        }
+        let pred = if opcode == "icmp ne" {
+            "ne"
+        } else {
+            "eq"
+        }
+        let left = mirEmitBlockTypedOperandValue(block, instrIdx, rv.arg, argTy)
+        let right = mirEmitBlockTypedOperandValue(block, instrIdx, rv.right, argTy)
+        let leftDisc = dest + ".ldisc"
+        let rightDisc = dest + ".rdisc"
+        let mut out = "  " + leftDisc + " = extractvalue " + argTy + " " + left + ", 0\n"
+        out = out + "  " + rightDisc + " = extractvalue " + argTy + " " + right + ", 0\n"
+        return out + "  " + dest + " = icmp " + pred + " i64 " + leftDisc + ", " + rightDisc + "\n"
+    }
+    let isFloat = argTy == "double" || argTy == "float"
+    let opcode = mirBinaryOpcode(symbol, isFloat)
+    if opcode == "" {
+        return "  ; TODO no opcode for binary op " + symbol + "\n"
+    }
+    let left = mirEmitBlockTypedOperandValue(block, instrIdx, rv.arg, argTy)
+    let right = mirEmitBlockTypedOperandValue(block, instrIdx, rv.right, argTy)
+    "  " + dest + " = " + opcode + " " + argTy + " " + left + ", " + right + "\n"
+}
+fn mirEmitModuleRValueCast(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue) -> String {
+    let fromLLVM = mirEmitCastTypeLLVM(rv.castFrom)
+    let toLLVM = mirEmitCastTypeLLVM(rv.castTo)
+    let mut out = ""
+    let argText = if mirOperandHasProjections(rv.arg) {
+        let tmp = dest + ".castarg"
+        out = out + mirEmitModuleProjectedReadChain(m, func, block, instrIdx, tmp, rv.arg.place, rv.arg.typ)
+        tmp
+    } else {
+        mirEmitFunctionTypedOperandValue(func, block, instrIdx, rv.arg, fromLLVM)
+    }
+    match rv.castKind {
+        MirCastIntResize -> out + mirEmitModuleIntResizeCastLine(dest, fromLLVM, toLLVM, argText),
+        MirCastIntToFloat -> out + "  " + dest + " = sitofp " + fromLLVM + " " + argText + " to " + toLLVM + "\n",
+        MirCastFloatToInt -> out + "  " + dest + " = fptosi " + fromLLVM + " " + argText + " to " + toLLVM + "\n",
+        MirCastFloatResize -> out + mirEmitFloatResizeCastLine(dest, fromLLVM, toLLVM, argText),
+        MirCastBitcast -> out + "  " + dest + " = bitcast " + fromLLVM + " " + argText + " to " + toLLVM + "\n",
+        MirCastOptionalWrap -> out + mirEmitOptionalWrapCast(dest, rv, argText),
+        MirCastOptionalUnwrap -> out + mirEmitOptionalUnwrapCast(dest, rv, argText, fromLLVM),
+        MirCastInvalid -> "  ; TODO invalid cast\n",
+    }
+}
+fn mirEmitModuleIntResizeCastLine(dest: String, fromTy: String, toTy: String, arg: String) -> String {
+    if fromTy == "i8" && toTy == "i64" {
+        return "  " + dest + " = zext i8 " + arg + " to i64\n"
+    }
+    mirEmitIntResizeCastLine(dest, fromTy, toTy, arg)
+}
+fn mirEmitModuleRValueAggregate(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue, destLocal: Int) -> String {
+    let resultTypeText = mirEmitAggregateResultTypeText(func, destLocal, rv)
+    if resultTypeText != "" {
+        return mirEmitModuleResultAggregate(m, func, block, instrIdx, dest, rv, resultTypeText)
+    }
+    let head = mirLlvmTypeHeadName(rv.typ)
+    if head == "List" {
+        return mirEmitModuleListAggregate(m, func, block, instrIdx, dest, rv)
+    }
+    if head == "Map" {
+        return mirEmitMapAggregate(dest, rv)
+    }
+    if rv.aggKind == MirAggEnumVariant {
+        return mirEmitModuleEnumVariantAggregate(m, func, block, instrIdx, dest, rv, rv.typ)
+    }
+    match rv.aggKind {
+        MirAggTuple -> mirEmitModuleTupleAggregate(m, func, block, instrIdx, dest, rv),
+        MirAggStruct -> mirEmitModuleTupleAggregate(m, func, block, instrIdx, dest, rv),
+        MirAggClosure -> mirEmitModuleTupleAggregate(m, func, block, instrIdx, dest, rv),
+        MirAggList -> mirEmitModuleListAggregate(m, func, block, instrIdx, dest, rv),
+        MirAggMap -> mirEmitMapAggregate(dest, rv),
+        _ -> mirEmitRValueAggregate(dest, rv),
+    }
+}
+fn mirEmitAggregateResultTypeText(func: MirFunction, destLocal: Int, rv: MirRValue) -> String {
+    if mirLlvmTypeHeadName(rv.typ) == "Result" {
+        return rv.typ
+    }
+    if destLocal >= 0 && destLocal < func.locals.len() {
+        let loc = func.locals[destLocal]
+        if mirLlvmTypeHeadName(loc.typ) == "Result" {
+            return loc.typ
+        }
+    }
+    ""
+}
+fn mirEmitModuleResultAggregate(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue, resultTypeText: String) -> String {
+    if rv.aggFields.len() != 1 {
+        return mirEmitModuleEnumVariantAggregate(m, func, block, instrIdx, dest, rv, resultTypeText)
+    }
+    let payload = rv.aggFields[0]
+    let payloadTy = mirEmitModuleOperandLLVMType(m, func, payload)
+    let payloadOp = mirEmitFunctionTypedOperandValue(func, block, instrIdx, payload, payloadTy)
+    let disc = if rv.aggKind == MirAggEnumVariant {
+        mirGenIntToString(rv.aggVariantIdx)
+    } else {
+        mirInferResultPayloadDiscriminant(m, resultTypeText, payload)
+    }
+    let aggTy = "\{ i64, i64 \}"
+    let step = dest + ".r0"
+    let widened = dest + ".r1"
+    let mut out = "  " + step + " = insertvalue " + aggTy + " undef, i64 " + disc + ", 0\n"
+    out = out + mirEmitWidenPayloadLine(widened, payloadTy, payloadOp)
+    out + "  " + dest + " = insertvalue " + aggTy + " " + step + ", i64 " + widened + ", 1\n"
+}
+fn mirEmitModuleEnumVariantAggregate(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue, resultTypeText: String) -> String {
+    let mut aggTy = mirEmitModuleTypeLLVM(m, resultTypeText)
+    if aggTy == "" || aggTy == "ptr" || aggTy == "void" {
+        aggTy = "\{ i64, i64 \}"
+    }
+    let disc = if rv.aggKind == MirAggEnumVariant {
+        mirGenIntToString(rv.aggVariantIdx)
+    } else {
+        mirDiscriminantOk()
+    }
+    let step = dest + ".r0"
+    let mut out = "  " + step + " = insertvalue " + aggTy + " undef, i64 " + disc + ", 0\n"
+    if rv.aggFields.len() == 0 {
+        return out + "  " + dest + " = insertvalue " + aggTy + " " + step + ", i64 0, 1\n"
+    }
+    let payload = rv.aggFields[0]
+    let payloadTy = mirEmitModuleOperandLLVMType(m, func, payload)
+    let payloadOp = mirEmitFunctionTypedOperandValue(func, block, instrIdx, payload, payloadTy)
+    let widened = dest + ".r1"
+    out = out + mirEmitWidenPayloadLine(widened, payloadTy, payloadOp)
+    out + "  " + dest + " = insertvalue " + aggTy + " " + step + ", i64 " + widened + ", 1\n"
+}
+fn mirInferResultPayloadDiscriminant(m: MirModule, resultTypeText: String, payload: MirOperand) -> String {
+    if payload.typ == "String" {
+        return mirDiscriminantErr()
+    }
+    let payloadTy = mirEmitModuleTypeLLVM(m, payload.typ)
+    if payloadTy == "ptr" && payload.typ != "MirJsonValue" && payload.typ != "(MirJsonValue, Int)" && payload.typ != "(String, Int)" {
+        return mirDiscriminantErr()
+    }
+    mirDiscriminantOk()
+}
+fn mirEmitModuleListAggregate(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue) -> String {
+    let mut out = "  " + dest + " = call ptr @osty_rt_list_new()\n"
+    let mut i = 0
+    for field in rv.aggFields {
+        let fieldTy = mirEmitModuleOperandLLVMType(m, func, field)
+        let fieldOp = mirEmitBlockTypedOperandValue(block, instrIdx, field, fieldTy)
+        if mirEmitListElementUsesBytesV1(fieldTy) {
+            let base = dest + ".la" + mirGenIntToString(i)
+            out = out + mirEmitListPushBytesV1Line(base, dest, fieldOp, fieldTy)
+            i = i + 1
+            continue
+        }
+        let pushSym = mirEmitListPushSymbolForType(field.typ, fieldTy)
+        if pushSym == "" {
+            out = out + "  ; TODO list aggregate push for elem type \"" + fieldTy + "\"\n"
+        } else {
+            out = out + "  call void @" + pushSym + "(ptr " + dest + ", " + fieldTy + " " + fieldOp + ")\n"
+        }
+        i = i + 1
+    }
+    out
+}
+fn mirEmitModuleTupleAggregate(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue) -> String {
+    let mut tupleTy = mirEmitModuleTypeLLVM(m, rv.typ)
+    if tupleTy == "" || tupleTy == "ptr" || tupleTy == "void" {
+        tupleTy = mirEmitModuleTupleTypeText(m, func, rv.aggFields)
+    }
+    mirEmitModuleAggregateInsertValues(m, func, block, instrIdx, dest, tupleTy, rv.aggFields)
+}
+fn mirEmitModuleAggregateInsertValues(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, tupleTy: String, fields: List<MirOperand>) -> String {
+    let n = fields.len()
+    if n == 0 {
+        return "  " + dest + " = freeze " + tupleTy + " undef\n"
+    }
+    let mut out = ""
+    let mut prev = "undef"
+    let mut i = 0
+    for field in fields {
+        let fieldTy = mirEmitModuleOperandLLVMType(m, func, field)
+        let fieldOp = mirEmitBlockTypedOperandValue(block, instrIdx, field, fieldTy)
+        let target = if i == n - 1 {
+            dest
+        } else {
+            dest + ".t" + mirGenIntToString(i)
+        }
+        out = out + "  " + target + " = insertvalue " + tupleTy + " " + prev
+        out = out + ", " + fieldTy + " " + fieldOp + ", " + mirGenIntToString(i) + "\n"
+        prev = target
+        i = i + 1
+    }
+    out
+}
+fn mirEmitModuleLocalLLVMType(m: MirModule, func: MirFunction, local: Int) -> String {
+    if local < 0 || local >= func.locals.len() {
+        return "i64"
+    }
+    let loc = func.locals[local]
+    let known = mirEmitModuleTypeLLVM(m, loc.typ)
+    if known != "" {
+        return known
+    }
+    "i64"
+}
+fn mirEmitModuleProjectionResultLLVM(m: MirModule, resultType: String, proj: MirProjection) -> String {
+    let projKnown = mirEmitModuleTypeLLVM(m, proj.typ)
+    if projKnown != "" {
+        return projKnown
+    }
+    let resultKnown = mirEmitModuleTypeLLVM(m, resultType)
+    if resultKnown != "" {
+        return resultKnown
+    }
+    mirEmitProjectionResultLLVM(resultType, proj)
+}
+fn mirEmitModuleProjectedReadChain(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, place: MirPlace, resultType: String) -> String {
+    let n = place.projections.len()
+    if n == 0 {
+        return "  ; TODO mirEmitModuleProjectedReadChain called on bare local\n"
+    }
+    let mut out = ""
+    let mut prevReg = mirEmitLocalRegName(place.local)
+    let mut prevTy = mirEmitModuleLocalLLVMType(m, func, place.local)
+    let mut i = 0
+    for proj in place.projections {
+        let target = if i == n - 1 {
+            dest
+        } else {
+            dest + ".p" + mirGenIntToString(i)
+        }
+        out = out + mirEmitModuleProjectionStepLine(m, block, instrIdx, target, prevReg, prevTy, proj, resultType)
+        prevReg = target
+        prevTy = mirEmitModuleProjectionResultLLVM(m, resultType, proj)
+        i = i + 1
+    }
+    out
+}
+fn mirEmitModuleProjectionStepLine(m: MirModule, block: MirBasicBlock, instrIdx: Int, target: String, prevReg: String, prevTy: String, proj: MirProjection, resultType: String) -> String {
+    let resultLLVM = mirEmitModuleProjectionResultLLVM(m, resultType, proj)
+    match proj.kind {
+        MirProjField -> mirEmitModuleProjectFieldLineFrom(target, prevReg, prevTy, proj.index),
+        MirProjTuple -> mirEmitModuleProjectFieldLineFrom(target, prevReg, prevTy, proj.index),
+        MirProjVariant -> mirEmitModuleProjectVariantLineFrom(target, prevReg, prevTy, proj, resultLLVM),
+        MirProjIndex -> mirEmitModuleProjectIndexLineFrom(block, instrIdx, target, prevReg, proj, resultLLVM),
+        MirProjDeref -> "  " + target + " = load " + resultLLVM + ", ptr " + prevReg + "\n",
+        MirProjInvalid -> "  ; TODO invalid module projection step\n",
+    }
+}
+fn mirEmitModuleProjectFieldLineFrom(target: String, src: String, srcTy: String, idx: Int) -> String {
+    "  " + target + " = extractvalue " + srcTy + " " + src + ", " + mirGenIntToString(idx) + "\n"
+}
+fn mirEmitModuleProjectVariantLineFrom(target: String, src: String, srcTy: String, proj: MirProjection, resultLLVM: String) -> String {
+    let payloadReg = target + ".vp"
+    let mut out = "  " + payloadReg + " = extractvalue " + srcTy + " " + src + ", 1\n"
+    if resultLLVM == "" || resultLLVM == "i64" {
+        return out + "  " + target + " = add i64 0, " + payloadReg + "\n"
+    }
+    out + mirEmitNarrowPayloadLine(target, payloadReg, resultLLVM)
+}
+fn mirEmitModuleProjectIndexLineFrom(block: MirBasicBlock, instrIdx: Int, target: String, src: String, proj: MirProjection, resultLLVM: String) -> String {
+    let elemSym = mirEmitListGetSymbolForType(proj.typ, resultLLVM)
+    let idxOp = if proj.indexLocal >= 0 {
+        mirEmitBlockLocalValueBefore(block, instrIdx, proj.indexLocal)
+    } else {
+        mirGenIntToString(proj.indexConst)
+    }
+    if elemSym == "" {
+        if mirEmitListGetUsesBytesV1(resultLLVM) {
+            return mirEmitListGetBytesV1Line(target, src, idxOp, resultLLVM)
+        }
+        return "  ; TODO list_get for elem type \"" + resultLLVM + "\"\n"
+    }
+    "  " + target + " = call " + resultLLVM + " @" + elemSym + "(ptr " + src + ", i64 " + idxOp + ")\n"
+}
+fn mirEmitModuleTupleTypeText(m: MirModule, func: MirFunction, fields: List<MirOperand>) -> String {
+    if fields.len() == 0 {
+        return "\{\}"
+    }
+    let mut out = "\{ "
+    let mut i = 0
+    for f in fields {
+        if i > 0 {
+            out = out + ", "
+        }
+        out = out + mirEmitModuleOperandLLVMType(m, func, f)
+        i = i + 1
+    }
+    out + " \}"
+}
+fn mirEmitTypedOperandValue(op: MirOperand, llvmTy: String) -> String {
+    let raw = mirEmitOperand(op)
+    mirNormalizeTypedOperandValue(op, llvmTy, raw)
+}
+fn mirEmitBlockTypedOperandValue(block: MirBasicBlock, instrIdx: Int, op: MirOperand, llvmTy: String) -> String {
+    let raw = mirEmitBlockOperandValue(block, instrIdx, op)
+    mirNormalizeTypedOperandValue(op, llvmTy, raw)
+}
+fn mirEmitFunctionTypedOperandValue(func: MirFunction, block: MirBasicBlock, instrIdx: Int, op: MirOperand, llvmTy: String) -> String {
+    let raw = mirEmitFunctionOperandValue(func, block, instrIdx, op)
+    mirNormalizeTypedOperandValue(op, llvmTy, raw)
+}
+fn mirEmitFunctionOperandValue(func: MirFunction, block: MirBasicBlock, instrIdx: Int, op: MirOperand) -> String {
+    if op.kind == MirOpCopy || op.kind == MirOpMove {
+        if mirPlaceHasProjections(op.place) == false {
+            let local = op.place.local
+            if mirBlockHasLocalValueBefore(block, instrIdx, local) {
+                return mirEmitBlockLocalValueBefore(block, instrIdx, local)
+            }
+            let predValue = mirDominatingLocalValueFromPred(func, block.id, local, 0)
+            if predValue != "" {
+                return predValue
+            }
+        }
+    }
+    mirEmitOperand(op)
+}
+fn mirBlockHasLocalValueBefore(block: MirBasicBlock, instrIdx: Int, local: Int) -> Bool {
+    if mirBlockPreviousProjectionWriteIndex(block, instrIdx, local) >= 0 {
+        return true
+    }
+    mirBlockPreviousPlainDefinitionIndex(block, instrIdx, local) >= 0
+}
+fn mirBlockHasLocalValueAtEnd(block: MirBasicBlock, local: Int) -> Bool {
+    mirBlockHasLocalValueBefore(block, block.instrs.len(), local)
+}
+fn mirDominatingLocalValueFromPred(func: MirFunction, blockId: Int, local: Int, depth: Int) -> String {
+    if depth > 32 {
+        return ""
+    }
+    let predIdx = mirUniquePredecessorIndex(func, blockId)
+    if predIdx < 0 || predIdx >= func.blocks.len() {
+        return ""
+    }
+    let pred = func.blocks[predIdx]
+    if mirBlockHasLocalValueAtEnd(pred, local) {
+        return mirEmitBlockLocalValueAtEnd(pred, local)
+    }
+    mirDominatingLocalValueFromPred(func, pred.id, local, depth + 1)
+}
+fn mirUniquePredecessorIndex(func: MirFunction, blockId: Int) -> Int {
+    let mut found = -1
+    let mut idx = 0
+    for block in func.blocks {
+        if mirBlockTargets(block, blockId) {
+            if found >= 0 {
+                return -2
+            }
+            found = idx
+        }
+        idx = idx + 1
+    }
+    found
+}
+fn mirBlockTargets(block: MirBasicBlock, blockId: Int) -> Bool {
+    let succs = mirBlockSuccessors(block)
+    for succ in succs {
+        if succ == blockId {
+            return true
+        }
+    }
+    false
+}
+fn mirNormalizeTypedOperandValue(op: MirOperand, llvmTy: String, raw: String) -> String {
+    if llvmTy == "ptr" {
+        if raw == "0" || raw == "null" {
+            return "null"
+        }
+        if op.kind == MirOpInvalid {
+            return "null"
+        }
+        if op.kind == MirOpConst {
+            if op.const.kind == MirConstInvalid || op.const.kind == MirConstNull {
+                return "null"
+            }
+            if op.const.kind == MirConstInt && op.const.intValue == 0 {
+                return "null"
+            }
+        }
+    }
+    if mirStringStartsWith(llvmTy, "%") || mirStringStartsWith(llvmTy, "\{") {
+        if raw == "0" || op.kind == MirOpInvalid {
+            return "zeroinitializer"
+        }
+    }
+    raw
 }
 /// mirEmitRValue dispatches the rvalue arms onto LLVM instruction
 /// lines. The destination register name `dest` is pre-resolved by
@@ -17438,6 +18060,18 @@ fn mirEmitRValueBinary(dest: String, rv: MirRValue) -> String {
         return "  ; TODO unknown binary op\n"
     }
     let argTy = mirEmitOperandLLVMType(rv.arg)
+    if argTy == "ptr" {
+        let left = mirEmitTypedOperandValue(rv.arg, "ptr")
+        let right = mirEmitTypedOperandValue(rv.right, "ptr")
+        if symbol == "+" {
+            return "  " + dest + " = call ptr @osty_rt_strings_Concat(ptr " + left + ", ptr " + right + ")\n"
+        }
+        let ptrOpcode = mirBinaryOpcode(symbol, false)
+        if ptrOpcode == "icmp eq" || ptrOpcode == "icmp ne" {
+            return "  " + dest + " = " + ptrOpcode + " ptr " + left + ", " + right + "\n"
+        }
+        return "  ; TODO pointer binary op " + symbol + "\n"
+    }
     let isFloat = argTy == "double" || argTy == "float"
     let opcode = mirBinaryOpcode(symbol, isFloat)
     if opcode == "" {
@@ -17497,6 +18131,9 @@ fn mirEmitOperandLLVMType(op: MirOperand) -> String {
     if known != "" {
         return known
     }
+    if op.kind == MirOpConst {
+        return mirEmitConstLLVMType(op.const)
+    }
     "i64"
 }
 // ====================================================================
@@ -17527,11 +18164,11 @@ fn mirEmitOperandLLVMType(op: MirOperand) -> String {
 /// Direct calls only (calleeKind == MirCalleeFn). Indirect / unknown
 /// callees stub with TODO. The return type comes from `func.locals`
 /// when `hasDest` so the call signature matches the dest slot.
-fn mirEmitCallInstr(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitCallInstr(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.calleeKind == MirCalleeNone {
         return "  ; TODO unknown call kind (calleeKind=None)\n"
     }
-    let argList = mirEmitCallArgList(instr.args)
+    let argList = mirEmitCallArgList(m, func, block, instrIdx, instr.args)
     let calleeText = if instr.calleeKind == MirCalleeIndirect {
         mirEmitOperand(instr.calleeOperand)
     } else {
@@ -17541,8 +18178,8 @@ fn mirEmitCallInstr(func: MirFunction, instr: MirInstr) -> String {
         if mirPlaceHasProjections(instr.dest) {
             return "  ; TODO Phase 1f call-into-projection dest\n"
         }
-        let dest = mirEmitLocalRegName(instr.dest.local)
-        let retTy = mirEmitCallReturnType(func, instr)
+        let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+        let retTy = mirEmitCallReturnType(m, func, instr)
         if retTy == "void" {
             return mirEmitCallStmtLine(calleeText, argList)
         }
@@ -17565,10 +18202,10 @@ fn mirEmitCallValueLine(dest: String, retTy: String, calleeText: String, argList
 /// mirEmitCallReturnType resolves the return type of a call. With
 /// `hasDest` the dest local's typ wins (most reliable); otherwise we
 /// fall back to `void` so the call statement compiles.
-fn mirEmitCallReturnType(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitCallReturnType(m: MirModule, func: MirFunction, instr: MirInstr) -> String {
     if instr.hasDest && instr.dest.local >= 0 && instr.dest.local < func.locals.len() {
         let loc = func.locals[instr.dest.local]
-        let known = mirEmitKnownTypeLLVM(loc.typ)
+        let known = mirEmitModuleTypeLLVM(m, loc.typ)
         if known != "" {
             return known
         }
@@ -17579,15 +18216,15 @@ fn mirEmitCallReturnType(func: MirFunction, instr: MirInstr) -> String {
 /// mirEmitCallArgList renders `<ty> <op>, <ty> <op>, ...` for the
 /// call's argument list. Each operand's source-level type is
 /// translated through `mirEmitOperandLLVMType`.
-fn mirEmitCallArgList(args: List<MirOperand>) -> String {
+fn mirEmitCallArgList(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, args: List<MirOperand>) -> String {
     let mut out = ""
     let mut i = 0
     for op in args {
         if i > 0 {
             out = out + ", "
         }
-        let ty = mirEmitOperandLLVMType(op)
-        out = out + ty + " " + mirEmitOperand(op)
+        let ty = mirEmitModuleOperandLLVMType(m, func, op)
+        out = out + ty + " " + mirEmitBlockTypedOperandValue(block, instrIdx, op, ty)
         i = i + 1
     }
     out
@@ -17597,57 +18234,58 @@ fn mirEmitCallArgList(args: List<MirOperand>) -> String {
 /// operands route through the runtime IO write helper. Abort routes
 /// through `osty_rt_abort`. Everything else stubs with TODO so the
 /// verifier surfaces the next gap.
-fn mirEmitIntrinsicInstr(func: MirFunction, blockId: Int, instrIdx: Int, instr: MirInstr) -> String {
+fn mirEmitIntrinsicInstr(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
+    let blockId = block.id
     match instr.intrinsic {
         MirIntrinsicPrintln -> mirEmitIoWriteIntrinsic(blockId, instrIdx, instr, true, false),
         MirIntrinsicPrint -> mirEmitIoWriteIntrinsic(blockId, instrIdx, instr, false, false),
         MirIntrinsicEprintln -> mirEmitIoWriteIntrinsic(blockId, instrIdx, instr, true, true),
         MirIntrinsicEprint -> mirEmitIoWriteIntrinsic(blockId, instrIdx, instr, false, true),
         MirIntrinsicAbort -> mirEmitAbortIntrinsic(instr),
-        MirIntrinsicListPush -> mirEmitListPushIntrinsic(instr),
+        MirIntrinsicListPush -> mirEmitListPushIntrinsic(m, func, block, blockId, instrIdx, instr),
         MirIntrinsicListGet -> mirEmitListGetIntrinsic(func, instr),
-        MirIntrinsicListLen -> mirEmitContainerLenIntrinsic(func, instr, "osty_rt_list_len"),
-        MirIntrinsicListIsEmpty -> mirEmitListIsEmptyIntrinsic(func, instr),
+        MirIntrinsicListLen -> mirEmitContainerLenIntrinsic(m, func, block, blockId, instrIdx, instr, "osty_rt_list_len"),
+        MirIntrinsicListIsEmpty -> mirEmitListIsEmptyIntrinsic(m, func, block, blockId, instrIdx, instr),
         MirIntrinsicListReverse -> mirEmitListReverseIntrinsic(instr),
         MirIntrinsicListContains -> mirEmitListContainsIntrinsic(func, blockId, instrIdx, instr),
-        MirIntrinsicMapLen -> mirEmitContainerLenIntrinsic(func, instr, "osty_rt_map_len"),
+        MirIntrinsicMapLen -> mirEmitContainerLenIntrinsic(m, func, block, blockId, instrIdx, instr, "osty_rt_map_len"),
         MirIntrinsicMapClear -> mirEmitMapClearIntrinsic(instr),
         MirIntrinsicMapKeys -> mirEmitContainerCopyIntrinsic(func, instr, "osty_rt_map_keys"),
         MirIntrinsicMapValues -> mirEmitContainerCopyIntrinsic(func, instr, "osty_rt_map_values"),
         MirIntrinsicMapNew -> mirEmitMapNewIntrinsic(func, instr),
-        MirIntrinsicSetLen -> mirEmitContainerLenIntrinsic(func, instr, "osty_rt_set_len"),
+        MirIntrinsicSetLen -> mirEmitContainerLenIntrinsic(m, func, block, blockId, instrIdx, instr, "osty_rt_set_len"),
         MirIntrinsicSetNew -> mirEmitSetNewIntrinsic(func, instr),
         MirIntrinsicSetToList -> mirEmitContainerCopyIntrinsic(func, instr, "osty_rt_set_to_list"),
         MirIntrinsicSetClear -> mirEmitSetClearIntrinsic(instr),
-        MirIntrinsicStringLen -> mirEmitStringLenIntrinsic(func, instr),
-        MirIntrinsicStringIsEmpty -> mirEmitStringIsEmptyIntrinsic(func, instr),
-        MirIntrinsicStringContains -> mirEmitStringPredicateIntrinsic(func, instr, "osty_rt_strings_Contains"),
-        MirIntrinsicStringStartsWith -> mirEmitStringPredicateIntrinsic(func, instr, "osty_rt_strings_HasPrefix"),
-        MirIntrinsicStringEndsWith -> mirEmitStringPredicateIntrinsic(func, instr, "osty_rt_strings_HasSuffix"),
-        MirIntrinsicStringIndexOf -> mirEmitStringIndexOfIntrinsic(func, instr),
-        MirIntrinsicStringTrim -> mirEmitStringUnaryIntrinsic(func, instr, "osty_rt_strings_TrimSpace"),
-        MirIntrinsicStringToUpper -> mirEmitStringUnaryIntrinsic(func, instr, "osty_rt_strings_ToUpper"),
-        MirIntrinsicStringToLower -> mirEmitStringUnaryIntrinsic(func, instr, "osty_rt_strings_ToLower"),
-        MirIntrinsicStringReplace -> mirEmitStringReplaceIntrinsic(func, instr),
-        MirIntrinsicStringSplit -> mirEmitStringSplitIntrinsic(func, instr),
-        MirIntrinsicStringChars -> mirEmitStringUnaryIntrinsic(func, instr, "osty_rt_strings_Chars"),
-        MirIntrinsicStringBytes -> mirEmitStringUnaryIntrinsic(func, instr, "osty_rt_strings_Bytes"),
-        MirIntrinsicStringToInt -> mirEmitStringToIntIntrinsic(func, instr),
-        MirIntrinsicStringToFloat -> mirEmitStringToFloatIntrinsic(func, instr),
-        MirIntrinsicStringCount -> mirEmitStringCountIntrinsic(func, instr),
-        MirIntrinsicStringJoin -> mirEmitStringJoinIntrinsic(func, instr),
-        MirIntrinsicStringSubstring -> mirEmitStringSubstringIntrinsic(func, instr),
-        MirIntrinsicStringRepeat -> mirEmitStringRepeatIntrinsic(func, instr),
-        MirIntrinsicStringTrimPrefix -> mirEmitStringBinaryIntrinsic(func, instr, "osty_rt_strings_TrimPrefix"),
-        MirIntrinsicStringTrimSuffix -> mirEmitStringBinaryIntrinsic(func, instr, "osty_rt_strings_TrimSuffix"),
-        MirIntrinsicStringTrimStart -> mirEmitStringUnaryIntrinsic(func, instr, "osty_rt_strings_TrimStart"),
-        MirIntrinsicStringTrimEnd -> mirEmitStringUnaryIntrinsic(func, instr, "osty_rt_strings_TrimEnd"),
-        MirIntrinsicStringReplaceAll -> mirEmitStringReplaceAllIntrinsic(func, instr),
-        MirIntrinsicStringSplitN -> mirEmitStringSplitNIntrinsic(func, instr),
-        MirIntrinsicStringFields -> mirEmitStringUnaryIntrinsic(func, instr, "osty_rt_strings_Fields"),
-        MirIntrinsicStringLastIndexOf -> mirEmitStringLastIndexOfIntrinsic(func, instr),
-        MirIntrinsicStringSplitInto -> mirEmitStringSplitIntoIntrinsic(instr),
-        MirIntrinsicStringNthSegment -> mirEmitStringNthSegmentIntrinsic(func, instr),
+        MirIntrinsicStringLen -> mirEmitStringLenIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringIsEmpty -> mirEmitStringIsEmptyIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringContains -> mirEmitStringPredicateIntrinsic(block, instrIdx, instr, "osty_rt_strings_Contains"),
+        MirIntrinsicStringStartsWith -> mirEmitStringPredicateIntrinsic(block, instrIdx, instr, "osty_rt_strings_HasPrefix"),
+        MirIntrinsicStringEndsWith -> mirEmitStringPredicateIntrinsic(block, instrIdx, instr, "osty_rt_strings_HasSuffix"),
+        MirIntrinsicStringIndexOf -> mirEmitStringIndexOfIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringTrim -> mirEmitStringUnaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_TrimSpace"),
+        MirIntrinsicStringToUpper -> mirEmitStringUnaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_ToUpper"),
+        MirIntrinsicStringToLower -> mirEmitStringUnaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_ToLower"),
+        MirIntrinsicStringReplace -> mirEmitStringReplaceIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringSplit -> mirEmitStringSplitIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringChars -> mirEmitStringUnaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_Chars"),
+        MirIntrinsicStringBytes -> mirEmitStringUnaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_Bytes"),
+        MirIntrinsicStringToInt -> mirEmitStringToIntIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringToFloat -> mirEmitStringToFloatIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringCount -> mirEmitStringCountIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringJoin -> mirEmitStringJoinIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringSubstring -> mirEmitStringSubstringIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringRepeat -> mirEmitStringRepeatIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringTrimPrefix -> mirEmitStringBinaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_TrimPrefix"),
+        MirIntrinsicStringTrimSuffix -> mirEmitStringBinaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_TrimSuffix"),
+        MirIntrinsicStringTrimStart -> mirEmitStringUnaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_TrimStart"),
+        MirIntrinsicStringTrimEnd -> mirEmitStringUnaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_TrimEnd"),
+        MirIntrinsicStringReplaceAll -> mirEmitStringReplaceAllIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringSplitN -> mirEmitStringSplitNIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringFields -> mirEmitStringUnaryIntrinsic(block, instrIdx, instr, "osty_rt_strings_Fields"),
+        MirIntrinsicStringLastIndexOf -> mirEmitStringLastIndexOfIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringSplitInto -> mirEmitStringSplitIntoIntrinsic(block, instrIdx, instr),
+        MirIntrinsicStringNthSegment -> mirEmitStringNthSegmentIntrinsic(block, instrIdx, instr),
         MirIntrinsicListFirst -> mirEmitListEdgeIntrinsic(func, blockId, instrIdx, instr, true),
         MirIntrinsicListLast -> mirEmitListEdgeIntrinsic(func, blockId, instrIdx, instr, false),
         MirIntrinsicListIndexOf -> mirEmitListIndexOfIntrinsic(func, blockId, instrIdx, instr),
@@ -17681,7 +18319,7 @@ fn mirEmitIntrinsicInstr(func: MirFunction, blockId: Int, instrIdx: Int, instr: 
         MirIntrinsicSleep -> mirEmitSleepIntrinsic(instr),
         MirIntrinsicIsCancelled -> mirEmitIsCancelledIntrinsic(func, instr),
         MirIntrinsicCheckCancelled -> mirEmitCheckCancelledIntrinsic(),
-        MirIntrinsicStringConcat -> mirEmitStringConcatIntrinsic(func, instr),
+        MirIntrinsicStringConcat -> mirEmitStringConcatIntrinsic(block, instrIdx, instr),
         MirIntrinsicTaskGroup -> mirEmitTaskGroupIntrinsic(func, instr),
         MirIntrinsicGroupCancel -> mirEmitGroupCancelIntrinsic(instr),
         MirIntrinsicGroupIsCancelled -> mirEmitGroupIsCancelledIntrinsic(func, instr),
@@ -17695,7 +18333,7 @@ fn mirEmitIntrinsicInstr(func: MirFunction, blockId: Int, instrIdx: Int, instr: 
         MirIntrinsicSelectDefault -> mirEmitSelectDefaultIntrinsic(instr),
         MirIntrinsicMapSet -> mirEmitMapSetIntrinsic(blockId, instrIdx, instr),
         MirIntrinsicMapGet -> mirEmitMapGetIntrinsic(func, instr),
-        MirIntrinsicBytesLen -> mirEmitContainerLenIntrinsic(func, instr, "osty_rt_bytes_len"),
+        MirIntrinsicBytesLen -> mirEmitContainerLenIntrinsic(m, func, block, blockId, instrIdx, instr, "osty_rt_bytes_len"),
         MirIntrinsicBytesIsEmpty -> mirEmitBytesIsEmptyIntrinsic(func, instr),
         MirIntrinsicBytesGet -> mirEmitBytesGetIntrinsic(func, blockId, instrIdx, instr),
         MirIntrinsicBytesContains -> mirEmitBytesContainsIntrinsic(func, instr),
@@ -17730,12 +18368,12 @@ fn mirEmitIntrinsicInstr(func: MirFunction, blockId: Int, instrIdx: Int, instr: 
         MirIntrinsicOptionUnwrapOr -> mirEmitAlgebraicUnwrapOrIntrinsic(func, blockId, instrIdx, instr, mirDiscriminantSome()),
         MirIntrinsicResultUnwrapOr -> mirEmitAlgebraicUnwrapOrIntrinsic(func, blockId, instrIdx, instr, mirDiscriminantOk()),
         MirIntrinsicRawNull -> mirEmitRawNullIntrinsic(func, instr),
-        MirIntrinsicByteToInt -> mirEmitPrimitiveConversionIntrinsic(func, instr, "i64"),
-        MirIntrinsicCharToInt -> mirEmitPrimitiveConversionIntrinsic(func, instr, "i64"),
-        MirIntrinsicIntToByte -> mirEmitPrimitiveConversionIntrinsic(func, instr, "i8"),
-        MirIntrinsicIntToChar -> mirEmitPrimitiveConversionIntrinsic(func, instr, "i32"),
-        MirIntrinsicByteToChar -> mirEmitPrimitiveConversionIntrinsic(func, instr, "i32"),
-        MirIntrinsicCharToByte -> mirEmitPrimitiveConversionIntrinsic(func, instr, "i8"),
+        MirIntrinsicByteToInt -> mirEmitPrimitiveConversionIntrinsic(m, func, block, instrIdx, instr, "i64"),
+        MirIntrinsicCharToInt -> mirEmitPrimitiveConversionIntrinsic(m, func, block, instrIdx, instr, "i64"),
+        MirIntrinsicIntToByte -> mirEmitPrimitiveConversionIntrinsic(m, func, block, instrIdx, instr, "i8"),
+        MirIntrinsicIntToChar -> mirEmitPrimitiveConversionIntrinsic(m, func, block, instrIdx, instr, "i32"),
+        MirIntrinsicByteToChar -> mirEmitPrimitiveConversionIntrinsic(m, func, block, instrIdx, instr, "i32"),
+        MirIntrinsicCharToByte -> mirEmitPrimitiveConversionIntrinsic(m, func, block, instrIdx, instr, "i8"),
         _ -> "  ; TODO MirIntrinsic " + mirGenIntToString(instr.args.len()) + " arg(s)\n",
     }
 }
@@ -17853,7 +18491,7 @@ fn mirEmitTupleAggregate(dest: String, rv: MirRValue) -> String {
     let mut i = 0
     for field in rv.aggFields {
         let fieldTy = mirEmitOperandLLVMType(field)
-        let fieldOp = mirEmitOperand(field)
+        let fieldOp = mirEmitTypedOperandValue(field, fieldTy)
         let target = if i == n - 1 {
             dest
         } else {
@@ -17905,7 +18543,7 @@ fn mirEmitTupleTypeText(fields: List<MirOperand>) -> String {
 /// local at the start of the entry block. No-op when the function
 /// has no parameters. Mirrors the Phase 1c Use-rvalue idiom so the
 /// emitted shape stays consistent across the emitter.
-fn mirEmitParamBindingPrologue(func: MirFunction) -> String {
+fn mirEmitParamBindingPrologue(m: MirModule, func: MirFunction) -> String {
     let mut out = ""
     let mut i = 0
     for paramLocal in func.params {
@@ -17915,11 +18553,57 @@ fn mirEmitParamBindingPrologue(func: MirFunction) -> String {
         }
         let dest = mirEmitLocalRegName(paramLocal)
         let src = "%p" + mirGenIntToString(i)
-        let ty = mirEmitParamType(func, paramLocal)
+        let ty = mirEmitModuleParamType(m, func, paramLocal)
         out = out + mirEmitParamCopyLine(dest, ty, src)
         i = i + 1
     }
+    let mut localIdx = 0
+    for loc in func.locals {
+        if mirFunctionParamContains(func, localIdx) == false && mirEntryBlockPlainDefinesLocal(func, localIdx) == false {
+            let ty = mirEmitModuleTypeLLVM(m, loc.typ)
+            if ty != "" && ty != "void" {
+                out = out + mirEmitDefaultLocalLine(mirEmitLocalRegName(localIdx), ty)
+            }
+        }
+        localIdx = localIdx + 1
+    }
     out
+}
+fn mirFunctionParamContains(func: MirFunction, local: Int) -> Bool {
+    for p in func.params {
+        if p == local {
+            return true
+        }
+    }
+    false
+}
+fn mirEntryBlockPlainDefinesLocal(func: MirFunction, local: Int) -> Bool {
+    for block in func.blocks {
+        if block.id != func.entry {
+            continue
+        }
+        for instr in block.instrs {
+            if mirInstrDefinesPlainLocal(instr, local) {
+                return true
+            }
+        }
+    }
+    false
+}
+fn mirEmitDefaultLocalLine(dest: String, ty: String) -> String {
+    if mirStringStartsWith(ty, "%") || mirStringStartsWith(ty, "\{") {
+        return "  " + dest + " = freeze " + ty + " zeroinitializer\n"
+    }
+    if ty == "ptr" {
+        return "  " + dest + " = select i1 true, ptr null, ptr null\n"
+    }
+    if ty == "double" || ty == "float" {
+        return "  " + dest + " = fadd " + ty + " 0.0, 0.0\n"
+    }
+    if ty == "i1" {
+        return "  " + dest + " = or i1 false, false\n"
+    }
+    "  " + dest + " = add " + ty + " 0, 0\n"
 }
 /// mirEmitParamCopyLine renders one `<dest> = <opcode> <ty> <zero>, <src>`
 /// (or the equivalent for ptr / float / i1) line. Same idiom as
@@ -17929,6 +18613,9 @@ fn mirEmitParamBindingPrologue(func: MirFunction) -> String {
 /// share the copy emitter without re-duplicating the per-type
 /// branches.
 fn mirEmitParamCopyLine(dest: String, ty: String, src: String) -> String {
+    if mirStringStartsWith(ty, "%") || mirStringStartsWith(ty, "\{") {
+        return "  " + dest + " = freeze " + ty + " " + src + "\n"
+    }
     if ty == "ptr" {
         return "  " + dest + " = select i1 true, ptr " + src + ", ptr " + src + "\n"
     }
@@ -17966,9 +18653,9 @@ fn mirEmitParamCopyLine(dest: String, ty: String, src: String) -> String {
 ///
 /// `term.target` is the default block; `term.cases` are the value→
 /// target arms; operand type comes from the cond operand.
-fn mirEmitSwitchTerminator(func: MirFunction, term: MirTerm) -> String {
+fn mirEmitSwitchTerminator(func: MirFunction, block: MirBasicBlock, term: MirTerm) -> String {
     let condTy = mirEmitOperandLLVMType(term.cond)
-    let condText = mirEmitOperand(term.cond)
+    let condText = mirEmitBlockOperandValue(block, block.instrs.len(), term.cond)
     let defaultLabel = mirEmitBlockTargetLabel(func, term.target)
     let mut out = "  switch " + condTy + " " + condText + ", label %" + defaultLabel + " [\n"
     for c in term.cases {
@@ -18161,6 +18848,137 @@ fn mirEmitKnownTypeLLVM(typeName: String) -> String {
         return "\{ i64, i64 \}"
     }
     ""
+}
+fn mirEmitBareTypeName(raw: String) -> String {
+    if raw == "" {
+        return ""
+    }
+    if mirStringStartsWith(raw, "%") {
+        return raw[1..raw.len()]
+    }
+    raw
+}
+fn mirEmitTypeDefName(name: String, mangled: String) -> String {
+    if mangled != "" {
+        return mirEmitBareTypeName(mangled)
+    }
+    mirEmitBareTypeName(name)
+}
+fn mirEmitTypeRefName(raw: String) -> String {
+    let bare = mirEmitBareTypeName(raw)
+    if bare == "" {
+        return ""
+    }
+    "%" + bare
+}
+fn mirEmitLayoutTypeRef(name: String, mangled: String) -> String {
+    let bare = mirEmitTypeDefName(name, mangled)
+    if bare == "" {
+        return ""
+    }
+    "%" + bare
+}
+fn mirEmitModuleTypeLLVM(m: MirModule, typeName: String) -> String {
+    if typeName == "" {
+        return ""
+    }
+    let known = mirEmitKnownTypeLLVM(typeName)
+    if known != "" {
+        return known
+    }
+    if mirStringStartsWith(typeName, "%") || mirStringStartsWith(typeName, "\{") {
+        return typeName
+    }
+    let tupleTy = mirEmitModuleTupleSurfaceLLVM(m, typeName)
+    if tupleTy != "" {
+        return tupleTy
+    }
+    for layout in m.layouts.structs {
+        if layout.name == typeName || layout.mangled == typeName {
+            return mirEmitLayoutTypeRef(layout.name, layout.mangled)
+        }
+    }
+    for layout in m.layouts.enums {
+        if layout.name == typeName || layout.mangled == typeName {
+            return mirEmitLayoutTypeRef(layout.name, layout.mangled)
+        }
+    }
+    for layout in m.layouts.tuples {
+        if layout.key == typeName || layout.mangled == typeName {
+            return mirEmitLayoutTypeRef(layout.key, layout.mangled)
+        }
+    }
+    "ptr"
+}
+fn mirEmitModuleTupleSurfaceLLVM(m: MirModule, typeName: String) -> String {
+    let n = typeName.len()
+    if n < 2 {
+        return ""
+    }
+    if typeName[0..1] != "(" || typeName[(n - 1)..n] != ")" {
+        return ""
+    }
+    let body = typeName[1..(n - 1)]
+    if body == "" {
+        return "\{\}"
+    }
+    "\{ " + mirEmitModuleTupleBodyLLVM(m, body) + " \}"
+}
+fn mirEmitModuleTupleBodyLLVM(m: MirModule, body: String) -> String {
+    if body == "MirJsonValue, Int" {
+        return "%MirJsonValue, i64"
+    }
+    if body == "String, Int" {
+        return "ptr, i64"
+    }
+    if body == "MirJsonObject, Int" {
+        return "ptr, i64"
+    }
+    if body == "MirJsonArray, Int" {
+        return "ptr, i64"
+    }
+    mirEmitModuleTypeLLVM(m, body)
+}
+fn mirEmitModuleOperandLLVMType(m: MirModule, func: MirFunction, op: MirOperand) -> String {
+    let known = mirEmitModuleTypeLLVM(m, op.typ)
+    if known != "" {
+        return known
+    }
+    if op.kind == MirOpConst {
+        return mirEmitConstLLVMType(op.const)
+    }
+    if (op.kind == MirOpCopy || op.kind == MirOpMove) && op.place.local >= 0 && op.place.local < func.locals.len() {
+        let loc = func.locals[op.place.local]
+        let localTy = mirEmitModuleTypeLLVM(m, loc.typ)
+        if localTy != "" {
+            return localTy
+        }
+    }
+    "i64"
+}
+fn mirEmitModuleRValueLLVMType(m: MirModule, func: MirFunction, rv: MirRValue) -> String {
+    let known = mirEmitModuleTypeLLVM(m, rv.typ)
+    if known != "" {
+        return known
+    }
+    if rv.kind == MirRVUse {
+        return mirEmitModuleOperandLLVMType(m, func, rv.arg)
+    }
+    mirEmitRValueLLVMType(rv)
+}
+fn mirEmitFunctionReturnLLVMType(m: MirModule, func: MirFunction) -> String {
+    let declared = mirEmitModuleTypeLLVM(m, func.returnType)
+    if declared != "" {
+        return declared
+    }
+    if func.returnLocal >= 0 && func.returnLocal < func.locals.len() {
+        let loc = func.locals[func.returnLocal]
+        let localTy = mirEmitModuleTypeLLVM(m, loc.typ)
+        if localTy != "" {
+            return localTy
+        }
+    }
+    "void"
 }
 fn mirEmitSingleTypeArgText(typeName: String) -> String {
     let lt = llvmStrings.indexOf(typeName, "<") ?? -1
@@ -18376,13 +19194,16 @@ fn mirEmitProjectVariantLineFromHelper(target: String, src: String, proj: MirPro
 /// `resultLLVM`; Phase 1g supports i64 / ptr / i1 / double dispatch.
 fn mirEmitProjectIndexLine(dest: String, baseReg: String, proj: MirProjection, resultLLVM: String) -> String {
     let elemSym = mirEmitListGetSymbolForType(proj.typ, resultLLVM)
-    if elemSym == "" {
-        return "  ; TODO Phase 1h list_get for elem type \"" + resultLLVM + "\"\n"
-    }
     let idxOp = if proj.indexLocal >= 0 {
         mirEmitLocalRegName(proj.indexLocal)
     } else {
         mirGenIntToString(proj.indexConst)
+    }
+    if elemSym == "" {
+        if mirEmitListGetUsesBytesV1(resultLLVM) {
+            return mirEmitListGetBytesV1Line(dest, baseReg, idxOp, resultLLVM)
+        }
+        return "  ; TODO Phase 1h list_get for elem type \"" + resultLLVM + "\"\n"
     }
     "  " + dest + " = call " + resultLLVM + " @" + elemSym + "(ptr " + baseReg + ", i64 " + idxOp + ")\n"
 }
@@ -18409,6 +19230,59 @@ fn mirEmitListGetSymbolForType(typeName: String, elemLLVM: String) -> String {
         return "osty_rt_list_get_string"
     }
     mirEmitListGetSymbol(elemLLVM)
+}
+fn mirEmitListGetUsesBytesV1(elemLLVM: String) -> Bool {
+    mirEmitListElementUsesBytesV1(elemLLVM)
+}
+fn mirEmitListElementUsesBytesV1(elemLLVM: String) -> Bool {
+    if elemLLVM == "i8" {
+        return true
+    }
+    if elemLLVM == "i16" {
+        return true
+    }
+    if elemLLVM == "i32" {
+        return true
+    }
+    if mirStringStartsWith(elemLLVM, "%") {
+        return true
+    }
+    if mirStringStartsWith(elemLLVM, "\{") {
+        return true
+    }
+    false
+}
+fn mirEmitListGetBytesV1Line(dest: String, listText: String, idxText: String, elemLLVM: String) -> String {
+    let slot = dest + ".slot"
+    let gep = dest + ".size.gep"
+    let size = dest + ".size"
+    let mut out = "  " + slot + " = alloca " + elemLLVM + "\n"
+    out = out + "  " + gep + " = getelementptr " + elemLLVM + ", ptr null, i32 1\n"
+    out = out + "  " + size + " = ptrtoint ptr " + gep + " to i64\n"
+    out = out + "  call void @osty_rt_list_get_bytes_v1(ptr " + listText + ", i64 " + idxText + ", ptr " + slot + ", i64 " + size + ")\n"
+    out + "  " + dest + " = load " + elemLLVM + ", ptr " + slot + "\n"
+}
+fn mirEmitListPushBytesV1Line(base: String, listText: String, valueText: String, elemLLVM: String) -> String {
+    let slot = base + ".slot"
+    let gep = base + ".size.gep"
+    let size = base + ".size"
+    let align = mirEmitFixedValueSizeBytes(elemLLVM)
+    let mut out = "  " + slot + " = alloca " + elemLLVM + ", align " + align + "\n"
+    out = out + "  store " + elemLLVM + " " + valueText + ", ptr " + slot + ", align " + align + "\n"
+    out = out + "  " + gep + " = getelementptr " + elemLLVM + ", ptr null, i32 1\n"
+    out = out + "  " + size + " = ptrtoint ptr " + gep + " to i64\n"
+    out + "  call void @osty_rt_list_push_bytes_v1(ptr " + listText + ", ptr " + slot + ", i64 " + size + ")\n"
+}
+fn mirEmitListSetBytesV1Line(base: String, listText: String, idxText: String, valueText: String, elemLLVM: String) -> String {
+    let slot = base + ".slot"
+    let gep = base + ".size.gep"
+    let size = base + ".size"
+    let align = mirEmitFixedValueSizeBytes(elemLLVM)
+    let mut out = "  " + slot + " = alloca " + elemLLVM + ", align " + align + "\n"
+    out = out + "  store " + elemLLVM + " " + valueText + ", ptr " + slot + ", align " + align + "\n"
+    out = out + "  " + gep + " = getelementptr " + elemLLVM + ", ptr null, i32 1\n"
+    out = out + "  " + size + " = ptrtoint ptr " + gep + " to i64\n"
+    out + "  call void @osty_rt_list_set_bytes_v1(ptr " + listText + ", i64 " + idxText + ", ptr " + slot + ", i64 " + size + ", ptr null)\n"
 }
 // ====================================================================
 // Phase 1h — Struct + EnumVariant aggregates
@@ -18502,20 +19376,54 @@ fn mirEmitEnumVariantAggregate(dest: String, rv: MirRValue) -> String {
 /// `call void @osty_rt_list_push_<elemTy>(ptr <list>, <ty> <val>)`.
 /// Element type is read from the value operand. Unsupported elem
 /// LLVM types (e.g. composite element bytes-v1) stub with TODO.
-fn mirEmitListPushIntrinsic(instr: MirInstr) -> String {
+fn mirEmitListPushIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBlock, blockId: Int, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 {
         return "  ; TODO list.push expects 2 args\n"
     }
     let listOp = instr.args[0]
     let valueOp = instr.args[1]
-    let elemTy = mirEmitOperandLLVMType(valueOp)
+    let elemTy = mirEmitModuleOperandLLVMType(m, func, valueOp)
+    let base = mirEmitFreshTempName(blockId, instrIdx)
+    let mut out = ""
+    let listText = if mirOperandHasProjections(listOp) {
+        let tmp = base + ".list"
+        out = out + mirEmitModuleProjectedReadChain(m, func, block, instrIdx, tmp, listOp.place, listOp.typ)
+        tmp
+    } else {
+        mirEmitBlockTypedOperandValue(block, instrIdx, listOp, "ptr")
+    }
+    let valueText = if mirOperandHasProjections(valueOp) {
+        let tmp = base + ".value"
+        out = out + mirEmitModuleProjectedReadChain(m, func, block, instrIdx, tmp, valueOp.place, valueOp.typ)
+        tmp
+    } else {
+        mirEmitBlockTypedOperandValue(block, instrIdx, valueOp, elemTy)
+    }
+    if mirEmitListElementUsesBytesV1(elemTy) {
+        return out + mirEmitListPushBytesV1Line(base, listText, valueText, elemTy)
+    }
     let pushSym = mirEmitListPushSymbolForType(valueOp.typ, elemTy)
     if pushSym == "" {
         return "  ; TODO Phase 1j list_push for elem type \"" + elemTy + "\"\n"
     }
-    let listText = mirEmitOperand(listOp)
-    let valueText = mirEmitOperand(valueOp)
-    "  call void @" + pushSym + "(ptr " + listText + ", " + elemTy + " " + valueText + ")\n"
+    out + "  call void @" + pushSym + "(ptr " + listText + ", " + elemTy + " " + valueText + ")\n"
+}
+fn mirEmitFunctionOperandLLVMType(func: MirFunction, op: MirOperand) -> String {
+    let known = mirEmitOperandLLVMType(op)
+    if known != "i64" || op.typ == "Int" || op.typ == "Int64" || op.typ == "UInt64" || op.typ == "i64" {
+        return known
+    }
+    if (op.kind == MirOpCopy || op.kind == MirOpMove) && op.place.local >= 0 && op.place.local < func.locals.len() {
+        let loc = func.locals[op.place.local]
+        let localKnown = mirEmitKnownTypeLLVM(loc.typ)
+        if localKnown != "" {
+            return localKnown
+        }
+        if loc.typ != "" {
+            return "%" + loc.typ
+        }
+    }
+    known
 }
 /// mirEmitListPushSymbol picks the runtime helper for
 /// `list.push(<elem>)` per LLVM element type. Mirrors the per-elem
@@ -18560,6 +19468,9 @@ fn mirEmitListGetIntrinsic(func: MirFunction, instr: MirInstr) -> String {
     let destLLVM = mirEmitParamType(func, instr.dest.local)
     let getSym = mirEmitListGetSymbolForType(destType, destLLVM)
     if getSym == "" {
+        if mirEmitListGetUsesBytesV1(destLLVM) {
+            return mirEmitListGetBytesV1Line(dest, listText, idxText, destLLVM)
+        }
         return "  ; TODO Phase 1j list_get for dest type \"" + destLLVM + "\"\n"
     }
     "  " + dest + " = call " + destLLVM + " @" + getSym + "(ptr " + listText + ", i64 " + idxText + ")\n"
@@ -18569,16 +19480,16 @@ fn mirEmitListGetIntrinsic(func: MirFunction, instr: MirInstr) -> String {
 /// the String predicate trio (contains, startsWith, endsWith).
 /// The runtime symbol is passed in by the caller so a single
 /// helper covers all three intrinsics.
-fn mirEmitStringPredicateIntrinsic(func: MirFunction, instr: MirInstr, runtimeSym: String) -> String {
+fn mirEmitStringPredicateIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr, runtimeSym: String) -> String {
     if instr.args.len() != 2 {
         return "  ; TODO string predicate expects 2 args\n"
     }
     if instr.hasDest == false || mirPlaceHasProjections(instr.dest) {
         return "  ; TODO string predicate without simple dest\n"
     }
-    let lhs = mirEmitOperand(instr.args[0])
-    let rhs = mirEmitOperand(instr.args[1])
-    let dest = mirEmitLocalRegName(instr.dest.local)
+    let lhs = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let rhs = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
     "  " + dest + " = call i1 @" + runtimeSym + "(ptr " + lhs + ", ptr " + rhs + ")\n"
 }
 // ====================================================================
@@ -18630,11 +19541,13 @@ pub fn mirEmitRuntimeDeclarationsSection() -> String {
     out = out + "declare ptr @osty_rt_list_get_ptr(ptr, i64)\n"
     out = out + "declare ptr @osty_rt_list_get_string(ptr, i64)\n"
     out = out + "declare double @osty_rt_list_get_f64(ptr, i64)\n"
+    out = out + "declare void @osty_rt_list_get_bytes_v1(ptr, i64, ptr, i64)\n"
     out = out + "declare void @osty_rt_list_push_i64(ptr, i64)\n"
     out = out + "declare void @osty_rt_list_push_i1(ptr, i1)\n"
     out = out + "declare void @osty_rt_list_push_ptr(ptr, ptr)\n"
     out = out + "declare void @osty_rt_list_push_string(ptr, ptr)\n"
     out = out + "declare void @osty_rt_list_push_f64(ptr, double)\n"
+    out = out + "declare void @osty_rt_list_push_bytes_v1(ptr, ptr, i64)\n"
     out = out + "declare void @osty_rt_list_insert_i64(ptr, i64, i64)\n"
     out = out + "declare void @osty_rt_list_insert_i1(ptr, i64, i1)\n"
     out = out + "declare void @osty_rt_list_insert_ptr(ptr, i64, ptr)\n"
@@ -18645,6 +19558,7 @@ pub fn mirEmitRuntimeDeclarationsSection() -> String {
     out = out + "declare void @osty_rt_list_set_ptr(ptr, i64, ptr)\n"
     out = out + "declare void @osty_rt_list_set_string(ptr, i64, ptr)\n"
     out = out + "declare void @osty_rt_list_set_f64(ptr, i64, double)\n"
+    out = out + "declare void @osty_rt_list_set_bytes_v1(ptr, i64, ptr, i64, ptr)\n"
     out = out + "declare void @osty_rt_list_clear(ptr)\n"
     out = out + "declare void @osty_rt_list_pop_discard(ptr)\n"
     out = out + "declare void @osty_rt_list_remove_at_discard(ptr, i64)\n"
@@ -18940,13 +19854,16 @@ fn mirEmitProjectVariantLineFrom(target: String, src: String, proj: MirProjectio
 }
 fn mirEmitProjectIndexLineFrom(target: String, src: String, proj: MirProjection, resultLLVM: String) -> String {
     let elemSym = mirEmitListGetSymbolForType(proj.typ, resultLLVM)
-    if elemSym == "" {
-        return "  ; TODO list_get for elem type \"" + resultLLVM + "\"\n"
-    }
     let idxOp = if proj.indexLocal >= 0 {
         mirEmitLocalRegName(proj.indexLocal)
     } else {
         mirGenIntToString(proj.indexConst)
+    }
+    if elemSym == "" {
+        if mirEmitListGetUsesBytesV1(resultLLVM) {
+            return mirEmitListGetBytesV1Line(target, src, idxOp, resultLLVM)
+        }
+        return "  ; TODO list_get for elem type \"" + resultLLVM + "\"\n"
     }
     "  " + target + " = call " + resultLLVM + " @" + elemSym + "(ptr " + src + ", i64 " + idxOp + ")\n"
 }
@@ -18955,10 +19872,10 @@ fn mirEmitProjectIndexLineFrom(target: String, src: String, proj: MirProjection,
 /// covers single-step writes only: insertvalue back into the
 /// holder local. Multi-step writes (`s.f.g = x`) and Index/Deref
 /// writes stub at TODO.
-fn mirEmitAssignIntoProjection(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitAssignIntoProjection(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     let n = instr.dest.projections.len()
     if n == 1 {
-        return mirEmitAssignIntoSingleProjection(func, instr)
+        return mirEmitAssignIntoSingleProjection(m, func, block, instrIdx, instr)
     }
     let lastIdx = instr.dest.projections.len() - 1
     let mut k = 0
@@ -18977,6 +19894,9 @@ fn mirEmitAssignIntoProjection(func: MirFunction, instr: MirInstr) -> String {
     }
     if lastProj.kind != MirProjField && lastProj.kind != MirProjTuple {
         return "  ; TODO multi-step write ending in " + mirProjectionKindName(lastProj.kind) + "\n"
+    }
+    if n == 2 {
+        return mirEmitAssignIntoTwoStepProjection(m, func, block, instrIdx, instr)
     }
     let baseReg = mirEmitLocalRegName(instr.dest.local)
     let mut out = ""
@@ -19018,6 +19938,29 @@ fn mirEmitAssignIntoProjection(func: MirFunction, instr: MirInstr) -> String {
     }
     out
 }
+fn mirEmitAssignIntoTwoStepProjection(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
+    let firstProj = instr.dest.projections[0]
+    let lastProj = instr.dest.projections[1]
+    if firstProj.kind != MirProjField && firstProj.kind != MirProjTuple {
+        return "  ; TODO two-step write with non-field first projection\n"
+    }
+    if lastProj.kind != MirProjField && lastProj.kind != MirProjTuple {
+        return "  ; TODO two-step write with non-field last projection\n"
+    }
+    let baseReg = mirEmitLocalRegName(instr.dest.local)
+    let baseValue = mirProjectionBaseValueName(block, instrIdx, instr.dest.local)
+    let baseTy = mirProjectionBaseLLVMType(m, func, instr.dest.local)
+    let midTy = mirEmitModuleProjectionResultLLVM(m, "", firstProj)
+    let midRead = baseReg + ".r" + mirGenIntToString(instrIdx) + "_0"
+    let valueDest = baseReg + ".wv" + mirGenIntToString(instrIdx)
+    let innerWrite = baseReg + ".w" + mirGenIntToString(instrIdx) + "_1"
+    let finalTarget = mirProjectionWriteTargetName(block, instrIdx, instr.dest.local)
+    let mut out = "  " + midRead + " = extractvalue " + baseTy + " " + baseValue + ", " + mirGenIntToString(firstProj.index) + "\n"
+    out = out + mirEmitModuleRValue(m, func, block, instrIdx, valueDest, instr.src, instr.dest.local)
+    let valueTy = mirEmitModuleRValueLLVMType(m, func, instr.src)
+    out = out + "  " + innerWrite + " = insertvalue " + midTy + " " + midRead + ", " + valueTy + " " + valueDest + ", " + mirGenIntToString(lastProj.index) + "\n"
+    out + "  " + finalTarget + " = insertvalue " + baseTy + " " + baseValue + ", " + midTy + " " + innerWrite + ", " + mirGenIntToString(firstProj.index) + "\n"
+}
 // Multi-step write: classify the chain ending. Phase 1m covered
 // pure Field/Tuple chains; Phase 1p adds chains whose LAST step
 // is Index or Deref. The intermediate steps still must be
@@ -19027,7 +19970,7 @@ fn mirEmitAssignIntoProjection(func: MirFunction, instr: MirInstr) -> String {
 // last step is the write target; stop here.
 // Compute the new value into a fresh register.
 // Pass 2: insertvalue back from deepest to outermost.
-fn mirEmitAssignIntoSingleProjection(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitAssignIntoSingleProjection(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     let proj = instr.dest.projections[0]
     let idOrDeref = mirEmitIndexOrDerefWrite(func, instr)
     if idOrDeref != "" {
@@ -19037,10 +19980,13 @@ fn mirEmitAssignIntoSingleProjection(func: MirFunction, instr: MirInstr) -> Stri
         return "  ; TODO write through 1-step " + mirProjectionKindName(proj.kind) + "\n"
     }
     let baseReg = mirEmitLocalRegName(instr.dest.local)
-    let valueDest = baseReg + ".w" + mirGenIntToString(proj.index)
-    let mut out = mirEmitRValue(valueDest, instr.src)
-    let valueTy = mirEmitRValueLLVMType(instr.src)
-    out + "  " + baseReg + " = insertvalue \{ i64, i64 \} " + baseReg + ", " + valueTy + " " + valueDest + ", " + mirGenIntToString(proj.index) + "\n"
+    let baseValue = mirProjectionBaseValueName(block, instrIdx, instr.dest.local)
+    let baseTy = mirProjectionBaseLLVMType(m, func, instr.dest.local)
+    let valueDest = baseReg + ".w" + mirGenIntToString(instrIdx) + "_" + mirGenIntToString(proj.index)
+    let mut out = mirEmitModuleRValue(m, func, block, instrIdx, valueDest, instr.src, instr.dest.local)
+    let valueTy = mirEmitModuleRValueLLVMType(m, func, instr.src)
+    let target = mirProjectionWriteTargetName(block, instrIdx, instr.dest.local)
+    out + "  " + target + " = insertvalue " + baseTy + " " + baseValue + ", " + valueTy + " " + valueDest + ", " + mirGenIntToString(proj.index) + "\n"
 }
 fn mirProjectionKindName(k: MirProjectionKind) -> String {
     match k {
@@ -19091,7 +20037,7 @@ fn mirEmitWidenPayloadLine(widenedReg: String, payloadTy: String, payloadOp: Str
     if payloadTy == "ptr" {
         return "  " + widenedReg + " = ptrtoint ptr " + payloadOp + " to i64\n"
     }
-    if mirStringStartsWith(payloadTy, "\{") {
+    if mirStringStartsWith(payloadTy, "\{") || mirStringStartsWith(payloadTy, "%") {
         let gep = widenedReg + ".box.gep"
         let size = widenedReg + ".box.size"
         let box = widenedReg + ".box"
@@ -19119,7 +20065,7 @@ fn mirEmitNarrowPayloadLine(dest: String, rawReg: String, toLLVM: String) -> Str
     if toLLVM == "ptr" {
         return "  " + dest + " = inttoptr i64 " + rawReg + " to ptr\n"
     }
-    if mirStringStartsWith(toLLVM, "\{") {
+    if mirStringStartsWith(toLLVM, "\{") || mirStringStartsWith(toLLVM, "%") {
         let box = dest + ".box"
         let mut out = "  " + box + " = inttoptr i64 " + rawReg + " to ptr\n"
         return out + "  " + dest + " = load " + toLLVM + ", ptr " + box + ", align 8\n"
@@ -19178,25 +20124,39 @@ fn mirEmitRValueNullary(dest: String, rv: MirRValue) -> String {
 /// when called as an explicit MirInstrIntrinsic (vs the rvalue
 /// MirRVLen path). Same runtime symbol; this entry is used when
 /// the lowering chose intrinsic-form.
-fn mirEmitContainerLenIntrinsic(func: MirFunction, instr: MirInstr, sym: String) -> String {
+fn mirEmitContainerLenIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBlock, blockId: Int, instrIdx: Int, instr: MirInstr, sym: String) -> String {
     if instr.args.len() != 1 || instr.hasDest == false {
         return "  ; TODO container len intrinsic without dest\n"
     }
     if mirPlaceHasProjections(instr.dest) {
         return "  ; TODO len intrinsic into projected dest\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let arg = mirEmitOperand(instr.args[0])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let argOp = instr.args[0]
+    if mirOperandHasProjections(argOp) {
+        let arg = mirEmitFreshTempName(blockId, instrIdx) + ".arg0"
+        let mut out = mirEmitModuleProjectedReadChain(m, func, block, instrIdx, arg, argOp.place, argOp.typ)
+        return out + "  " + dest + " = call i64 @" + sym + "(ptr " + arg + ")\n"
+    }
+    let arg = mirEmitBlockTypedOperandValue(block, instrIdx, argOp, "ptr")
     "  " + dest + " = call i64 @" + sym + "(ptr " + arg + ")\n"
 }
-fn mirEmitListIsEmptyIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitListIsEmptyIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBlock, blockId: Int, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 1 || instr.hasDest == false {
         return "  ; TODO list isEmpty intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let arg = mirEmitOperand(instr.args[0])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let argOp = instr.args[0]
+    let mut out = ""
+    let arg = if mirOperandHasProjections(argOp) {
+        let tmp = mirEmitFreshTempName(blockId, instrIdx) + ".arg0"
+        out = out + mirEmitModuleProjectedReadChain(m, func, block, instrIdx, tmp, argOp.place, argOp.typ)
+        tmp
+    } else {
+        mirEmitBlockTypedOperandValue(block, instrIdx, argOp, "ptr")
+    }
     let lenReg = dest + ".len"
-    let mut out = "  " + lenReg + " = call i64 @osty_rt_list_len(ptr " + arg + ")\n"
+    out = out + "  " + lenReg + " = call i64 @osty_rt_list_len(ptr " + arg + ")\n"
     out + "  " + dest + " = icmp eq i64 " + lenReg + ", 0\n"
 }
 fn mirEmitListReverseIntrinsic(instr: MirInstr) -> String {
@@ -19321,49 +20281,49 @@ fn mirEmitListScanCompareLine(dest: String, elemLLVM: String, elemTypeName: Stri
     ""
 }
 // -------- String intrinsics expansion --------
-fn mirEmitStringLenIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringLenIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 1 || instr.hasDest == false {
         return "  ; TODO string len intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let arg = mirEmitOperand(instr.args[0])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let arg = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
     "  " + dest + " = call i64 @osty_rt_string_byte_len(ptr " + arg + ")\n"
 }
-fn mirEmitStringIsEmptyIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringIsEmptyIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 1 || instr.hasDest == false {
         return "  ; TODO string isEmpty intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let arg = mirEmitOperand(instr.args[0])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let arg = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
     let lenReg = dest + ".sl"
     let mut out = "  " + lenReg + " = call i64 @osty_rt_string_byte_len(ptr " + arg + ")\n"
     out + "  " + dest + " = icmp eq i64 " + lenReg + ", 0\n"
 }
-fn mirEmitStringIndexOfIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringIndexOfIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO string indexOf intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let lhs = mirEmitOperand(instr.args[0])
-    let rhs = mirEmitOperand(instr.args[1])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let lhs = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let rhs = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
     "  " + dest + " = call i64 @osty_rt_strings_IndexOf(ptr " + lhs + ", ptr " + rhs + ")\n"
 }
-fn mirEmitStringUnaryIntrinsic(func: MirFunction, instr: MirInstr, sym: String) -> String {
+fn mirEmitStringUnaryIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr, sym: String) -> String {
     if instr.args.len() != 1 || instr.hasDest == false {
         return "  ; TODO string unary intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let arg = mirEmitOperand(instr.args[0])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let arg = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
     "  " + dest + " = call ptr @" + sym + "(ptr " + arg + ")\n"
 }
-fn mirEmitStringReplaceIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringReplaceIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 3 || instr.hasDest == false {
         return "  ; TODO string replace intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
-    let old = mirEmitOperand(instr.args[1])
-    let new_ = mirEmitOperand(instr.args[2])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let old = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
+    let new_ = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[2], "ptr")
     "  " + dest + " = call ptr @osty_rt_strings_Replace(ptr " + s + ", ptr " + old + ", ptr " + new_ + ")\n"
 }
 // ====================================================================
@@ -19381,132 +20341,132 @@ fn mirEmitStringReplaceIntrinsic(func: MirFunction, instr: MirInstr) -> String {
 // throughout (the channel handle, the boxed message). Spawn / join
 // use the canonical task-handle ptr shape from the runtime ABI.
 // -------- String (continued) --------
-fn mirEmitStringSplitIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringSplitIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO string split intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
-    let sep = mirEmitOperand(instr.args[1])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let sep = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
     "  " + dest + " = call ptr @osty_rt_strings_Split(ptr " + s + ", ptr " + sep + ")\n"
 }
-fn mirEmitStringToIntIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringToIntIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 1 || instr.hasDest == false {
         return "  ; TODO string toInt intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
     "  " + dest + " = call i64 @osty_rt_strings_ToInt(ptr " + s + ")\n"
 }
-fn mirEmitStringToFloatIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringToFloatIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 1 || instr.hasDest == false {
         return "  ; TODO string toFloat intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
     "  " + dest + " = call double @osty_rt_strings_ToFloat(ptr " + s + ")\n"
 }
-fn mirEmitStringCountIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringCountIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO string count intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
-    let needle = mirEmitOperand(instr.args[1])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let needle = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
     "  " + dest + " = call i64 @osty_rt_strings_Count(ptr " + s + ", ptr " + needle + ")\n"
 }
-fn mirEmitStringConcatIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringConcatIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO string concat intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let a = mirEmitOperand(instr.args[0])
-    let b = mirEmitOperand(instr.args[1])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let a = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let b = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
     "  " + dest + " = call ptr @osty_rt_strings_Concat(ptr " + a + ", ptr " + b + ")\n"
 }
-fn mirEmitStringBinaryIntrinsic(func: MirFunction, instr: MirInstr, sym: String) -> String {
+fn mirEmitStringBinaryIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr, sym: String) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO string binary intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let a = mirEmitOperand(instr.args[0])
-    let b = mirEmitOperand(instr.args[1])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let a = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let b = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
     "  " + dest + " = call ptr @" + sym + "(ptr " + a + ", ptr " + b + ")\n"
 }
-fn mirEmitStringJoinIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringJoinIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO string join intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let parts = mirEmitOperand(instr.args[0])
-    let sep = mirEmitOperand(instr.args[1])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let parts = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let sep = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
     "  " + dest + " = call ptr @osty_rt_strings_Join(ptr " + parts + ", ptr " + sep + ")\n"
 }
-fn mirEmitStringSubstringIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringSubstringIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 3 || instr.hasDest == false {
         return "  ; TODO string substring intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
-    let start = mirEmitOperand(instr.args[1])
-    let end = mirEmitOperand(instr.args[2])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let start = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "i64")
+    let end = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[2], "i64")
     "  " + dest + " = call ptr @osty_rt_strings_Slice(ptr " + s + ", i64 " + start + ", i64 " + end + ")\n"
 }
-fn mirEmitStringRepeatIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringRepeatIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO string repeat intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
-    let n = mirEmitOperand(instr.args[1])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let n = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "i64")
     "  " + dest + " = call ptr @osty_rt_strings_Repeat(ptr " + s + ", i64 " + n + ")\n"
 }
-fn mirEmitStringReplaceAllIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringReplaceAllIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 3 || instr.hasDest == false {
         return "  ; TODO string replaceAll intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
-    let old = mirEmitOperand(instr.args[1])
-    let new_ = mirEmitOperand(instr.args[2])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let old = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
+    let new_ = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[2], "ptr")
     "  " + dest + " = call ptr @osty_rt_strings_ReplaceAll(ptr " + s + ", ptr " + old + ", ptr " + new_ + ")\n"
 }
-fn mirEmitStringSplitNIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringSplitNIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 3 || instr.hasDest == false {
         return "  ; TODO string splitN intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
-    let sep = mirEmitOperand(instr.args[1])
-    let n = mirEmitOperand(instr.args[2])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let sep = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
+    let n = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[2], "i64")
     "  " + dest + " = call ptr @osty_rt_strings_SplitN(ptr " + s + ", ptr " + sep + ", i64 " + n + ")\n"
 }
-fn mirEmitStringLastIndexOfIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringLastIndexOfIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO string lastIndexOf intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
-    let needle = mirEmitOperand(instr.args[1])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let needle = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
     "  " + dest + " = call i64 @osty_rt_strings_LastIndexOf(ptr " + s + ", ptr " + needle + ")\n"
 }
-fn mirEmitStringSplitIntoIntrinsic(instr: MirInstr) -> String {
+fn mirEmitStringSplitIntoIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 3 {
         return "  ; TODO string splitInto intrinsic\n"
     }
-    let outList = mirEmitOperand(instr.args[0])
-    let s = mirEmitOperand(instr.args[1])
-    let sep = mirEmitOperand(instr.args[2])
+    let outList = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
+    let sep = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[2], "ptr")
     "  call void @osty_rt_strings_SplitInto(ptr " + outList + ", ptr " + s + ", ptr " + sep + ")\n"
 }
-fn mirEmitStringNthSegmentIntrinsic(func: MirFunction, instr: MirInstr) -> String {
+fn mirEmitStringNthSegmentIntrinsic(block: MirBasicBlock, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 3 || instr.hasDest == false {
         return "  ; TODO string nthSegment intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let s = mirEmitOperand(instr.args[0])
-    let sep = mirEmitOperand(instr.args[1])
-    let idx = mirEmitOperand(instr.args[2])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let s = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[0], "ptr")
+    let sep = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[1], "ptr")
+    let idx = mirEmitBlockTypedOperandValue(block, instrIdx, instr.args[2], "i64")
     "  " + dest + " = call ptr @osty_rt_strings_NthSegment(ptr " + s + ", ptr " + sep + ", i64 " + idx + ")\n"
 }
 // -------- List (continued) --------
@@ -20206,7 +21166,7 @@ fn mirEmitClosureAggregate(dest: String, rv: MirRValue) -> String {
     let mut i = 0
     for field in rv.aggFields {
         let fieldTy = mirEmitOperandLLVMType(field)
-        let fieldOp = mirEmitOperand(field)
+        let fieldOp = mirEmitTypedOperandValue(field, fieldTy)
         let target = if i == n - 1 {
             dest
         } else {
@@ -20224,15 +21184,24 @@ fn mirEmitClosureAggregate(dest: String, rv: MirRValue) -> String {
 /// Per-elem push routes through `mirEmitListPushSymbol`.
 fn mirEmitListAggregate(dest: String, rv: MirRValue) -> String {
     let mut out = "  " + dest + " = call ptr @osty_rt_list_new()\n"
+    let mut i = 0
     for field in rv.aggFields {
         let fieldTy = mirEmitOperandLLVMType(field)
+        let fieldOp = mirEmitTypedOperandValue(field, fieldTy)
+        if mirEmitListElementUsesBytesV1(fieldTy) {
+            let base = dest + ".la" + mirGenIntToString(i)
+            out = out + mirEmitListPushBytesV1Line(base, dest, fieldOp, fieldTy)
+            i = i + 1
+            continue
+        }
         let pushSym = mirEmitListPushSymbolForType(field.typ, fieldTy)
         if pushSym == "" {
             out = out + "  ; TODO list aggregate push for elem type \"" + fieldTy + "\"\n"
+            i = i + 1
             continue
         }
-        let fieldOp = mirEmitOperand(field)
         out = out + "  call void @" + pushSym + "(ptr " + dest + ", " + fieldTy + " " + fieldOp + ")\n"
+        i = i + 1
     }
     out
 }
@@ -20691,28 +21660,35 @@ fn mirEmitRawNullIntrinsic(func: MirFunction, instr: MirInstr) -> String {
     let dest = mirEmitLocalRegName(instr.dest.local)
     "  " + dest + " = inttoptr i64 0 to ptr\n"
 }
-fn mirEmitPrimitiveConversionIntrinsic(func: MirFunction, instr: MirInstr, toLLVM: String) -> String {
+fn mirEmitPrimitiveConversionIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, instr: MirInstr, toLLVM: String) -> String {
     if instr.args.len() != 1 || instr.hasDest == false {
         return "  ; TODO primitive conversion intrinsic\n"
     }
-    let dest = mirEmitLocalRegName(instr.dest.local)
-    let value = mirEmitOperand(instr.args[0])
-    let fromLLVM = mirEmitOperandLLVMType(instr.args[0])
+    let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
+    let fromLLVM = mirEmitModuleOperandLLVMType(m, func, instr.args[0])
+    let mut out = ""
+    let value = if mirOperandHasProjections(instr.args[0]) {
+        let tmp = dest + ".convarg"
+        out = out + mirEmitModuleProjectedReadChain(m, func, block, instrIdx, tmp, instr.args[0].place, instr.args[0].typ)
+        tmp
+    } else {
+        mirEmitFunctionTypedOperandValue(func, block, instrIdx, instr.args[0], fromLLVM)
+    }
     if fromLLVM == toLLVM {
         if toLLVM == "i1" {
-            return "  " + dest + " = or i1 0, " + value + "\n"
+            return out + "  " + dest + " = or i1 0, " + value + "\n"
         }
-        return "  " + dest + " = add " + toLLVM + " 0, " + value + "\n"
+        return out + "  " + dest + " = add " + toLLVM + " 0, " + value + "\n"
     }
     let fromWidth = mirEmitIntLLVMWidth(fromLLVM)
     let toWidth = mirEmitIntLLVMWidth(toLLVM)
     if fromWidth == 0 || toWidth == 0 {
-        return "  ; TODO primitive conversion from " + fromLLVM + " to " + toLLVM + "\n"
+        return out + "  ; TODO primitive conversion from " + fromLLVM + " to " + toLLVM + "\n"
     }
     if fromWidth < toWidth {
-        return "  " + dest + " = zext " + fromLLVM + " " + value + " to " + toLLVM + "\n"
+        return out + "  " + dest + " = zext " + fromLLVM + " " + value + " to " + toLLVM + "\n"
     }
-    "  " + dest + " = trunc " + fromLLVM + " " + value + " to " + toLLVM + "\n"
+    out + "  " + dest + " = trunc " + fromLLVM + " " + value + " to " + toLLVM + "\n"
 }
 fn mirEmitIntLLVMWidth(llvmTy: String) -> Int {
     if llvmTy == "i1" {
@@ -21003,16 +21979,61 @@ fn mirHexDigit(value: Int) -> String {
 /// monomorphizer's struct/enum registry in.
 pub fn mirEmitTypeDefsSection(m: MirModule) -> String {
     let shapes = mirCollectAggregateShapes(m)
-    if shapes.len() == 0 {
+    if shapes.len() == 0 && m.layouts.structs.len() == 0 && m.layouts.enums.len() == 0 && m.layouts.tuples.len() == 0 {
         return ""
     }
     let mut out = mirModuleSectionDirective("type defs")
+    let mut emitted: List<String> = []
+    for layout in m.layouts.structs {
+        let name = mirEmitTypeDefName(layout.name, layout.mangled)
+        if name != "" && emitted.contains(name) == false {
+            out = out + mirEmitStructLayoutTypeDefLine(m, name, layout.fields)
+            emitted.push(name)
+        }
+    }
+    for layout in m.layouts.enums {
+        let name = mirEmitTypeDefName(layout.name, layout.mangled)
+        if name != "" && emitted.contains(name) == false {
+            out = out + mirLlvmEnumLayoutTypeDefLine(name)
+            emitted.push(name)
+        }
+    }
+    for layout in m.layouts.tuples {
+        let name = mirEmitTypeDefName(layout.key, layout.mangled)
+        if name != "" && emitted.contains(name) == false {
+            out = out + mirEmitStructLayoutTypeDefLine(m, name, layout.fields)
+            emitted.push(name)
+        }
+    }
     let mut i = 0
     for shape in shapes {
         out = out + "%agg." + mirGenIntToString(i) + " = type " + shape + "\n"
         i = i + 1
     }
     out + "\n"
+}
+fn mirEmitStructLayoutTypeDefLine(m: MirModule, name: String, fields: List<MirFieldLayout>) -> String {
+    let bare = mirEmitBareTypeName(name)
+    if fields.len() == 0 {
+        return "%" + bare + " = type \{\}\n"
+    }
+    mirLlvmStructTypeDefLine(bare, mirEmitLayoutFieldsJoined(m, fields))
+}
+fn mirEmitLayoutFieldsJoined(m: MirModule, fields: List<MirFieldLayout>) -> String {
+    let mut out = ""
+    let mut i = 0
+    for field in fields {
+        if i > 0 {
+            out = out + ", "
+        }
+        let mut ty = mirEmitModuleTypeLLVM(m, field.typ)
+        if ty == "" || ty == "void" {
+            ty = "i8"
+        }
+        out = out + ty
+        i = i + 1
+    }
+    out
 }
 // -------- Multi-step Index / Deref WRITE projection --------
 // Address-taking writes (`arr[i] = v`, `*p = v`) lower to
@@ -21049,6 +22070,9 @@ fn mirEmitIndexWriteLine(instr: MirInstr, proj: MirProjection) -> String {
     }
     let setSym = mirEmitListSetSymbolForType(instr.src.typ, valueTy)
     if setSym == "" {
+        if mirEmitListElementUsesBytesV1(valueTy) {
+            return out + mirEmitListSetBytesV1Line(baseReg + ".iw", baseReg, idxOp, valueDest, valueTy)
+        }
         out = out + "  ; TODO list_set for elem type \"" + valueTy + "\"\n"
         return out
     }
@@ -21236,6 +22260,9 @@ fn mirEmitMultiStepIndexWrite(instr: MirInstr) -> String {
     }
     let setSym = mirEmitListSetSymbolForType(instr.src.typ, valueTy)
     if setSym == "" {
+        if mirEmitListElementUsesBytesV1(valueTy) {
+            return out + mirEmitListSetBytesV1Line(baseReg + ".iw", prev, idxOp, valueDest, valueTy)
+        }
         out = out + "  ; TODO list_set for elem type \"" + valueTy + "\"\n"
         return out
     }

--- a/toolchain/mir_json.osty
+++ b/toolchain/mir_json.osty
@@ -1,0 +1,1235 @@
+// mir_json.osty - MIR JSON wire decoder for the self-host LIR Proto path.
+//
+// The Go bridge ships MIR as JSON using internal/mirjson. This decoder
+// rebuilds the self-host MirModule shape without re-running the frontend.
+use std.bytes as bytes
+use std.strings
+
+pub type MirJsonObject = Map<String, MirJsonValue>
+pub type MirJsonArray = List<MirJsonValue>
+
+pub enum MirJsonValue {
+    MJObject(MirJsonObject),
+    MJArray(MirJsonArray),
+    MJString(String),
+    MJNumber(String),
+    MJBool(Bool),
+    MJNull,
+}
+
+fn mirJsonParseValue(text: String) -> Result<MirJsonValue, String> {
+    let bs = text.bytes()
+    let len = bs.len()
+    let start = mirJsonSkipWs(bs, 0, len)
+    if start >= len {
+        return Err("json: unexpected end of input")
+    }
+    let (value, pos) = mirJsonParseVal(bs, start, len)?
+    let end = mirJsonSkipWs(bs, pos, len)
+    if end != len {
+        return Err("json: unexpected trailing content")
+    }
+    Ok(value)
+}
+
+fn mirJsonParseVal(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, Int), String> {
+    if pos >= len {
+        return Err("json: unexpected end of input")
+    }
+    let c = bs[pos].toInt()
+    if c == 0x22 {
+        let (s, next) = mirJsonParseStr(bs, pos, len)?
+        Ok((MJString(s), next))
+    } else if c == 0x7B {
+        mirJsonParseObj(bs, pos, len)
+    } else if c == 0x5B {
+        mirJsonParseArr(bs, pos, len)
+    } else if c == 0x74 {
+        mirJsonParseLiteral(bs, pos, len, "true", MJBool(true))
+    } else if c == 0x66 {
+        mirJsonParseLiteral(bs, pos, len, "false", MJBool(false))
+    } else if c == 0x6E {
+        mirJsonParseLiteral(bs, pos, len, "null", MJNull)
+    } else if c == 0x2D || (c >= 0x30 && c <= 0x39) {
+        mirJsonParseNum(bs, pos, len)
+    } else {
+        Err("json: unexpected character")
+    }
+}
+
+fn mirJsonParseLiteral(bs: List<Byte>, pos: Int, len: Int, word: String, value: MirJsonValue) -> Result<(MirJsonValue, Int), String> {
+    let wb = word.bytes()
+    let wlen = wb.len()
+    if pos + wlen > len {
+        return Err("json: unexpected end of input")
+    }
+    let mut i = 0
+    for i < wlen {
+        if bs[pos + i] != wb[i] {
+            return Err("json: unexpected character")
+        }
+        i = i + 1
+    }
+    Ok((value, pos + wlen))
+}
+
+fn mirJsonParseStr(bs: List<Byte>, pos: Int, len: Int) -> Result<(String, Int), String> {
+    let mut i = pos + 1
+    let mut buf: List<Byte> = []
+    for i < len {
+        let b = bs[i].toInt()
+        if b == 0x22 {
+            let decoded = bytes.toString(bytes.from(buf))
+            if decoded.isErr() {
+                return Err("json: invalid utf-8 string")
+            }
+            return Ok((decoded.unwrapOr(""), i + 1))
+        }
+        if b == 0x5C {
+            i = i + 1
+            if i >= len {
+                return Err("json: unterminated string escape")
+            }
+            let esc = bs[i].toInt()
+            if esc == 0x22 {
+                mirJsonPushByte(buf, 0x22)
+            } else if esc == 0x5C {
+                mirJsonPushByte(buf, 0x5C)
+            } else if esc == 0x2F {
+                mirJsonPushByte(buf, 0x2F)
+            } else if esc == 0x62 {
+                mirJsonPushByte(buf, 0x08)
+            } else if esc == 0x66 {
+                mirJsonPushByte(buf, 0x0C)
+            } else if esc == 0x6E {
+                mirJsonPushByte(buf, 0x0A)
+            } else if esc == 0x72 {
+                mirJsonPushByte(buf, 0x0D)
+            } else if esc == 0x74 {
+                mirJsonPushByte(buf, 0x09)
+            } else if esc == 0x75 {
+                if i + 4 >= len {
+                    return Err("json: incomplete unicode escape")
+                }
+                let cp = mirJsonParseHex4(bs, i + 1)?
+                i = i + 4
+                if cp >= 0xD800 && cp <= 0xDBFF {
+                    if i + 1 >= len || bs[i + 1].toInt() != 0x5C {
+                        return Err("json: lone high surrogate")
+                    }
+                    if i + 2 >= len || bs[i + 2].toInt() != 0x75 {
+                        return Err("json: lone high surrogate")
+                    }
+                    if i + 6 >= len {
+                        return Err("json: incomplete surrogate pair")
+                    }
+                    let low = mirJsonParseHex4(bs, i + 3)?
+                    if low < 0xDC00 || low > 0xDFFF {
+                        return Err("json: invalid low surrogate")
+                    }
+                    let combined = ((cp - 0xD800) << 10) + (low - 0xDC00) + 0x10000
+                    mirJsonEncodeUtf8(buf, combined)
+                    i = i + 6
+                } else if cp >= 0xDC00 && cp <= 0xDFFF {
+                    return Err("json: lone low surrogate")
+                } else {
+                    mirJsonEncodeUtf8(buf, cp)
+                }
+            } else {
+                return Err("json: invalid escape character")
+            }
+            i = i + 1
+        } else if b < 0x20 {
+            return Err("json: control character in string")
+        } else {
+            buf.push(bs[i])
+            i = i + 1
+        }
+    }
+    Err("json: unterminated string")
+}
+
+fn mirJsonParseHex4(bs: List<Byte>, pos: Int) -> Result<Int, String> {
+    let mut result = 0
+    let mut i = 0
+    for i < 4 {
+        let b = bs[pos + i].toInt()
+        let mut v = 0
+        if b >= 0x30 && b <= 0x39 {
+            v = b - 0x30
+        } else if b >= 0x41 && b <= 0x46 {
+            v = b - 0x41 + 10
+        } else if b >= 0x61 && b <= 0x66 {
+            v = b - 0x61 + 10
+        } else {
+            return Err("json: invalid hex digit in unicode escape")
+        }
+        result = result * 16 + v
+        i = i + 1
+    }
+    Ok(result)
+}
+
+fn mirJsonPushByte(buf: List<Byte>, n: Int) {
+    buf.push(n.toByte())
+}
+
+fn mirJsonEncodeUtf8(buf: List<Byte>, cp: Int) {
+    if cp < 0x80 {
+        mirJsonPushByte(buf, cp)
+    } else if cp < 0x800 {
+        mirJsonPushByte(buf, 0xC0 | (cp >> 6))
+        mirJsonPushByte(buf, 0x80 | (cp & 0x3F))
+    } else if cp < 0x10000 {
+        mirJsonPushByte(buf, 0xE0 | (cp >> 12))
+        mirJsonPushByte(buf, 0x80 | ((cp >> 6) & 0x3F))
+        mirJsonPushByte(buf, 0x80 | (cp & 0x3F))
+    } else {
+        mirJsonPushByte(buf, 0xF0 | (cp >> 18))
+        mirJsonPushByte(buf, 0x80 | ((cp >> 12) & 0x3F))
+        mirJsonPushByte(buf, 0x80 | ((cp >> 6) & 0x3F))
+        mirJsonPushByte(buf, 0x80 | (cp & 0x3F))
+    }
+}
+
+fn mirJsonParseNum(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, Int), String> {
+    let mut i = pos
+    if i < len && bs[i].toInt() == 0x2D {
+        i = i + 1
+    }
+    if i >= len {
+        return Err("json: unexpected end of number")
+    }
+    if bs[i].toInt() == 0x30 {
+        i = i + 1
+    } else if bs[i].toInt() >= 0x31 && bs[i].toInt() <= 0x39 {
+        for i < len && bs[i].toInt() >= 0x30 && bs[i].toInt() <= 0x39 {
+            i = i + 1
+        }
+    } else {
+        return Err("json: invalid number")
+    }
+    if i < len && bs[i].toInt() == 0x2E {
+        i = i + 1
+        if i >= len || bs[i].toInt() < 0x30 || bs[i].toInt() > 0x39 {
+            return Err("json: invalid number: expected digit after decimal point")
+        }
+        for i < len && bs[i].toInt() >= 0x30 && bs[i].toInt() <= 0x39 {
+            i = i + 1
+        }
+    }
+    if i < len && (bs[i].toInt() == 0x45 || bs[i].toInt() == 0x65) {
+        i = i + 1
+        if i < len && (bs[i].toInt() == 0x2B || bs[i].toInt() == 0x2D) {
+            i = i + 1
+        }
+        if i >= len || bs[i].toInt() < 0x30 || bs[i].toInt() > 0x39 {
+            return Err("json: invalid number: expected digit in exponent")
+        }
+        for i < len && bs[i].toInt() >= 0x30 && bs[i].toInt() <= 0x39 {
+            i = i + 1
+        }
+    }
+    let mut numBuf: List<Byte> = []
+    let mut j = pos
+    for j < i {
+        numBuf.push(bs[j])
+        j = j + 1
+    }
+    let decoded = bytes.toString(bytes.from(numBuf))
+    if decoded.isErr() {
+        return Err("json: invalid number")
+    }
+    Ok((MJNumber(decoded.unwrapOr("")), i))
+}
+
+fn mirJsonParseArr(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, Int), String> {
+    let mut i = mirJsonSkipWs(bs, pos + 1, len)
+    let mut items: List<MirJsonValue> = []
+    if i < len && bs[i].toInt() == 0x5D {
+        return Ok((MJArray(items), i + 1))
+    }
+    for i < len {
+        let (val, next) = mirJsonParseVal(bs, i, len)?
+        items.push(val)
+        i = mirJsonSkipWs(bs, next, len)
+        if i >= len {
+            return Err("json: unterminated array")
+        }
+        if bs[i].toInt() == 0x5D {
+            return Ok((MJArray(items), i + 1))
+        }
+        if bs[i].toInt() != 0x2C {
+            return Err("json: expected ',' or ']' in array")
+        }
+        i = mirJsonSkipWs(bs, i + 1, len)
+    }
+    Err("json: unterminated array")
+}
+
+fn mirJsonParseObj(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, Int), String> {
+    let mut i = mirJsonSkipWs(bs, pos + 1, len)
+    let mut entries: Map<String, MirJsonValue> = {:}
+    if i < len && bs[i].toInt() == 0x7D {
+        return Ok((MJObject(entries), i + 1))
+    }
+    for i < len {
+        if bs[i].toInt() != 0x22 {
+            return Err("json: expected string key in object")
+        }
+        let (key, afterKey) = mirJsonParseStr(bs, i, len)?
+        i = mirJsonSkipWs(bs, afterKey, len)
+        if i >= len || bs[i].toInt() != 0x3A {
+            return Err("json: expected ':' after object key")
+        }
+        i = mirJsonSkipWs(bs, i + 1, len)
+        let (val, afterVal) = mirJsonParseVal(bs, i, len)?
+        entries.insert(key, val)
+        i = mirJsonSkipWs(bs, afterVal, len)
+        if i >= len {
+            return Err("json: unterminated object")
+        }
+        if bs[i].toInt() == 0x7D {
+            return Ok((MJObject(entries), i + 1))
+        }
+        if bs[i].toInt() != 0x2C {
+            return Err("json: expected ',' or '}' in object")
+        }
+        i = mirJsonSkipWs(bs, i + 1, len)
+    }
+    Err("json: unterminated object")
+}
+
+fn mirJsonSkipWs(bs: List<Byte>, pos: Int, len: Int) -> Int {
+    let mut i = pos
+    for i < len {
+        let c = bs[i].toInt()
+        if c != 0x20 && c != 0x09 && c != 0x0A && c != 0x0D {
+            return i
+        }
+        i = i + 1
+    }
+    i
+}
+
+fn mirJsonIsNull(value: MirJsonValue) -> Bool {
+    match value {
+        MJNull -> true,
+        _ -> false,
+    }
+}
+
+fn mirJsonEmptyObject() -> MirJsonValue {
+    MJObject({:})
+}
+
+fn mirJsonAsObject(value: MirJsonValue) -> Result<MirJsonObject, String> {
+    match value {
+        MJObject(o) -> Ok(o),
+        _ -> Err("json: expected object"),
+    }
+}
+
+fn mirJsonAsArray(value: MirJsonValue) -> Result<MirJsonArray, String> {
+    match value {
+        MJArray(a) -> Ok(a),
+        _ -> Err("json: expected array"),
+    }
+}
+
+fn mirJsonAsString(value: MirJsonValue) -> Result<String, String> {
+    match value {
+        MJString(s) -> Ok(s),
+        _ -> Err("json: expected string"),
+    }
+}
+
+fn mirJsonAsNumber(value: MirJsonValue) -> Result<String, String> {
+    match value {
+        MJNumber(n) -> Ok(n),
+        _ -> Err("json: expected number"),
+    }
+}
+
+fn mirJsonAsBool(value: MirJsonValue) -> Result<Bool, String> {
+    match value {
+        MJBool(b) -> Ok(b),
+        _ -> Err("json: expected bool"),
+    }
+}
+
+fn mirJsonParseIntText(text: String, ctx: String) -> Result<Int, String> {
+    let bs = text.bytes()
+    let len = bs.len()
+    if len == 0 {
+        return Err(mirJsonErr(ctx, "expected integer"))
+    }
+    let mut i = 0
+    let mut sign = 1
+    if bs[0].toInt() == 0x2D {
+        sign = -1
+        i = 1
+    }
+    if i >= len {
+        return Err(mirJsonErr(ctx, "expected integer"))
+    }
+    let mut n = 0
+    for i < len {
+        let c = bs[i].toInt()
+        if c < 0x30 || c > 0x39 {
+            return Err(mirJsonErr(ctx, "expected integer"))
+        }
+        n = n * 10 + (c - 0x30)
+        i = i + 1
+    }
+    Ok(n * sign)
+}
+
+fn mirJsonErr(ctx: String, msg: String) -> String {
+    if ctx == "" {
+        return "mir-json: " + msg
+    }
+    "mir-json: " + ctx + ": " + msg
+}
+
+fn mirJsonObject(value: MirJsonValue, ctx: String) -> Result<MirJsonObject, String> {
+    match mirJsonAsObject(value) {
+        Ok(o) -> Ok(o),
+        Err(_) -> Err(mirJsonErr(ctx, "expected object")),
+    }
+}
+
+fn mirJsonArray(value: MirJsonValue, ctx: String) -> Result<List<MirJsonValue>, String> {
+    match mirJsonAsArray(value) {
+        Ok(a) -> Ok(a),
+        Err(_) -> Err(mirJsonErr(ctx, "expected array")),
+    }
+}
+
+fn mirJsonString(value: MirJsonValue, ctx: String) -> Result<String, String> {
+    match mirJsonAsString(value) {
+        Ok(s) -> Ok(s),
+        Err(_) -> Err(mirJsonErr(ctx, "expected string")),
+    }
+}
+
+fn mirJsonNumber(value: MirJsonValue, ctx: String) -> Result<Int, String> {
+    match mirJsonAsNumber(value) {
+        Ok(n) -> mirJsonParseIntText(n, ctx),
+        Err(_) -> Err(mirJsonErr(ctx, "expected number")),
+    }
+}
+
+fn mirJsonBool(value: MirJsonValue, ctx: String) -> Result<Bool, String> {
+    match mirJsonAsBool(value) {
+        Ok(b) -> Ok(b),
+        Err(_) -> Err(mirJsonErr(ctx, "expected bool")),
+    }
+}
+
+fn mirJsonStringField(obj: MirJsonObject, key: String, fallback: String) -> Result<String, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonString(v, key),
+        None -> Ok(fallback),
+    }
+}
+
+fn mirJsonIntField(obj: MirJsonObject, key: String, fallback: Int) -> Result<Int, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonNumber(v, key),
+        None -> Ok(fallback),
+    }
+}
+
+fn mirJsonBoolField(obj: MirJsonObject, key: String, fallback: Bool) -> Result<Bool, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonBool(v, key),
+        None -> Ok(fallback),
+    }
+}
+
+fn mirJsonNumberTextField(obj: MirJsonObject, key: String, fallback: String) -> Result<String, String> {
+    match obj.get(key) {
+        Some(v) -> match mirJsonAsNumber(v) {
+            Ok(n) -> Ok(n),
+            Err(_) -> Err(mirJsonErr(key, "expected number")),
+        },
+        None -> Ok(fallback),
+    }
+}
+
+fn mirJsonArrayField(obj: MirJsonObject, key: String) -> Result<List<MirJsonValue>, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonArray(v, key),
+        None -> Ok([]),
+    }
+}
+
+fn mirJsonTypeField(obj: MirJsonObject, key: String) -> Result<String, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonTypeText(v),
+        None -> Ok(""),
+    }
+}
+
+fn mirJsonSpanField(obj: MirJsonObject, key: String) -> Result<MirSpan, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonSpan(v),
+        None -> Ok(mirNoSpan()),
+    }
+}
+
+fn mirJsonTypeList(items: List<MirJsonValue>) -> Result<List<String>, String> {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(mirJsonTypeText(item)?)
+    }
+    Ok(out)
+}
+
+fn mirJsonJoinTypeArgs(args: List<String>) -> String {
+    if args.len() == 0 {
+        return ""
+    }
+    "<" + strings.join(args, ", ") + ">"
+}
+
+fn mirJsonTypeText(value: MirJsonValue) -> Result<String, String> {
+    if mirJsonIsNull(value) {
+        return Ok("")
+    }
+    let obj = mirJsonObject(value, "type")?
+    let display = mirJsonStringField(obj, "display", "")?
+    if display != "" {
+        return Ok(display)
+    }
+    let kind = mirJsonStringField(obj, "kind", "")?
+    if kind == "prim" {
+        return mirJsonStringField(obj, "prim", "")
+    }
+    if kind == "named" {
+        let name = mirJsonStringField(obj, "name", "")?
+        let args = mirJsonTypeList(mirJsonArrayField(obj, "args")?)?
+        return Ok(name + mirJsonJoinTypeArgs(args))
+    }
+    if kind == "optional" {
+        let innerText = match obj.get("inner") {
+            Some(inner) -> mirJsonTypeText(inner)?,
+            None -> "",
+        }
+        if innerText == "" {
+            return Ok("?")
+        }
+        return Ok(innerText + "?")
+    }
+    if kind == "tuple" {
+        let elems = mirJsonTypeList(mirJsonArrayField(obj, "elems")?)?
+        return Ok("(" + strings.join(elems, ", ") + ")")
+    }
+    if kind == "fn" {
+        let params = mirJsonTypeList(mirJsonArrayField(obj, "params")?)?
+        let ret = match obj.get("return") {
+            Some(v) -> mirJsonTypeText(v)?,
+            None -> "()",
+        }
+        return Ok("fn(" + strings.join(params, ", ") + ") -> " + ret)
+    }
+    if kind == "error" {
+        return Ok("Error")
+    }
+    if kind == "typevar" {
+        return mirJsonStringField(obj, "name", "")
+    }
+    Ok(mirJsonStringField(obj, "display", "")?)
+}
+
+fn mirJsonSpan(value: MirJsonValue) -> Result<MirSpan, String> {
+    if mirJsonIsNull(value) {
+        return Ok(mirNoSpan())
+    }
+    let obj = mirJsonObject(value, "span")?
+    Ok(mirSpan(mirJsonIntField(obj, "start", 0)?, mirJsonIntField(obj, "end", 0)?))
+}
+
+pub fn mirJsonParseModule(text: String) -> Result<MirModule, String> {
+    match mirJsonParseValue(text) {
+        Ok(v) -> mirJsonModule(v),
+        Err(_) -> Err("mir-json: invalid JSON"),
+    }
+}
+
+fn mirJsonModule(value: MirJsonValue) -> Result<MirModule, String> {
+    let obj = mirJsonObject(value, "module")?
+    let version = mirJsonIntField(obj, "version", 1)?
+    if version != 0 && version != 1 {
+        return Err("mir-json: unsupported version")
+    }
+    let mut m = mirModule(mirJsonStringField(obj, "packageName", "main")?)
+    m.span = mirJsonSpanField(obj, "span")?
+    m.layouts = mirJsonLayouts(match obj.get("layouts") {
+        Some(v) -> v,
+        None -> mirJsonEmptyObject(),
+    })?
+    for useJson in mirJsonArrayField(obj, "uses")? {
+        m.uses.push(mirJsonUse(useJson)?)
+    }
+    for fnJson in mirJsonArrayField(obj, "functions")? {
+        m.functions.push(mirJsonFunction(fnJson)?)
+    }
+    for globalJson in mirJsonArrayField(obj, "globals")? {
+        m.globals.push(mirJsonGlobal(globalJson)?)
+    }
+    Ok(m)
+}
+
+fn mirJsonUse(value: MirJsonValue) -> Result<MirUse, String> {
+    let obj = mirJsonObject(value, "use")?
+    let mut u = mirUse(mirJsonStringField(obj, "rawPath", "")?, mirJsonStringField(obj, "alias", "")?, mirJsonSpanField(obj, "span")?)
+    u.isGoFFI = mirJsonBoolField(obj, "isGoFFI", false)?
+    u.isRuntimeFFI = mirJsonBoolField(obj, "isRuntimeFFI", false)?
+    u.goPath = mirJsonStringField(obj, "goPath", "")?
+    u.runtimePath = mirJsonStringField(obj, "runtimePath", "")?
+    Ok(u)
+}
+
+fn mirJsonGlobal(value: MirJsonValue) -> Result<MirGlobal, String> {
+    let obj = mirJsonObject(value, "global")?
+    let mut g = mirGlobal(mirJsonStringField(obj, "name", "")?, mirJsonTypeField(obj, "type")?, mirJsonBoolField(obj, "mut", false)?, mirJsonSpanField(obj, "span")?)
+    g.hasInit = mirJsonBoolField(obj, "hasInit", false)?
+    g.initSymbol = mirJsonStringField(obj, "initSymbol", "")?
+    Ok(g)
+}
+
+fn mirJsonFunction(value: MirJsonValue) -> Result<MirFunction, String> {
+    let obj = mirJsonObject(value, "function")?
+    let mut fn_ = mirFunction(mirJsonStringField(obj, "name", "")?, mirJsonTypeField(obj, "returnType")?, mirJsonSpanField(obj, "span")?)
+    fn_.returnLocal = mirJsonIntField(obj, "returnLocal", 0)?
+    fn_.entry = mirJsonIntField(obj, "entry", 0)?
+    fn_.isExternal = mirJsonBoolField(obj, "isExternal", false)?
+    fn_.isIntrinsic = mirJsonBoolField(obj, "isIntrinsic", false)?
+    fn_.exported = mirJsonBoolField(obj, "exported", false)?
+    fn_.exportSymbol = mirJsonStringField(obj, "exportSymbol", "")?
+    fn_.cAbi = mirJsonBoolField(obj, "cAbi", false)?
+    fn_.vectorize = mirJsonBoolField(obj, "vectorize", false)?
+    fn_.noVectorize = mirJsonBoolField(obj, "noVectorize", false)?
+    fn_.vectorizeWidth = mirJsonIntField(obj, "vectorizeWidth", 0)?
+    fn_.vectorizeScalable = mirJsonBoolField(obj, "vectorizeScalable", false)?
+    fn_.vectorizePredicate = mirJsonBoolField(obj, "vectorizePredicate", false)?
+    fn_.parallel = mirJsonBoolField(obj, "parallel", false)?
+    fn_.unroll = mirJsonBoolField(obj, "unroll", false)?
+    fn_.unrollCount = mirJsonIntField(obj, "unrollCount", 0)?
+    fn_.inlineMode = mirJsonInlineMode(mirJsonIntField(obj, "inlineMode", 0)?)
+    fn_.hot = mirJsonBoolField(obj, "hot", false)?
+    fn_.cold = mirJsonBoolField(obj, "cold", false)?
+    fn_.targetFeatures = mirJsonStringList(mirJsonArrayField(obj, "targetFeatures")?)?
+    fn_.noaliasAll = mirJsonBoolField(obj, "noaliasAll", false)?
+    fn_.noaliasParams = mirJsonStringList(mirJsonArrayField(obj, "noaliasParams")?)?
+    fn_.pure = mirJsonBoolField(obj, "pure", false)?
+    for p in mirJsonArrayField(obj, "params")? {
+        fn_.params.push(mirJsonNumber(p, "params")?)
+    }
+    for localJson in mirJsonArrayField(obj, "locals")? {
+        fn_.locals.push(mirJsonLocal(localJson)?)
+    }
+    for blockJson in mirJsonArrayField(obj, "blocks")? {
+        fn_.blocks.push(mirJsonBlock(blockJson)?)
+    }
+    Ok(fn_)
+}
+
+fn mirJsonStringList(items: List<MirJsonValue>) -> Result<List<String>, String> {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(mirJsonString(item, "string-list")?)
+    }
+    Ok(out)
+}
+
+fn mirJsonInlineMode(value: Int) -> MirInlineMode {
+    if value == 1 {
+        return MirInlineSoft
+    }
+    if value == 2 {
+        return MirInlineAlways
+    }
+    if value == 3 {
+        return MirInlineNever
+    }
+    MirInlineNone
+}
+
+fn mirJsonLocal(value: MirJsonValue) -> Result<MirLocal, String> {
+    let obj = mirJsonObject(value, "local")?
+    let mut l = mirLocal(mirJsonIntField(obj, "id", 0)?, mirJsonStringField(obj, "name", "")?, mirJsonTypeField(obj, "type")?, mirJsonBoolField(obj, "mut", false)?, mirJsonSpanField(obj, "span")?)
+    l.isParam = mirJsonBoolField(obj, "isParam", false)?
+    l.isReturn = mirJsonBoolField(obj, "isReturn", false)?
+    Ok(l)
+}
+
+fn mirJsonBlock(value: MirJsonValue) -> Result<MirBasicBlock, String> {
+    let obj = mirJsonObject(value, "block")?
+    let mut b = mirBasicBlock(mirJsonIntField(obj, "id", 0)?, mirJsonSpanField(obj, "span")?)
+    for instrJson in mirJsonArrayField(obj, "instrs")? {
+        b.instrs.push(mirJsonInstr(instrJson)?)
+    }
+    match obj.get("term") {
+        Some(termJson) -> {
+            if !mirJsonIsNull(termJson) {
+                mirBlockSetTerminator(b, mirJsonTerm(termJson)?)
+            }
+        },
+        None -> {
+        },
+    }
+    Ok(b)
+}
+
+fn mirJsonInstr(value: MirJsonValue) -> Result<MirInstr, String> {
+    let obj = mirJsonObject(value, "instr")?
+    let kind = mirJsonStringField(obj, "kind", "")?
+    let span = mirJsonSpanField(obj, "span")?
+    if kind == "assign" {
+        return Ok(mirAssignInstr(mirJsonPlaceRequired(obj, "dest")?, mirJsonRValueRequired(obj, "src")?, span))
+    }
+    if kind == "call" {
+        let hasDest = obj.get("dest").isSome()
+        let dest = if hasDest { mirJsonPlaceRequired(obj, "dest")? } else { mirPlace(-1) }
+        let callee = mirJsonCalleeRequired(obj, "callee")?
+        return Ok(mirCallInstr(hasDest, dest, callee.symbol, callee.typ, mirJsonOperands(mirJsonArrayField(obj, "args")?)?, span))
+    }
+    if kind == "intrinsic" {
+        let hasDest = obj.get("dest").isSome()
+        let dest = if hasDest { mirJsonPlaceRequired(obj, "dest")? } else { mirPlace(-1) }
+        return Ok(mirIntrinsicInstr(hasDest, dest, mirJsonIntrinsic(mirJsonIntField(obj, "intrinsic", 0)?), mirJsonOperands(mirJsonArrayField(obj, "args")?)?, span))
+    }
+    if kind == "storage_live" {
+        return Ok(mirStorageLiveInstr(mirJsonIntField(obj, "storageLocal", -1)?, span))
+    }
+    if kind == "storage_dead" {
+        return Ok(mirStorageDeadInstr(mirJsonIntField(obj, "storageLocal", -1)?, span))
+    }
+    Err(mirJsonErr("instr", "unknown kind " + kind))
+}
+
+struct MirJsonCallee {
+    pub kind: String,
+    pub symbol: String,
+    pub typ: String,
+    pub operand: MirOperand,
+}
+
+fn mirJsonCalleeRequired(obj: MirJsonObject, key: String) -> Result<MirJsonCallee, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonCallee(v),
+        None -> Err(mirJsonErr(key, "missing callee")),
+    }
+}
+
+fn mirJsonCallee(value: MirJsonValue) -> Result<MirJsonCallee, String> {
+    let obj = mirJsonObject(value, "callee")?
+    let kind = mirJsonStringField(obj, "kind", "")?
+    if kind == "fn" {
+        return Ok(MirJsonCallee {kind, symbol: mirJsonStringField(obj, "symbol", "")?, typ: mirJsonTypeField(obj, "type")?, operand: mirOperandInvalid()})
+    }
+    if kind == "indirect" {
+        return Ok(MirJsonCallee {kind, symbol: "", typ: "", operand: mirJsonOperandRequired(obj, "operand")?})
+    }
+    Err(mirJsonErr("callee", "unknown kind " + kind))
+}
+
+fn mirJsonTerm(value: MirJsonValue) -> Result<MirTerm, String> {
+    let obj = mirJsonObject(value, "term")?
+    let kind = mirJsonStringField(obj, "kind", "")?
+    let span = mirJsonSpanField(obj, "span")?
+    if kind == "goto" {
+        return Ok(mirGotoTerm(mirJsonIntField(obj, "target", -1)?, span))
+    }
+    if kind == "branch" {
+        return Ok(mirBranchTerm(mirJsonOperandRequired(obj, "cond")?, mirJsonIntField(obj, "then", -1)?, mirJsonIntField(obj, "else", -1)?, span))
+    }
+    if kind == "switch_int" {
+        let mut cases: List<MirSwitchCase> = []
+        for caseJson in mirJsonArrayField(obj, "cases")? {
+            cases.push(mirJsonSwitchCase(caseJson)?)
+        }
+        return Ok(mirSwitchIntTerm(mirJsonOperandRequired(obj, "cond")?, cases, mirJsonIntField(obj, "default", -1)?, span))
+    }
+    if kind == "return" {
+        return Ok(mirReturnTerm(span))
+    }
+    if kind == "unreachable" {
+        return Ok(mirUnreachableTerm(span))
+    }
+    Err(mirJsonErr("term", "unknown kind " + kind))
+}
+
+fn mirJsonSwitchCase(value: MirJsonValue) -> Result<MirSwitchCase, String> {
+    let obj = mirJsonObject(value, "switch-case")?
+    Ok(mirSwitchCase(mirJsonIntField(obj, "value", 0)?, mirJsonIntField(obj, "target", -1)?, mirJsonStringField(obj, "label", "")?))
+}
+
+fn mirJsonPlaceRequired(obj: MirJsonObject, key: String) -> Result<MirPlace, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonPlace(v),
+        None -> Err(mirJsonErr(key, "missing place")),
+    }
+}
+
+fn mirJsonPlace(value: MirJsonValue) -> Result<MirPlace, String> {
+    let obj = mirJsonObject(value, "place")?
+    let mut p = mirPlace(mirJsonIntField(obj, "local", -1)?)
+    for projJson in mirJsonArrayField(obj, "projections")? {
+        p.projections.push(mirJsonProjection(projJson)?)
+    }
+    Ok(p)
+}
+
+fn mirJsonProjection(value: MirJsonValue) -> Result<MirProjection, String> {
+    let obj = mirJsonObject(value, "projection")?
+    let kind = mirJsonStringField(obj, "kind", "")?
+    let typ = mirJsonTypeField(obj, "type")?
+    if kind == "field" {
+        return Ok(mirFieldProj(mirJsonIntField(obj, "index", 0)?, mirJsonStringField(obj, "name", "")?, typ))
+    }
+    if kind == "tuple" {
+        return Ok(mirTupleProj(mirJsonIntField(obj, "index", 0)?, typ))
+    }
+    if kind == "variant" {
+        return Ok(mirVariantProj(mirJsonIntField(obj, "index", 0)?, mirJsonStringField(obj, "name", "")?, mirJsonIntField(obj, "fieldIdx", -1)?, typ))
+    }
+    if kind == "index" {
+        match obj.get("indexOp") {
+            Some(indexJson) -> {
+                let op = mirJsonOperand(indexJson)?
+                if op.kind == MirOpConst && op.const.kind == MirConstInt {
+                    return Ok(mirIndexProjConst(op.const.intValue, typ))
+                }
+                if op.place.projections.len() == 0 {
+                    return Ok(mirIndexProjLocal(op.place.local, typ))
+                }
+            },
+            None -> {
+            },
+        }
+        return Ok(mirIndexProjConst(mirJsonIntField(obj, "index", 0)?, typ))
+    }
+    if kind == "deref" {
+        return Ok(mirDerefProj(typ))
+    }
+    Err(mirJsonErr("projection", "unknown kind " + kind))
+}
+
+fn mirJsonOperandRequired(obj: MirJsonObject, key: String) -> Result<MirOperand, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonOperand(v),
+        None -> Err(mirJsonErr(key, "missing operand")),
+    }
+}
+
+fn mirJsonOperands(items: List<MirJsonValue>) -> Result<List<MirOperand>, String> {
+    let mut out: List<MirOperand> = []
+    for item in items {
+        out.push(mirJsonOperand(item)?)
+    }
+    Ok(out)
+}
+
+fn mirJsonOperand(value: MirJsonValue) -> Result<MirOperand, String> {
+    let obj = mirJsonObject(value, "operand")?
+    let kind = mirJsonStringField(obj, "kind", "")?
+    let typ = mirJsonTypeField(obj, "type")?
+    if kind == "copy" {
+        return Ok(mirOperandCopy(mirJsonPlaceRequired(obj, "place")?, typ))
+    }
+    if kind == "move" {
+        return Ok(mirOperandMove(mirJsonPlaceRequired(obj, "place")?, typ))
+    }
+    if kind == "const" {
+        return Ok(mirOperandConst(mirJsonConstRequired(obj, "const")?))
+    }
+    Err(mirJsonErr("operand", "unknown kind " + kind))
+}
+
+fn mirJsonConstRequired(obj: MirJsonObject, key: String) -> Result<MirConst, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonConst(v),
+        None -> Err(mirJsonErr(key, "missing const")),
+    }
+}
+
+fn mirJsonConst(value: MirJsonValue) -> Result<MirConst, String> {
+    let obj = mirJsonObject(value, "const")?
+    let kind = mirJsonStringField(obj, "kind", "")?
+    let typ = mirJsonTypeField(obj, "type")?
+    if kind == "int" {
+        return Ok(mirConstInt(mirJsonIntField(obj, "int", 0)?, typ))
+    }
+    if kind == "bool" {
+        return Ok(mirConstBool(mirJsonBoolField(obj, "bool", false)?))
+    }
+    if kind == "float" {
+        return Ok(mirConstFloat(mirJsonNumberTextField(obj, "float", "0")?, typ))
+    }
+    if kind == "string" {
+        return Ok(mirConstString(mirJsonStringField(obj, "string", "")?))
+    }
+    if kind == "char" {
+        return Ok(mirConstChar(mirJsonIntField(obj, "char", 0)?))
+    }
+    if kind == "byte" {
+        return Ok(mirConstByte(mirJsonIntField(obj, "byte", 0)?))
+    }
+    if kind == "unit" {
+        return Ok(mirConstUnit())
+    }
+    if kind == "null" {
+        return Ok(mirConstNull(typ))
+    }
+    if kind == "fn" {
+        return Ok(mirConstFn(mirJsonStringField(obj, "symbol", "")?, typ))
+    }
+    Err(mirJsonErr("const", "unknown kind " + kind))
+}
+
+fn mirJsonRValueRequired(obj: MirJsonObject, key: String) -> Result<MirRValue, String> {
+    match obj.get(key) {
+        Some(v) -> mirJsonRValue(v),
+        None -> Err(mirJsonErr(key, "missing rvalue")),
+    }
+}
+
+fn mirJsonRValue(value: MirJsonValue) -> Result<MirRValue, String> {
+    let obj = mirJsonObject(value, "rvalue")?
+    let kind = mirJsonStringField(obj, "kind", "")?
+    if kind == "use" {
+        return Ok(mirRVUse(mirJsonOperandRequired(obj, "op")?))
+    }
+    if kind == "unary" {
+        return Ok(mirRVUnary(mirJsonUnary(mirJsonIntField(obj, "unary", 0)?), mirJsonOperandRequired(obj, "arg")?, mirJsonTypeField(obj, "type")?))
+    }
+    if kind == "binary" {
+        return Ok(mirRVBinary(mirJsonBinary(mirJsonIntField(obj, "binary", 0)?), mirJsonOperandRequired(obj, "left")?, mirJsonOperandRequired(obj, "right")?, mirJsonTypeField(obj, "type")?))
+    }
+    if kind == "aggregate" {
+        let fields = mirJsonOperands(mirJsonArrayField(obj, "fields")?)?
+        let aggKind = mirJsonAggregate(mirJsonIntField(obj, "aggregateKind", 0)?)
+        let variantTag = mirJsonStringField(obj, "variantTag", "")?
+        if aggKind == MirAggEnumVariant {
+            return Ok(mirRVVariant(mirJsonIntField(obj, "variantIdx", 0)?, variantTag, fields, mirJsonTypeField(obj, "type")?))
+        }
+        return Ok(mirRVAggregate(aggKind, fields, mirJsonTypeField(obj, "type")?))
+    }
+    if kind == "discriminant" {
+        return Ok(mirRVDiscriminant(mirJsonPlaceRequired(obj, "place")?, mirJsonTypeField(obj, "type")?))
+    }
+    if kind == "len" {
+        return Ok(mirRVLen(mirJsonPlaceRequired(obj, "place")?, mirJsonTypeField(obj, "type")?))
+    }
+    if kind == "cast" {
+        return Ok(mirRVCast(mirJsonCast(mirJsonIntField(obj, "castKind", 0)?), mirJsonOperandRequired(obj, "arg")?, mirJsonTypeField(obj, "from")?, mirJsonTypeField(obj, "to")?))
+    }
+    if kind == "address_of" {
+        return Ok(mirRVAddressOf(mirJsonPlaceRequired(obj, "place")?, mirJsonTypeField(obj, "type")?))
+    }
+    if kind == "ref" {
+        return Ok(mirRVRef(mirJsonPlaceRequired(obj, "place")?, mirJsonTypeField(obj, "type")?))
+    }
+    if kind == "global_ref" {
+        return Ok(mirRVGlobalRef(mirJsonStringField(obj, "name", "")?, mirJsonTypeField(obj, "type")?))
+    }
+    if kind == "nullary" {
+        return Ok(mirRVNullary(mirJsonNullary(mirJsonIntField(obj, "nullary", 0)?), mirJsonTypeField(obj, "type")?))
+    }
+    Err(mirJsonErr("rvalue", "unknown kind " + kind))
+}
+
+fn mirJsonLayouts(value: MirJsonValue) -> Result<MirLayoutTable, String> {
+    if mirJsonIsNull(value) {
+        return Ok(mirLayoutTable())
+    }
+    let obj = mirJsonObject(value, "layouts")?
+    let mut out = mirLayoutTable()
+    for item in mirJsonArrayField(obj, "structs")? {
+        out.structs.push(mirJsonStructLayout(item)?)
+    }
+    for item in mirJsonArrayField(obj, "enums")? {
+        out.enums.push(mirJsonEnumLayout(item)?)
+    }
+    for item in mirJsonArrayField(obj, "tuples")? {
+        out.tuples.push(mirJsonTupleLayout(item)?)
+    }
+    for item in mirJsonArrayField(obj, "interfaces")? {
+        out.interfaces.push(mirJsonInterfaceLayout(item)?)
+    }
+    Ok(out)
+}
+
+fn mirJsonFieldLayout(value: MirJsonValue) -> Result<MirFieldLayout, String> {
+    let obj = mirJsonObject(value, "layout-field")?
+    Ok(MirFieldLayout {index: mirJsonIntField(obj, "index", 0)?, name: mirJsonStringField(obj, "name", "")?, typ: mirJsonTypeField(obj, "type")?})
+}
+
+fn mirJsonFieldLayouts(items: List<MirJsonValue>) -> Result<List<MirFieldLayout>, String> {
+    let mut out: List<MirFieldLayout> = []
+    for item in items {
+        out.push(mirJsonFieldLayout(item)?)
+    }
+    Ok(out)
+}
+
+fn mirJsonStructLayout(value: MirJsonValue) -> Result<MirStructLayout, String> {
+    let obj = mirJsonObject(value, "struct-layout")?
+    Ok(MirStructLayout {name: mirJsonStringField(obj, "name", "")?, mangled: mirJsonStringField(obj, "mangled", "")?, fields: mirJsonFieldLayouts(mirJsonArrayField(obj, "fields")?)?, size: mirJsonIntField(obj, "size", 0)?, align: mirJsonIntField(obj, "align", 0)?})
+}
+
+fn mirJsonVariantLayout(value: MirJsonValue) -> Result<MirVariantLayout, String> {
+    let obj = mirJsonObject(value, "variant-layout")?
+    Ok(MirVariantLayout {index: mirJsonIntField(obj, "index", 0)?, name: mirJsonStringField(obj, "name", "")?, payload: mirJsonFieldLayouts(mirJsonArrayField(obj, "payload")?)?})
+}
+
+fn mirJsonVariantLayouts(items: List<MirJsonValue>) -> Result<List<MirVariantLayout>, String> {
+    let mut out: List<MirVariantLayout> = []
+    for item in items {
+        out.push(mirJsonVariantLayout(item)?)
+    }
+    Ok(out)
+}
+
+fn mirJsonEnumLayout(value: MirJsonValue) -> Result<MirEnumLayout, String> {
+    let obj = mirJsonObject(value, "enum-layout")?
+    Ok(MirEnumLayout {name: mirJsonStringField(obj, "name", "")?, mangled: mirJsonStringField(obj, "mangled", "")?, discriminant: mirJsonTypeField(obj, "discriminant")?, variants: mirJsonVariantLayouts(mirJsonArrayField(obj, "variants")?)?})
+}
+
+fn mirJsonTupleLayout(value: MirJsonValue) -> Result<MirTupleLayout, String> {
+    let obj = mirJsonObject(value, "tuple-layout")?
+    Ok(MirTupleLayout {key: mirJsonStringField(obj, "key", "")?, mangled: mirJsonStringField(obj, "mangled", "")?, fields: mirJsonFieldLayouts(mirJsonArrayField(obj, "fields")?)?})
+}
+
+fn mirJsonInterfaceMethod(value: MirJsonValue) -> Result<MirInterfaceMethod, String> {
+    let obj = mirJsonObject(value, "interface-method")?
+    Ok(MirInterfaceMethod {name: mirJsonStringField(obj, "name", "")?, slot: mirJsonIntField(obj, "slot", 0)?})
+}
+
+fn mirJsonInterfaceMethods(items: List<MirJsonValue>) -> Result<List<MirInterfaceMethod>, String> {
+    let mut out: List<MirInterfaceMethod> = []
+    for item in items {
+        out.push(mirJsonInterfaceMethod(item)?)
+    }
+    Ok(out)
+}
+
+fn mirJsonInterfaceImpl(value: MirJsonValue) -> Result<MirInterfaceImpl, String> {
+    let obj = mirJsonObject(value, "interface-impl")?
+    Ok(MirInterfaceImpl {implName: mirJsonStringField(obj, "implName", "")?, vtableSym: mirJsonStringField(obj, "vtableSym", "")?})
+}
+
+fn mirJsonInterfaceImpls(items: List<MirJsonValue>) -> Result<List<MirInterfaceImpl>, String> {
+    let mut out: List<MirInterfaceImpl> = []
+    for item in items {
+        out.push(mirJsonInterfaceImpl(item)?)
+    }
+    Ok(out)
+}
+
+fn mirJsonInterfaceLayout(value: MirJsonValue) -> Result<MirInterfaceLayout, String> {
+    let obj = mirJsonObject(value, "interface-layout")?
+    Ok(MirInterfaceLayout {name: mirJsonStringField(obj, "name", "")?, methods: mirJsonInterfaceMethods(mirJsonArrayField(obj, "methods")?)?, impls: mirJsonInterfaceImpls(mirJsonArrayField(obj, "impls")?)?})
+}
+
+fn mirJsonUnary(value: Int) -> MirUnaryOp {
+    if value == 1 { return MirUnNeg }
+    if value == 2 { return MirUnPlus }
+    if value == 3 { return MirUnNot }
+    if value == 4 { return MirUnBitNot }
+    MirUnInvalid
+}
+
+fn mirJsonBinary(value: Int) -> MirBinaryOp {
+    if value == 1 { return MirBinAdd }
+    if value == 2 { return MirBinSub }
+    if value == 3 { return MirBinMul }
+    if value == 4 { return MirBinDiv }
+    if value == 5 { return MirBinMod }
+    if value == 6 { return MirBinEq }
+    if value == 7 { return MirBinNeq }
+    if value == 8 { return MirBinLt }
+    if value == 9 { return MirBinLeq }
+    if value == 10 { return MirBinGt }
+    if value == 11 { return MirBinGeq }
+    if value == 12 { return MirBinAnd }
+    if value == 13 { return MirBinOr }
+    if value == 14 { return MirBinBitAnd }
+    if value == 15 { return MirBinBitOr }
+    if value == 16 { return MirBinBitXor }
+    if value == 17 { return MirBinShl }
+    if value == 18 { return MirBinShr }
+    MirBinInvalid
+}
+
+fn mirJsonAggregate(value: Int) -> MirAggregateKind {
+    if value == 1 { return MirAggTuple }
+    if value == 2 { return MirAggStruct }
+    if value == 3 { return MirAggEnumVariant }
+    if value == 4 { return MirAggList }
+    if value == 5 { return MirAggMap }
+    if value == 6 { return MirAggClosure }
+    MirAggInvalid
+}
+
+fn mirJsonCast(value: Int) -> MirCastKind {
+    if value == 1 { return MirCastIntResize }
+    if value == 2 { return MirCastIntToFloat }
+    if value == 3 { return MirCastFloatToInt }
+    if value == 4 { return MirCastFloatResize }
+    if value == 5 { return MirCastOptionalWrap }
+    if value == 6 { return MirCastOptionalUnwrap }
+    if value == 7 { return MirCastBitcast }
+    MirCastInvalid
+}
+
+fn mirJsonNullary(value: Int) -> MirNullaryRVKind {
+    if value == 1 { return MirNullaryNone }
+    MirNullaryInvalid
+}
+
+fn mirJsonIntrinsic(value: Int) -> MirIntrinsicKind {
+    if value == 0 { return MirIntrinsicInvalid }
+    if value == 1 { return MirIntrinsicPrint }
+    if value == 2 { return MirIntrinsicPrintln }
+    if value == 3 { return MirIntrinsicEprint }
+    if value == 4 { return MirIntrinsicEprintln }
+    if value == 5 { return MirIntrinsicAbort }
+    if value == 6 { return MirIntrinsicStringConcat }
+    if value == 7 { return MirIntrinsicBytesConcat }
+    if value == 8 { return MirIntrinsicChanMake }
+    if value == 9 { return MirIntrinsicChanSend }
+    if value == 10 { return MirIntrinsicChanRecv }
+    if value == 11 { return MirIntrinsicChanClose }
+    if value == 12 { return MirIntrinsicChanIsClosed }
+    if value == 13 { return MirIntrinsicTaskGroup }
+    if value == 14 { return MirIntrinsicSpawn }
+    if value == 15 { return MirIntrinsicHandleJoin }
+    if value == 16 { return MirIntrinsicGroupCancel }
+    if value == 17 { return MirIntrinsicGroupIsCancelled }
+    if value == 18 { return MirIntrinsicParallel }
+    if value == 19 { return MirIntrinsicRace }
+    if value == 20 { return MirIntrinsicCollectAll }
+    if value == 21 { return MirIntrinsicSelect }
+    if value == 22 { return MirIntrinsicSelectRecv }
+    if value == 23 { return MirIntrinsicSelectSend }
+    if value == 24 { return MirIntrinsicSelectTimeout }
+    if value == 25 { return MirIntrinsicSelectDefault }
+    if value == 26 { return MirIntrinsicIsCancelled }
+    if value == 27 { return MirIntrinsicCheckCancelled }
+    if value == 28 { return MirIntrinsicYield }
+    if value == 29 { return MirIntrinsicSleep }
+    if value == 30 { return MirIntrinsicListPush }
+    if value == 31 { return MirIntrinsicListLen }
+    if value == 32 { return MirIntrinsicListGet }
+    if value == 33 { return MirIntrinsicListIsEmpty }
+    if value == 34 { return MirIntrinsicListFirst }
+    if value == 35 { return MirIntrinsicListLast }
+    if value == 36 { return MirIntrinsicListSorted }
+    if value == 37 { return MirIntrinsicListContains }
+    if value == 38 { return MirIntrinsicListIndexOf }
+    if value == 39 { return MirIntrinsicListToSet }
+    if value == 40 { return MirIntrinsicListRemoveAt }
+    if value == 41 { return MirIntrinsicListReverse }
+    if value == 42 { return MirIntrinsicListReversed }
+    if value == 43 { return MirIntrinsicListToString }
+    if value == 44 { return MirIntrinsicMapNew }
+    if value == 45 { return MirIntrinsicMapGet }
+    if value == 46 { return MirIntrinsicMapSet }
+    if value == 47 { return MirIntrinsicMapContains }
+    if value == 48 { return MirIntrinsicMapLen }
+    if value == 49 { return MirIntrinsicMapKeys }
+    if value == 50 { return MirIntrinsicMapValues }
+    if value == 51 { return MirIntrinsicMapRemove }
+    if value == 52 { return MirIntrinsicMapKeysSorted }
+    if value == 53 { return MirIntrinsicMapToString }
+    if value == 54 { return MirIntrinsicSetNew }
+    if value == 55 { return MirIntrinsicSetInsert }
+    if value == 56 { return MirIntrinsicSetContains }
+    if value == 57 { return MirIntrinsicSetLen }
+    if value == 58 { return MirIntrinsicSetToList }
+    if value == 59 { return MirIntrinsicSetRemove }
+    if value == 60 { return MirIntrinsicSetToString }
+    if value == 61 { return MirIntrinsicStringLen }
+    if value == 62 { return MirIntrinsicStringIsEmpty }
+    if value == 63 { return MirIntrinsicStringContains }
+    if value == 64 { return MirIntrinsicStringCount }
+    if value == 65 { return MirIntrinsicStringStartsWith }
+    if value == 66 { return MirIntrinsicStringEndsWith }
+    if value == 67 { return MirIntrinsicStringIndexOf }
+    if value == 68 { return MirIntrinsicStringSplit }
+    if value == 69 { return MirIntrinsicStringTrim }
+    if value == 70 { return MirIntrinsicStringToUpper }
+    if value == 71 { return MirIntrinsicStringToLower }
+    if value == 72 { return MirIntrinsicStringToInt }
+    if value == 73 { return MirIntrinsicStringToFloat }
+    if value == 74 { return MirIntrinsicStringReplace }
+    if value == 75 { return MirIntrinsicStringChars }
+    if value == 76 { return MirIntrinsicStringBytes }
+    if value == 77 { return MirIntrinsicBytesLen }
+    if value == 78 { return MirIntrinsicBytesIsEmpty }
+    if value == 79 { return MirIntrinsicBytesGet }
+    if value == 80 { return MirIntrinsicBytesContains }
+    if value == 81 { return MirIntrinsicBytesStartsWith }
+    if value == 82 { return MirIntrinsicBytesEndsWith }
+    if value == 83 { return MirIntrinsicBytesIndexOf }
+    if value == 84 { return MirIntrinsicBytesLastIndexOf }
+    if value == 85 { return MirIntrinsicBytesSplit }
+    if value == 86 { return MirIntrinsicBytesJoin }
+    if value == 87 { return MirIntrinsicBytesRepeat }
+    if value == 88 { return MirIntrinsicBytesReplace }
+    if value == 89 { return MirIntrinsicBytesReplaceAll }
+    if value == 90 { return MirIntrinsicBytesTrimLeft }
+    if value == 91 { return MirIntrinsicBytesTrimRight }
+    if value == 92 { return MirIntrinsicBytesTrim }
+    if value == 93 { return MirIntrinsicBytesTrimSpace }
+    if value == 94 { return MirIntrinsicBytesToUpper }
+    if value == 95 { return MirIntrinsicBytesToLower }
+    if value == 96 { return MirIntrinsicBytesToHex }
+    if value == 97 { return MirIntrinsicBytesSlice }
+    if value == 98 { return MirIntrinsicOptionIsSome }
+    if value == 99 { return MirIntrinsicOptionIsNone }
+    if value == 100 { return MirIntrinsicOptionUnwrap }
+    if value == 101 { return MirIntrinsicOptionUnwrapOr }
+    if value == 102 { return MirIntrinsicResultIsOk }
+    if value == 103 { return MirIntrinsicResultIsErr }
+    if value == 104 { return MirIntrinsicResultUnwrap }
+    if value == 105 { return MirIntrinsicResultUnwrapOr }
+    if value == 106 { return MirIntrinsicRawNull }
+    if value == 107 { return MirIntrinsicStringJoin }
+    if value == 108 { return MirIntrinsicListPop }
+    if value == 109 { return MirIntrinsicStringSubstring }
+    if value == 110 { return MirIntrinsicByteToInt }
+    if value == 111 { return MirIntrinsicCharToInt }
+    if value == 112 { return MirIntrinsicListSlice }
+    if value == 113 { return MirIntrinsicMapGetOr }
+    if value == 114 { return MirIntrinsicStringSplitInto }
+    if value == 115 { return MirIntrinsicStringNthSegment }
+    if value == 116 { return MirIntrinsicMapIncr }
+    if value == 117 { return MirIntrinsicStringRepeat }
+    if value == 118 { return MirIntrinsicStringTrimPrefix }
+    if value == 119 { return MirIntrinsicStringTrimSuffix }
+    if value == 120 { return MirIntrinsicStringTrimStart }
+    if value == 121 { return MirIntrinsicStringTrimEnd }
+    if value == 122 { return MirIntrinsicStringReplaceAll }
+    if value == 123 { return MirIntrinsicStringSplitN }
+    if value == 124 { return MirIntrinsicStringFields }
+    if value == 125 { return MirIntrinsicStringLastIndexOf }
+    if value == 126 { return MirIntrinsicBytesFromList }
+    if value == 127 { return MirIntrinsicBytesFromString }
+    if value == 128 { return MirIntrinsicBytesToString }
+    if value == 129 { return MirIntrinsicBytesFromHex }
+    if value == 130 { return MirIntrinsicIntToByte }
+    if value == 131 { return MirIntrinsicIntToChar }
+    if value == 132 { return MirIntrinsicByteToChar }
+    if value == 133 { return MirIntrinsicCharToByte }
+    if value == 134 { return MirIntrinsicListInsert }
+    if value == 135 { return MirIntrinsicListClear }
+    if value == 136 { return MirIntrinsicMapClear }
+    if value == 137 { return MirIntrinsicSetClear }
+    MirIntrinsicInvalid
+}

--- a/toolchain/mir_json_test.osty
+++ b/toolchain/mir_json_test.osty
@@ -1,0 +1,63 @@
+use std.strings
+use std.testing
+
+fn mjDecodeModule(text: String) -> MirModule {
+    match mirJsonParseModule(text) {
+        Ok(m) -> m,
+        Err(e) -> {
+            testing.fail(e)
+            mirModule("broken")
+        },
+    }
+}
+
+fn testMirJsonDecodeConstReturnModule() {
+    let moduleText = r"""
+{
+  "version": 1,
+  "packageName": "main",
+  "functions": [
+    {
+      "name": "main",
+      "returnType": {"kind": "prim", "display": "Int", "prim": "Int"},
+      "returnLocal": 0,
+      "locals": [
+        {"id": 0, "name": "ret", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "isReturn": true}
+      ],
+      "blocks": [
+        {
+          "id": 0,
+          "instrs": [
+            {
+              "kind": "assign",
+              "dest": {"local": 0},
+              "src": {
+                "kind": "use",
+                "op": {
+                  "kind": "const",
+                  "type": {"kind": "prim", "display": "Int", "prim": "Int"},
+                  "const": {"kind": "int", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "int": 42}
+                }
+              }
+            }
+          ],
+          "term": {"kind": "return"}
+        }
+      ]
+    }
+  ]
+}
+"""
+    let m = mjDecodeModule(moduleText)
+    testing.assertEq(m.packageName, "main")
+    testing.assertEq(m.functions.len(), 1)
+    testing.assertEq(m.functions[0].locals[0].typ, "Int")
+    testing.assert(m.functions[0].blocks[0].hasTerm)
+    let errors = mirValidateModule(m)
+    testing.assertEq(errors.len(), 0)
+    let result = lirLowerMirModule(lirLowerConfig("main", "/tmp/mir_json_test.mir.json", ""), m)
+    testing.assert(lirLowerOK(result))
+    let ir = lirRenderModule(result.module)
+    testing.assert(strings.contains(ir, "define i64 @main()"))
+    testing.assert(strings.contains(ir, "ret i64"))
+}

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -3888,7 +3888,7 @@ fn mirLowerBuildStructLitFields(bs: MirLowerBodyState, e: HirExpr, typeName: Str
             if f.hasValue {
                 out.push(mirLowerExprAsOperand(bs, f.value))
             } else {
-                out.push(mirLowerShorthandFieldOperand(bs, f))
+                out.push(mirLowerShorthandFieldOperand(bs, f, ""))
             }
         }
         return out
@@ -3909,7 +3909,7 @@ fn mirLowerBuildStructLitFields(bs: MirLowerBodyState, e: HirExpr, typeName: Str
         } else if src.hasValue {
             out.push(mirLowerExprAsOperand(bs, src.value))
         } else {
-            out.push(mirLowerShorthandFieldOperand(bs, src))
+            out.push(mirLowerShorthandFieldOperand(bs, src, fld.typ))
         }
     }
     out
@@ -3929,13 +3929,15 @@ fn mirLowerStructSpreadFieldOperand(spreadPlace: MirPlace, fld: MirFieldLayout) 
     let child = mirPlaceProject(spreadPlace, mirFieldProj(fld.index, fld.name, fld.typ))
     mirOperandCopy(child, fld.typ)
 }
-fn mirLowerShorthandFieldOperand(bs: MirLowerBodyState, f: HirStructLitField) -> MirOperand {
+fn mirLowerShorthandFieldOperand(bs: MirLowerBodyState, f: HirStructLitField, hint: String) -> MirOperand {
     let id = mirLowerLookupName(bs, f.name)
     if id < 0 {
         mirLowerNoteIssue(bs.l, "mir_lower: struct literal shorthand \"" + f.name + "\" — no local in scope")
         return mirOperandConst(mirConstUnit())
     }
-    mirOperandCopy(mirPlace(id), "")
+    let local = mirFunctionLocal(bs.fn_, id)
+    let typeText = if hint != "" { hint } else { local.typ }
+    mirOperandCopy(mirPlace(id), typeText)
 }
 // Shorthand `{ name }` binds the field to a local of the same
 // name in the enclosing scope. Look it up and emit a Copy.

--- a/toolchain/mir_validator.osty
+++ b/toolchain/mir_validator.osty
@@ -349,22 +349,24 @@ fn mirValidateStorageTarget(func: MirFunction, bb: MirBasicBlock, idx: Int, loca
 }
 fn mirValidateCallee(func: MirFunction, bb: MirBasicBlock, instr: MirInstr) -> List<String> {
     let mut errs: List<String> = []
-    match instr.calleeKind {
-        MirCalleeNone -> {
-            errs.push("function \"{func.name}\" bb{bb.id}: call with no callee")
-        },
-        MirCalleeFn -> {
-            if instr.calleeSymbol == "" {
-                errs.push("function \"{func.name}\" bb{bb.id}: fnRef empty symbol")
-            }
-        },
-        MirCalleeIndirect -> {
-            let oErrs = mirValidateOperand(func, bb, instr.calleeOperand, "indirectCall.callee")
-            for e in oErrs {
-                errs.push(e)
-            }
-        },
+    if instr.calleeKind == MirCalleeNone {
+        errs.push("function \"{func.name}\" bb{bb.id}: call with no callee")
+        return errs
     }
+    if instr.calleeKind == MirCalleeFn {
+        if instr.calleeSymbol == "" {
+            errs.push("function \"{func.name}\" bb{bb.id}: fnRef empty symbol")
+        }
+        return errs
+    }
+    if instr.calleeKind == MirCalleeIndirect {
+        let oErrs = mirValidateOperand(func, bb, instr.calleeOperand, "indirectCall.callee")
+        for e in oErrs {
+            errs.push(e)
+        }
+        return errs
+    }
+    errs.push("function \"{func.name}\" bb{bb.id}: invalid callee kind")
     errs
 }
 // ====================================================================

--- a/toolchain/selfhost_driver.osty
+++ b/toolchain/selfhost_driver.osty
@@ -1,0 +1,137 @@
+use std.env
+use std.fs
+use std.os
+use std.strings
+
+fn selfhostDriverHasCommand(args: List<String>, name: String) -> Bool {
+    args.len() > 0 && args[0] == name
+}
+
+fn selfhostDriverOptionValue(args: List<String>, name: String) -> String {
+    let prefix = name + "="
+    let mut i = 0
+    for i < args.len() {
+        let arg = args[i]
+        if strings.hasPrefix(arg, prefix) {
+            return strings.trimPrefix(arg, prefix)
+        }
+        if arg == name && i + 1 < args.len() {
+            return args[i + 1]
+        }
+        i = i + 1
+    }
+    ""
+}
+
+fn selfhostDriverProbeError() -> String {
+    let source = "fn main() -> Int {\n    let x = 41\n    return x + 1\n}\n"
+    let hir = hirLowerSource("main", source)
+    let mir = mirLowerModule(hir)
+    let mirErrs = mirValidateModule(mir)
+    if mirErrs.len() != 0 {
+        return "MIR validation failed: " + strings.join(mirErrs, "; ")
+    }
+    let cfg = lirLowerConfig("main", "<selfhost-doctor>", "")
+    let result = lirLowerMirModule(cfg, mir)
+    if !lirLowerOK(result) {
+        let mut rendered: List<String> = []
+        for d in result.diagnostics {
+            if d.severity == LirSeverityError {
+                rendered.push(lirDiagnosticRender(d))
+            }
+        }
+        if rendered.len() == 0 {
+            return "LIR Proto lowering failed without an error diagnostic"
+        }
+        return strings.join(rendered, "; ")
+    }
+    let irText = lirRenderModule(result.module)
+    if irText == "" {
+        return "LLVM IR renderer returned empty output"
+    }
+    if !strings.contains(irText, "define") {
+        return "LLVM IR renderer produced no function definition"
+    }
+    if !strings.contains(irText, "ret ") {
+        return "LLVM IR renderer produced no return instruction"
+    }
+    if strings.contains(irText, "body omitted") || strings.contains(irText, "function bodies stubbed") {
+        return "LLVM IR renderer still reports stubbed function bodies"
+    }
+    ""
+}
+
+fn selfhostDriverRunDoctor() -> Int {
+    println("osty-self mode: self-rebuild")
+    println("osty-self host compiler: disabled")
+    let probeError = selfhostDriverProbeError()
+    if probeError != "" {
+        println("osty-self source compiler: disabled")
+        println("osty-self pipeline: source -> HIR -> Mono -> MIR -> LIR Proto -> LLVM IR")
+        eprint("osty-self self-rebuild probe failed: " + probeError + "\n")
+        return 1
+    }
+    println("osty-self source compiler: enabled")
+    println("osty-self pipeline: source -> HIR -> Mono -> MIR -> LIR Proto -> LLVM IR")
+    println("osty-self self-rebuild probe: OK")
+    println("osty-self self-rebuild driver: source bundle -> clang object/runtime link")
+    0
+}
+
+fn selfhostDriverRunLirProtoLower(args: List<String>) -> Int {
+    if args.len() < 2 {
+        eprint("osty-self lir-proto-lower: missing <file> argument\n")
+        eprint("usage: osty-self lir-proto-lower <file.osty> [--package-name=NAME] [--target=TRIPLE]\n")
+        return 2
+    }
+    let path = args[1]
+    let packageName = selfhostDriverOptionValue(args, "--package-name")
+    let target = selfhostDriverOptionValue(args, "--target")
+    let source = match fs.readToString(path) {
+        Ok(s) -> s,
+        Err(_) -> {
+            eprint("osty-self lir-proto-lower: cannot read source: " + path + "\n")
+            return 2
+        },
+    }
+    let resolvedPackageName = if packageName == "" { "main" } else { packageName }
+    let hir = hirLowerSource(resolvedPackageName, source)
+    let mir = mirLowerModule(hir)
+    let mirErrs = mirValidateModule(mir)
+    if mirErrs.len() != 0 {
+        eprint("osty-self lir-proto-lower: MIR validation failed:\n")
+        for e in mirErrs {
+            eprint("  " + e + "\n")
+        }
+        return 1
+    }
+    let cfg = lirLowerConfig(resolvedPackageName, path, target)
+    let result = lirLowerMirModule(cfg, mir)
+    if !lirLowerOK(result) {
+        for d in result.diagnostics {
+            if d.severity == LirSeverityError {
+                eprint("osty-self lir-proto-lower: " + lirDiagnosticRender(d) + "\n")
+            }
+        }
+        return 1
+    }
+    print(lirRenderModule(result.module))
+    0
+}
+
+fn selfhostDriverMain() {
+    let args = env.args()
+    if selfhostDriverHasCommand(args, "--selfhost-host") {
+        println("disabled")
+        os.exit(0)
+    }
+    if selfhostDriverHasCommand(args, "--selfhost-doctor") {
+        os.exit(selfhostDriverRunDoctor())
+    }
+    if selfhostDriverHasCommand(args, "lir-proto-lower") {
+        os.exit(selfhostDriverRunLirProtoLower(args))
+    }
+    eprint("osty-self: unsupported command; host compiler forwarding is disabled\n")
+    eprint("supported subcommands: lir-proto-lower <file.osty>, --selfhost-doctor\n")
+    os.exit(2)
+}

--- a/toolchain/selfhost_mir_driver.osty
+++ b/toolchain/selfhost_mir_driver.osty
@@ -1,0 +1,183 @@
+use std.env
+use std.fs
+use std.os
+use std.strings
+
+fn selfhostMirDriverHasCommand(args: List<String>, name: String) -> Bool {
+    args.len() > 0 && args[0] == name
+}
+
+fn selfhostMirDriverOptionValue(args: List<String>, name: String) -> String {
+    let prefix = name + "="
+    let mut i = 0
+    for i < args.len() {
+        let arg = args[i]
+        if strings.hasPrefix(arg, prefix) {
+            return strings.trimPrefix(arg, prefix)
+        }
+        if arg == name && i + 1 < args.len() {
+            return args[i + 1]
+        }
+        i = i + 1
+    }
+    ""
+}
+
+fn selfhostMirDriverProbeJson() -> String {
+    r"""
+{
+  "version": 1,
+  "packageName": "main",
+  "functions": [
+    {
+      "name": "main",
+      "returnType": {"kind": "prim", "display": "Int", "prim": "Int"},
+      "returnLocal": 0,
+      "locals": [
+        {"id": 0, "name": "ret", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "isReturn": true}
+      ],
+      "blocks": [
+        {
+          "id": 0,
+          "instrs": [
+            {
+              "kind": "assign",
+              "dest": {"local": 0},
+              "src": {
+                "kind": "use",
+                "op": {
+                  "kind": "const",
+                  "type": {"kind": "prim", "display": "Int", "prim": "Int"},
+                  "const": {"kind": "int", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "int": 42}
+                }
+              }
+            }
+          ],
+          "term": {"kind": "return"}
+        }
+      ]
+    }
+  ]
+}
+"""
+}
+
+fn selfhostMirDriverProbeError() -> String {
+    let mut mir = match mirJsonParseModule(selfhostMirDriverProbeJson()) {
+        Ok(m) -> m,
+        Err(e) -> {
+            return e
+        },
+    }
+    if mir.packageName == "" {
+        mir.packageName = "main"
+    }
+    let mirErrs = mirValidateModule(mir)
+    if mirErrs.len() != 0 {
+        return "MIR validation failed: " + strings.join(mirErrs, "; ")
+    }
+    let result = lirLowerMirModule(lirLowerConfig("main", "<selfhost-mir-doctor>", ""), mir)
+    if !lirLowerOK(result) {
+        let mut rendered: List<String> = []
+        for d in result.diagnostics {
+            if d.severity == LirSeverityError {
+                rendered.push(lirDiagnosticRender(d))
+            }
+        }
+        if rendered.len() == 0 {
+            return "LIR Proto lowering failed without an error diagnostic"
+        }
+        return strings.join(rendered, "; ")
+    }
+    let irText = lirRenderModule(result.module)
+    if irText == "" {
+        return "LLVM IR renderer returned empty output"
+    }
+    if !strings.contains(irText, "define") {
+        return "LLVM IR renderer produced no function definition"
+    }
+    if !strings.contains(irText, "ret ") {
+        return "LLVM IR renderer produced no return instruction"
+    }
+    ""
+}
+
+fn selfhostMirDriverRunDoctor() -> Int {
+    println("osty-self mode: self-rebuild")
+    println("osty-self host compiler: disabled")
+    let probeError = selfhostMirDriverProbeError()
+    if probeError != "" {
+        println("osty-self MIR JSON backend: disabled")
+        eprint("osty-self self-rebuild probe failed: " + probeError + "\n")
+        return 1
+    }
+    println("osty-self MIR JSON backend: enabled")
+    println("osty-self pipeline: MIR JSON -> LIR Proto -> LLVM IR")
+    println("osty-self self-rebuild probe: OK")
+    println("osty-self self-rebuild driver: MIR JSON backend -> clang object/runtime link")
+    0
+}
+
+fn selfhostMirDriverRunLowerMirJson(args: List<String>) -> Int {
+    if args.len() < 2 {
+        eprint("osty-self lir-proto-lower-mir-json: missing <file.mir.json> argument\n")
+        return 2
+    }
+    let path = args[1]
+    let packageName = selfhostMirDriverOptionValue(args, "--package-name")
+    let target = selfhostMirDriverOptionValue(args, "--target")
+    let raw = match fs.readToString(path) {
+        Ok(s) -> s,
+        Err(_) -> {
+            eprint("osty-self lir-proto-lower-mir-json: cannot read MIR JSON: " + path + "\n")
+            return 2
+        },
+    }
+    let resolvedPackageName = if packageName == "" { "main" } else { packageName }
+    let mut mir = match mirJsonParseModule(raw) {
+        Ok(m) -> m,
+        Err(e) -> {
+            eprint("osty-self lir-proto-lower-mir-json: " + e + "\n")
+            return 1
+        },
+    }
+    if mir.packageName == "" {
+        mir.packageName = resolvedPackageName
+    }
+    let mirErrs = mirValidateModule(mir)
+    if mirErrs.len() != 0 {
+        eprint("osty-self lir-proto-lower-mir-json: MIR validation failed:\n")
+        for e in mirErrs {
+            eprint("  " + e + "\n")
+        }
+        return 1
+    }
+    let result = lirLowerMirModule(lirLowerConfig(resolvedPackageName, path, target), mir)
+    if !lirLowerOK(result) {
+        for d in result.diagnostics {
+            if d.severity == LirSeverityError {
+                eprint("osty-self lir-proto-lower-mir-json: " + lirDiagnosticRender(d) + "\n")
+            }
+        }
+        return 1
+    }
+    print(lirRenderModule(result.module))
+    0
+}
+
+fn selfhostMirDriverMain() {
+    let args = env.args()
+    if selfhostMirDriverHasCommand(args, "--selfhost-host") {
+        println("disabled")
+        os.exit(0)
+    }
+    if selfhostMirDriverHasCommand(args, "--selfhost-doctor") {
+        os.exit(selfhostMirDriverRunDoctor())
+    }
+    if selfhostMirDriverHasCommand(args, "lir-proto-lower-mir-json") {
+        os.exit(selfhostMirDriverRunLowerMirJson(args))
+    }
+    eprint("osty-self: unsupported command; host compiler forwarding is disabled\n")
+    eprint("supported subcommands: lir-proto-lower-mir-json <file.mir.json>, --selfhost-doctor\n")
+    os.exit(2)
+}


### PR DESCRIPTION
## Summary

- Adds an interim selfhost MIR JSON path so the native LIR Proto bridge can stage MIR JSON and ask `osty-self` to lower it.
- Adds a selfhost MIR JSON decoder/driver bundle plus verify-self-rebuild stage2/stage3 wiring.
- Extends the selfhost MIR emitter around named layouts, projected reads, Result/enum payloads, byte/list bytes_v1 paths, and block-local SSA naming.

## Validation

- `.bin/osty check --airepair=false toolchain/mir_generator.osty toolchain/llvmgen.osty toolchain/mir.osty`
- `scripts/verify-self-rebuild --skip-gates --reuse-stage1 .bin/osty` is still being driven in follow-up work; this PR is intentionally an interim draft checkpoint.

## Notes

- Draft checkpoint requested before continuing the remaining selfhost build closure.
