### PR TITLE
[codex] harden selfhost lirproto stage0

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -35,6 +35,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/osty/osty/internal/backend/stage0"
+	"github.com/osty/osty/internal/llvmabi"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/mirjson"
 	"github.com/osty/osty/internal/nativelirproto"
 	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
@@ -101,6 +105,37 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 		args = append(args, "--target="+req.Target)
 	}
 
+	resp, declineReason, err := runSelfLower(selfBin, args)
+	if err != nil || !resp.Declined {
+		return resp, err
+	}
+	if command == "lir-proto-lower-mir-json" && isUnsupportedSelfCommand(declineReason) {
+		return lowerLegacyMIRJSON(req, selfBin)
+	}
+	return resp, nil
+}
+
+func lowerSourceCompat(selfBin string, req nativelirproto.Request) (nativelirproto.Response, error) {
+	sourcePath, _, cleanup, err := stageInput(req)
+	if cleanup != nil && os.Getenv("OSTY_LIRPROTO_KEEP_STAGED") == "" {
+		defer cleanup()
+	}
+	if err != nil {
+		return nativelirproto.Response{}, err
+	}
+	pkgName := req.PackageName
+	if pkgName == "" {
+		pkgName = "main"
+	}
+	args := []string{"lir-proto-lower", sourcePath, "--package-name=" + pkgName}
+	if req.Target != "" {
+		args = append(args, "--target="+req.Target)
+	}
+	resp, _, err := runSelfLower(selfBin, args)
+	return resp, err
+}
+
+func runSelfLower(selfBin string, args []string) (nativelirproto.Response, string, error) {
 	cmd := exec.Command(selfBin, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -111,13 +146,115 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 		if msg == "" {
 			msg = err.Error()
 		}
-		return nativelirproto.Response{Declined: true, Error: msg}, nil
+		return nativelirproto.Response{Declined: true, Error: msg}, msg, nil
 	}
 	ir := stdout.String()
 	if ir == "" {
-		return nativelirproto.Response{Declined: true, Error: "osty-self lir-proto-lower produced empty IR"}, nil
+		command := "command"
+		if len(args) > 0 {
+			command = args[0]
+		}
+		msg := fmt.Sprintf("osty-self %s produced empty IR", command)
+		return nativelirproto.Response{Declined: true, Error: msg}, msg, nil
 	}
-	return nativelirproto.Response{LLVMIR: ir}, nil
+	return nativelirproto.Response{LLVMIR: ir}, "", nil
+}
+
+func isUnsupportedSelfCommand(msg string) bool {
+	return strings.Contains(msg, "osty-self: unsupported command") ||
+		(strings.Contains(msg, "unsupported command") && strings.Contains(msg, "lir-proto-lower-mir-json"))
+}
+
+func lowerLegacyMIRJSON(req nativelirproto.Request, selfBin string) (nativelirproto.Response, error) {
+	// Older bootstrap seeds know `lir-proto-lower` but predate the
+	// MIR JSON entry point. Prefer the already-lowered MIR payload so
+	// object/library requests keep their caller-provided entrypoint,
+	// then use source re-lowering only as a last compatibility step.
+	stage0Resp, triedStage0 := lowerMIRJSONStage0Compat(req)
+	if triedStage0 && !stage0Resp.Declined {
+		return stage0Resp, nil
+	}
+	if req.Source == "" {
+		if triedStage0 {
+			return stage0Resp, nil
+		}
+		return nativelirproto.Response{Declined: true, Error: "legacy osty-self does not support MIR JSON requests"}, nil
+	}
+	sourceReq := req
+	sourceReq.MIR = nil
+	sourceResp, err := lowerSourceCompat(selfBin, sourceReq)
+	if err != nil || !sourceResp.Declined || !triedStage0 {
+		return sourceResp, err
+	}
+	return nativelirproto.Response{
+		Declined: true,
+		Error:    combineDeclineErrors(stage0Resp.Error, sourceResp.Error),
+	}, nil
+}
+
+func lowerMIRJSONStage0Compat(req nativelirproto.Request) (nativelirproto.Response, bool) {
+	if req.MIR == nil {
+		return nativelirproto.Response{}, false
+	}
+	encoded, err := json.Marshal(req.MIR)
+	if err != nil {
+		return nativelirproto.Response{Declined: true, Error: fmt.Sprintf("stage0 MIR compat: marshal MIR JSON: %v", err)}, true
+	}
+	var payload mirjson.Module
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		return nativelirproto.Response{Declined: true, Error: fmt.Sprintf("stage0 MIR compat: decode MIR JSON: %v", err)}, true
+	}
+	mod, err := mirjson.ToModule(&payload)
+	if err != nil {
+		return nativelirproto.Response{Declined: true, Error: fmt.Sprintf("stage0 MIR compat: convert MIR JSON: %v", err)}, true
+	}
+	if len(mod.Functions) == 0 {
+		return nativelirproto.Response{Declined: true, Error: "stage0 MIR compat: module has no functions"}, true
+	}
+	if errs := mir.Validate(mod); len(errs) > 0 {
+		return nativelirproto.Response{Declined: true, Error: fmt.Sprintf("stage0 MIR compat: invalid MIR: %s", joinErrors(errs))}, true
+	}
+	pkgName := req.PackageName
+	if pkgName == "" {
+		pkgName = payload.PackageName
+	}
+	if pkgName == "" {
+		pkgName = "main"
+	}
+	ir, err := stage0.EmitMIRAllowNoMain(mod, llvmabi.Options{
+		PackageName: pkgName,
+		SourcePath:  req.SourcePath,
+		Source:      []byte(req.Source),
+		Target:      req.Target,
+		UseMIR:      true,
+		EmitGC:      true,
+	})
+	if err != nil {
+		return nativelirproto.Response{Declined: true, Error: fmt.Sprintf("stage0 MIR compat: %v", err)}, true
+	}
+	return nativelirproto.Response{LLVMIR: string(ir)}, true
+}
+
+func joinErrors(errs []error) string {
+	parts := make([]string, 0, len(errs))
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		parts = append(parts, err.Error())
+	}
+	return strings.Join(parts, "; ")
+}
+
+func combineDeclineErrors(primary, secondary string) string {
+	switch {
+	case primary == "":
+		return secondary
+	case secondary == "":
+		return primary
+	default:
+		return primary + "; source compat: " + secondary
+	}
 }
 
 // resolveOstySelfBin returns the path to the self-host `osty-self`

--- a/cmd/osty-native-lirproto/main_test.go
+++ b/cmd/osty-native-lirproto/main_test.go
@@ -12,6 +12,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/mirjson"
 	"github.com/osty/osty/internal/nativelirproto"
 )
 
@@ -196,6 +199,146 @@ func TestRunMIRPayloadInvokesMirJSONLower(t *testing.T) {
 	}
 }
 
+func TestRunMIRPayloadRetriesSourceWhenMirJSONUnsupported(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	captureDir := t.TempDir()
+	captureArgs := filepath.Join(captureDir, "args.json")
+	captureSource := filepath.Join(captureDir, "source.osty")
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_REJECT_MIR_JSON", "1")
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_SOURCE", captureSource)
+	t.Setenv("FAKE_OSTY_SELF_STDOUT", "; compat source IR\ndefine i64 @main() {\n  ret i64 7\n}\n")
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		Source:      "fn main() -> Int { 7 }\n",
+		MIR: map[string]any{
+			"version":     1,
+			"packageName": "main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if resp.Declined {
+		t.Fatalf("Declined = true, want false: %+v", resp)
+	}
+	if !strings.Contains(resp.LLVMIR, "compat source IR") {
+		t.Fatalf("LLVMIR missing compat output:\n%s", resp.LLVMIR)
+	}
+	args := readCapturedArgs(t, captureArgs)
+	if len(args) < 2 || args[0] != "lir-proto-lower" {
+		t.Fatalf("compat args = %v, want source lir-proto-lower retry", args)
+	}
+	if staged := readFile(t, captureSource); !strings.Contains(staged, "fn main() -> Int { 7 }") {
+		t.Fatalf("compat retry staged %q, want original source", staged)
+	}
+}
+
+func TestRunMIRPayloadUsesStage0CompatWhenMirJSONUnsupported(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	captureDir := t.TempDir()
+	captureArgs := filepath.Join(captureDir, "args.json")
+
+	payload, err := mirjson.FromModule(&mir.Module{
+		Package: "main",
+		Functions: []*mir.Function{
+			{
+				Name:        "zero",
+				ReturnType:  ir.TInt,
+				ReturnLocal: 0,
+				Locals: []*mir.Local{
+					{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+				},
+				Entry: 0,
+				Blocks: []*mir.BasicBlock{
+					{
+						ID: 0,
+						Instrs: []mir.Instr{
+							&mir.AssignInstr{
+								Dest: mir.Place{Local: 0},
+								Src: &mir.UseRV{Op: &mir.ConstOp{
+									Const: &mir.IntConst{Value: 7, T: ir.TInt},
+									T:     ir.TInt,
+								}},
+							},
+						},
+						Term: &mir.ReturnTerm{},
+					},
+				},
+			},
+		},
+		Layouts: mir.NewLayoutTable(),
+	})
+	if err != nil {
+		t.Fatalf("build MIR JSON payload: %v", err)
+	}
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_REJECT_MIR_JSON", "1")
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
+	t.Setenv("FAKE_OSTY_SELF_STDOUT", "; source fallback should not run\n")
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/zero.osty",
+		MIR:         payload,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if resp.Declined {
+		t.Fatalf("Declined = true, want false: %+v", resp)
+	}
+	if !strings.Contains(resp.LLVMIR, "define i64 @zero()") || !strings.Contains(resp.LLVMIR, "ret i64 7") {
+		t.Fatalf("LLVMIR missing stage0 compat function:\n%s", resp.LLVMIR)
+	}
+	if strings.Contains(resp.LLVMIR, "source fallback should not run") {
+		t.Fatalf("stage0 compat unexpectedly used source fallback:\n%s", resp.LLVMIR)
+	}
+	args := readCapturedArgs(t, captureArgs)
+	if len(args) < 2 || args[0] != "lir-proto-lower-mir-json" {
+		t.Fatalf("first args = %v, want MIR JSON attempt before compat", args)
+	}
+}
+
+func TestUnsupportedSelfCommandDetection(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{msg: "osty-self: unsupported command; host compiler forwarding is disabled", want: true},
+		{msg: "unsupported command: lir-proto-lower-mir-json", want: true},
+		{msg: "unsupported command: compile", want: false},
+		{msg: "parse error", want: false},
+	}
+	for _, tc := range cases {
+		if got := isUnsupportedSelfCommand(tc.msg); got != tc.want {
+			t.Fatalf("isUnsupportedSelfCommand(%q) = %t, want %t", tc.msg, got, tc.want)
+		}
+	}
+}
+
 // TestRunDeclinesWhenOstySelfExitsNonZero pins the second
 // fall-back: a non-zero exit from osty-self (parse failure,
 // unsupported MIR shape, etc.) lands as a `declined: true`
@@ -331,6 +474,10 @@ func main() {
 				_, _ = io.Copy(dst, src)
 			}
 		}
+	}
+	if os.Getenv("FAKE_OSTY_SELF_REJECT_MIR_JSON") != "" && len(os.Args) > 1 && os.Args[1] == "lir-proto-lower-mir-json" {
+		_, _ = os.Stderr.WriteString("osty-self: unsupported command; host compiler forwarding is disabled\n")
+		os.Exit(1)
 	}
 	if msg := os.Getenv("FAKE_OSTY_SELF_STDERR"); msg != "" {
 		_, _ = os.Stderr.WriteString(msg)

--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -83,6 +83,7 @@ func tryMIRRequestViaLIRProto(req llvmgenRequest) ([]byte, []string, bool) {
 	resp, err := nativelirproto.Run(req.MIR.SourcePath, nativelirproto.Request{
 		PackageName: req.MIR.PackageName,
 		SourcePath:  req.MIR.SourcePath,
+		Source:      req.MIR.Source,
 		Target:      req.MIR.Target,
 		MIR:         req.MIR.Module,
 	})

--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -76,6 +76,7 @@ func TestRunMIRPayloadPrefersLIRProtoWhenSelected(t *testing.T) {
 		MIR: &llvmgenMIRInput{
 			PackageName: entry.PackageName,
 			SourcePath:  entry.SourcePath,
+			Source:      string(entry.Source),
 			Target:      "x86_64-unknown-linux-gnu",
 			Module:      payload,
 		},
@@ -102,7 +103,7 @@ func TestRunMIRPayloadPrefersLIRProtoWhenSelected(t *testing.T) {
 		MIR         json.RawMessage `json:"mir"`
 	}
 	decodeCapturedLIRRequest(t, capture, &lirReq)
-	if lirReq.PackageName != "main" || lirReq.SourcePath != entry.SourcePath || lirReq.Source != "" || lirReq.Target != "x86_64-unknown-linux-gnu" || len(lirReq.MIR) == 0 {
+	if lirReq.PackageName != "main" || lirReq.SourcePath != entry.SourcePath || !strings.Contains(lirReq.Source, "fn main() -> Int { 7 }") || lirReq.Target != "x86_64-unknown-linux-gnu" || len(lirReq.MIR) == 0 {
 		t.Fatalf("captured LIR request = %#v", lirReq)
 	}
 }

--- a/internal/backend/llvm_runtime_stage0_audit_symbols_test.go
+++ b/internal/backend/llvm_runtime_stage0_audit_symbols_test.go
@@ -24,16 +24,26 @@ func TestBundledRuntimeStage0AuditAliasesLinkWithThinLTO(t *testing.T) {
 	}
 
 	ir := `@.path = private unnamed_addr constant [2 x i8] c".\00"
+@.missing = private unnamed_addr constant [26 x i8] c"stage0-alias-missing-path\00"
 @.fmt = private unnamed_addr constant [6 x i8] c"%lld\0A\00"
 @stderr = external global ptr
-@llvm.used = appending global [14 x ptr] [
+@llvm.used = appending global [23 x ptr] [
   ptr @Char__toString,
   ptr @Char__len,
   ptr @std.strings.fromChar,
   ptr @std.strings.compare,
   ptr @std.env.args,
   ptr @std.env.get,
+  ptr @std.testing.assert,
+  ptr @std.testing.assertTrue,
+  ptr @std.testing.assertFalse,
+  ptr @std.testing.assertEq,
+  ptr @std.testing.assertNe,
+  ptr @std.testing.fail,
   ptr @std.fs.readToString,
+  ptr @std.fs.walk,
+  ptr @std.fs.mkdirAll,
+  ptr @std.fs.writeString,
   ptr @std.os.exit,
   ptr @std.process.abort,
   ptr @runtime.path.filepath.Base,
@@ -49,7 +59,16 @@ declare ptr @std.strings.fromChar(i32)
 declare i64 @std.strings.compare(ptr, ptr)
 declare ptr @std.env.args()
 declare ptr @std.env.get(ptr)
+declare void @std.testing.assert(i1)
+declare void @std.testing.assertTrue(i1)
+declare void @std.testing.assertFalse(i1)
+declare void @std.testing.assertEq(i64, i64)
+declare void @std.testing.assertNe(i64, i64)
+declare void @std.testing.fail(ptr)
 declare ptr @std.fs.readToString(ptr)
+declare ptr @std.fs.walk(ptr)
+declare ptr @std.fs.mkdirAll(ptr)
+declare ptr @std.fs.writeString(ptr, ptr)
 declare void @std.os.exit(i64)
 declare void @std.process.abort(ptr)
 declare ptr @runtime.path.filepath.Base(ptr)
@@ -66,7 +85,15 @@ entry:
   %cmp = call i64 @std.strings.compare(ptr %from_char, ptr %to_string)
   %args = call ptr @std.env.args()
   %env = call ptr @std.env.get(ptr %from_char)
+  call void @std.testing.assert(i1 true)
+  call void @std.testing.assertTrue(i1 true)
+  call void @std.testing.assertFalse(i1 false)
+  call void @std.testing.assertEq(i64 7, i64 7)
+  call void @std.testing.assertNe(i64 7, i64 8)
   %file = call ptr @std.fs.readToString(ptr @.path)
+  %walk = call ptr @std.fs.walk(ptr @.missing)
+  %mkdir = call ptr @std.fs.mkdirAll(ptr @.path)
+  %write = call ptr @std.fs.writeString(ptr @.path, ptr %from_char)
   %base = call ptr @runtime.path.filepath.Base(ptr @.path)
   %ext = call ptr @runtime.path.filepath.Ext(ptr @.path)
   %interp = call ptr @__interp()

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -355,22 +355,22 @@ func TestEmitLLVMIRTextMatchesBackendArtifactOutput(t *testing.T) {
 	req.Features = []string{"mir-backend"}
 
 	got, _, directErr := EmitLLVMIRText(req.Entry, "", req.Features)
-	if directErr == nil {
-		t.Fatal("EmitLLVMIRText should return error with Go MIR emitter removed")
+	if directErr != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", directErr)
 	}
 	result, err := backend.Emit(context.Background(), req)
-	if err == nil {
-		t.Fatal("backend.Emit should return error with Go MIR emitter removed")
+	if err != nil {
+		t.Fatalf("backend.Emit returned error: %v", err)
 	}
 	want, readErr := os.ReadFile(result.Artifacts.LLVMIR)
 	if readErr != nil {
 		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
 	}
-	if !strings.Contains(string(got), "LLVM000") || !strings.Contains(string(got), "source_filename") {
-		t.Fatalf("direct skeleton should contain diagnostic header:\n%s", got)
+	if string(got) != string(want) {
+		t.Fatalf("direct IR and artifact IR differ\ndirect:\n%s\nartifact:\n%s", got, want)
 	}
-	if !strings.Contains(string(want), "LLVM000") || !strings.Contains(string(want), "source_filename") {
-		t.Fatalf("artifact skeleton should contain diagnostic header:\n%s", want)
+	if !strings.Contains(string(got), "define i32 @main()") || !strings.Contains(string(got), "@printf") {
+		t.Fatalf("emitted IR missing expected main/printf body:\n%s", got)
 	}
 }
 
@@ -804,12 +804,23 @@ func TestLLVMBackendDispatchTraceReportsSelectedRoute(t *testing.T) {
 `)
 	req.Features = []string{"mir-backend"}
 
-	_, emitErr, trace := captureLLVMBackendTrace(t, backend, req)
-	if emitErr == nil {
-		t.Fatal("Emit should return an error; Go MIR emitter fallback has been removed")
+	result, emitErr, trace := captureLLVMBackendTrace(t, backend, req)
+	if emitErr != nil {
+		t.Fatalf("Emit returned error: %v", emitErr)
 	}
-	if !strings.Contains(trace, "mir-direct unsupported") {
-		t.Fatalf("dispatch trace should show unsupported route, got:\n%s", trace)
+	if result == nil {
+		t.Fatal("Emit returned nil result")
+	}
+	for _, want := range []string{
+		"backend trace: llvm mir-direct emit",
+		"backend trace: llvm mir-direct succeeded",
+	} {
+		if !strings.Contains(trace, want) {
+			t.Fatalf("dispatch trace missing %q:\n%s", want, trace)
+		}
+	}
+	if strings.Contains(trace, "mir-direct unsupported") {
+		t.Fatalf("dispatch trace unexpectedly reported unsupported route:\n%s", trace)
 	}
 }
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -31026,6 +31026,84 @@ void *osty_rt_audit_i64_placeholder(void) {
   return osty_rt_string_dup_site("", 0, "stage0.audit.i64_placeholder");
 }
 
+static void osty_rt_audit_testing_fail_message(const char *name) {
+    fputs("std.testing.", stderr);
+    fputs(name != NULL ? name : "assert", stderr);
+    fputs(" failed\n", stderr);
+    abort();
+}
+
+static void osty_rt_audit_testing_fail_eq(const char *name, int64_t actual, int64_t expected) {
+    fprintf(stderr, "std.testing.%s failed: actual=%lld expected=%lld\n",
+        name != NULL ? name : "assertEq", (long long)actual, (long long)expected);
+    abort();
+}
+
+/* std.testing assertion aliases used by stage0 object/library output.
+ * The ordinary LLVM backend lowers these directly into the test harness;
+ * stage0 leaves declaration-only stdlib helpers as external calls, so
+ * the runtime provides the same process-failing contract at link time. */
+void osty_rt_audit_testing_assert(bool cond) __asm__(OSTY_RT_AUDIT_SYMBOL("std.testing.assert")) OSTY_RT_AUDIT_USED;
+void osty_rt_audit_testing_assert(bool cond) {
+    if (!cond) {
+        osty_rt_audit_testing_fail_message("assert");
+    }
+}
+
+void osty_rt_audit_testing_assertTrue(bool cond) __asm__(OSTY_RT_AUDIT_SYMBOL("std.testing.assertTrue")) OSTY_RT_AUDIT_USED;
+void osty_rt_audit_testing_assertTrue(bool cond) {
+    if (!cond) {
+        osty_rt_audit_testing_fail_message("assertTrue");
+    }
+}
+
+void osty_rt_audit_testing_assertFalse(bool cond) __asm__(OSTY_RT_AUDIT_SYMBOL("std.testing.assertFalse")) OSTY_RT_AUDIT_USED;
+void osty_rt_audit_testing_assertFalse(bool cond) {
+    if (cond) {
+        osty_rt_audit_testing_fail_message("assertFalse");
+    }
+}
+
+void osty_rt_audit_testing_assertEq(int64_t actual, int64_t expected) __asm__(OSTY_RT_AUDIT_SYMBOL("std.testing.assertEq")) OSTY_RT_AUDIT_USED;
+void osty_rt_audit_testing_assertEq(int64_t actual, int64_t expected) {
+    if (actual != expected) {
+        osty_rt_audit_testing_fail_eq("assertEq", actual, expected);
+    }
+}
+
+void osty_rt_audit_testing_assertNe(int64_t actual, int64_t expected) __asm__(OSTY_RT_AUDIT_SYMBOL("std.testing.assertNe")) OSTY_RT_AUDIT_USED;
+void osty_rt_audit_testing_assertNe(int64_t actual, int64_t expected) {
+    if (actual == expected) {
+        osty_rt_audit_testing_fail_eq("assertNe", actual, expected);
+    }
+}
+
+void osty_rt_audit_testing_fail(const char *msg) __asm__(OSTY_RT_AUDIT_SYMBOL("std.testing.fail")) OSTY_RT_AUDIT_USED;
+void osty_rt_audit_testing_fail(const char *msg) {
+    if (msg != NULL) {
+        char msg_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+        const char *msg_ptr = msg;
+        osty_rt_string_decode_to_buf_if_inline(&msg_ptr, msg_buf);
+        fputs(msg_ptr, stderr);
+        fputc('\n', stderr);
+    }
+    osty_rt_audit_testing_fail_message("fail");
+}
+
+static void *osty_rt_audit_result_box(int64_t tag, void *payload, const char *site) {
+    int64_t *box = (int64_t *)osty_rt_stage0_alloc((int64_t)(sizeof(int64_t) * 2));
+    if (box == NULL) {
+        return NULL;
+    }
+    box[0] = tag;
+    box[1] = 0;
+    if (payload != NULL) {
+        memcpy(&box[1], &payload, sizeof(payload));
+    }
+    (void)site;
+    return box;
+}
+
 /* std.fs.readToString(path) — read the entire file at `path` as a
  * UTF-8 String. Returns a heap-allocated `%stage0.Result.ptr`
  * ({ i64 tag, ptr value }): tag=0 (Ok) with the contents on success,
@@ -31042,13 +31120,11 @@ void *osty_rt_audit_i64_placeholder(void) {
 void *osty_rt_audit_fs_readToString(const char *path) __asm__(
     OSTY_RT_AUDIT_SYMBOL("std.fs.readToString")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_fs_readToString(const char *path) {
-  int64_t *box =
-      (int64_t *)osty_rt_stage0_alloc((int64_t)(sizeof(int64_t) * 2));
+  int64_t *box = (int64_t *)osty_rt_audit_result_box(
+      1, NULL, "stage0.audit.fs.readToString.result");
   if (box == NULL) {
     return NULL;
   }
-  box[0] = 1; /* Err */
-  box[1] = 0;
   if (path == NULL) {
     return box;
   }
@@ -31090,74 +31166,35 @@ void *osty_rt_audit_fs_readToString(const char *path) {
   return box;
 }
 
-/* std.fs.writeString(path, contents) — write `contents` to `path` as UTF-8
- * text. Returns a heap-allocated `%stage0.Result.ptr`: tag=0 (Ok) on success,
- * tag=1 (Err) with an error pointer on failure. */
-void *
-osty_rt_audit_fs_writeString(const char *path, const char *contents) __asm__(
-    OSTY_RT_AUDIT_SYMBOL("std.fs.writeString")) OSTY_RT_AUDIT_USED;
-void *osty_rt_audit_fs_writeString(const char *path, const char *contents) {
-  int64_t *box =
-      (int64_t *)osty_rt_stage0_alloc((int64_t)(sizeof(int64_t) * 2));
-  if (box == NULL) {
-    return NULL;
-  }
-  box[0] = 1; /* Err */
-  box[1] = 0;
-  void *err = osty_rt_fs_write_string(path, contents);
-  if (err != NULL) {
-    memcpy(&box[1], &err, sizeof(err));
-    return box;
-  }
-  box[0] = 0; /* Ok */
-  return box;
-}
-
-/* std.fs.mkdirAll(path) — create directory and all parents.
- * Returns a heap-allocated `%stage0.Result.ptr`: tag=0 (Ok) on success,
- * tag=1 (Err) with an error pointer on failure. */
-void *osty_rt_audit_fs_mkdirAll(const char *path) __asm__(
-    OSTY_RT_AUDIT_SYMBOL("std.fs.mkdirAll")) OSTY_RT_AUDIT_USED;
-void *osty_rt_audit_fs_mkdirAll(const char *path) {
-  int64_t *box =
-      (int64_t *)osty_rt_stage0_alloc((int64_t)(sizeof(int64_t) * 2));
-  if (box == NULL) {
-    return NULL;
-  }
-  box[0] = 1; /* Err */
-  box[1] = 0;
-  void *err = osty_rt_fs_mkdir_all(path);
-  if (err != NULL) {
-    memcpy(&box[1], &err, sizeof(err));
-    return box;
-  }
-  box[0] = 0; /* Ok */
-  return box;
-}
-
-/* std.fs.walk(root) — recursively list all descendants under `root`.
- * Returns a heap-allocated `%stage0.Result.ptr`: tag=0 (Ok) with a
- * `List<String>` on success, tag=1 (Err) with an error pointer on failure. */
-void *osty_rt_audit_fs_walk(const char *root) __asm__(
-    OSTY_RT_AUDIT_SYMBOL("std.fs.walk")) OSTY_RT_AUDIT_USED;
+/* std.fs.walk(path) — forward to the runtime walker and wrap the
+ * List<String> / Error result in the Result box shape stage0 expects. */
+void *osty_rt_audit_fs_walk(const char *root) __asm__(OSTY_RT_AUDIT_SYMBOL("std.fs.walk")) OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_fs_walk(const char *root) {
-  int64_t *box =
-      (int64_t *)osty_rt_stage0_alloc((int64_t)(sizeof(int64_t) * 2));
-  if (box == NULL) {
-    return NULL;
-  }
-  box[0] = 1; /* Err */
-  box[1] = 0;
-  void *list = osty_rt_fs_walk(root);
-  if (list == NULL) {
-    void *err =
-        osty_rt_fs_error_message("walk failed", "runtime.fs.walk.error");
-    memcpy(&box[1], &err, sizeof(err));
-    return box;
-  }
-  box[0] = 0; /* Ok */
-  memcpy(&box[1], &list, sizeof(list));
-  return box;
+    void *paths = osty_rt_fs_walk(root);
+    if (paths == NULL) {
+        return osty_rt_audit_result_box(1, osty_rt_fs_error(), "stage0.audit.fs.walk.err");
+    }
+    return osty_rt_audit_result_box(0, paths, "stage0.audit.fs.walk.ok");
+}
+
+/* std.fs.mkdirAll(path) — Result<(), Error>. */
+void *osty_rt_audit_fs_mkdirAll(const char *path) __asm__(OSTY_RT_AUDIT_SYMBOL("std.fs.mkdirAll")) OSTY_RT_AUDIT_USED;
+void *osty_rt_audit_fs_mkdirAll(const char *path) {
+    void *err = osty_rt_fs_mkdir_all(path);
+    if (err != NULL) {
+        return osty_rt_audit_result_box(1, err, "stage0.audit.fs.mkdirAll.err");
+    }
+    return osty_rt_audit_result_box(0, NULL, "stage0.audit.fs.mkdirAll.ok");
+}
+
+/* std.fs.writeString(path, contents) — Result<(), Error>. */
+void *osty_rt_audit_fs_writeString(const char *path, const char *contents) __asm__(OSTY_RT_AUDIT_SYMBOL("std.fs.writeString")) OSTY_RT_AUDIT_USED;
+void *osty_rt_audit_fs_writeString(const char *path, const char *contents) {
+    void *err = osty_rt_fs_write_string(path, contents);
+    if (err != NULL) {
+        return osty_rt_audit_result_box(1, err, "stage0.audit.fs.writeString.err");
+    }
+    return osty_rt_audit_result_box(0, NULL, "stage0.audit.fs.writeString.ok");
 }
 
 #undef OSTY_RT_AUDIT_USED

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -109,6 +109,16 @@ func declineReason(err error) string {
 //     tuple (classifyAggregateReturnType). All params scalar. The callee
 //     prototype is declared if it is not a locally-defined symbol.
 func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
+	return emitMIR(module, opts, true)
+}
+
+// EmitMIRAllowNoMain emits a stage0 module for object/library style
+// consumers that provide their own entry point at link time.
+func EmitMIRAllowNoMain(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
+	return emitMIR(module, opts, false)
+}
+
+func emitMIR(module *mir.Module, opts llvmabi.Options, requireMain bool) ([]byte, error) {
 	if module == nil {
 		return nil, fmt.Errorf("stage0: nil MIR module")
 	}
@@ -172,7 +182,7 @@ func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 				emittedMain = true
 			}
 		}
-		if !emittedMain {
+		if requireMain && !emittedMain {
 			return nil, fmt.Errorf("%w: module has no `main` function", ErrUnsupported)
 		}
 		if mctx.extraDecls.Len() > 0 {
@@ -327,7 +337,7 @@ func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 	// audit harness's module-level clang verify) can do so. Pre-existing
 	// callers that ignore bytes on err == non-nil are unaffected.
 	aggregated := listAll && len(declines) > 0
-	if !emittedMain {
+	if requireMain && !emittedMain {
 		return nil, fmt.Errorf("%w: module has no `main` function", ErrUnsupported)
 	}
 
@@ -877,6 +887,15 @@ func (m *moduleCtx) freshTempName(label string) string {
 		return "%stage0.tmp"
 	}
 	name := fmt.Sprintf("%%stage0.%s.%d", sanitizeLLVMName(label, "tmp"), m.nextTempID)
+	m.nextTempID++
+	return name
+}
+
+func (m *moduleCtx) freshLabelName(label string) string {
+	if m == nil {
+		return "stage0.tmp"
+	}
+	name := fmt.Sprintf("stage0.%s.%d", sanitizeLLVMName(label, "tmp"), m.nextTempID)
 	m.nextTempID++
 	return name
 }
@@ -1437,6 +1456,11 @@ type pendingInstr struct {
 type callArg struct {
 	expr string
 	ty   string // LLVM type ("i64" / "i1")
+}
+
+type testingArg struct {
+	expr string
+	ty   scalarType
 }
 
 type resolvedCallArgs struct {
@@ -2332,6 +2356,9 @@ func classifyCallStep(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.Loca
 	if ref.Symbol == "" {
 		return pendingInstr{}, 0, scalarUnknown, false
 	}
+	if pending, destID, destType, ok := classifyKnownIntMethodCallStep(fn, ci, bindings, mctx, ref.Symbol); ok {
+		return pending, destID, destType, true
+	}
 	allowOpaqueUserNamed := true
 	destID := ci.Dest.Local
 	destLocal := lookupLocal(fn, destID)
@@ -2388,6 +2415,111 @@ func classifyCallStep(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.Loca
 		callSymbol: ref.Symbol,
 		callArgs:   args,
 	}, destID, destType, true
+}
+
+func classifyKnownIntMethodCallStep(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.LocalID]localBinding, mctx *moduleCtx, symbol string) (pendingInstr, mir.LocalID, scalarType, bool) {
+	arity, ok := knownIntMethodArity(symbol)
+	if !ok || ci == nil || ci.Dest == nil || ci.Dest.HasProjections() || len(ci.Args) != arity {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	if lookupLocal(fn, ci.Dest.Local) == nil {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	exprs := make([]string, 0, len(ci.Args))
+	var prelude strings.Builder
+	for _, op := range ci.Args {
+		argPrelude, argExpr, argTy, ok := resolveOperandWithPrelude(fn, op, bindings, mctx)
+		if !ok || argTy != scalarInt {
+			return pendingInstr{}, 0, scalarUnknown, false
+		}
+		prelude.WriteString(argPrelude)
+		exprs = append(exprs, argExpr)
+	}
+	body, result, ok := renderKnownIntMethodCall(symbol, exprs, func(label string) string {
+		return mctx.freshTempName(label)
+	})
+	if !ok {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	return pendingInstr{
+		kind:          instrIntrinsic,
+		binDestReg:    result,
+		intrinsicLine: prelude.String() + body,
+	}, ci.Dest.Local, scalarInt, true
+}
+
+func knownIntMethodArity(symbol string) (int, bool) {
+	switch symbol {
+	case "Int__abs", "Int__signum":
+		return 1, true
+	case "Int__min", "Int__max":
+		return 2, true
+	case "Int__clamp":
+		return 3, true
+	}
+	return 0, false
+}
+
+func renderKnownIntMethodCall(symbol string, args []string, fresh func(string) string) (string, string, bool) {
+	if fresh == nil {
+		return "", "", false
+	}
+	var out strings.Builder
+	switch symbol {
+	case "Int__abs":
+		if len(args) != 1 {
+			return "", "", false
+		}
+		neg := fresh("int.abs.neg")
+		isNeg := fresh("int.abs.isneg")
+		result := fresh("int.abs")
+		fmt.Fprintf(&out, "  %s = sub i64 0, %s\n", neg, args[0])
+		fmt.Fprintf(&out, "  %s = icmp slt i64 %s, 0\n", isNeg, args[0])
+		fmt.Fprintf(&out, "  %s = select i1 %s, i64 %s, i64 %s\n", result, isNeg, neg, args[0])
+		return out.String(), result, true
+	case "Int__min", "Int__max":
+		if len(args) != 2 {
+			return "", "", false
+		}
+		pred := "slt"
+		label := "int.min"
+		if symbol == "Int__max" {
+			pred = "sgt"
+			label = "int.max"
+		}
+		cmp := fresh(label + ".cmp")
+		result := fresh(label)
+		fmt.Fprintf(&out, "  %s = icmp %s i64 %s, %s\n", cmp, pred, args[0], args[1])
+		fmt.Fprintf(&out, "  %s = select i1 %s, i64 %s, i64 %s\n", result, cmp, args[0], args[1])
+		return out.String(), result, true
+	case "Int__clamp":
+		if len(args) != 3 {
+			return "", "", false
+		}
+		ltLo := fresh("int.clamp.ltlo")
+		lower := fresh("int.clamp.lower")
+		gtHi := fresh("int.clamp.gthi")
+		result := fresh("int.clamp")
+		fmt.Fprintf(&out, "  %s = icmp slt i64 %s, %s\n", ltLo, args[0], args[1])
+		fmt.Fprintf(&out, "  %s = select i1 %s, i64 %s, i64 %s\n", lower, ltLo, args[1], args[0])
+		fmt.Fprintf(&out, "  %s = icmp sgt i64 %s, %s\n", gtHi, lower, args[2])
+		fmt.Fprintf(&out, "  %s = select i1 %s, i64 %s, i64 %s\n", result, gtHi, args[2], lower)
+		return out.String(), result, true
+	case "Int__signum":
+		if len(args) != 1 {
+			return "", "", false
+		}
+		ltZero := fresh("int.signum.ltzero")
+		gtZero := fresh("int.signum.gtzero")
+		nonNeg := fresh("int.signum.nonneg")
+		result := fresh("int.signum")
+		fmt.Fprintf(&out, "  %s = icmp slt i64 %s, 0\n", ltZero, args[0])
+		fmt.Fprintf(&out, "  %s = icmp sgt i64 %s, 0\n", gtZero, args[0])
+		fmt.Fprintf(&out, "  %s = select i1 %s, i64 1, i64 0\n", nonNeg, gtZero)
+		fmt.Fprintf(&out, "  %s = select i1 %s, i64 -1, i64 %s\n", result, ltZero, nonNeg)
+		return out.String(), result, true
+	}
+	return "", "", false
 }
 
 func classifyProjectedCallLine(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.LocalID]localBinding, mctx *moduleCtx) (string, bool) {
@@ -2509,6 +2641,9 @@ func classifyVoidCallLine(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.
 	if !ok || ref.Symbol == "" {
 		return "", false
 	}
+	if line, ok := classifyTestingVoidCallLine(fn, ci, bindings, mctx, ref.Symbol); ok {
+		return line, true
+	}
 	allowOpaqueUserNamed := true
 	var args []callArg
 	if fnTy, ok := ref.Type.(*ir.FnType); ok && fnTy != nil {
@@ -2552,6 +2687,118 @@ func classifyVoidCallLine(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.
 		declareVoidFunctionPrototype(mctx, ref.Symbol, args)
 		return resolved.prelude + renderVoidCallLine(ref.Symbol, args), true
 	}
+}
+
+func classifyTestingVoidCallLine(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.LocalID]localBinding, mctx *moduleCtx, symbol string) (string, bool) {
+	if !isStage0TestingSymbol(symbol) {
+		return "", false
+	}
+	args := make([]testingArg, 0, len(ci.Args))
+	var prelude strings.Builder
+	for _, op := range ci.Args {
+		argPrelude, argExpr, argTy, ok := resolveOperandWithPrelude(fn, op, bindings, mctx)
+		if !ok || argTy == scalarUnknown {
+			return "", false
+		}
+		prelude.WriteString(argPrelude)
+		args = append(args, testingArg{expr: argExpr, ty: argTy})
+	}
+	body, ok := renderTestingVoidCall(mctx, symbol, args)
+	if !ok {
+		return "", false
+	}
+	return prelude.String() + body, true
+}
+
+func isStage0TestingSymbol(symbol string) bool {
+	switch symbol {
+	case "std.testing.assert", "std.testing.assertTrue", "std.testing.assertFalse",
+		"std.testing.assertEq", "std.testing.assertNe", "std.testing.fail":
+		return true
+	}
+	return false
+}
+
+func renderTestingVoidCall(mctx *moduleCtx, symbol string, args []testingArg) (string, bool) {
+	name := strings.TrimPrefix(symbol, "std.testing.")
+	switch name {
+	case "assert", "assertTrue":
+		if len(args) != 1 || args[0].ty != scalarBool {
+			return "", false
+		}
+		return renderTestingAssert(mctx, name, args[0].expr), true
+	case "assertFalse":
+		if len(args) != 1 || args[0].ty != scalarBool {
+			return "", false
+		}
+		okReg := mctx.freshTempName("testing.assertFalse")
+		return fmt.Sprintf("  %s = xor i1 %s, true\n", okReg, args[0].expr) +
+			renderTestingAssert(mctx, name, okReg), true
+	case "assertEq", "assertNe":
+		if len(args) != 2 {
+			return "", false
+		}
+		compare, cond, ok := renderTestingCompare(mctx, args[0], args[1], name == "assertEq")
+		if !ok {
+			return "", false
+		}
+		return compare + renderTestingAssert(mctx, name, cond), true
+	case "fail":
+		if len(args) != 1 || args[0].ty != scalarString {
+			return "", false
+		}
+		return renderTestingFail(mctx, args[0].expr), true
+	}
+	return "", false
+}
+
+func renderTestingCompare(mctx *moduleCtx, left, right testingArg, wantEqual bool) (string, string, bool) {
+	if left.ty != right.ty || left.ty == scalarUnknown {
+		return "", "", false
+	}
+	pred := "eq"
+	if !wantEqual {
+		pred = "ne"
+	}
+	condReg := mctx.freshTempName("testing.cmp")
+	switch left.ty {
+	case scalarString:
+		declareStringCompareRuntime(mctx)
+		cmpReg := mctx.freshTempName("testing.strcmp")
+		return fmt.Sprintf("  %s = call i64 @osty_rt_strings_Compare(ptr %s, ptr %s)\n", cmpReg, left.expr, right.expr) +
+			fmt.Sprintf("  %s = icmp %s i64 %s, 0\n", condReg, pred, cmpReg), condReg, true
+	case scalarFloat:
+		fpred := "oeq"
+		if !wantEqual {
+			fpred = "one"
+		}
+		return fmt.Sprintf("  %s = fcmp %s double %s, %s\n", condReg, fpred, left.expr, right.expr), condReg, true
+	case scalarOpaquePtr:
+		return fmt.Sprintf("  %s = icmp %s ptr %s, %s\n", condReg, pred, left.expr, right.expr), condReg, true
+	case scalarInt, scalarBool, scalarByte, scalarChar:
+		return fmt.Sprintf("  %s = icmp %s %s %s, %s\n", condReg, pred, left.ty.llvm(), left.expr, right.expr), condReg, true
+	}
+	return "", "", false
+}
+
+func renderTestingAssert(mctx *moduleCtx, name, okExpr string) string {
+	declareVoidFunctionPrototype(mctx, "osty_rt_panic", []callArg{{ty: "ptr"}})
+	failLabel := mctx.freshLabelName("testing.fail")
+	okLabel := mctx.freshLabelName("testing.ok")
+	msg := mctx.internStringConst("std.testing." + name + " failed")
+	return fmt.Sprintf("  br i1 %s, label %%%s, label %%%s\n", okExpr, okLabel, failLabel) +
+		fmt.Sprintf("%s:\n", failLabel) +
+		fmt.Sprintf("  call void @osty_rt_panic(ptr %s)\n", msg) +
+		"  unreachable\n" +
+		fmt.Sprintf("%s:\n", okLabel)
+}
+
+func renderTestingFail(mctx *moduleCtx, msgExpr string) string {
+	declareVoidFunctionPrototype(mctx, "osty_rt_panic", []callArg{{ty: "ptr"}})
+	contLabel := mctx.freshLabelName("testing.fail.cont")
+	return fmt.Sprintf("  call void @osty_rt_panic(ptr %s)\n", msgExpr) +
+		"  unreachable\n" +
+		fmt.Sprintf("%s:\n", contLabel)
 }
 
 func isErrType(t mir.Type) bool {
@@ -10668,6 +10915,9 @@ func emitWhileCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInst
 		return false
 	}
 	recordWhileCallStructResult(ctx, ci, ref)
+	if emitWhileKnownIntMethodCall(ctx, out, ci, ref.Symbol) {
+		return true
+	}
 	allowOpaqueUserNamed := true
 	fnTy, ok := ref.Type.(*ir.FnType)
 	if !ok || fnTy == nil {
@@ -10708,6 +10958,29 @@ func emitWhileCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInst
 	}
 	declareFunctionPrototype(ctx.mctx, ref.Symbol, destType, args)
 	return emitWhileCallToPlace(ctx, out, *ci.Dest, destType, ref.Symbol, args)
+}
+
+func emitWhileKnownIntMethodCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInstr, symbol string) bool {
+	arity, ok := knownIntMethodArity(symbol)
+	if !ok || ctx == nil || ctx.mctx == nil || ci == nil || ci.Dest == nil || ci.Dest.HasProjections() || len(ci.Args) != arity {
+		return false
+	}
+	exprs := make([]string, 0, len(ci.Args))
+	for _, op := range ci.Args {
+		expr, argTy, ok := resolveOperandWithLoad(ctx, out, op)
+		if !ok || argTy != scalarInt {
+			return false
+		}
+		exprs = append(exprs, expr)
+	}
+	body, result, ok := renderKnownIntMethodCall(symbol, exprs, func(string) string {
+		return freshReg(ctx)
+	})
+	if !ok {
+		return false
+	}
+	out.WriteString(body)
+	return bindWhileResult(ctx, out, ci.Dest.Local, scalarInt, result)
 }
 
 func placeHasErrProjection(place mir.Place) bool {
@@ -10774,6 +11047,9 @@ func emitWhileVoidCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.Call
 	if !ok || ref.Symbol == "" {
 		return false
 	}
+	if emitWhileTestingVoidCall(ctx, out, ci, ref.Symbol) {
+		return true
+	}
 	args := make([]callArg, 0, len(ci.Args))
 	if fnTy, ok := ref.Type.(*ir.FnType); ok && fnTy != nil {
 		if len(fnTy.Params) != len(ci.Args) {
@@ -10819,6 +11095,26 @@ func emitWhileVoidCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.Call
 	}
 	declareVoidFunctionPrototype(ctx.mctx, ref.Symbol, args)
 	out.WriteString(renderVoidCallLine(ref.Symbol, args))
+	return true
+}
+
+func emitWhileTestingVoidCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInstr, symbol string) bool {
+	if ctx == nil || ctx.mctx == nil || !isStage0TestingSymbol(symbol) {
+		return false
+	}
+	args := make([]testingArg, 0, len(ci.Args))
+	for _, op := range ci.Args {
+		expr, argTy, ok := resolveOperandWithLoad(ctx, out, op)
+		if !ok || argTy == scalarUnknown {
+			return false
+		}
+		args = append(args, testingArg{expr: expr, ty: argTy})
+	}
+	line, ok := renderTestingVoidCall(ctx.mctx, symbol, args)
+	if !ok {
+		return false
+	}
+	out.WriteString(line)
 	return true
 }
 
@@ -14707,6 +15003,9 @@ func stage0KnownCallScalarResult(symbol string) scalarType {
 		return scalarUnknown
 	}
 	if strings.HasSuffix(symbol, "__len") {
+		return scalarInt
+	}
+	if _, ok := knownIntMethodArity(symbol); ok {
 		return scalarInt
 	}
 	return scalarUnknown

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -124,6 +124,27 @@ func moduleWith(fns ...*mir.Function) *mir.Module {
 	}
 }
 
+func testingCall(symbol string, params []mir.Type, args ...mir.Operand) *mir.CallInstr {
+	return &mir.CallInstr{
+		Callee: &mir.FnRef{
+			Symbol: symbol,
+			Type: &ir.FnType{
+				Params: params,
+				Return: ir.TUnit,
+			},
+		},
+		Args: args,
+	}
+}
+
+func intMethodCall(symbol string, dest mir.LocalID, args ...mir.Operand) *mir.CallInstr {
+	return &mir.CallInstr{
+		Callee: &mir.FnRef{Symbol: symbol, Type: ir.TInt},
+		Dest:   &mir.Place{Local: dest},
+		Args:   args,
+	}
+}
+
 func emit(t *testing.T, fns ...*mir.Function) string {
 	t.Helper()
 	got, err := EmitMIR(moduleWith(fns...), llvmabi.Options{PackageName: "main"})
@@ -177,6 +198,194 @@ func TestStage0RejectsModuleWithoutMain(t *testing.T) {
 	err := mustReject(t, intLit)
 	if !strings.Contains(err.Error(), "module has no `main` function") {
 		t.Fatalf("err = %q, want missing-main reason", err.Error())
+	}
+}
+
+func TestStage0AllowNoMainEmitsObjectModule(t *testing.T) {
+	t.Parallel()
+	intLit := makeFn(fnSpec{name: "zero", retT: ir.TInt, src: useRV(intConst(0))})
+	got, err := EmitMIRAllowNoMain(moduleWith(intLit), llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIRAllowNoMain: %v", err)
+	}
+	if !strings.Contains(string(got), "define i64 @zero()") {
+		t.Fatalf("emitted IR missing zero function:\n%s", got)
+	}
+	if strings.Contains(string(got), "define i32 @main()") {
+		t.Fatalf("allow-no-main emitted synthetic main:\n%s", got)
+	}
+}
+
+func TestStage0LowersTestingAssertionsInline(t *testing.T) {
+	t.Parallel()
+	fn := &mir.Function{
+		Name:        "testAssertions",
+		ReturnType:  ir.TUnit,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TUnit, IsReturn: true},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{
+				ID: 0,
+				Instrs: []mir.Instr{
+					testingCall("std.testing.assertTrue", []mir.Type{ir.TBool}, boolConst(true)),
+					testingCall("std.testing.assertFalse", []mir.Type{ir.TBool}, boolConst(false)),
+					testingCall("std.testing.assertEq", []mir.Type{ir.TInt, ir.TInt}, intConst(7), intConst(7)),
+					testingCall("std.testing.assertNe", []mir.Type{ir.TInt, ir.TInt}, intConst(7), intConst(8)),
+					testingCall("std.testing.assertEq", []mir.Type{ir.TString, ir.TString}, stringConst("same"), stringConst("same")),
+				},
+				Term: &mir.ReturnTerm{},
+			},
+		},
+	}
+	gotBytes, err := EmitMIRAllowNoMain(moduleWith(fn), llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIRAllowNoMain: %v", err)
+	}
+	got := string(gotBytes)
+	for _, want := range []string{
+		"define void @testAssertions()",
+		"declare void @osty_rt_panic(ptr)",
+		"declare i64 @osty_rt_strings_Compare(ptr, ptr)",
+		"icmp eq i64 7, 7",
+		"icmp ne i64 7, 8",
+		"call i64 @osty_rt_strings_Compare",
+		"br i1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "@std.testing.assert") {
+		t.Fatalf("testing assertions should be lowered inline, got external std.testing call:\n%s", got)
+	}
+}
+
+func TestStage0LowersKnownIntMethodsInline(t *testing.T) {
+	t.Parallel()
+	fn := &mir.Function{
+		Name:        "testIntMethods",
+		ReturnType:  ir.TUnit,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TUnit, IsReturn: true},
+			{ID: 1, Name: "abs", Type: ir.TInt},
+			{ID: 2, Name: "min", Type: ir.TInt},
+			{ID: 3, Name: "max", Type: ir.TInt},
+			{ID: 4, Name: "clamp", Type: ir.TInt},
+			{ID: 5, Name: "signum", Type: ir.ErrTypeVal},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{
+				ID: 0,
+				Instrs: []mir.Instr{
+					intMethodCall("Int__abs", 1, intConst(-7)),
+					testingCall("std.testing.assertEq", []mir.Type{ir.TInt, ir.TInt}, localCopy(1, ir.TInt), intConst(7)),
+					intMethodCall("Int__min", 2, intConst(9), intConst(3)),
+					testingCall("std.testing.assertEq", []mir.Type{ir.TInt, ir.TInt}, localCopy(2, ir.TInt), intConst(3)),
+					intMethodCall("Int__max", 3, intConst(3), intConst(9)),
+					testingCall("std.testing.assertEq", []mir.Type{ir.TInt, ir.TInt}, localCopy(3, ir.TInt), intConst(9)),
+					intMethodCall("Int__clamp", 4, intConst(99), intConst(0), intConst(10)),
+					testingCall("std.testing.assertEq", []mir.Type{ir.TInt, ir.TInt}, localCopy(4, ir.TInt), intConst(10)),
+					intMethodCall("Int__signum", 5, intConst(-7)),
+					testingCall("std.testing.assertEq", []mir.Type{ir.TInt, ir.TInt}, localCopy(5, ir.ErrTypeVal), intConst(-1)),
+				},
+				Term: &mir.ReturnTerm{},
+			},
+		},
+	}
+	gotBytes, err := EmitMIRAllowNoMain(moduleWith(fn), llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIRAllowNoMain: %v", err)
+	}
+	got := string(gotBytes)
+	for _, want := range []string{
+		"define void @testIntMethods()",
+		"sub i64 0, -7",
+		"icmp slt i64 9, 3",
+		"icmp sgt i64 3, 9",
+		"icmp slt i64 99, 0",
+		"icmp sgt i64 -7, 0",
+		"select i1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "@Int__") {
+		t.Fatalf("known Int methods should be lowered inline, got external Int method call:\n%s", got)
+	}
+}
+
+func TestStage0InfersKnownIntMethodResultInGenericStructFlow(t *testing.T) {
+	t.Parallel()
+	pointTy := &ir.NamedType{Name: "Point"}
+	field := func(index int, name string) mir.Projection {
+		return &mir.FieldProj{Index: index, Name: name, Type: ir.TInt}
+	}
+	fn := &mir.Function{
+		Name:        "testStructFieldSignum",
+		ReturnType:  ir.TUnit,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TUnit, IsReturn: true},
+			{ID: 1, Name: "p", Type: pointTy},
+			{ID: 2, Name: "sum", Type: ir.TInt},
+			{ID: 3, Name: "", Type: ir.ErrTypeVal},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{
+				ID: 0,
+				Instrs: []mir.Instr{
+					assign(1, &mir.AggregateRV{
+						Kind:   mir.AggStruct,
+						T:      pointTy,
+						Fields: []mir.Operand{intConst(-9), intConst(4)},
+					}),
+					assign(2, binaryRV(mir.BinAdd,
+						&mir.CopyOp{Place: mir.Place{Local: 1, Projections: []mir.Projection{field(0, "x")}}, T: ir.TInt},
+						&mir.CopyOp{Place: mir.Place{Local: 1, Projections: []mir.Projection{field(1, "y")}}, T: ir.TInt},
+						ir.TInt,
+					)),
+					intMethodCall("Int__signum", 3, localCopy(2, ir.TInt)),
+					testingCall("std.testing.assertEq", []mir.Type{ir.TInt, ir.TInt}, localCopy(3, ir.ErrTypeVal), intConst(-1)),
+				},
+				Term: &mir.ReturnTerm{},
+			},
+		},
+	}
+	module := moduleWith(fn)
+	module.Layouts.Structs["Point"] = &mir.StructLayout{
+		Name: "Point",
+		Fields: []mir.FieldLayout{
+			{Index: 0, Name: "x", Type: ir.TInt},
+			{Index: 1, Name: "y", Type: ir.TInt},
+		},
+	}
+	gotBytes, err := EmitMIRAllowNoMain(module, llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIRAllowNoMain: %v", err)
+	}
+	got := string(gotBytes)
+	for _, want := range []string{
+		"define void @testStructFieldSignum()",
+		"%Point = type { i64, i64 }",
+		"getelementptr inbounds %Point",
+		"add i64",
+		"icmp slt i64",
+		"select i1",
+		"ret void",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "@Int__") {
+		t.Fatalf("known Int methods should be inferred and lowered inline, got external Int method call:\n%s", got)
 	}
 }
 

--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -20,6 +20,8 @@ var (
 	managedProjectRootFunc = defaultManagedProjectRoot
 	sourceRepoRootFunc     = defaultSourceRepoRoot
 	installNativeChecker   = buildNativeChecker
+	renameManagedFile      = os.Rename
+	removeManagedFile      = os.Remove
 )
 
 // Version returns the toolchain version stamp used to scope managed artifacts.
@@ -119,16 +121,25 @@ func buildNativeChecker(dest string) error {
 			return fmt.Errorf("chmod managed osty-native-checker: %w", err)
 		}
 	}
-	if err := os.Rename(tmpPath, dest); err != nil {
-		if fileExists(dest) {
-			return nil
-		}
-		return fmt.Errorf("install managed osty-native-checker: %w", err)
-	}
-	return nil
+	return installManagedBinary(tmpPath, dest, "osty-native-checker")
 }
 
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
+}
+
+func installManagedBinary(tmpPath, dest, label string) error {
+	if err := renameManagedFile(tmpPath, dest); err == nil {
+		return nil
+	} else {
+		firstErr := err
+		if err := removeManagedFile(dest); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("replace managed %s: remove stale artifact: %w (initial rename failed: %v)", label, err, firstErr)
+		}
+		if err := renameManagedFile(tmpPath, dest); err != nil {
+			return fmt.Errorf("install managed %s: %w (initial rename failed: %v)", label, err, firstErr)
+		}
+	}
+	return nil
 }

--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -1,6 +1,7 @@
 package toolchain
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -134,6 +135,9 @@ func installManagedBinary(tmpPath, dest, label string) error {
 		return nil
 	} else {
 		firstErr := err
+		if !shouldRetryManagedReplace(tmpPath, dest, firstErr) {
+			return fmt.Errorf("install managed %s: %w", label, firstErr)
+		}
 		if err := removeManagedFile(dest); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("replace managed %s: remove stale artifact: %w (initial rename failed: %v)", label, err, firstErr)
 		}
@@ -142,4 +146,11 @@ func installManagedBinary(tmpPath, dest, label string) error {
 		}
 	}
 	return nil
+}
+
+func shouldRetryManagedReplace(tmpPath, dest string, err error) bool {
+	if !errors.Is(err, os.ErrExist) {
+		return false
+	}
+	return fileExists(tmpPath) && fileExists(dest)
 }

--- a/internal/toolchain/native_checker_test.go
+++ b/internal/toolchain/native_checker_test.go
@@ -78,7 +78,7 @@ func TestInstallManagedBinaryReplacesExistingArtifactAfterRenameFailure(t *testi
 	renameManagedFile = func(oldpath, newpath string) error {
 		renameCalls++
 		if renameCalls == 1 {
-			return errors.New("destination exists")
+			return os.ErrExist
 		}
 		return os.Rename(oldpath, newpath)
 	}
@@ -103,5 +103,52 @@ func TestInstallManagedBinaryReplacesExistingArtifactAfterRenameFailure(t *testi
 	}
 	if removeCalls != 1 {
 		t.Fatalf("remove calls = %d, want 1", removeCalls)
+	}
+}
+
+func TestInstallManagedBinaryPreservesExistingArtifactAfterUnrelatedRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	tmp := filepath.Join(dir, "tmp-bin")
+	dest := filepath.Join(dir, "managed-bin")
+	if err := os.WriteFile(tmp, []byte("new"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", tmp, err)
+	}
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", dest, err)
+	}
+
+	oldRename := renameManagedFile
+	oldRemove := removeManagedFile
+	t.Cleanup(func() {
+		renameManagedFile = oldRename
+		removeManagedFile = oldRemove
+	})
+
+	renameCalls := 0
+	renameManagedFile = func(string, string) error {
+		renameCalls++
+		return errors.New("permission denied")
+	}
+	removeCalls := 0
+	removeManagedFile = func(name string) error {
+		removeCalls++
+		return os.Remove(name)
+	}
+
+	if err := installManagedBinary(tmp, dest, "test-tool"); err == nil {
+		t.Fatal("installManagedBinary returned nil, want unrelated rename failure")
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", dest, err)
+	}
+	if string(got) != "old" {
+		t.Fatalf("managed artifact = %q, want old artifact preserved", got)
+	}
+	if renameCalls != 1 {
+		t.Fatalf("rename calls = %d, want 1", renameCalls)
+	}
+	if removeCalls != 0 {
+		t.Fatalf("remove calls = %d, want 0", removeCalls)
 	}
 }

--- a/internal/toolchain/native_checker_test.go
+++ b/internal/toolchain/native_checker_test.go
@@ -1,6 +1,7 @@
 package toolchain
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,5 +53,55 @@ func TestManagedNativeCheckerPathIncludesVersionedToolchainDir(t *testing.T) {
 	want := filepath.Join(root, ".osty", "toolchain", Version(), NativeCheckerBinaryName())
 	if got != want {
 		t.Fatalf("ManagedNativeCheckerPath = %q, want %q", got, want)
+	}
+}
+
+func TestInstallManagedBinaryReplacesExistingArtifactAfterRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	tmp := filepath.Join(dir, "tmp-bin")
+	dest := filepath.Join(dir, "managed-bin")
+	if err := os.WriteFile(tmp, []byte("new"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", tmp, err)
+	}
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", dest, err)
+	}
+
+	oldRename := renameManagedFile
+	oldRemove := removeManagedFile
+	t.Cleanup(func() {
+		renameManagedFile = oldRename
+		removeManagedFile = oldRemove
+	})
+
+	renameCalls := 0
+	renameManagedFile = func(oldpath, newpath string) error {
+		renameCalls++
+		if renameCalls == 1 {
+			return errors.New("destination exists")
+		}
+		return os.Rename(oldpath, newpath)
+	}
+	removeCalls := 0
+	removeManagedFile = func(name string) error {
+		removeCalls++
+		return os.Remove(name)
+	}
+
+	if err := installManagedBinary(tmp, dest, "test-tool"); err != nil {
+		t.Fatalf("installManagedBinary: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", dest, err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("managed artifact = %q, want new", got)
+	}
+	if renameCalls != 2 {
+		t.Fatalf("rename calls = %d, want 2", renameCalls)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("remove calls = %d, want 1", removeCalls)
 	}
 }

--- a/internal/toolchain/native_lirproto.go
+++ b/internal/toolchain/native_lirproto.go
@@ -22,7 +22,13 @@ var (
 // is the managed wrapper around the Osty-owned LIR Proto subprocess boundary.
 var nativeLIRProtoSourceInputs = []string{
 	"cmd/osty-native-lirproto",
+	"internal/backend",
+	"internal/ir",
+	"internal/llvmabi",
+	"internal/mir",
+	"internal/mirjson",
 	"internal/nativelirproto",
+	"internal/toolchain/selfhostcache",
 	"go.mod",
 	"go.sum",
 }
@@ -162,11 +168,5 @@ func buildNativeLIRProto(dest string) error {
 			return fmt.Errorf("chmod managed osty-native-lirproto: %w", err)
 		}
 	}
-	if err := os.Rename(tmpPath, dest); err != nil {
-		if fileExists(dest) {
-			return nil
-		}
-		return fmt.Errorf("install managed osty-native-lirproto: %w", err)
-	}
-	return nil
+	return installManagedBinary(tmpPath, dest, "osty-native-lirproto")
 }

--- a/internal/toolchain/native_lirproto_test.go
+++ b/internal/toolchain/native_lirproto_test.go
@@ -1,0 +1,112 @@
+package toolchain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestEnsureNativeLIRProtoBuildsManagedArtifactOnce(t *testing.T) {
+	root := t.TempDir()
+	oldProjectRoot := managedProjectRootFunc
+	oldSourceRoot := sourceRepoRootFunc
+	oldInstaller := installNativeLIRProto
+	t.Cleanup(func() {
+		managedProjectRootFunc = oldProjectRoot
+		sourceRepoRootFunc = oldSourceRoot
+		installNativeLIRProto = oldInstaller
+	})
+
+	managedProjectRootFunc = func(string) (string, error) { return root, nil }
+	sourceRepoRootFunc = func() (string, error) { return t.TempDir(), nil }
+	calls := 0
+	installNativeLIRProto = func(dest string) error {
+		calls++
+		return os.WriteFile(dest, []byte("managed lirproto"), 0o755)
+	}
+
+	path, err := EnsureNativeLIRProto(".")
+	if err != nil {
+		t.Fatalf("EnsureNativeLIRProto error: %v", err)
+	}
+	want := filepath.Join(root, ".osty", "toolchain", Version(), NativeLIRProtoBinaryName())
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+	if calls != 1 {
+		t.Fatalf("installer calls = %d, want 1", calls)
+	}
+
+	path2, err := EnsureNativeLIRProto(".")
+	if err != nil {
+		t.Fatalf("second EnsureNativeLIRProto error: %v", err)
+	}
+	if path2 != want {
+		t.Fatalf("second path = %q, want %q", path2, want)
+	}
+	if calls != 1 {
+		t.Fatalf("installer calls after second ensure = %d, want 1", calls)
+	}
+}
+
+func TestManagedNativeLIRProtoPathIncludesVersionedToolchainDir(t *testing.T) {
+	root := t.TempDir()
+	got := ManagedNativeLIRProtoPath(root)
+	want := filepath.Join(root, ".osty", "toolchain", Version(), NativeLIRProtoBinaryName())
+	if got != want {
+		t.Fatalf("ManagedNativeLIRProtoPath = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureNativeLIRProtoRebuildsWhenStage0SourcesAreNewer(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	oldProjectRoot := managedProjectRootFunc
+	oldSourceRoot := sourceRepoRootFunc
+	oldInstaller := installNativeLIRProto
+	t.Cleanup(func() {
+		managedProjectRootFunc = oldProjectRoot
+		sourceRepoRootFunc = oldSourceRoot
+		installNativeLIRProto = oldInstaller
+	})
+
+	managedProjectRootFunc = func(string) (string, error) { return root, nil }
+	sourceRepoRootFunc = func() (string, error) { return repo, nil }
+	stage0Source := filepath.Join(repo, "internal/backend/stage0/emit.go")
+	if err := os.MkdirAll(filepath.Dir(stage0Source), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(stage0Source), err)
+	}
+	if err := os.WriteFile(stage0Source, []byte("fresh stage0 source"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", stage0Source, err)
+	}
+
+	path := ManagedNativeLIRProtoPath(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("stale lirproto"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+	oldTime := time.Unix(1, 0)
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatalf("Chtimes(%q): %v", path, err)
+	}
+
+	calls := 0
+	installNativeLIRProto = func(dest string) error {
+		calls++
+		return os.WriteFile(dest, []byte("rebuilt lirproto"), 0o755)
+	}
+
+	got, err := EnsureNativeLIRProto(".")
+	if err != nil {
+		t.Fatalf("EnsureNativeLIRProto error: %v", err)
+	}
+	if got != path {
+		t.Fatalf("path = %q, want %q", got, path)
+	}
+	if calls != 1 {
+		t.Fatalf("installer calls = %d, want 1", calls)
+	}
+}

--- a/internal/toolchain/native_llvmgen.go
+++ b/internal/toolchain/native_llvmgen.go
@@ -23,6 +23,7 @@ var nativeLLVMGenSourceInputs = []string{
 	"internal/mirjson",
 	"internal/nativelirproto",
 	"internal/nativellvmgen",
+	"internal/toolchain",
 	"go.mod",
 	"go.sum",
 }
@@ -160,11 +161,5 @@ func buildNativeLLVMGen(dest string) error {
 			return fmt.Errorf("chmod managed osty-native-llvmgen: %w", err)
 		}
 	}
-	if err := os.Rename(tmpPath, dest); err != nil {
-		if fileExists(dest) {
-			return nil
-		}
-		return fmt.Errorf("install managed osty-native-llvmgen: %w", err)
-	}
-	return nil
+	return installManagedBinary(tmpPath, dest, "osty-native-llvmgen")
 }

--- a/internal/toolchain/native_llvmgen_test.go
+++ b/internal/toolchain/native_llvmgen_test.go
@@ -78,6 +78,7 @@ func TestEnsureNativeLLVMGenRebuildsWhenSourcesAreNewer(t *testing.T) {
 		"internal/backend/llvm.go",
 		"internal/llvmabi/api.go",
 		"internal/nativellvmgen/exec.go",
+		"internal/toolchain/native_lirproto.go",
 		"go.mod",
 	} {
 		path := filepath.Join(repo, rel)


### PR DESCRIPTION
## Summary

- Add a stage0 MIR compatibility path for legacy self-host `lir-proto-lower-mir-json` gaps, preferring MIR payload lowering before source fallback.
- Inline stage0 lowering for `std.testing` assertions and known `Int` helpers, including generic CFG inference for `ErrType`-shaped Int method results.
- Expand runtime audit aliases and managed native toolchain rebuild/replacement guards so stale native helpers do not mask source changes.

## Why

The self-host/native LIR Proto path could fall back into older self-host binaries that did not understand MIR JSON, and managed native helper binaries could remain stale after dependent source changes. That left self-host example suites sensitive to cache state rather than the current source tree.

## Validation

- `git diff --check`
- `go test -count=1 -vet=off ./internal/backend/stage0 ./cmd/osty-native-lirproto -run 'TestStage0AllowNoMainEmitsObjectModule|TestStage0InfersKnownIntMethodResultInGenericStructFlow|TestRunMIRPayloadUsesStage0CompatWhenMirJSONUnsupported|TestRunMIRPayloadRetriesSourceWhenMirJSONUnsupported'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestBundledRuntimeStage0AuditAliasesLinkWithThinLTO|TestEmitLLVMIRTextMatchesBackendArtifactOutput|TestLLVMBackendDispatchTraceReportsSelectedRoute'`
- `OSTY_STAGE0_FALLBACK=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 just bootstrap`
- `just osty-tests`