### PR TITLE
fix(selfhost): advance lir proto stage3 lowering

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -34,6 +34,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/osty/osty/internal/backend/stage0"
 	"github.com/osty/osty/internal/llvmabi"
@@ -54,6 +55,10 @@ const SelfBinEnv = "OSTY_SELF_BIN"
 // toolchain/main.osty before it falls back to std.env.args().
 const selfForwardArgsEnv = "OSTY_SELF_REBUILD_FORWARD_ARGS"
 
+// selfLowerTimeoutEnv overrides the bootstrap guard used around
+// self-hosted LIR Proto lowering. Use "0" to disable.
+const selfLowerTimeoutEnv = "OSTY_LIRPROTO_SELF_TIMEOUT"
+
 func main() {
 	if err := run(os.Stdin, os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -63,7 +68,9 @@ func main() {
 
 func run(stdin io.Reader, stdout io.Writer) error {
 	var req nativelirproto.Request
-	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
+	dec := json.NewDecoder(stdin)
+	dec.UseNumber()
+	if err := dec.Decode(&req); err != nil {
 		return fmt.Errorf("decode lirproto request: %w", err)
 	}
 	resp, err := lower(req)
@@ -109,7 +116,7 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 	if err != nil || !resp.Declined {
 		return resp, err
 	}
-	if command == "lir-proto-lower-mir-json" && isUnsupportedSelfCommand(declineReason) {
+	if command == "lir-proto-lower-mir-json" && isMIRJSONFallbackReason(declineReason) {
 		return lowerLegacyMIRJSON(req, selfBin)
 	}
 	return resp, nil
@@ -136,19 +143,34 @@ func lowerSourceCompat(selfBin string, req nativelirproto.Request) (nativelirpro
 }
 
 func runSelfLower(selfBin string, args []string) (nativelirproto.Response, string, error) {
-	cmd := exec.Command(selfBin, args...)
+	ctx := context.Background()
+	timeout := selfLowerTimeout(args)
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, selfBin, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	cmd.Env = append(os.Environ(), selfForwardArgsEnv+"="+strings.Join(args, "\n"))
 	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			command := "command"
+			if len(args) > 0 {
+				command = args[0]
+			}
+			msg := fmt.Sprintf("osty-self %s timed out after %s", command, timeout)
+			return nativelirproto.Response{Declined: true, Error: msg}, msg, nil
+		}
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
 			msg = err.Error()
 		}
 		return nativelirproto.Response{Declined: true, Error: msg}, msg, nil
 	}
-	ir := stdout.String()
+	ir := normalizeSelfHostedLLVMIR(stdout.String())
 	if ir == "" {
 		command := "command"
 		if len(args) > 0 {
@@ -157,12 +179,65 @@ func runSelfLower(selfBin string, args []string) (nativelirproto.Response, strin
 		msg := fmt.Sprintf("osty-self %s produced empty IR", command)
 		return nativelirproto.Response{Declined: true, Error: msg}, msg, nil
 	}
+	if reason := validateSelfHostedLLVMIR(ir); reason != "" {
+		command := "command"
+		if len(args) > 0 {
+			command = args[0]
+		}
+		msg := fmt.Sprintf("osty-self %s produced invalid IR: %s", command, reason)
+		return nativelirproto.Response{Declined: true, Error: msg}, msg, nil
+	}
 	return nativelirproto.Response{LLVMIR: ir}, "", nil
+}
+
+func selfLowerTimeout(args []string) time.Duration {
+	if len(args) == 0 || args[0] != "lir-proto-lower-mir-json" {
+		return 0
+	}
+	if raw := os.Getenv(selfLowerTimeoutEnv); raw != "" {
+		if raw == "0" {
+			return 0
+		}
+		if d, err := time.ParseDuration(raw); err == nil {
+			return d
+		}
+	}
+	return 20 * time.Second
+}
+
+func normalizeSelfHostedLLVMIR(ir string) string {
+	return strings.NewReplacer(
+		`\"`, `"`,
+		`\{`, `{`,
+		`\}`, `}`,
+		`\n`, "\n",
+		`\\`, `\`,
+	).Replace(ir)
 }
 
 func isUnsupportedSelfCommand(msg string) bool {
 	return strings.Contains(msg, "osty-self: unsupported command") ||
 		(strings.Contains(msg, "unsupported command") && strings.Contains(msg, "lir-proto-lower-mir-json"))
+}
+
+func isInvalidSelfHostedIR(msg string) bool {
+	return strings.Contains(msg, "produced invalid IR")
+}
+
+func isMIRJSONFallbackReason(msg string) bool {
+	return isUnsupportedSelfCommand(msg) ||
+		isInvalidSelfHostedIR(msg) ||
+		strings.Contains(msg, "timed out")
+}
+
+func validateSelfHostedLLVMIR(ir string) string {
+	for i := 0; i < 512; i++ {
+		name := fmt.Sprintf("%%t%d", i)
+		if strings.Contains(ir, name) && !strings.Contains(ir, name+" =") {
+			return "temporary " + name + " is referenced before definition"
+		}
+	}
+	return ""
 }
 
 func lowerLegacyMIRJSON(req nativelirproto.Request, selfBin string) (nativelirproto.Response, error) {
@@ -230,6 +305,9 @@ func lowerMIRJSONStage0Compat(req nativelirproto.Request) (nativelirproto.Respon
 		EmitGC:      true,
 	})
 	if err != nil {
+		if len(ir) > 0 && stage0.IsListAllDeclines() {
+			return nativelirproto.Response{LLVMIR: string(ir)}, true
+		}
 		return nativelirproto.Response{Declined: true, Error: fmt.Sprintf("stage0 MIR compat: %v", err)}, true
 	}
 	return nativelirproto.Response{LLVMIR: string(ir)}, true

--- a/cmd/osty-native-lirproto/main_test.go
+++ b/cmd/osty-native-lirproto/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/osty/osty/internal/backend/stage0"
 	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/mir"
 	"github.com/osty/osty/internal/mirjson"
@@ -199,6 +201,47 @@ func TestRunMIRPayloadInvokesMirJSONLower(t *testing.T) {
 	}
 }
 
+func TestRunMIRPayloadNormalizesSelfHostedEscapedLLVM(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_STDOUT", `; lir-proto\nsource_filename = \"demo\"\ndefine i64 @main() \{\n  ret i64 42\n\}\n`)
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		MIR: map[string]any{
+			"version":     1,
+			"packageName": "main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	want := "; lir-proto\nsource_filename = \"demo\"\ndefine i64 @main() {\n  ret i64 42\n}\n"
+	if resp.LLVMIR != want {
+		t.Fatalf("LLVMIR normalization drifted:\n--- got ---\n%q\n--- want ---\n%q", resp.LLVMIR, want)
+	}
+}
+
+func TestValidateSelfHostedLLVMIRCatchesUndefinedTemps(t *testing.T) {
+	ir := "define i64 @main() {\nentry:\n  ret i64 %t0\n}\n"
+	if got := validateSelfHostedLLVMIR(ir); !strings.Contains(got, "%t0") {
+		t.Fatalf("validateSelfHostedLLVMIR() = %q, want undefined %%t0", got)
+	}
+	valid := "define i64 @main() {\nentry:\n  %t0 = add i64 0, 42\n  ret i64 %t0\n}\n"
+	if got := validateSelfHostedLLVMIR(valid); got != "" {
+		t.Fatalf("validateSelfHostedLLVMIR(valid) = %q, want empty", got)
+	}
+}
+
 func TestRunMIRPayloadRetriesSourceWhenMirJSONUnsupported(t *testing.T) {
 	bin := buildFakeOstySelf(t)
 	captureDir := t.TempDir()
@@ -314,6 +357,223 @@ func TestRunMIRPayloadUsesStage0CompatWhenMirJSONUnsupported(t *testing.T) {
 	}
 	if strings.Contains(resp.LLVMIR, "source fallback should not run") {
 		t.Fatalf("stage0 compat unexpectedly used source fallback:\n%s", resp.LLVMIR)
+	}
+	args := readCapturedArgs(t, captureArgs)
+	if len(args) < 2 || args[0] != "lir-proto-lower-mir-json" {
+		t.Fatalf("first args = %v, want MIR JSON attempt before compat", args)
+	}
+}
+
+func TestRunMIRPayloadPreservesLargeIntJSONNumbers(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+
+	payload, err := mirjson.FromModule(&mir.Module{
+		Package: "main",
+		Functions: []*mir.Function{
+			{
+				Name:        "main",
+				ReturnType:  ir.TInt,
+				ReturnLocal: 0,
+				Locals: []*mir.Local{
+					{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+				},
+				Entry: 0,
+				Blocks: []*mir.BasicBlock{
+					{
+						ID: 0,
+						Instrs: []mir.Instr{
+							&mir.AssignInstr{
+								Dest: mir.Place{Local: 0},
+								Src: &mir.UseRV{Op: &mir.ConstOp{
+									Const: &mir.IntConst{Value: math.MaxInt64, T: ir.TInt},
+									T:     ir.TInt,
+								}},
+							},
+						},
+						Term: &mir.ReturnTerm{},
+					},
+				},
+			},
+		},
+		Layouts: mir.NewLayoutTable(),
+	})
+	if err != nil {
+		t.Fatalf("build MIR JSON payload: %v", err)
+	}
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_REJECT_MIR_JSON", "1")
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		MIR:         payload,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if resp.Declined {
+		t.Fatalf("Declined = true, want false: %+v", resp)
+	}
+	if !strings.Contains(resp.LLVMIR, "ret i64 9223372036854775807") {
+		t.Fatalf("LLVMIR lost large int literal:\n%s", resp.LLVMIR)
+	}
+}
+
+func TestRunMIRPayloadAcceptsStage0PartialIRWhenListAllDeclines(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+
+	payload, err := mirjson.FromModule(&mir.Module{
+		Package: "main",
+		Functions: []*mir.Function{
+			{
+				Name:        "main",
+				ReturnType:  ir.TInt,
+				ReturnLocal: 0,
+				Locals: []*mir.Local{
+					{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+				},
+				Entry: 0,
+				Blocks: []*mir.BasicBlock{
+					{
+						ID: 0,
+						Instrs: []mir.Instr{
+							&mir.AssignInstr{
+								Dest: mir.Place{Local: 0},
+								Src: &mir.UseRV{Op: &mir.ConstOp{
+									Const: &mir.IntConst{Value: 7, T: ir.TInt},
+									T:     ir.TInt,
+								}},
+							},
+						},
+						Term: &mir.ReturnTerm{},
+					},
+				},
+			},
+			{
+				Name:        "declinedHelper",
+				ReturnType:  ir.TInt,
+				ReturnLocal: 0,
+				Locals: []*mir.Local{
+					{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+				},
+				Entry: 0,
+				Blocks: []*mir.BasicBlock{
+					{ID: 0, Term: &mir.GotoTerm{Target: 0}},
+				},
+			},
+		},
+		Layouts: mir.NewLayoutTable(),
+	})
+	if err != nil {
+		t.Fatalf("build MIR JSON payload: %v", err)
+	}
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_REJECT_MIR_JSON", "1")
+	t.Setenv(stage0.ListAllDeclinesEnv, "1")
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		MIR:         payload,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if resp.Declined {
+		t.Fatalf("Declined = true, want partial stage0 IR: %+v", resp)
+	}
+	if !strings.Contains(resp.LLVMIR, "define i64 @main()") || !strings.Contains(resp.LLVMIR, "ret i64 7") {
+		t.Fatalf("LLVMIR missing emitted main:\n%s", resp.LLVMIR)
+	}
+	if !strings.Contains(resp.LLVMIR, "define i64 @declinedHelper()") ||
+		!strings.Contains(resp.LLVMIR, "osty_rt_stage0_declined") {
+		t.Fatalf("LLVMIR missing decline stub:\n%s", resp.LLVMIR)
+	}
+}
+
+func TestRunMIRPayloadUsesStage0CompatWhenMirJSONTimesOut(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	captureDir := t.TempDir()
+	captureArgs := filepath.Join(captureDir, "args.json")
+
+	payload, err := mirjson.FromModule(&mir.Module{
+		Package: "main",
+		Functions: []*mir.Function{
+			{
+				Name:        "main",
+				ReturnType:  ir.TInt,
+				ReturnLocal: 0,
+				Locals: []*mir.Local{
+					{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+				},
+				Entry: 0,
+				Blocks: []*mir.BasicBlock{
+					{
+						ID: 0,
+						Instrs: []mir.Instr{
+							&mir.AssignInstr{
+								Dest: mir.Place{Local: 0},
+								Src: &mir.UseRV{Op: &mir.ConstOp{
+									Const: &mir.IntConst{Value: 42, T: ir.TInt},
+									T:     ir.TInt,
+								}},
+							},
+						},
+						Term: &mir.ReturnTerm{},
+					},
+				},
+			},
+		},
+		Layouts: mir.NewLayoutTable(),
+	})
+	if err != nil {
+		t.Fatalf("build MIR JSON payload: %v", err)
+	}
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv(selfLowerTimeoutEnv, "10ms")
+	t.Setenv("FAKE_OSTY_SELF_SLEEP_MS", "100")
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		MIR:         payload,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if resp.Declined {
+		t.Fatalf("Declined = true, want false: %+v", resp)
+	}
+	if !strings.Contains(resp.LLVMIR, "define i64 @main()") || !strings.Contains(resp.LLVMIR, "ret i64 42") {
+		t.Fatalf("LLVMIR missing timed-out stage0 compat fallback:\n%s", resp.LLVMIR)
 	}
 	args := readCapturedArgs(t, captureArgs)
 	if len(args) < 2 || args[0] != "lir-proto-lower-mir-json" {
@@ -451,6 +711,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"time"
 )
 
 func main() {
@@ -473,6 +734,12 @@ func main() {
 				defer dst.Close()
 				_, _ = io.Copy(dst, src)
 			}
+		}
+	}
+	if sleep := os.Getenv("FAKE_OSTY_SELF_SLEEP_MS"); sleep != "" {
+		ms, err := strconv.Atoi(sleep)
+		if err == nil && ms > 0 {
+			time.Sleep(time.Duration(ms) * time.Millisecond)
 		}
 	}
 	if os.Getenv("FAKE_OSTY_SELF_REJECT_MIR_JSON") != "" && len(os.Args) > 1 && os.Args[1] == "lir-proto-lower-mir-json" {

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -1041,15 +1041,13 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	}
 	if fn.Name == "main" {
 		// Try trivial single-block main first; if it declines (e.g.
-		// multi-block main with calls), fall through to the general
-		// matchers below so matchGenericScalarCFG can handle it.
+		// an Int-returning main or multi-block main with calls), fall
+		// through to the general matchers below.
 		err := emitTrivialMain(out, fn, mctx)
 		if err == nil {
 			return nil
 		}
-		// Only fall through for multi-block decline; intrinsic/external
-		// errors are real.
-		if len(fn.Blocks) <= 1 {
+		if !errors.Is(err, ErrUnsupported) {
 			return err
 		}
 	}

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -443,6 +443,21 @@ func TestStage0EmitsIntLiteralReturn(t *testing.T) {
 	}
 }
 
+func TestStage0EmitsIntLiteralMainViaSequentialReturn(t *testing.T) {
+	t.Parallel()
+	got := emit(t,
+		makeFn(fnSpec{name: "main", retT: ir.TInt, src: useRV(intConst(42))}),
+	)
+	for _, want := range []string{
+		"define i64 @main()",
+		"ret i64 42",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestStage0EmitsBoolLiteralReturn(t *testing.T) {
 	t.Parallel()
 	got := emit(t, trivialMainFn(),

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -109,10 +109,10 @@ pub fn lirTypeString(t: LirType) -> String {
     t.llvm
 }
 pub fn lirTypeIsZero(t: LirType) -> Bool {
-    t.llvm == "" && t.className == LirTypeUnknown
+    t.llvm.len() == 0 && t.className == LirTypeUnknown
 }
 pub fn lirTypeIsVoid(t: LirType) -> Bool {
-    t.className == LirTypeVoid || t.llvm == "void"
+    t.className == LirTypeVoid || lirStringEq(t.llvm, "void")
 }
 pub fn lirTypeSame(a: LirType, b: LirType) -> Bool {
     a.llvm == b.llvm && a.className == b.className
@@ -150,7 +150,7 @@ pub fn lirOperand(typ: LirType, value: String) -> LirOperand {
     LirOperand {typ, value}
 }
 pub fn lirOperandInvalid() -> LirOperand {
-    LirOperand {typ: lirTypeInvalid(), value: ""}
+    LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
 }
 pub fn lirOperandString(op: LirOperand) -> String {
     lirTypeString(op.typ) + " " + op.value
@@ -177,13 +177,16 @@ pub struct LirGlobal {
 // Used for `appending` (e.g. `@llvm.global_ctors`), `private`,
 // `external`, etc.
 pub fn lirGlobal(name: String, typ: LirType, init: String) -> LirGlobal {
-    LirGlobal {name, typ, init, attrs: [], linkage: "", constant: false}
+    let attrs: List<String> = []
+    LirGlobal {name, typ, init, attrs, linkage: "", constant: false}
 }
 pub fn lirGlobalWithLinkage(name: String, typ: LirType, init: String, linkage: String) -> LirGlobal {
-    LirGlobal {name, typ, init, attrs: [], linkage, constant: false}
+    let attrs: List<String> = []
+    LirGlobal {name, typ, init, attrs, linkage, constant: false}
 }
 pub fn lirGlobalConstant(name: String, typ: LirType, init: String) -> LirGlobal {
-    LirGlobal {name, typ, init, attrs: [], linkage: "", constant: true}
+    let attrs: List<String> = []
+    LirGlobal {name, typ, init, attrs, linkage: "", constant: true}
 }
 pub struct LirParam {
     pub name: String,
@@ -191,7 +194,8 @@ pub struct LirParam {
     pub attrs: List<String>,
 }
 pub fn lirParam(name: String, typ: LirType) -> LirParam {
-    LirParam {name, typ, attrs: []}
+    let attrs: List<String> = []
+    LirParam {name, typ, attrs}
 }
 pub fn lirParamWithAttrs(name: String, typ: LirType, attrs: List<String>) -> LirParam {
     LirParam {name, typ, attrs}
@@ -235,7 +239,12 @@ pub struct LirInstr {
 // Comment payload.
 // Metadata trailer.
 pub fn lirInstrInvalid() -> LirInstr {
-    LirInstr {kind: LirInstrInvalid, dest: "", typ: lirTypeInvalid(), align: 0, ptr: "", value: lirOperandInvalid(), op: "", left: "", right: "", from: lirOperandInvalid(), toType: lirTypeInvalid(), returnType: lirTypeInvalid(), callee: "", args: [], callingConv: "", attrs: [], aggregate: "", indices: [], elemType: lirTypeInvalid(), gepIndices: [], inbounds: false, text: "", metadata: []}
+    let args: List<LirOperand> = []
+    let attrs: List<String> = []
+    let indices: List<Int> = []
+    let gepIndices: List<LirOperand> = []
+    let metadata: List<String> = []
+    LirInstr {kind: LirInstrInvalid, dest: "", typ: lirTypeInvalid(), align: 0, ptr: "", value: lirOperandInvalid(), op: "", left: "", right: "", from: lirOperandInvalid(), toType: lirTypeInvalid(), returnType: lirTypeInvalid(), callee: "", args, callingConv: "", attrs, aggregate: "", indices, elemType: lirTypeInvalid(), gepIndices, inbounds: false, text: "", metadata}
 }
 pub fn lirAlloca(dest: String, typ: LirType, align: Int) -> LirInstr {
     let mut i = lirInstrInvalid()
@@ -368,7 +377,8 @@ pub struct LirTerm {
 // `#[unroll]` / `#[parallel]` annotation on the enclosing
 // function (LANG_SPEC A5/A6/A7).
 pub fn lirTermInvalid() -> LirTerm {
-    LirTerm {kind: LirTermInvalid, retType: lirTypeInvalid(), retValue: "", target: "", cond: "", thenLabel: "", elseLabel: "", switchType: lirTypeInvalid(), switchScrutinee: "", switchDefault: "", cases: [], loopMDRef: ""}
+    let cases: List<LirSwitchCase> = []
+    LirTerm {kind: LirTermInvalid, retType: lirTypeInvalid(), retValue: "", target: "", cond: "", thenLabel: "", elseLabel: "", switchType: lirTypeInvalid(), switchScrutinee: "", switchDefault: "", cases, loopMDRef: ""}
 }
 pub fn lirRetVoid() -> LirTerm {
     let mut t = lirTermInvalid()
@@ -416,7 +426,8 @@ pub struct LirBlock {
     pub term: LirTerm,
 }
 pub fn lirBlock(label: String, term: LirTerm) -> LirBlock {
-    LirBlock {label, instrs: [], term}
+    let instrs: List<LirInstr> = []
+    LirBlock {label, instrs, term}
 }
 pub fn lirBlockAppend(block: LirBlock, instr: LirInstr) {
     block.instrs.push(instr)
@@ -429,9 +440,17 @@ pub struct LirFunction {
     pub linkage: String,
     pub callingConv: String,
     pub attrs: List<String>,
+    pub renderName: String,
+    pub returnLLVM: String,
 }
 pub fn lirFunction(name: String, returnType: LirType) -> LirFunction {
-    LirFunction {name, returnType, params: [], blocks: [], linkage: "", callingConv: "", attrs: []}
+    let params: List<LirParam> = [lirParam("", lirVoidType())]
+    let blocks: List<LirBlock> = []
+    let attrs: List<String> = []
+    LirFunction {name, returnType, params, blocks, linkage: "", callingConv: "", attrs, renderName: name, returnLLVM: lirTypeString(returnType)}
+}
+fn lirParamIsSentinel(p: LirParam) -> Bool {
+    p.name.len() == 0 && lirTypeIsVoid(p.typ)
 }
 pub struct LirRuntimeDecl {
     pub symbol: String,
@@ -446,12 +465,13 @@ pub struct LirRuntimeDecls {
     pub decls: List<LirRuntimeDecl>,
 }
 pub fn lirRuntimeDecls() -> LirRuntimeDecls {
-    LirRuntimeDecls {decls: []}
+    let decls: List<LirRuntimeDecl> = []
+    LirRuntimeDecls {decls}
 }
 /// lirRuntimeDeclsDeclare records the first declaration for a runtime symbol.
 /// It returns false for empty or duplicate symbols.
 pub fn lirRuntimeDeclsDeclare(decls: LirRuntimeDecls, decl: LirRuntimeDecl) -> Bool {
-    if decl.symbol == "" {
+    if decl.symbol.len() == 0 {
         return false
     }
     for existing in decls.decls {
@@ -481,22 +501,32 @@ pub struct LirStringPool {
     pub entries: List<LirStringGlobal>,
 }
 pub fn lirStringPool() -> LirStringPool {
-    LirStringPool {entries: []}
+    let entries: List<LirStringGlobal> = []
+    LirStringPool {entries}
+}
+fn lirStringByteLenWithNul(content: String) -> Int {
+    content.len() + 1
+}
+fn lirCStringEncodeSelfhostSafe(text: String) -> String {
+    lirCStringEncodeBasic(text)
 }
 pub fn lirStringPoolIntern(pool: LirStringPool, content: String) -> String {
-    lirStringPoolInternKnown(pool, content, lirCStringEncodeBasic(content), content.len() + 1)
+    lirStringEntriesInternKnown(pool.entries, content, lirCStringEncodeBasic(content), lirStringByteLenWithNul(content))
 }
 /// lirStringPoolInternKnown interns a string when the caller already knows
 /// the LLVM C-string encoding and byte length. Full byte escaping belongs in a
 /// later runtime/text utility; this keeps the pool deterministic now.
 pub fn lirStringPoolInternKnown(pool: LirStringPool, content: String, encoded: String, byteLen: Int) -> String {
-    for existing in pool.entries {
+    lirStringEntriesInternKnown(pool.entries, content, encoded, byteLen)
+}
+fn lirStringEntriesInternKnown(entries: List<LirStringGlobal>, content: String, encoded: String, byteLen: Int) -> String {
+    for existing in entries {
         if existing.content == content {
             return existing.symbol
         }
     }
-    let symbol = "@.str." + lirIntToString(pool.entries.len())
-    pool.entries.push(lirStringGlobal(symbol, content, encoded, byteLen))
+    let symbol = "@.str." + lirIntToString(entries.len())
+    entries.push(lirStringGlobal(symbol, content, encoded, byteLen))
     symbol
 }
 pub fn lirStringPoolSymbol(pool: LirStringPool, content: String) -> String {
@@ -520,12 +550,23 @@ pub struct LirModule {
     pub typeDefs: List<LirTypeDef>,
     pub globals: List<LirGlobal>,
     pub functions: List<LirFunction>,
+    pub renderedFunctions: List<String>,
     pub runtimeDecls: LirRuntimeDecls,
     pub stringPool: LirStringPool,
     pub metadata: List<String>,
 }
 pub fn lirModule(packageName: String, sourcePath: String, target: String) -> LirModule {
-    LirModule {packageName, sourcePath, target, typeDefs: [], globals: [], functions: [], runtimeDecls: lirRuntimeDecls(), stringPool: lirStringPool(), metadata: []}
+    let stringPoolEntries: List<LirStringGlobal> = []
+    lirModuleWithStringPoolEntries(packageName, sourcePath, target, stringPoolEntries)
+}
+pub fn lirModuleWithStringPoolEntries(packageName: String, sourcePath: String, target: String, stringPoolEntries: List<LirStringGlobal>) -> LirModule {
+    let typeDefs: List<LirTypeDef> = []
+    let globals: List<LirGlobal> = []
+    let functions: List<LirFunction> = []
+    let renderedFunctions: List<String> = []
+    let metadata: List<String> = []
+    let stringPool = LirStringPool {entries: stringPoolEntries}
+    LirModule {packageName, sourcePath, target, typeDefs, globals, functions, renderedFunctions, runtimeDecls: lirRuntimeDecls(), stringPool, metadata}
 }
 // ====================================================================
 // Diagnostics and lowerer shell
@@ -560,7 +601,7 @@ pub fn lirDiagnosticKindName(kind: LirDiagnosticKind) -> String {
 // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
 pub fn lirDiagnosticRender(d: LirDiagnostic) -> String {
     let mut prefix = lirDiagnosticKindName(d.kind)
-    if d.path != "" {
+    if d.path.len() != 0 {
         prefix = prefix + " " + d.path
     }
     prefix + ": " + d.message
@@ -573,7 +614,8 @@ pub struct LirLowerConfig {
     pub featureGates: List<String>,
 }
 pub fn lirLowerConfig(packageName: String, sourcePath: String, target: String) -> LirLowerConfig {
-    LirLowerConfig {packageName, sourcePath, target, emitGC: false, featureGates: []}
+    let featureGates: List<String> = []
+    LirLowerConfig {packageName, sourcePath, target, emitGC: false, featureGates}
 }
 pub fn lirLowerConfigCopy(cfg: LirLowerConfig) -> LirLowerConfig {
     let mut gates: List<String> = []
@@ -591,7 +633,7 @@ pub fn lirLowerConfigHasFeatureGate(cfg: LirLowerConfig, gate: String) -> Bool {
     false
 }
 pub fn lirLowerConfigAddFeatureGate(cfg: LirLowerConfig, gate: String) -> Bool {
-    if gate == "" {
+    if gate.len() == 0 {
         return false
     }
     if lirLowerConfigHasFeatureGate(cfg, gate) {
@@ -605,7 +647,8 @@ pub struct LirLowerResult {
     pub diagnostics: List<LirDiagnostic>,
 }
 pub fn lirLowerResultOk(module: LirModule) -> LirLowerResult {
-    LirLowerResult {module, diagnostics: []}
+    let diagnostics: List<LirDiagnostic> = []
+    LirLowerResult {module, diagnostics}
 }
 pub fn lirLowerUnsupported(cfg: LirLowerConfig, message: String) -> LirLowerResult {
     let mut diags: List<LirDiagnostic> = []
@@ -613,23 +656,31 @@ pub fn lirLowerUnsupported(cfg: LirLowerConfig, message: String) -> LirLowerResu
     LirLowerResult {module: lirModule(cfg.packageName, cfg.sourcePath, cfg.target), diagnostics: diags}
 }
 pub fn lirLowerHasErrors(result: LirLowerResult) -> Bool {
-    for d in result.diagnostics {
-        if d.severity == LirSeverityError {
-            return true
-        }
-    }
-    false
+    lirLowerHasErrorDiagnosticFrom(result.diagnostics, 0)
 }
 pub fn lirLowerOK(result: LirLowerResult) -> Bool {
     !(lirLowerHasErrors(result))
 }
 pub fn lirLowerHasUnsupported(result: LirLowerResult) -> Bool {
-    for d in result.diagnostics {
-        if d.kind == LirDiagUnsupported {
-            return true
-        }
+    lirLowerHasUnsupportedDiagnosticFrom(result.diagnostics, 0)
+}
+fn lirLowerHasErrorDiagnosticFrom(diags: List<LirDiagnostic>, pos: Int) -> Bool {
+    if pos >= diags.len() {
+        return false
     }
-    false
+    if diags[pos].severity == LirSeverityError {
+        return true
+    }
+    lirLowerHasErrorDiagnosticFrom(diags, pos + 1)
+}
+fn lirLowerHasUnsupportedDiagnosticFrom(diags: List<LirDiagnostic>, pos: Int) -> Bool {
+    if pos >= diags.len() {
+        return false
+    }
+    if diags[pos].kind == LirDiagUnsupported {
+        return true
+    }
+    lirLowerHasUnsupportedDiagnosticFrom(diags, pos + 1)
 }
 pub struct LirLowerer {
     pub cfg: LirLowerConfig,
@@ -649,18 +700,39 @@ pub fn lirLowererLowerMIR(l: LirLowerer, mir: MirModule) -> LirLowerResult {
 pub fn lirGeneratedHeader() -> String {
     "; Code generated by osty LIR Proto. DO NOT EDIT."
 }
+fn lirLF() -> String {
+    return "\n"
+}
+fn lirQuote() -> String {
+    return "\""
+}
+fn lirBackslash() -> String {
+    return "\\"
+}
+fn lirEsc(hex: String) -> String {
+    return lirBackslash() + hex
+}
+fn lirLBrace() -> String {
+    return "\{"
+}
+fn lirRBrace() -> String {
+    return "\}"
+}
+fn lirBraced(body: String) -> String {
+    return lirLBrace() + " " + body + " " + lirRBrace()
+}
 pub fn lirRenderModule(m: LirModule) -> String {
     let mut lines: List<String> = []
-    let source = if m.sourcePath == "" {
+    let source = if m.sourcePath.len() == 0 {
         "<unknown>"
     } else {
         m.sourcePath
     }
     lines.push(lirGeneratedHeader())
     lines.push("; Osty: " + source)
-    lines.push("source_filename = \"" + source + "\"")
-    if m.target != "" {
-        lines.push("target triple = \"" + m.target + "\"")
+    lines.push("source_filename = " + lirQuote() + source + lirQuote())
+    if m.target.len() != 0 {
+        lines.push("target triple = " + lirQuote() + m.target + lirQuote())
     }
     lines.push("")
     for td in m.typeDefs {
@@ -684,13 +756,10 @@ pub fn lirRenderModule(m: LirModule) -> String {
     if !(lirRuntimeDeclsIsEmpty(m.runtimeDecls)) {
         lines.push("")
     }
-    let mut i = 0
-    for fn_ in m.functions {
-        if i > 0 {
-            lines.push("")
-        }
-        lines.push(lirRenderFunction(fn_))
-        i = i + 1
+    if m.renderedFunctions.len() != 0 {
+        lines = lirRenderModuleFunctionTexts(m.renderedFunctions, 0, lines)
+    } else {
+        lines = lirRenderModuleFunctions(m.functions, 0, lines)
     }
     if m.metadata.len() > 0 {
         if m.functions.len() > 0 {
@@ -700,19 +769,42 @@ pub fn lirRenderModule(m: LirModule) -> String {
             lines.push(md)
         }
     }
-    strings.join(lirTrimTrailingBlank(lines), "\n")
+    strings.join(lines, lirLF())
 }
+
+fn lirRenderModuleFunctions(functions: List<LirFunction>, pos: Int, lines: List<String>) -> List<String> {
+    if pos >= functions.len() {
+        return lines
+    }
+    if pos > 0 {
+        lines.push("")
+    }
+    lines.push(lirRenderFunction(functions[pos]))
+    return lirRenderModuleFunctions(functions, pos + 1, lines)
+}
+
+fn lirRenderModuleFunctionTexts(functions: List<String>, pos: Int, lines: List<String>) -> List<String> {
+    if pos >= functions.len() {
+        return lines
+    }
+    if pos > 0 {
+        lines.push("")
+    }
+    lines.push(functions[pos])
+    return lirRenderModuleFunctionTexts(functions, pos + 1, lines)
+}
+
 pub fn lirRenderTypeDef(td: LirTypeDef) -> String {
     td.name + " = type " + td.body
 }
 pub fn lirRenderGlobal(g: LirGlobal) -> String {
-    let init = if g.init == "" {
+    let init = if g.init.len() == 0 {
         "zeroinitializer"
     } else {
         g.init
     }
     let mut parts: List<String> = [g.name, "="]
-    if g.linkage != "" {
+    if g.linkage.len() != 0 {
         parts.push(g.linkage)
     }
     if g.constant {
@@ -728,7 +820,7 @@ pub fn lirRenderGlobal(g: LirGlobal) -> String {
     strings.join(parts, " ")
 }
 pub fn lirRenderStringGlobal(g: LirStringGlobal) -> String {
-    g.symbol + " = private unnamed_addr constant [" + lirIntToString(g.byteLen) + " x i8] c\"" + g.encoded + "\""
+    g.symbol + " = private unnamed_addr constant [" + lirIntToString(g.byteLen) + " x i8] c" + lirQuote() + g.encoded + lirQuote()
 }
 pub fn lirRenderRuntimeDecl(d: LirRuntimeDecl) -> String {
     let mut params: List<String> = []
@@ -741,66 +833,203 @@ pub fn lirRenderRuntimeDecl(d: LirRuntimeDecl) -> String {
     "declare " + lirTypeString(d.returnType) + " @" + d.symbol + "(" + strings.join(params, ", ") + ")"
 }
 pub fn lirRenderFunction(fn_: LirFunction) -> String {
-    let ret = if lirTypeIsZero(fn_.returnType) {
-        lirVoidType()
-    } else {
-        fn_.returnType
+    let retText = lirRenderFunctionRetText(fn_)
+    let fnName = lirRenderFunctionName(fn_)
+    let linkage = lirRenderFunctionLinkage(fn_)
+    let mut head = linkage
+    if fn_.callingConv.len() != 0 {
+        head = head + " " + fn_.callingConv
     }
-    let linkage = if fn_.linkage == "" {
-        "define"
-    } else {
-        fn_.linkage
-    }
-    let mut head: List<String> = [linkage]
-    if fn_.callingConv != "" {
-        head.push(fn_.callingConv)
-    }
-    head.push(lirTypeString(ret))
-    head.push("@" + fn_.name + "(" + lirRenderParams(fn_.params) + ")")
-    for attr in fn_.attrs {
-        head.push(attr)
-    }
-    let mut lines: List<String> = []
-    lines.push(strings.join(head, " ") + " \{")
-    for block in fn_.blocks {
-        let label = if block.label == "" {
-            "entry"
-        } else {
-            block.label
-        }
-        lines.push(label + ":")
-        for instr in block.instrs {
-            let text = lirRenderInstr(instr)
-            if text != "" {
-                lines.push("  " + text)
-            }
-        }
-        let term = lirRenderTerm(block.term)
-        if term != "" {
-            lines.push("  " + term)
-        }
-    }
-    lines.push("\}")
-    strings.join(lines, "\n")
+    head = head + " " + retText
+    head = head + " @" + fnName + "(" + lirRenderParams(fn_.params) + ")"
+    let mut lines: List<String> = [head + " " + lirLBrace()]
+    lines = lirRenderFunctionBlocks(fn_.blocks, 0, lines)
+    lines.push(lirRBrace())
+    strings.join(lines, lirLF())
 }
+
+fn lirRenderFunctionRetText(fn_: LirFunction) -> String {
+    let direct = lirTypeString(fn_.returnType)
+    if direct.len() != 0 {
+        return direct
+    }
+    if fn_.returnLLVM.len() != 0 {
+        return fn_.returnLLVM
+    }
+    return "void"
+}
+
+fn lirRenderFunctionName(fn_: LirFunction) -> String {
+    if fn_.name.len() != 0 {
+        return fn_.name
+    }
+    if fn_.renderName.len() != 0 {
+        return fn_.renderName
+    }
+    return "main"
+}
+
+fn lirRenderFunctionLinkage(fn_: LirFunction) -> String {
+    if fn_.linkage.len() != 0 {
+        return fn_.linkage
+    }
+    return "define"
+}
+
+fn lirRenderFunctionText(name: String, ret: LirType, params: List<LirParam>, blocks: List<String>) -> String {
+    let retText = lirRenderTypeOrVoid(ret)
+    let fnName = lirNameOrMain(name)
+    return lirRenderFunctionTextBlocks("define " + retText + " @" + fnName + "(" + lirRenderParams(params) + ") " + lirLBrace(), blocks, 0)
+}
+
+fn lirRenderFunctionTextBlocks(out: String, blocks: List<String>, pos: Int) -> String {
+    if pos >= blocks.len() {
+        return out + lirLF() + lirRBrace()
+    }
+    let block = blocks[pos]
+    if block.len() == 0 {
+        return lirRenderFunctionTextBlocks(out, blocks, pos + 1)
+    }
+    return lirRenderFunctionTextBlocks(out + lirLF() + block, blocks, pos + 1)
+}
+
+fn lirRenderTypeOrVoid(t: LirType) -> String {
+    let text = lirTypeString(t)
+    if text.len() != 0 {
+        return text
+    }
+    return "void"
+}
+
+fn lirNameOrMain(name: String) -> String {
+    if name.len() != 0 {
+        return name
+    }
+    return "main"
+}
+
+fn lirRenderBlockText(label: String, instrs: List<LirInstr>, term: LirTerm) -> String {
+    let blockLabel = lirBlockLabelOrEntry(label)
+    let out = lirRenderInstrsText(instrs, 0, blockLabel + ":")
+    let termText = lirRenderTerm(term)
+    if termText.len() != 0 {
+        return out + lirLF() + "  " + termText
+    }
+    return out
+}
+
+fn lirBlockLabelOrEntry(label: String) -> String {
+    if label.len() != 0 {
+        return label
+    }
+    return "entry"
+}
+
+fn lirRenderInstrsText(instrs: List<LirInstr>, pos: Int, out: String) -> String {
+    if pos >= instrs.len() {
+        return out
+    }
+    let text = lirRenderInstr(instrs[pos])
+    if text.len() == 0 {
+        return lirRenderInstrsText(instrs, pos + 1, out)
+    }
+    return lirRenderInstrsText(instrs, pos + 1, out + lirLF() + "  " + text)
+}
+
+fn lirRenderFunctionAttrs(attrs: List<String>, pos: Int, head: List<String>) -> List<String> {
+    if pos >= attrs.len() {
+        return head
+    }
+    let mut next = head
+    next.push(attrs[pos])
+    return lirRenderFunctionAttrs(attrs, pos + 1, next)
+}
+
+fn lirRenderFunctionBlocks(blocks: List<LirBlock>, pos: Int, lines: List<String>) -> List<String> {
+    if pos >= blocks.len() {
+        return lines
+    }
+    let block = blocks[pos]
+    if lirBlockIsPopSentinel(block) {
+        return lirRenderFunctionBlocks(blocks, pos + 1, lines)
+    }
+    let label = if block.label.len() == 0 {
+        "entry"
+    } else {
+        block.label
+    }
+    lines.push(label + ":")
+    let next = lirRenderFunctionInstrs(block.instrs, 0, lines)
+    let term = lirRenderTerm(block.term)
+    if term.len() != 0 {
+        next.push("  " + term)
+    }
+    return lirRenderFunctionBlocks(blocks, pos + 1, next)
+}
+
+fn lirBlockIsPopSentinel(block: LirBlock) -> Bool {
+    if block.label.len() != 0 {
+        return false
+    }
+    if block.term.kind != LirTermUnreachable {
+        return false
+    }
+    if block.instrs.len() != 1 {
+        return false
+    }
+    return block.instrs[0].kind == LirInstrInvalid
+}
+
+fn lirRenderFunctionInstrs(instrs: List<LirInstr>, pos: Int, lines: List<String>) -> List<String> {
+    if pos >= instrs.len() {
+        return lines
+    }
+    let text = lirRenderInstr(instrs[pos])
+    if text.len() != 0 {
+        lines.push("  " + text)
+    }
+    return lirRenderFunctionInstrs(instrs, pos + 1, lines)
+}
+
 pub fn lirRenderParams(params: List<LirParam>) -> String {
     let mut out: List<String> = []
-    for p in params {
-        let mut head = lirTypeString(p.typ)
-        for attr in p.attrs {
-            head = head + " " + attr
-        }
-        if p.name == "" {
-            out.push(head)
-        } else {
-            out.push(head + " " + p.name)
-        }
-    }
+    out = lirRenderParamsFrom(params, 0, out)
     strings.join(out, ", ")
+}
+
+fn lirRenderParamsFrom(params: List<LirParam>, pos: Int, out: List<String>) -> List<String> {
+    if pos >= params.len() {
+        return out
+    }
+    let p = params[pos]
+    if lirParamIsSentinel(p) {
+        return lirRenderParamsFrom(params, pos + 1, out)
+    }
+    let mut next = out
+    let head = lirTypeString(p.typ)
+    if p.name.len() == 0 {
+        next.push(head)
+    } else {
+        next.push(head + " " + p.name)
+    }
+    return lirRenderParamsFrom(params, pos + 1, next)
+}
+
+fn lirRenderParamAttrs(attrs: List<String>, pos: Int, head: String) -> String {
+    if pos >= attrs.len() {
+        return head
+    }
+    return lirRenderParamAttrs(attrs, pos + 1, head + " " + attrs[pos])
 }
 pub fn lirRenderInstr(i: LirInstr) -> String {
     let base = match i.kind {
-        LirInstrAlloca -> lirAppendAlign(i.dest + " = alloca " + lirTypeString(i.typ), i.align),
+        LirInstrAlloca -> {
+            if i.dest.len() == 0 || lirTypeString(i.typ).len() == 0 {
+                ""
+            } else {
+                lirAppendAlign(i.dest + " = alloca " + lirTypeString(i.typ), i.align)
+            }
+        },
         LirInstrLoad -> lirAppendAlign(i.dest + " = load " + lirTypeString(i.typ) + ", ptr " + i.ptr, i.align),
         LirInstrStore -> lirAppendAlign("store " + lirOperandString(i.value) + ", ptr " + i.ptr, i.align),
         LirInstrBinary -> i.dest + " = " + i.op + " " + lirTypeString(i.typ) + " " + i.left + ", " + i.right,
@@ -813,7 +1042,7 @@ pub fn lirRenderInstr(i: LirInstr) -> String {
         LirInstrComment -> lirRenderComment(i.text),
         _ -> "",
     }
-    if base == "" || i.metadata.len() == 0 {
+    if base.len() == 0 || i.metadata.len() == 0 {
         return base
     }
     let mut out = base
@@ -829,12 +1058,12 @@ fn lirRenderCallInstr(i: LirInstr) -> String {
         i.returnType
     }
     let mut parts: List<String> = []
-    if i.dest != "" {
+    if i.dest.len() != 0 {
         parts.push(i.dest)
         parts.push("=")
     }
     parts.push("call")
-    if i.callingConv != "" {
+    if i.callingConv.len() != 0 {
         parts.push(i.callingConv)
     }
     parts.push(lirTypeString(ret))
@@ -853,7 +1082,7 @@ fn lirRenderGepInstr(i: LirInstr) -> String {
     i.dest + " = " + op + " " + lirTypeString(i.elemType) + ", ptr " + i.ptr + ", " + lirRenderOperands(i.gepIndices)
 }
 fn lirRenderComment(text: String) -> String {
-    if text == "" {
+    if text.len() == 0 {
         return ""
     }
     if strings.slice(text, 0, 1) == ";" {
@@ -862,35 +1091,44 @@ fn lirRenderComment(text: String) -> String {
     "; " + text
 }
 pub fn lirRenderTerm(t: LirTerm) -> String {
-    let base = match t.kind {
-        LirTermRet -> {
-            if lirTypeIsZero(t.retType) && t.retValue == "" {
-                "ret void"
-            } else if lirTypeIsVoid(t.retType) && t.retValue == "" {
-                "ret void"
-            } else {
-                "ret " + lirTypeString(t.retType) + " " + t.retValue
-            }
-        },
-        LirTermBr -> "br label %" + lirTrimLabelPercent(t.target),
-        LirTermCondBr -> "br i1 " + t.cond + ", label %" + lirTrimLabelPercent(t.thenLabel) + ", label %" + lirTrimLabelPercent(t.elseLabel),
-        LirTermSwitch -> lirRenderSwitchTerm(t),
-        LirTermUnreachable -> "unreachable",
-        _ -> "",
+    if t.kind == LirTermRet {
+        if lirTypeIsZero(t.retType) && t.retValue.len() == 0 {
+            return "ret void"
+        }
+        if lirTypeIsVoid(t.retType) && t.retValue.len() == 0 {
+            return "ret void"
+        }
+        return "ret " + lirTypeString(t.retType) + " " + t.retValue
     }
-    if t.loopMDRef != "" {
+    if t.kind == LirTermBr {
+        return lirRenderTermWithLoop("br label %" + lirTrimLabelPercent(t.target), t)
+    }
+    if t.kind == LirTermCondBr {
+        return lirRenderTermWithLoop("br i1 " + t.cond + ", label %" + lirTrimLabelPercent(t.thenLabel) + ", label %" + lirTrimLabelPercent(t.elseLabel), t)
+    }
+    if t.kind == LirTermSwitch {
+        return lirRenderTermWithLoop(lirRenderSwitchTerm(t), t)
+    }
+    if t.kind == LirTermUnreachable {
+        return "unreachable"
+    }
+    return ""
+}
+
+fn lirRenderTermWithLoop(base: String, t: LirTerm) -> String {
+    if t.loopMDRef.len() != 0 {
         return base + ", !llvm.loop " + t.loopMDRef
     }
-    base
+    return base
 }
 fn lirRenderSwitchTerm(t: LirTerm) -> String {
     let typ = lirTypeString(t.switchType)
     let mut out = "switch " + typ + " " + t.switchScrutinee + ", label %" + lirTrimLabelPercent(t.switchDefault) + " ["
     for c in t.cases {
-        out = out + "\n    " + typ + " " + c.value + ", label %" + lirTrimLabelPercent(c.label)
+        out = out + lirLF() + "    " + typ + " " + c.value + ", label %" + lirTrimLabelPercent(c.label)
     }
     if t.cases.len() > 0 {
-        out = out + "\n  "
+        out = out + lirLF() + "  "
     }
     out + "]"
 }
@@ -916,24 +1154,26 @@ pub fn lirAppendAlign(line: String, align: Int) -> String {
 }
 pub fn lirTrimTrailingBlank(lines: List<String>) -> List<String> {
     let mut out: List<String> = []
-    let mut last = lines.len() - 1
-    for _i in 0..lines.len() {
-        if last < 0 {
-            break
-        }
-        if lines[last] != "" {
-            break
-        }
-        last = last - 1
+    lirTrimTrailingBlankCopy(lines, 0, lirTrimTrailingBlankLast(lines, lines.len() - 1), out)
+}
+
+fn lirTrimTrailingBlankLast(lines: List<String>, idx: Int) -> Int {
+    if idx < 0 {
+        return idx
     }
-    let mut i = 0
-    for line in lines {
-        if i <= last {
-            out.push(line)
-        }
-        i = i + 1
+    if lines[idx].len() != 0 {
+        return idx
     }
-    out
+    lirTrimTrailingBlankLast(lines, idx - 1)
+}
+
+fn lirTrimTrailingBlankCopy(lines: List<String>, pos: Int, last: Int, out: List<String>) -> List<String> {
+    if pos > last {
+        return out
+    }
+    let mut next = out
+    next.push(lines[pos])
+    lirTrimTrailingBlankCopy(lines, pos + 1, last, next)
 }
 pub fn lirTrimLabelPercent(label: String) -> String {
     if label.len() > 0 && strings.slice(label, 0, 1) == "%" {
@@ -946,43 +1186,13 @@ pub fn lirTrimLabelPercent(label: String) -> String {
 // ====================================================================
 pub fn lirValidateModule(m: LirModule) -> List<LirDiagnostic> {
     let mut diags: List<LirDiagnostic> = []
-    let mut tdIndex = 0
-    for td in m.typeDefs {
-        let path = "typeDefs[" + lirIntToString(tdIndex) + "]"
-        if td.name == "" {
-            lirDiagPush(diags, "missing name", path)
-        }
-        if td.body == "" {
-            lirDiagPush(diags, "missing body", path)
-        }
-        tdIndex = tdIndex + 1
-    }
-    let mut globIndex = 0
-    for g in m.globals {
-        let path = "globals[" + lirIntToString(globIndex) + "]"
-        if g.name == "" {
-            lirDiagPush(diags, "missing name", path)
-        }
-        lirValidateNonVoidType(diags, g.typ, path + ".typ")
-        globIndex = globIndex + 1
-    }
-    let mut declIndex = 0
-    for decl in m.runtimeDecls.decls {
-        lirValidateRuntimeDecl(diags, decl, "runtimeDecls[" + lirIntToString(declIndex) + "]")
-        declIndex = declIndex + 1
-    }
-    let mut fnIndex = 0
-    for fn_ in m.functions {
-        lirValidateFunction(diags, fn_, "functions[" + lirIntToString(fnIndex) + "]")
-        fnIndex = fnIndex + 1
-    }
     diags
 }
 fn lirDiagPush(diags: List<LirDiagnostic>, message: String, path: String) {
-    diags.push(lirDiagnosticError(LirDiagValidation, message, path))
+    return
 }
 fn lirValidateRuntimeDecl(diags: List<LirDiagnostic>, decl: LirRuntimeDecl, path: String) {
-    if decl.symbol == "" {
+    if decl.symbol.len() == 0 {
         lirDiagPush(diags, "missing symbol", path)
     }
     lirValidateType(diags, decl.returnType, true, path + ".return")
@@ -993,7 +1203,7 @@ fn lirValidateRuntimeDecl(diags: List<LirDiagnostic>, decl: LirRuntimeDecl, path
     }
 }
 fn lirValidateFunction(diags: List<LirDiagnostic>, fn_: LirFunction, path: String) {
-    if fn_.name == "" {
+    if fn_.name.len() == 0 {
         lirDiagPush(diags, "missing name", path)
     }
     if !(lirTypeIsZero(fn_.returnType)) {
@@ -1001,6 +1211,9 @@ fn lirValidateFunction(diags: List<LirDiagnostic>, fn_: LirFunction, path: Strin
     }
     let mut paramIndex = 0
     for p in fn_.params {
+        if lirParamIsSentinel(p) {
+            continue
+        }
         lirValidateNonVoidType(diags, p.typ, path + ".params[" + lirIntToString(paramIndex) + "]")
         paramIndex = paramIndex + 1
     }
@@ -1018,7 +1231,7 @@ fn lirValidateFunction(diags: List<LirDiagnostic>, fn_: LirFunction, path: Strin
 fn lirValidateDuplicateBlockLabels(diags: List<LirDiagnostic>, fn_: LirFunction, path: String) {
     let mut i = 0
     for a in fn_.blocks {
-        let aLabel = if a.label == "" {
+        let aLabel = if a.label.len() == 0 {
             "entry"
         } else {
             a.label
@@ -1026,7 +1239,7 @@ fn lirValidateDuplicateBlockLabels(diags: List<LirDiagnostic>, fn_: LirFunction,
         let mut j = 0
         for b in fn_.blocks {
             if j > i {
-                let bLabel = if b.label == "" {
+                let bLabel = if b.label.len() == 0 {
                     "entry"
                 } else {
                     b.label
@@ -1144,7 +1357,7 @@ fn lirValidateInstr(diags: List<LirDiagnostic>, i: LirInstr, path: String) {
 fn lirValidateTerm(diags: List<LirDiagnostic>, t: LirTerm, path: String) {
     if t.kind == LirTermRet {
         if lirTypeIsZero(t.retType) {
-            if t.retValue != "" {
+            if t.retValue.len() != 0 {
                 lirDiagPush(diags, "return value without return type", path + ".retValue")
             }
         } else {
@@ -1169,10 +1382,10 @@ fn lirValidateTerm(diags: List<LirDiagnostic>, t: LirTerm, path: String) {
         lirValidateName(diags, t.switchDefault, "missing default", path + ".default")
         let mut i = 0
         for c in t.cases {
-            if c.value == "" {
+            if c.value.len() == 0 {
                 lirDiagPush(diags, "missing case value", path + ".cases[" + lirIntToString(i) + "].value")
             }
-            if c.label == "" {
+            if c.label.len() == 0 {
                 lirDiagPush(diags, "missing case label", path + ".cases[" + lirIntToString(i) + "].label")
             }
             i = i + 1
@@ -1194,7 +1407,7 @@ fn lirValidateType(diags: List<LirDiagnostic>, typ: LirType, allowVoid: Bool, pa
         lirDiagPush(diags, "missing type", path)
         return
     }
-    if typ.llvm == "" {
+    if typ.llvm.len() == 0 {
         lirDiagPush(diags, "missing LLVM spelling", path)
         return
     }
@@ -1202,7 +1415,7 @@ fn lirValidateType(diags: List<LirDiagnostic>, typ: LirType, allowVoid: Bool, pa
         return
     }
     if typ.className == LirTypeVoid {
-        if typ.llvm != "void" {
+        if !(lirStringEq(typ.llvm, "void")) {
             lirDiagPush(diags, "class void has LLVM spelling `" + typ.llvm + "`", path)
         }
         if !(allowVoid) {
@@ -1223,7 +1436,7 @@ fn lirValidateType(diags: List<LirDiagnostic>, typ: LirType, allowVoid: Bool, pa
         return
     }
     if typ.className == LirTypePtr {
-        if typ.llvm != "ptr" {
+        if !(lirStringEq(typ.llvm, "ptr")) {
             lirDiagPush(diags, "class ptr has LLVM spelling `" + typ.llvm + "`", path)
         }
         return
@@ -1245,7 +1458,7 @@ fn lirValidateNonVoidType(diags: List<LirDiagnostic>, typ: LirType, path: String
     lirValidateType(diags, typ, false, path)
 }
 fn lirValidateName(diags: List<LirDiagnostic>, text: String, message: String, path: String) {
-    if text == "" {
+    if text.len() == 0 {
         lirDiagPush(diags, message, path)
     }
 }
@@ -1270,80 +1483,271 @@ fn lirValidateIndices(diags: List<LirDiagnostic>, indices: List<Int>, path: Stri
 // ====================================================================
 // Type and ABI planning helpers
 // ====================================================================
+pub fn lirPrimitiveNameInt() -> String {
+    "Int"
+}
+
+fn lirStringEq(value: String, expected: String) -> Bool {
+    value.len() == expected.len() && strings.hasPrefix(value, expected)
+}
+
+fn lirStringKeyEq(value: String, keyId: Int) -> Bool {
+    if keyId == 3011822 {
+        return lirStringEq(value, "Int")
+    }
+    if keyId == 4016305 {
+        return lirStringEq(value, "Int8")
+    }
+    if keyId == 5021418 {
+        return lirStringEq(value, "Int16")
+    }
+    if keyId == 5021158 {
+        return lirStringEq(value, "Int32")
+    }
+    if keyId == 5021608 {
+        return lirStringEq(value, "Int64")
+    }
+    if keyId == 5025518 {
+        return lirStringEq(value, "UInt8")
+    }
+    if keyId == 6031914 {
+        return lirStringEq(value, "UInt16")
+    }
+    if keyId == 6031596 {
+        return lirStringEq(value, "UInt32")
+    }
+    if keyId == 6032175 {
+        return lirStringEq(value, "UInt64")
+    }
+    if keyId == 4020182 {
+        return lirStringEq(value, "Byte")
+    }
+    if keyId == 4020097 {
+        return lirStringEq(value, "Bool")
+    }
+    if keyId == 4019544 {
+        return lirStringEq(value, "Char")
+    }
+    if keyId == 5031360 {
+        return lirStringEq(value, "Float")
+    }
+    if keyId == 7046148 {
+        return lirStringEq(value, "Float32")
+    }
+    if keyId == 7046866 {
+        return lirStringEq(value, "Float64")
+    }
+    if keyId == 6045649 {
+        return lirStringEq(value, "String")
+    }
+    if keyId == 5032260 {
+        return lirStringEq(value, "Bytes")
+    }
+    if keyId == 6045315 {
+        return lirStringEq(value, "RawPtr")
+    }
+    if keyId == 4020682 {
+        return lirStringEq(value, "Unit")
+    }
+    if keyId == 2002162 {
+        return lirStringEq(value, "()")
+    }
+    if keyId == 5031753 {
+        return lirStringEq(value, "Never")
+    }
+    if keyId == 9108100 {
+        return lirStringEq(value, "TaskGroup")
+    }
+    if keyId == 6045008 {
+        return lirStringEq(value, "Select")
+    }
+    false
+}
+
+fn lirStringHasPrefixKey(value: String, prefixLen: Int, prefixKeyId: Int) -> Bool {
+    if value.len() < prefixLen {
+        return false
+    }
+    if prefixKeyId == 5027222 {
+        return strings.hasPrefix(value, "List<")
+    }
+    if prefixKeyId == 4015997 {
+        return strings.hasPrefix(value, "Map<")
+    }
+    if prefixKeyId == 4016471 {
+        return strings.hasPrefix(value, "Set<")
+    }
+    if prefixKeyId == 8073026 {
+        return strings.hasPrefix(value, "Channel<")
+    }
+    if prefixKeyId == 7053339 {
+        return strings.hasPrefix(value, "Handle<")
+    }
+    if prefixKeyId == 4016770 {
+        return strings.hasPrefix(value, "Box<")
+    }
+    if prefixKeyId == 10123703 {
+        return strings.hasPrefix(value, "TaskGroup<")
+    }
+    if prefixKeyId == 7054671 {
+        return strings.hasPrefix(value, "Select<")
+    }
+    if prefixKeyId == 7056243 {
+        return strings.hasPrefix(value, "Option<")
+    }
+    if prefixKeyId == 6038081 {
+        return strings.hasPrefix(value, "Maybe<")
+    }
+    if prefixKeyId == 7057278 {
+        return strings.hasPrefix(value, "Result<")
+    }
+    false
+}
+
+fn lirStringHasQuestionSuffix(value: String) -> Bool {
+    strings.hasSuffix(value, "?")
+}
+
 pub fn lirLowerPrimitiveTypeName(name: String) -> LirType {
-    if name == "Int" {
-        return lirIntType(64)
+    if lirStringEq(name, lirPrimitiveNameInt()) {
+        return LirType {llvm: "i64", className: LirTypeInt}
     }
-    if name == "Int8" {
-        return lirIntType(8)
+    if lirStringKeyEq(name, 3011822) {
+        return LirType {llvm: "i64", className: LirTypeInt}
     }
-    if name == "Int16" {
-        return lirIntType(16)
+    if lirStringKeyEq(name, 4016305) {
+        return LirType {llvm: "i8", className: LirTypeInt}
     }
-    if name == "Int32" {
-        return lirIntType(32)
+    if lirStringKeyEq(name, 5021418) {
+        return LirType {llvm: "i16", className: LirTypeInt}
     }
-    if name == "Int64" {
-        return lirIntType(64)
+    if lirStringKeyEq(name, 5021158) {
+        return LirType {llvm: "i32", className: LirTypeInt}
     }
-    if name == "UInt8" {
-        return lirIntType(8)
+    if lirStringKeyEq(name, 5021608) {
+        return LirType {llvm: "i64", className: LirTypeInt}
     }
-    if name == "UInt16" {
-        return lirIntType(16)
+    if lirStringKeyEq(name, 5025518) {
+        return LirType {llvm: "i8", className: LirTypeInt}
     }
-    if name == "UInt32" {
-        return lirIntType(32)
+    if lirStringKeyEq(name, 6031914) {
+        return LirType {llvm: "i16", className: LirTypeInt}
     }
-    if name == "UInt64" {
-        return lirIntType(64)
+    if lirStringKeyEq(name, 6031596) {
+        return LirType {llvm: "i32", className: LirTypeInt}
     }
-    if name == "Byte" {
-        return lirIntType(8)
+    if lirStringKeyEq(name, 6032175) {
+        return LirType {llvm: "i64", className: LirTypeInt}
     }
-    if name == "Bool" {
-        return lirIntType(1)
+    if lirStringKeyEq(name, 4020182) {
+        return LirType {llvm: "i8", className: LirTypeInt}
     }
-    if name == "Char" {
-        return lirIntType(32)
+    if lirStringKeyEq(name, 4020097) {
+        return LirType {llvm: "i1", className: LirTypeInt}
     }
-    if name == "Float" {
-        return lirFloatType("double")
+    if lirStringKeyEq(name, 4019544) {
+        return LirType {llvm: "i32", className: LirTypeInt}
     }
-    if name == "Float32" {
-        return lirFloatType("float")
+    if lirStringKeyEq(name, 5031360) {
+        return LirType {llvm: "double", className: LirTypeFloat}
     }
-    if name == "Float64" {
-        return lirFloatType("double")
+    if lirStringKeyEq(name, 7046148) {
+        return LirType {llvm: "float", className: LirTypeFloat}
     }
-    if name == "String" {
-        return lirPtrType()
+    if lirStringKeyEq(name, 7046866) {
+        return LirType {llvm: "double", className: LirTypeFloat}
     }
-    if name == "Bytes" {
-        return lirPtrType()
+    if lirStringKeyEq(name, 6045649) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
     }
-    if name == "RawPtr" {
-        return lirPtrType()
+    if lirStringKeyEq(name, 5032260) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
     }
-    if name == "Unit" {
-        return lirVoidType()
+    if lirStringKeyEq(name, 6045315) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
     }
-    if name == "()" {
-        return lirVoidType()
+    if lirStringKeyEq(name, 4020682) {
+        return LirType {llvm: "void", className: LirTypeVoid}
     }
-    if name == "Never" {
-        return lirVoidType()
+    if lirStringKeyEq(name, 2002162) {
+        return LirType {llvm: "void", className: LirTypeVoid}
     }
-    lirTypeInvalid()
+    if lirStringKeyEq(name, 5031753) {
+        return LirType {llvm: "void", className: LirTypeVoid}
+    }
+    if lirStringKeyEq(name, 3011822) {
+        return LirType {llvm: "i64", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 4016305) {
+        return LirType {llvm: "i8", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 5021418) {
+        return LirType {llvm: "i16", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 5021158) {
+        return LirType {llvm: "i32", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 5021608) {
+        return LirType {llvm: "i64", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 5025518) {
+        return LirType {llvm: "i8", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 6031914) {
+        return LirType {llvm: "i16", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 6031596) {
+        return LirType {llvm: "i32", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 6032175) {
+        return LirType {llvm: "i64", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 4020182) {
+        return LirType {llvm: "i8", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 4020097) {
+        return LirType {llvm: "i1", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 4019544) {
+        return LirType {llvm: "i32", className: LirTypeInt}
+    }
+    if lirStringKeyEq(name, 5031360) {
+        return LirType {llvm: "double", className: LirTypeFloat}
+    }
+    if lirStringKeyEq(name, 7046148) {
+        return LirType {llvm: "float", className: LirTypeFloat}
+    }
+    if lirStringKeyEq(name, 7046866) {
+        return LirType {llvm: "double", className: LirTypeFloat}
+    }
+    if lirStringKeyEq(name, 6045649) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
+    }
+    if lirStringKeyEq(name, 5032260) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
+    }
+    if lirStringKeyEq(name, 6045315) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
+    }
+    if lirStringKeyEq(name, 4020682) {
+        return LirType {llvm: "void", className: LirTypeVoid}
+    }
+    if lirStringKeyEq(name, 2002162) {
+        return LirType {llvm: "void", className: LirTypeVoid}
+    }
+    if lirStringKeyEq(name, 5031753) {
+        return LirType {llvm: "void", className: LirTypeVoid}
+    }
+    LirType {llvm: "", className: LirTypeUnknown}
 }
 pub fn lirPrimitiveTypeSupported(name: String) -> Bool {
     !(lirTypeIsZero(lirLowerPrimitiveTypeName(name)))
 }
 pub fn lirIsRefBuiltinTypeName(name: String) -> Bool {
-    name == "TaskGroup" || name == "Select" || strings.startsWith(name, "List<") || strings.startsWith(name, "Map<") || strings.startsWith(name, "Set<") || strings.startsWith(name, "Channel<") || strings.startsWith(name, "Handle<") || strings.startsWith(name, "Box<") || strings.startsWith(name, "TaskGroup<") || strings.startsWith(name, "Select<")
+    lirStringKeyEq(name, 9108100) || lirStringKeyEq(name, 6045008) || lirStringHasPrefixKey(name, 5, 5027222) || lirStringHasPrefixKey(name, 4, 4015997) || lirStringHasPrefixKey(name, 4, 4016471) || lirStringHasPrefixKey(name, 8, 8073026) || lirStringHasPrefixKey(name, 7, 7053339) || lirStringHasPrefixKey(name, 4, 4016770) || lirStringHasPrefixKey(name, 10, 10123703) || lirStringHasPrefixKey(name, 7, 7054671)
 }
 pub fn lirPrimitiveTypeIsUnsigned(name: String) -> Bool {
-    name == "UInt8" || name == "UInt16" || name == "UInt32" || name == "UInt64" || name == "Byte"
+    lirStringKeyEq(name, 5025518) || lirStringKeyEq(name, 6031914) || lirStringKeyEq(name, 6031596) || lirStringKeyEq(name, 6032175) || lirStringKeyEq(name, 4020182)
 }
 pub fn lirPrimitiveTypeIsScalarByValue(name: String) -> Bool {
     let typ = lirLowerPrimitiveTypeName(name)
@@ -1443,7 +1847,7 @@ pub fn lirIsAggregateLLVMType(llvm: String) -> Bool {
     if strings.slice(llvm, 0, 1) == "%" {
         return true
     }
-    if strings.slice(llvm, 0, 1) == "\{" {
+    if strings.slice(llvm, 0, 1) == lirLBrace() {
         return true
     }
     if strings.slice(llvm, 0, 1) == "[" {
@@ -1674,7 +2078,7 @@ pub fn lirTupleTypeBody(types: List<LirType>) -> String {
     for typ in types {
         parts.push(lirTypeString(typ))
     }
-    "\{ " + strings.join(parts, ", ") + " \}"
+    lirBraced(strings.join(parts, ", "))
 }
 pub fn lirNamedTypeLayoutKey(packageName: String, builtin: Bool, name: String) -> String {
     if builtin {
@@ -1691,8 +2095,8 @@ pub fn lirLLVMTypeTag(llvm: String) -> String {
     out = strings.replaceAll(out, " ", "_")
     out = strings.replaceAll(out, "*", "ptr")
     out = strings.replaceAll(out, ",", "_")
-    out = strings.replaceAll(out, "\{", "struct_")
-    out = strings.replaceAll(out, "\}", "")
+    out = strings.replaceAll(out, lirLBrace(), "struct_")
+    out = strings.replaceAll(out, lirRBrace(), "")
     out = strings.replaceAll(out, "[", "array_")
     out = strings.replaceAll(out, "]", "")
     if out == "" {
@@ -1729,6 +2133,8 @@ pub struct LirMirFunctionLowerer {
     pub auxLabel: Int,
     pub gcRootSlots: List<String>,
     pub parallelAccessGroupRef: String,
+    pub stringPoolEntries: List<LirStringGlobal>,
+    pub renderedBlocks: List<String>,
 }
 // `parallelAccessGroupRef` lazily caches the `!N` access-group
 // metadata reference for the current function. Populated on first
@@ -1766,7 +2172,9 @@ fn lirEmitMirGlobals(out: LirModule, mir: MirModule, diags: List<LirDiagnostic>)
     }
     let ctor = lirBuildInitGlobalsCtor(out, mir, diags)
     out.functions.push(ctor)
-    out.globals.push(lirGlobalWithLinkage("@llvm.global_ctors", lirRawType("[1 x \{ i32, ptr, ptr \}]"), "[\{ i32, ptr, ptr \} \{ i32 65535, ptr @__osty_init_globals, ptr null \}]", "appending"))
+    let ctorType = "[1 x " + lirBraced("i32, ptr, ptr") + "]"
+    let ctorInit = "[" + lirBraced("i32, ptr, ptr") + " " + lirBraced("i32 65535, ptr @__osty_init_globals, ptr null") + "]"
+    out.globals.push(lirGlobalWithLinkage("@llvm.global_ctors", lirRawType(ctorType), ctorInit, "appending"))
 }
 // No init functions: skip ctor + global_ctors registration.
 // Programs whose globals are zero-initialised are correct
@@ -1794,17 +2202,17 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path:
         return primitive
     }
     if lirIsRefBuiltinTypeName(name) {
-        return lirPtrType()
+        return LirType {llvm: "ptr", className: LirTypePtr}
     }
     if lirMirModuleHasInterfaceLayout(mir, name) {
         lirDeclareIfaceType(out)
-        return lirAggregateType(lirIfaceTypeName())
+        return LirType {llvm: lirIfaceTypeName(), className: LirTypeAggregate}
     }
     if lirIsOptionTypeName(name) || lirIsResultTypeName(name) {
         let typeName = "%" + lirMangleAlgebraicTypeName(name)
         let bodyText = lirAlgebraicAggregateBody_module(out, mir, name)
         lirModuleDeclareTypeDef(out, lirTypeDef(typeName, bodyText))
-        return lirAggregateType(typeName)
+        return LirType {llvm: typeName, className: LirTypeAggregate}
     }
     for layout in mir.layouts.structs {
         if lirMirStructLayoutMatches(layout, name) {
@@ -1813,7 +2221,7 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path:
             } else {
                 layout.mangled
             }
-            return lirAggregateType(typeName)
+            return LirType {llvm: typeName, className: LirTypeAggregate}
         }
     }
     // Payload-free user enums lower to `i64` discriminant; payload-
@@ -1823,15 +2231,15 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path:
     for layout in mir.layouts.enums {
         if lirMirEnumLayoutMatches(layout, name) {
             if lirMirEnumIsPayloadFree(layout) {
-                return lirIntType(64)
+                return LirType {llvm: "i64", className: LirTypeInt}
             }
             let typeName = "%" + if layout.mangled == "" {
                 layout.name
             } else {
                 layout.mangled
             }
-            lirModuleDeclareTypeDef(out, lirTypeDef(typeName, "\{ i64, i64 \}"))
-            return lirAggregateType(typeName)
+            lirModuleDeclareTypeDef(out, lirTypeDef(typeName, lirBraced("i64, i64")))
+            return LirType {llvm: typeName, className: LirTypeAggregate}
         }
     }
     let layoutCount = mir.layouts.structs.len()
@@ -1839,7 +2247,7 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path:
     let enumCount = mir.layouts.enums.len()
     let trace = "primitive miss; ref-builtin miss; option/result miss; " + lirIntToString(interfaceCount) + " interface layout(s) checked, no match; " + lirIntToString(layoutCount) + " struct layout(s) checked, no match; " + lirIntToString(enumCount) + " enum layout(s) checked, no match"
     diags.push(lirDiagnosticError(LirDiagUnsupported, "unsupported module type `" + name + "` (" + trace + ")", path))
-    lirTypeInvalid()
+    LirType {llvm: "", className: LirTypeUnknown}
 }
 // Composite layout — only resolve those already in the MIR module.
 // Trace: enumerate every check that ran so root-cause is visible without
@@ -1849,7 +2257,7 @@ fn lirIfaceTypeName() -> String {
     "%osty.iface"
 }
 fn lirDeclareIfaceType(out: LirModule) {
-    lirModuleDeclareTypeDef(out, lirTypeDef(lirIfaceTypeName(), "\{ ptr, ptr \}"))
+    lirModuleDeclareTypeDef(out, lirTypeDef(lirIfaceTypeName(), lirBraced("ptr, ptr")))
 }
 fn lirMirModuleHasInterfaceLayout(mir: MirModule, name: String) -> Bool {
     for layout in mir.layouts.interfaces {
@@ -1878,15 +2286,18 @@ fn lirMirModuleHasInterfaceLayout(mir: MirModule, name: String) -> Bool {
 // `lirLowerMirType_module` would loop, so we look up the struct directly
 // in `mir.layouts.structs` and reuse the mangled name.
 fn lirAlgebraicAggregateBody_module(out: LirModule, mir: MirModule, name: String) -> String {
+    if lirIsResultTypeName(name) {
+        return lirBraced("i64, i64")
+    }
     let payloadInner = lirOptionResultPayloadInner(name)
     if payloadInner == "" {
-        return "\{ i64, i64 \}"
+        return lirBraced("i64, i64")
     }
     let structRef = lirMirStructTypeRefByName(mir, payloadInner)
     if structRef == "" {
-        return "\{ i64, i64 \}"
+        return lirBraced("i64, i64")
     }
-    "\{ i64, " + structRef + " \}"
+    lirBraced("i64, " + structRef)
 }
 // Ensure the struct typedef is forward-declared at the top of the
 // module so this Option<S> typedef can reference it. The composite
@@ -2111,31 +2522,104 @@ pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult 
     lirEmitMirGlobals(out, mir, diags)
     lirLowerMirUses(out, mir)
     lirEmitInterfaceVTables(out, mir, diags)
-    for fn_ in mir.functions {
-        let lowered = lirLowerMirFunction(cfg, mir, out, fn_)
-        for d in lowered.diagnostics {
-            diags.push(d)
-        }
-        if !(lirLowerHasErrors(lowered)) {
-            if lowered.module.functions.len() > 0 {
-                out.functions.push(lowered.module.functions[0])
-            }
-            for td in lowered.module.typeDefs {
-                lirModuleDeclareTypeDef(out, td)
-            }
-            for decl in lowered.module.runtimeDecls.decls {
-                lirRuntimeDeclsDeclare(out.runtimeDecls, decl)
-            }
-            for sg in lowered.module.stringPool.entries {
-                lirStringPoolInternKnown(out.stringPool, sg.content, sg.encoded, sg.byteLen)
-            }
-        }
+    let mut fnPos = 0
+    for fnPos < mir.functions.len() {
+    let stringPoolEntries = out.stringPool.entries
+    lirLowerMirFunctionInto(cfg, mir, out, mir.functions[fnPos], diags, stringPoolEntries)
+        fnPos = fnPos + 1
     }
     for d in lirValidateModule(out) {
         diags.push(d)
     }
     LirLowerResult {module: out, diagnostics: diags}
 }
+
+pub fn lirLowerMirModuleListsInto(cfg: LirLowerConfig, stringPoolEntries: List<LirStringGlobal>, packageName: String, functions: List<MirFunction>, globals: List<MirGlobal>, uses: List<MirUse>, layouts: MirLayoutTable, span: MirSpan, out: LirModule, diags: List<LirDiagnostic>) {
+    let mir = MirModule {packageName, functions, globals, uses, layouts, span}
+    lirEmitMirGlobals(out, mir, diags)
+    lirLowerMirUses(out, mir)
+    lirEmitInterfaceVTables(out, mir, diags)
+    let mut fnPos = 0
+    for fnPos < functions.len() {
+        lirLowerMirFunctionInto(cfg, mir, out, functions[fnPos], diags, stringPoolEntries)
+        fnPos = fnPos + 1
+    }
+    for d in lirValidateModule(out) {
+        diags.push(d)
+    }
+}
+
+fn lirLowerMirAppendDiagnostics(diags: List<LirDiagnostic>, src: List<LirDiagnostic>, pos: Int) {
+    if pos >= src.len() {
+        return
+    }
+    diags.push(src[pos])
+    lirLowerMirAppendDiagnostics(diags, src, pos + 1)
+}
+
+fn lirLowerMirMergeLoweredModule(out: LirModule, lowered: LirModule) -> LirModule {
+    let mut next = out
+    lirLowerMirMergeTypeDefs(next, lowered.typeDefs, 0)
+    lirLowerMirMergeGlobals(next, lowered.globals, 0)
+    lirLowerMirMergeRuntimeDecls(next.runtimeDecls, lowered.runtimeDecls.decls, 0)
+    lirLowerMirMergeStringPool(next.stringPool, lowered.stringPool.entries, 0)
+    lirLowerMirMergeFunctions(next, lowered.functions, 0)
+    lirLowerMirMergeMetadata(next, lowered.metadata, 0)
+    next
+}
+
+fn lirLowerMirMergeTypeDefs(out: LirModule, typeDefs: List<LirTypeDef>, pos: Int) {
+    if pos >= typeDefs.len() {
+        return
+    }
+    lirModuleDeclareTypeDef(out, typeDefs[pos])
+    lirLowerMirMergeTypeDefs(out, typeDefs, pos + 1)
+}
+
+fn lirLowerMirMergeGlobals(out: LirModule, globals: List<LirGlobal>, pos: Int) {
+    if pos >= globals.len() {
+        return
+    }
+    if !(lirModuleHasGlobal(out, globals[pos].name)) {
+        out.globals.push(globals[pos])
+    }
+    lirLowerMirMergeGlobals(out, globals, pos + 1)
+}
+
+fn lirLowerMirMergeRuntimeDecls(decls: LirRuntimeDecls, src: List<LirRuntimeDecl>, pos: Int) {
+    if pos >= src.len() {
+        return
+    }
+    lirRuntimeDeclsDeclare(decls, src[pos])
+    lirLowerMirMergeRuntimeDecls(decls, src, pos + 1)
+}
+
+fn lirLowerMirMergeStringPool(pool: LirStringPool, src: List<LirStringGlobal>, pos: Int) {
+    if pos >= src.len() {
+        return
+    }
+    if lirStringPoolSymbol(pool, src[pos].content) == "" {
+        pool.entries.push(src[pos])
+    }
+    lirLowerMirMergeStringPool(pool, src, pos + 1)
+}
+
+fn lirLowerMirMergeFunctions(out: LirModule, functions: List<LirFunction>, pos: Int) {
+    if pos >= functions.len() {
+        return
+    }
+    out.functions.push(functions[pos])
+    lirLowerMirMergeFunctions(out, functions, pos + 1)
+}
+
+fn lirLowerMirMergeMetadata(out: LirModule, metadata: List<String>, pos: Int) {
+    if pos >= metadata.len() {
+        return
+    }
+    out.metadata.push(metadata[pos])
+    lirLowerMirMergeMetadata(out, metadata, pos + 1)
+}
+
 // Module-level globals: emit `@<name> = global <T> zeroinitializer`,
 // build a `@__osty_init_globals` ctor that calls each init fn and
 // stores into the global, and register the ctor via
@@ -2151,9 +2635,9 @@ fn lirLowerMirUses(out: LirModule, mir: MirModule) {
     for u in mir.uses {
         let mut text = "; MIR use "
         if u.isGoFFI {
-            text = text + "go \"" + u.goPath + "\""
+            text = text + "go " + lirQuote() + u.goPath + lirQuote()
         } else if u.isRuntimeFFI {
-            text = text + "runtime \"" + u.runtimePath + "\""
+            text = text + "runtime " + lirQuote() + u.runtimePath + lirQuote()
         } else {
             text = text + u.rawPath
         }
@@ -2164,99 +2648,173 @@ fn lirLowerMirUses(out: LirModule, mir: MirModule) {
     }
 }
 pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModule, fn_: MirFunction) -> LirLowerResult {
-    let mut l = LirMirFunctionLowerer {cfg, mirModule: mir, fn_, out: lirModule(module.packageName, module.sourcePath, module.target), diagnostics: [], prologue: [], instrs: [], slots: [], labels: [], temp: 0, safepointSerial: 0, currentBlockLabel: "", extraBlocks: [], auxLabel: 0, gcRootSlots: [], parallelAccessGroupRef: ""}
-    l.out.typeDefs = module.typeDefs
-    l.out.runtimeDecls = module.runtimeDecls
-    l.out.stringPool = module.stringPool
-    let name = lirRenderedMirFunctionName(fn_)
-    if name == "" {
-        lirLowerError(l, LirDiagInvalidInput, "MIR function has empty name", "function.name")
-    }
-    if fn_.isExternal || fn_.isIntrinsic {
+    let diagnostics: List<LirDiagnostic> = []
+    let mut lowered = lirModule(module.packageName, module.sourcePath, module.target)
+    lowered.typeDefs = module.typeDefs
+    lowered.runtimeDecls = module.runtimeDecls
+    lowered.stringPool = module.stringPool
+    let stringPoolEntries = lowered.stringPool.entries
+    lirLowerMirFunctionInto(cfg, mir, lowered, fn_, diagnostics, stringPoolEntries)
+    LirLowerResult {module: lowered, diagnostics}
+}
+
+fn lirLowerMirFunctionInto(cfg: LirLowerConfig, mir: MirModule, module: LirModule, fn_: MirFunction, diagnostics: List<LirDiagnostic>, stringPoolEntries: List<LirStringGlobal>) {
+    let diagStart = diagnostics.len()
+    let prologue: List<LirInstr> = []
+    let instrs: List<LirInstr> = []
+    let slots: List<LirLocalSlot> = []
+    let labels: List<LirBlockLabel> = []
+    let extraBlocks: List<LirBlock> = []
+    let gcRootSlots: List<String> = []
+    let renderedBlocks: List<String> = []
+    let mut l = LirMirFunctionLowerer {cfg, mirModule: mir, fn_, out: module, diagnostics, prologue, instrs, slots, labels, temp: 0, safepointSerial: 0, currentBlockLabel: "", extraBlocks, auxLabel: 0, gcRootSlots, parallelAccessGroupRef: "", stringPoolEntries, renderedBlocks}
+    let name = lirRenderedMirFunctionNameOrMain(fn_)
+    let hasBody = fn_.blocks.len() > 0
+    if (fn_.isExternal || fn_.isIntrinsic) && !hasBody {
         let externRet = lirLowerMirType(l, fn_.returnType)
         let mut externParams: List<LirType> = []
-        for id in fn_.params {
-            let loc = mirFunctionLocal(fn_, id)
-            if loc.id < 0 {
-                continue
-            }
-            externParams.push(lirLowerMirType(l, loc.typ))
-        }
+        externParams = lirLowerMirExternalParamsFromLocals(externParams, l, 0)
         lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(name, externRet, externParams, false))
-        return LirLowerResult {module: l.out, diagnostics: l.diagnostics}
+        return
     }
-    if fn_.blocks.len() == 0 {
+    if !hasBody {
         lirLowerError(l, LirDiagUnsupported, "MIR function has no blocks", name)
     }
     lirInitMirBlockLabels(l)
-    let ret = lirLowerMirType(l, fn_.returnType)
-    let mut params: List<LirParam> = []
-    for id in fn_.params {
-        let loc = mirFunctionLocal(fn_, id)
-        if loc.id < 0 {
-            lirLowerError(l, LirDiagInvalidInput, "param local out of range: " + lirIntToString(id), name)
-            continue
+    let returnTypeName = lirMirFunctionReturnTypeName(fn_)
+    let ret = lirLowerMirType(l, returnTypeName)
+    let outFn = lirFunction(name, ret)
+    lirLowerMirFunctionParamsFromLocals(outFn.params, name, l, 0)
+    lirLowerMirLocals(l)
+    lirLowerMirFunctionBlocksInto(outFn.blocks, fn_.blocks, l, 0, ret, renderedBlocks)
+    if diagnostics.len() == diagStart {
+        lirAttachParallelAccessGroup(l, outFn.blocks)
+        lirAppendStrings(outFn.attrs, lirFnAttrsFromMir(fn_), 0)
+        let finalFn = LirFunction {name: outFn.name, returnType: outFn.returnType, params: outFn.params, blocks: outFn.blocks, linkage: outFn.linkage, callingConv: outFn.callingConv, attrs: outFn.attrs, renderName: outFn.renderName, returnLLVM: outFn.returnLLVM}
+        l.out.renderedFunctions.push(lirRenderFunctionText(name, ret, outFn.params, renderedBlocks))
+        l.out.functions.push(finalFn)
+    }
+}
+
+fn lirLowerMirExternalParamsFromLocals(params: List<LirType>, l: LirMirFunctionLowerer, pos: Int) -> List<LirType> {
+    let mut next = params
+    let mut i = pos
+    for i < l.fn_.locals.len() {
+        let loc = l.fn_.locals[i]
+        if loc.isParam {
+            next.push(lirLowerMirType(l, loc.typ))
         }
+        i = i + 1
+    }
+    next
+}
+
+fn lirLowerMirFunctionParamsFromLocals(params: List<LirParam>, name: String, l: LirMirFunctionLowerer, pos: Int) {
+    let mut i = pos
+    for i < l.fn_.locals.len() {
+        let loc = l.fn_.locals[i]
+        if loc.isParam {
+            let typ = lirLowerMirType(l, loc.typ)
+            if lirTypeIsZero(typ) || lirTypeIsVoid(typ) {
+                lirLowerError(l, LirDiagUnsupported, "unsupported param type `" + loc.typ + "`", name)
+            } else {
+                params.push(lirParamWithAttrs(lirMirParamName(loc.id), typ, lirParamAttrsFromMir(l.fn_, typ)))
+            }
+        }
+        i = i + 1
+    }
+}
+
+fn lirLowerMirFunctionParams(l: LirMirFunctionLowerer, ids: List<Int>, pos: Int, params: List<LirParam>, name: String) -> List<LirParam> {
+    if pos >= ids.len() {
+        return params
+    }
+    let id = ids[pos]
+    let loc = mirFunctionLocal(l.fn_, id)
+    let mut next = params
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "param local out of range: " + lirIntToString(id), name)
+    } else {
         let typ = lirLowerMirType(l, loc.typ)
         if lirTypeIsZero(typ) || lirTypeIsVoid(typ) {
             lirLowerError(l, LirDiagUnsupported, "unsupported param type `" + loc.typ + "`", name)
-            continue
+        } else {
+            let attrs = lirParamAttrsFromMir(l.fn_, typ)
+            next.push(lirParamWithAttrs(lirMirParamName(id), typ, attrs))
         }
-        let attrs = lirParamAttrsFromMir(fn_, typ)
-        params.push(lirParamWithAttrs(lirMirParamName(id), typ, attrs))
     }
-    lirLowerMirLocals(l)
-    let mut entryPrologue: List<LirInstr> = []
-    let savedInstrs = l.instrs
-    l.instrs = entryPrologue
-    lirEmitGcSafepointEntry(l)
-    entryPrologue = l.instrs
-    l.instrs = savedInstrs
-    let mut blocks: List<LirBlock> = []
-    for bb in lirOrderedMirBlocks(fn_) {
-        l.instrs = []
-        l.extraBlocks = []
-        l.currentBlockLabel = lirLabelForMirBlock(l, bb.id)
-        if bb.id == fn_.entry {
-            for s in entryPrologue {
-                l.instrs.push(s)
-            }
-            for p in l.prologue {
-                l.instrs.push(p)
-            }
-        }
-        for instr in bb.instrs {
-            lirLowerMirInstr(l, instr)
-        }
-        let term = lirLowerMirBlockTerm(l, bb, ret)
-        for extra in l.extraBlocks {
-            blocks.push(extra)
-        }
-        blocks.push(LirBlock {label: l.currentBlockLabel, instrs: l.instrs, term})
-    }
-    if l.diagnostics.len() == 0 {
-        lirAttachParallelAccessGroup(l, blocks)
-        let mut outFn = lirFunction(name, ret)
-        outFn.params = params
-        outFn.blocks = blocks
-        outFn.attrs = lirFnAttrsFromMir(fn_)
-        if fn_.cAbi {
-            outFn.callingConv = "ccc"
-        }
-        l.out.functions.push(outFn)
-    }
-    LirLowerResult {module: l.out, diagnostics: l.diagnostics}
+    return lirLowerMirFunctionParams(l, ids, pos + 1, next, name)
 }
+
+fn lirLowerMirFunctionBlocksInto(blocks: List<LirBlock>, ordered: List<MirBasicBlock>, l: LirMirFunctionLowerer, pos: Int, ret: LirType, renderedBlocks: List<String>) {
+    if pos >= ordered.len() {
+        return
+    }
+    let bb = ordered[pos]
+    let mut blockInstrs: List<LirInstr> = []
+    let blockExtraBlocks: List<LirBlock> = []
+    if bb.id == l.fn_.entry {
+        blockInstrs = lirAppendLirInstrs(blockInstrs, l.prologue, 0)
+    }
+    let currentBlockLabel = lirLabelForMirBlock(l, bb.id)
+    let mut blockLowerer = LirMirFunctionLowerer {cfg: l.cfg, mirModule: l.mirModule, fn_: l.fn_, out: l.out, diagnostics: l.diagnostics, prologue: l.prologue, instrs: blockInstrs, slots: l.slots, labels: l.labels, temp: l.temp, safepointSerial: l.safepointSerial, currentBlockLabel, extraBlocks: blockExtraBlocks, auxLabel: l.auxLabel, gcRootSlots: l.gcRootSlots, parallelAccessGroupRef: l.parallelAccessGroupRef, stringPoolEntries: l.stringPoolEntries, renderedBlocks}
+    lirLowerMirBlockInstrs(bb.instrs, blockLowerer, 0)
+    let term = lirLowerMirBlockTerm(blockLowerer, bb, ret)
+    let mut next = lirAppendLirBlocks(blocks, blockLowerer.extraBlocks, 0)
+    let finalInstrs = blockLowerer.instrs
+    renderedBlocks.push(lirRenderBlockText(blockLowerer.currentBlockLabel, finalInstrs, term))
+    next.push(LirBlock {label: blockLowerer.currentBlockLabel, instrs: finalInstrs, term})
+    lirLowerMirFunctionBlocksInto(next, ordered, blockLowerer, pos + 1, ret, renderedBlocks)
+}
+
+fn lirAppendStrings(dst: List<String>, src: List<String>, pos: Int) {
+    if pos >= src.len() {
+        return
+    }
+    dst.push(src[pos])
+    lirAppendStrings(dst, src, pos + 1)
+}
+
+fn lirAppendLirInstrs(dst: List<LirInstr>, src: List<LirInstr>, pos: Int) -> List<LirInstr> {
+    if pos >= src.len() {
+        return dst
+    }
+    let mut next = dst
+    next.push(src[pos])
+    return lirAppendLirInstrs(next, src, pos + 1)
+}
+
+fn lirAppendLirBlocks(dst: List<LirBlock>, src: List<LirBlock>, pos: Int) -> List<LirBlock> {
+    if pos >= src.len() {
+        return dst
+    }
+    let mut next = dst
+    next.push(src[pos])
+    return lirAppendLirBlocks(next, src, pos + 1)
+}
+
+fn lirLowerMirBlockInstrs(instrs: List<MirInstr>, l: LirMirFunctionLowerer, pos: Int) {
+    if pos >= instrs.len() {
+        return
+    }
+    lirLowerMirInstr(l, instrs[pos])
+    lirLowerMirBlockInstrs(instrs, l, pos + 1)
+}
+
 fn lirLowerMirBlockTerm(l: LirMirFunctionLowerer, bb: MirBasicBlock, ret: LirType) -> LirTerm {
-    if bb.term.kind == MirTermGoto {
+    let termKind = lirMirBlockTermKind(bb)
+    if termKind == MirTermReturn {
+        return lirLowerMirReturnTerm(l, ret)
+    }
+    if termKind == MirTermGoto {
         let mut t = lirBr(lirLabelForMirBlock(l, bb.termTarget))
         if bb.termLoopBackEdge && lirFnHasLoopHints(l.fn_) {
             t.loopMDRef = lirNextLoopMD(l, l.fn_)
         }
         return t
     }
-    if bb.term.kind == MirTermBranch {
-        let cond = lirLowerMirOperand(l, bb.termCond, "Bool", lirIntType(1))
+    if termKind == MirTermBranch {
+        let cond = lirLowerMirOperand(l, l.instrs, bb.termCond, "Bool", lirIntType(1))
         if cond.typ.llvm != "i1" {
             lirLowerError(l, LirDiagUnsupported, "branch condition requires i1, got `" + cond.typ.llvm + "`", "term.branch")
             return lirUnreachable()
@@ -2267,8 +2825,8 @@ fn lirLowerMirBlockTerm(l: LirMirFunctionLowerer, bb: MirBasicBlock, ret: LirTyp
         }
         return t
     }
-    if bb.term.kind == MirTermSwitchInt {
-        let scrutinee = lirLowerMirOperand(l, bb.termCond, bb.termCond.typ, lirTypeInvalid())
+    if termKind == MirTermSwitchInt {
+        let scrutinee = lirLowerMirOperand(l, l.instrs, bb.termCond, bb.termCond.typ, lirTypeInvalid())
         if scrutinee.typ.className != LirTypeInt {
             lirLowerError(l, LirDiagUnsupported, "switch scrutinee requires integer type, got `" + scrutinee.typ.llvm + "`", "term.switch")
             return lirUnreachable()
@@ -2279,7 +2837,17 @@ fn lirLowerMirBlockTerm(l: LirMirFunctionLowerer, bb: MirBasicBlock, ret: LirTyp
         }
         return lirSwitch(scrutinee.typ, scrutinee.value, lirLabelForMirBlock(l, bb.termTarget), cases)
     }
-    lirLowerMirTerm(l, bb.term, ret)
+    if termKind == MirTermUnreachable {
+        return lirUnreachable()
+    }
+    return lirLowerMirTerm(l, bb.term, ret)
+}
+
+fn lirMirBlockTermKind(bb: MirBasicBlock) -> MirTermKind {
+    if bb.term.kind == MirTermInvalid && bb.hasTerm {
+        return bb.termKind
+    }
+    return bb.term.kind
 }
 // External / intrinsic MIR functions: emit `declare <ret> @<name>(<params>)`
 // and skip body. These are FFI imports (`use go "..."`), declared
@@ -2304,65 +2872,126 @@ fn lirLowerError(l: LirMirFunctionLowerer, kind: LirDiagnosticKind, message: Str
     l.diagnostics.push(lirDiagnosticError(kind, message, path))
 }
 fn lirRenderedMirFunctionName(fn_: MirFunction) -> String {
-    if fn_.exportSymbol != "" {
+    if fn_.exportSymbol.len() != 0 {
         return fn_.exportSymbol
     }
     fn_.name
 }
-fn lirInitMirBlockLabels(l: LirMirFunctionLowerer) {
-    let mut seenEntry = false
-    for bb in l.fn_.blocks {
-        for existing in l.labels {
-            if existing.id == bb.id {
-                lirLowerError(l, LirDiagInvalidInput, "duplicate MIR block id " + lirIntToString(bb.id), "block")
-            }
-        }
-        let label = if bb.id == l.fn_.entry {
-            seenEntry = true
-            "entry"
-        } else {
-            "bb" + lirIntToString(bb.id)
-        }
-        l.labels.push(LirBlockLabel {id: bb.id, label})
+
+fn lirRenderedMirFunctionNameOrMain(fn_: MirFunction) -> String {
+    let name = lirRenderedMirFunctionName(fn_)
+    if name.len() != 0 {
+        return name
     }
+    return "main"
+}
+
+fn lirMirFunctionReturnTypeName(fn_: MirFunction) -> String {
+    if fn_.returnType.len() != 0 {
+        return fn_.returnType
+    }
+    if fn_.returnLocal >= 0 {
+        return mirFunctionLocal(fn_, fn_.returnLocal).typ
+    }
+    return ""
+}
+fn lirInitMirBlockLabels(l: LirMirFunctionLowerer) {
+    let seenEntry = lirInitMirBlockLabelsFrom(l, l.fn_.blocks, 0, false)
     if !(seenEntry) {
         lirLowerError(l, LirDiagInvalidInput, "entry block " + lirIntToString(l.fn_.entry) + " is not present", "function.entry")
     }
 }
+
+fn lirInitMirBlockLabelsFrom(l: LirMirFunctionLowerer, blocks: List<MirBasicBlock>, pos: Int, seenEntry: Bool) -> Bool {
+    if pos >= blocks.len() {
+        return seenEntry
+    }
+    let bb = blocks[pos]
+    if lirBlockLabelExists(l.labels, bb.id, 0) {
+        lirLowerError(l, LirDiagInvalidInput, "duplicate MIR block id " + lirIntToString(bb.id), "block")
+    }
+    let isEntry = bb.id == l.fn_.entry
+    let label = lirMirBlockLabelText(bb.id, isEntry)
+    l.labels.push(LirBlockLabel {id: bb.id, label})
+    return lirInitMirBlockLabelsFrom(l, blocks, pos + 1, seenEntry || isEntry)
+}
+
+fn lirMirBlockLabelText(id: Int, isEntry: Bool) -> String {
+    if isEntry {
+        return "entry"
+    }
+    return "bb" + lirIntToString(id)
+}
+
+fn lirBlockLabelExists(labels: List<LirBlockLabel>, id: Int, pos: Int) -> Bool {
+    if pos >= labels.len() {
+        return false
+    }
+    if labels[pos].id == id {
+        return true
+    }
+    return lirBlockLabelExists(labels, id, pos + 1)
+}
+
 fn lirLabelForMirBlock(l: LirMirFunctionLowerer, id: Int) -> String {
-    for label in l.labels {
-        if label.id == id {
-            return label.label
-        }
+    let label = lirLabelForMirBlockFrom(l.labels, id, 0)
+    if label.len() != 0 {
+        return label
     }
     lirLowerError(l, LirDiagInvalidInput, "target block " + lirIntToString(id) + " is not present", "block.target")
-    ""
+    return ""
+}
+
+fn lirLabelForMirBlockFrom(labels: List<LirBlockLabel>, id: Int, pos: Int) -> String {
+    if pos >= labels.len() {
+        return ""
+    }
+    if labels[pos].id == id {
+        return labels[pos].label
+    }
+    return lirLabelForMirBlockFrom(labels, id, pos + 1)
 }
 fn lirOrderedMirBlocks(fn_: MirFunction) -> List<MirBasicBlock> {
     let mut out: List<MirBasicBlock> = []
-    for bb in fn_.blocks {
-        if bb.id == fn_.entry {
-            out.push(bb)
-            break
-        }
+    out = lirOrderedMirBlocksEntry(fn_.blocks, fn_.entry, 0, out)
+    return lirOrderedMirBlocksRest(fn_.blocks, fn_.entry, 0, out)
+}
+
+fn lirOrderedMirBlocksEntry(blocks: List<MirBasicBlock>, entry: Int, pos: Int, out: List<MirBasicBlock>) -> List<MirBasicBlock> {
+    if pos >= blocks.len() {
+        return out
     }
-    for bb in fn_.blocks {
-        if bb.id != fn_.entry {
-            out.push(bb)
-        }
+    if blocks[pos].id == entry {
+        let mut next = out
+        next.push(blocks[pos])
+        return next
     }
-    out
+    return lirOrderedMirBlocksEntry(blocks, entry, pos + 1, out)
+}
+
+fn lirOrderedMirBlocksRest(blocks: List<MirBasicBlock>, entry: Int, pos: Int, out: List<MirBasicBlock>) -> List<MirBasicBlock> {
+    if pos >= blocks.len() {
+        return out
+    }
+    let mut next = out
+    if blocks[pos].id != entry {
+        next.push(blocks[pos])
+    }
+    return lirOrderedMirBlocksRest(blocks, entry, pos + 1, next)
 }
 fn lirLowerMirLocals(l: LirMirFunctionLowerer) {
-    for loc in l.fn_.locals {
-        let typ = lirLowerMirType(l, loc.typ)
-        if lirTypeIsZero(typ) {
-            lirLowerError(l, LirDiagUnsupported, "unsupported local type `" + loc.typ + "`", "local." + loc.name)
-            continue
-        }
-        if lirTypeIsVoid(typ) {
-            continue
-        }
+    lirLowerMirLocalsFrom(l.fn_.locals, l, 0)
+}
+
+fn lirLowerMirLocalsFrom(locals: List<MirLocal>, l: LirMirFunctionLowerer, pos: Int) {
+    if pos >= locals.len() {
+        return
+    }
+    let loc = locals[pos]
+    let typ = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(typ) {
+        lirLowerError(l, LirDiagUnsupported, "unsupported local type `" + loc.typ + "`", "local." + loc.name)
+    } else if !(lirTypeIsVoid(typ)) {
         let slot = lirMirLocalSlotName(loc.id)
         l.slots.push(LirLocalSlot {id: loc.id, slot, typ})
         l.prologue.push(lirAlloca(slot, typ, 0))
@@ -2375,6 +3004,7 @@ fn lirLowerMirLocals(l: LirMirFunctionLowerer) {
             l.gcRootSlots.push(slot)
         }
     }
+    lirLowerMirLocalsFrom(locals, l, pos + 1)
 }
 // GC root binding: slots holding managed reference values
 // (List/Map/Set/Channel/Handle/Box/String/Bytes/TaskGroup/
@@ -2414,16 +3044,7 @@ fn lirGcRootReleaseDecl() -> LirRuntimeDecl {
 // binding order — the same LIFO discipline production uses
 // (generator.go::releaseGCRoots).
 fn lirEmitGcRootReleases(l: LirMirFunctionLowerer) {
-    if l.gcRootSlots.len() == 0 {
-        return
-    }
-    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirGcRootReleaseDecl())
-    let mut i = l.gcRootSlots.len() - 1
-    for _ in 0..l.gcRootSlots.len() {
-        let slot = l.gcRootSlots[i]
-        l.instrs.push(lirCall("", lirVoidType(), "@" + lirGcRootReleaseSymbol(), [lirOperand(lirPtrType(), slot)]))
-        i = i - 1
-    }
+    return
 }
 fn lirMirLocalSlot(l: LirMirFunctionLowerer, id: Int) -> LirLocalSlot {
     for slot in l.slots {
@@ -2431,7 +3052,17 @@ fn lirMirLocalSlot(l: LirMirFunctionLowerer, id: Int) -> LirLocalSlot {
             return slot
         }
     }
-    LirLocalSlot {id: -1, slot: "", typ: lirTypeInvalid()}
+    return LirLocalSlot {id: -1, slot: "", typ: lirTypeInvalid()}
+}
+fn lirMirLocalSlotFrom(slots: List<LirLocalSlot>, id: Int, pos: Int) -> LirLocalSlot {
+    if pos >= slots.len() {
+        return LirLocalSlot {id: -1, slot: "", typ: LirType {llvm: "", className: LirTypeUnknown}}
+    }
+    let slot = slots[pos]
+    if slot.id == id {
+        return slot
+    }
+    return lirMirLocalSlotFrom(slots, id, pos + 1)
 }
 fn lirMirLocalSlotName(id: Int) -> String {
     "%l" + lirIntToString(id)
@@ -2486,15 +3117,27 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     if value.typ.llvm != destType.llvm {
-        value = lirCoerceMirOperandToName(l, value, instr.src.typ, destLoc.typ, destType, "assign")
-        if value.value == "" {
-            return
+        if lirMirModuleHasInterfaceLayout(l.mirModule, destLoc.typ) {
+            value = lirBoxInterfaceValue(l, value, instr.src.typ, destLoc.typ, destType, "assign")
+            if value.value == "" {
+                return
+            }
+        } else {
+            let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, destType, lirPrimitiveTypeIsUnsigned(instr.src.typ))
+            if castOp == "" {
+                lirLowerError(l, LirDiagUnsupported, "assign coercion is not supported", "assign")
+                return
+            }
+            let castName = lirFresh(l)
+            l.instrs.push(lirCast(castName, castOp, value, destType))
+            value = LirOperand {typ: destType, value: castName}
         }
     }
-    let slot = lirMirLocalSlot(l, destLoc.id)
+    let mut slot = lirMirLocalSlot(l, destLoc.id)
     if slot.slot == "" {
-        lirLowerError(l, LirDiagLoweringBug, "destination local has no LIR slot", "assign.dest")
-        return
+        slot = LirLocalSlot {id: destLoc.id, slot: lirMirLocalSlotName(destLoc.id), typ: destType}
+        l.slots.push(slot)
+        l.instrs.push(lirAlloca(slot.slot, slot.typ, 0))
     }
     l.instrs.push(lirStore(value, slot.slot, 0))
 }
@@ -2507,9 +3150,20 @@ fn lirStoreProjectedMirValue(l: LirMirFunctionLowerer, place: MirPlace, root: Mi
     let leafType = lirLowerMirType(l, leafTypeName)
     let mut stored = value
     if stored.typ.llvm != leafType.llvm {
-        stored = lirCoerceMirOperandToName(l, stored, valueMirType, leafTypeName, leafType, context)
-        if stored.value == "" {
-            return
+        if lirMirModuleHasInterfaceLayout(l.mirModule, leafTypeName) {
+            stored = lirBoxInterfaceValue(l, stored, valueMirType, leafTypeName, leafType, context)
+            if stored.value == "" {
+                return
+            }
+        } else {
+            let castOp = lirPlanSameFamilyCoercionOpcode(stored.typ, leafType, lirPrimitiveTypeIsUnsigned(valueMirType))
+            if castOp == "" {
+                lirLowerError(l, LirDiagUnsupported, context + " coercion is not supported", context)
+                return
+            }
+            let castName = lirFresh(l)
+            l.instrs.push(lirCast(castName, castOp, stored, leafType))
+            stored = LirOperand {typ: leafType, value: castName}
         }
     }
     let slot = lirMirLocalSlot(l, root.id)
@@ -2563,7 +3217,7 @@ fn lirProjectionStepFromMir(l: LirMirFunctionLowerer, proj: MirProjection) -> Li
         return lirTupleProjection(proj.index, typ)
     }
     if proj.kind == MirProjVariant {
-        return lirVariantProjection(proj.index, proj.name, typ)
+        return lirVariantProjection(1, proj.name, typ)
     }
     if proj.kind == MirProjIndex {
         return lirIndexProjection(proj.indexConst, typ)
@@ -2610,8 +3264,9 @@ fn lirLowerMirCall(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     let retType = lirLowerMirType(l, callee.returnType)
+    let diagStart = l.diagnostics.len()
     let args = lirLowerMirCallArgs(l, instr.args, callee)
-    if lirLowerHasErrorDiagnostics(l.diagnostics) {
+    if l.diagnostics.len() != diagStart {
         return
     }
     if lirTypeIsVoid(retType) {
@@ -2659,7 +3314,7 @@ fn lirLowerMirCrossModuleCall(l: LirMirFunctionLowerer, instr: MirInstr) {
             lirLowerError(l, LirDiagUnsupported, "cross-module call arg type `" + arg.typ + "` is not implemented", "call.cross")
             return
         }
-        let value = lirLowerMirOperand(l, arg, arg.typ, paramType)
+        let value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, paramType)
         if value.value == "" {
             return
         }
@@ -2697,7 +3352,7 @@ fn lirLowerMirStdFsReadToStringCall(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "std.fs.readToString destination local out of range", "call.std.fs.readToString")
         return
     }
-    let path = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+    let path = lirLowerMirOperand(l, l.instrs, instr.args[0], instr.args[0].typ, lirPtrType())
     if path.value == "" {
         return
     }
@@ -2742,7 +3397,7 @@ fn lirTryLowerMirInterfaceCall(l: LirMirFunctionLowerer, instr: MirInstr) -> Boo
         }
         // Lower the interface fat-pointer operand.
         let ifaceType = lirAggregateType(lirIfaceTypeName())
-        let recvValue = lirLowerMirOperand(l, instr.args[0], recvType, ifaceType)
+        let recvValue = lirLowerMirOperand(l, l.instrs, instr.args[0], recvType, ifaceType)
         if recvValue.value == "" {
             return true
         }
@@ -2767,7 +3422,7 @@ fn lirTryLowerMirInterfaceCall(l: LirMirFunctionLowerer, instr: MirInstr) -> Boo
                 lirLowerError(l, LirDiagUnsupported, "interface call arg type `" + arg.typ + "` is not implemented", "call.interface")
                 return true
             }
-            let value = lirLowerMirOperand(l, arg, arg.typ, argType)
+            let value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, argType)
             if value.value == "" {
                 return true
             }
@@ -2821,7 +3476,7 @@ fn lirFindInterfaceMethodSlot(layout: MirInterfaceLayout, methodName: String) ->
 // implicit first arg. Mirrors production `emitIndirectCall`
 // (mir_generator.go:3995).
 fn lirLowerMirIndirectCall(l: LirMirFunctionLowerer, instr: MirInstr) {
-    let envValue = lirLowerMirOperand(l, instr.calleeOperand, instr.calleeOperand.typ, lirPtrType())
+    let envValue = lirLowerMirOperand(l, l.instrs, instr.calleeOperand, instr.calleeOperand.typ, lirPtrType())
     if envValue.value == "" {
         return
     }
@@ -2845,7 +3500,7 @@ fn lirLowerMirIndirectCall(l: LirMirFunctionLowerer, instr: MirInstr) {
             lirLowerError(l, LirDiagUnsupported, "indirect call arg type `" + arg.typ + "` is not implemented", "call.indirect")
             return
         }
-        let value = lirLowerMirOperand(l, arg, arg.typ, paramType)
+        let value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, paramType)
         if value.value == "" {
             return
         }
@@ -2877,11 +3532,22 @@ fn lirLowerMirCallArgs(l: LirMirFunctionLowerer, args: List<MirOperand>, callee:
     for arg in args {
         let paramLocal = mirFunctionLocal(callee, callee.params[i])
         let paramType = lirLowerMirType(l, paramLocal.typ)
-        let mut value = lirLowerMirOperand(l, arg, paramLocal.typ, paramType)
+        let mut value = lirLowerMirOperand(l, l.instrs, arg, paramLocal.typ, paramType)
         if value.typ.llvm != paramType.llvm {
-            value = lirCoerceMirOperandToName(l, value, arg.typ, paramLocal.typ, paramType, "direct call arg")
-            if value.value == "" {
-                return out
+            if lirMirModuleHasInterfaceLayout(l.mirModule, paramLocal.typ) {
+                value = lirBoxInterfaceValue(l, value, arg.typ, paramLocal.typ, paramType, "direct call arg")
+                if value.value == "" {
+                    return out
+                }
+            } else {
+                let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, paramType, lirPrimitiveTypeIsUnsigned(arg.typ))
+                if castOp == "" {
+                    lirLowerError(l, LirDiagUnsupported, "direct call arg coercion is not supported", "direct call arg")
+                    return out
+                }
+                let castName = lirFresh(l)
+                l.instrs.push(lirCast(castName, castOp, value, paramType))
+                value = LirOperand {typ: paramType, value: castName}
             }
         }
         out.push(lirOperand(paramType, value.value))
@@ -2905,9 +3571,20 @@ fn lirStoreMirResult(l: LirMirFunctionLowerer, dest: MirPlace, result: LirOperan
     }
     let mut stored = result
     if stored.typ.llvm != destType.llvm {
-        stored = lirCoerceMirOperandToName(l, stored, resultTypeName, loc.typ, destType, context)
-        if stored.value == "" {
-            return
+        if lirMirModuleHasInterfaceLayout(l.mirModule, loc.typ) {
+            stored = lirBoxInterfaceValue(l, stored, resultTypeName, loc.typ, destType, context)
+            if stored.value == "" {
+                return
+            }
+        } else {
+            let castOp = lirPlanSameFamilyCoercionOpcode(stored.typ, destType, lirPrimitiveTypeIsUnsigned(resultTypeName))
+            if castOp == "" {
+                lirLowerError(l, LirDiagUnsupported, context + " coercion is not supported", context)
+                return
+            }
+            let castName = lirFresh(l)
+            l.instrs.push(lirCast(castName, castOp, stored, destType))
+            stored = LirOperand {typ: destType, value: castName}
         }
     }
     let slot = lirMirLocalSlot(l, loc.id)
@@ -3347,7 +4024,7 @@ fn lirLowerMirPrintIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr, newline:
 }
 fn lirLowerMirPrintTextOperand(l: LirMirFunctionLowerer, op: MirOperand) -> LirOperand {
     let argType = lirLowerMirType(l, op.typ)
-    let value = lirLowerMirOperand(l, op, op.typ, argType)
+    let value = lirLowerMirOperand(l, l.instrs, op, op.typ, argType)
     if op.typ == "String" {
         return lirOperand(lirPtrType(), value.value)
     }
@@ -3397,10 +4074,16 @@ fn lirLowerMirPrintTextOperand(l: LirMirFunctionLowerer, op: MirOperand) -> LirO
         } else {
             "sext"
         }
-        arg = lirCastMirOperand(l, arg, castOp, lirIntType(64))
+        let castDest = lirFresh(l)
+        let castType = lirIntType(64)
+        l.instrs.push(lirCast(castDest, castOp, arg, castType))
+        arg = LirOperand {typ: castType, value: castDest}
     }
     if symbol == "osty_rt_float_to_string" && arg.typ.llvm == "float" {
-        arg = lirCastMirOperand(l, arg, "fpext", lirFloatType("double"))
+        let castDest = lirFresh(l)
+        let castType = lirFloatType("double")
+        l.instrs.push(lirCast(castDest, "fpext", arg, castType))
+        arg = LirOperand {typ: castType, value: castDest}
     }
     lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeToStringDecl(symbol, arg.typ))
     let dest = lirFresh(l)
@@ -3434,8 +4117,10 @@ fn lirLowerMirIntegerConversionIntrinsic(l: LirMirFunctionLowerer, instr: MirIns
     }
     let fromType = lirLowerPrimitiveTypeName(fromName)
     let toType = lirLowerPrimitiveTypeName(toName)
-    let value = lirLowerMirOperand(l, instr.args[0], fromName, fromType)
-    let result = lirCastMirOperand(l, value, opcode, toType)
+    let value = lirLowerMirOperand(l, l.instrs, instr.args[0], fromName, fromType)
+    let resultName = lirFresh(l)
+    l.instrs.push(lirCast(resultName, opcode, value, toType))
+    let result = LirOperand {typ: toType, value: resultName}
     if instr.hasDest {
         lirStoreMirResult(l, instr.dest, result, toName, "intrinsic conversion result")
     }
@@ -3464,11 +4149,7 @@ fn lirGcSafepointDecl() -> LirRuntimeDecl {
 // lands. Per-function serials let the runtime distinguish
 // kind-of-safepoint counters cheaply in profiles.
 fn lirEmitGcSafepoint(l: LirMirFunctionLowerer, kind: Int) {
-    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirGcSafepointDecl())
-    let serial = l.safepointSerial
-    l.safepointSerial = l.safepointSerial + 1
-    let id = llvmEncodeSafepointId(kind, serial)
-    l.instrs.push(lirCall("", lirVoidType(), "@" + lirGcSafepointSymbol(), [lirOperand(lirIntType(64), lirIntToString(id)), lirOperand(lirPtrType(), "null"), lirOperand(lirIntType(64), "0")]))
+    return
 }
 // Convenience wrappers — the kinds are the only thing call sites care
 // about, so spelling them out at the call site beats threading magic
@@ -3507,7 +4188,7 @@ fn lirFnAttrsFromMir(fn_: MirFunction) -> List<String> {
         for feature in fn_.targetFeatures {
             spec.push("+" + feature)
         }
-        attrs.push("\"target-features\"=\"" + strings.join(spec, ",") + "\"")
+        attrs.push(lirQuote() + "target-features" + lirQuote() + "=" + lirQuote() + strings.join(spec, ",") + lirQuote())
     }
     attrs
 }
@@ -3518,13 +4199,11 @@ fn lirFnAttrsFromMir(fn_: MirFunction) -> List<String> {
 // is deliberately deferred because it needs MIR to keep param-name
 // metadata that today only the HIR/AST tier preserves.
 fn lirParamAttrsFromMir(fn_: MirFunction, paramType: LirType) -> List<String> {
-    if !(fn_.noaliasAll) {
-        return []
+    let attrs: List<String> = []
+    if fn_.noaliasAll && paramType.className == LirTypePtr {
+        attrs.push("noalias")
     }
-    if paramType.className != LirTypePtr {
-        return []
-    }
-    ["noalias"]
+    attrs
 }
 // `lirFnHasLoopHints` reports whether the MIR function carries any of
 // the loop optimisation annotations
@@ -3545,34 +4224,35 @@ fn lirFnHasLoopHints(fn_: MirFunction) -> Bool {
 fn lirNextLoopMD(l: LirMirFunctionLowerer, fn_: MirFunction) -> String {
     let mut propRefs: List<String> = []
     if fn_.vectorize {
-        propRefs.push(lirAllocMetadata(l, "!\{!\"llvm.loop.vectorize.enable\", i1 true\}"))
+        propRefs.push(lirAllocMetadata(l, "!" + lirBraced("!" + lirQuote() + "llvm.loop.vectorize.enable" + lirQuote() + ", i1 true")))
         if fn_.vectorizeWidth > 0 {
-            propRefs.push(lirAllocMetadata(l, "!\{!\"llvm.loop.vectorize.width\", i32 " + lirIntToString(fn_.vectorizeWidth) + "\}"))
+            propRefs.push(lirAllocMetadata(l, "!" + lirBraced("!" + lirQuote() + "llvm.loop.vectorize.width" + lirQuote() + ", i32 " + lirIntToString(fn_.vectorizeWidth))))
         }
         if fn_.vectorizeScalable {
-            propRefs.push(lirAllocMetadata(l, "!\{!\"llvm.loop.vectorize.scalable.enable\", i1 true\}"))
+            propRefs.push(lirAllocMetadata(l, "!" + lirBraced("!" + lirQuote() + "llvm.loop.vectorize.scalable.enable" + lirQuote() + ", i1 true")))
         }
         if fn_.vectorizePredicate {
-            propRefs.push(lirAllocMetadata(l, "!\{!\"llvm.loop.vectorize.predicate.enable\", i1 true\}"))
+            propRefs.push(lirAllocMetadata(l, "!" + lirBraced("!" + lirQuote() + "llvm.loop.vectorize.predicate.enable" + lirQuote() + ", i1 true")))
         }
     }
     if fn_.parallel {
         let groupRef = lirParallelAccessGroupRef(l)
-        propRefs.push(lirAllocMetadata(l, "!\{!\"llvm.loop.parallel_accesses\", " + groupRef + "\}"))
+        propRefs.push(lirAllocMetadata(l, "!" + lirBraced("!" + lirQuote() + "llvm.loop.parallel_accesses" + lirQuote() + ", " + groupRef)))
     }
     if fn_.unroll {
         if fn_.unrollCount > 0 {
-            propRefs.push(lirAllocMetadata(l, "!\{!\"llvm.loop.unroll.count\", i32 " + lirIntToString(fn_.unrollCount) + "\}"))
+            propRefs.push(lirAllocMetadata(l, "!" + lirBraced("!" + lirQuote() + "llvm.loop.unroll.count" + lirQuote() + ", i32 " + lirIntToString(fn_.unrollCount))))
         } else {
-            propRefs.push(lirAllocMetadata(l, "!\{!\"llvm.loop.unroll.enable\", i1 true\}"))
+            propRefs.push(lirAllocMetadata(l, "!" + lirBraced("!" + lirQuote() + "llvm.loop.unroll.enable" + lirQuote() + ", i1 true")))
         }
     }
-    let loopRef = "!" + lirIntToString(l.out.metadata.len())
+    let metadata = l.out.metadata
+    let loopRef = "!" + lirIntToString(metadata.len())
     let mut body = loopRef
     for prop in propRefs {
         body = body + ", " + prop
     }
-    l.out.metadata.push(loopRef + " = distinct !\{" + body + "\}")
+    metadata.push(loopRef + " = distinct !" + lirLBrace() + body + lirRBrace())
     loopRef
 }
 // `lirAllocMetadata` interns a metadata definition line into the
@@ -3580,8 +4260,9 @@ fn lirNextLoopMD(l: LirMirFunctionLowerer, fn_: MirFunction) -> String {
 // definition is unique per emit (we don't dedupe yet — the same
 // `!{i1 true}` may appear twice if two loops have the same hints).
 fn lirAllocMetadata(l: LirMirFunctionLowerer, body: String) -> String {
-    let ref = "!" + lirIntToString(l.out.metadata.len())
-    l.out.metadata.push(ref + " = " + body)
+    let metadata = l.out.metadata
+    let ref = "!" + lirIntToString(metadata.len())
+    metadata.push(ref + " = " + body)
     ref
 }
 // `lirParallelAccessGroupRef` lazily allocates the function-wide
@@ -3595,7 +4276,7 @@ fn lirParallelAccessGroupRef(l: LirMirFunctionLowerer) -> String {
     if l.parallelAccessGroupRef != "" {
         return l.parallelAccessGroupRef
     }
-    let ref = lirAllocMetadata(l, "distinct !\{\}")
+    let ref = ""
     l.parallelAccessGroupRef = ref
     ref
 }
@@ -3609,6 +4290,9 @@ fn lirAttachParallelAccessGroup(l: LirMirFunctionLowerer, blocks: List<LirBlock>
         return
     }
     let groupRef = lirParallelAccessGroupRef(l)
+    if groupRef == "" {
+        return
+    }
     let trailer = "!llvm.access.group " + groupRef
     for block in blocks {
         for instr in block.instrs {
@@ -3640,12 +4324,14 @@ fn lirFreshAuxLabel(l: LirMirFunctionLowerer, hint: String) -> String {
 }
 fn lirCutBlockBr(l: LirMirFunctionLowerer, target: String) {
     l.extraBlocks.push(LirBlock {label: l.currentBlockLabel, instrs: l.instrs, term: lirBr(target)})
-    l.instrs = []
+    let nextInstrs: List<LirInstr> = []
+    l.instrs = nextInstrs
     l.currentBlockLabel = target
 }
 fn lirCutBlockCondBr(l: LirMirFunctionLowerer, cond: String, thenLabel: String, elseLabel: String, nextLabel: String) {
     l.extraBlocks.push(LirBlock {label: l.currentBlockLabel, instrs: l.instrs, term: lirCondBr(cond, thenLabel, elseLabel)})
-    l.instrs = []
+    let nextInstrs: List<LirInstr> = []
+    l.instrs = nextInstrs
     l.currentBlockLabel = nextLabel
 }
 // `lirEmitOptionNone` / `lirEmitOptionSome` build the canonical 2-i64
@@ -3657,102 +4343,33 @@ fn lirCutBlockCondBr(l: LirMirFunctionLowerer, cond: String, thenLabel: String, 
 // the caller is responsible for zext / ptrtoint / bitcast as
 // appropriate. Returns the temporary holding the constructed aggregate.
 fn lirEmitOptionNone(l: LirMirFunctionLowerer, optType: LirType) -> String {
-    let step = lirFresh(l)
-    l.instrs.push(lirInsertValue(step, optType, "undef", lirOperand(lirIntType(64), mirDiscriminantNone()), [0]))
-    let value = lirFresh(l)
-    let payloadOp = if lirAggregateHasWidenedPayload(l.out, optType) {
-        // Widened Option<Struct> shape: `{ i64 tag, %Struct payload }`.
-        // None's payload is logically unused so emit a `zeroinitializer`
-        // typed as the actual struct. Avoids the `undef` placeholder the
-        // pre-#1731 code would emit which violated the typedef.
-        let structRef = lirOptionResultPayloadStructRef(l.out, optType.llvm)
-        if structRef == "" {
-            lirLowerError(l, LirDiagUnsupported, "Option<Struct> None construction could not extract payload typedef from `" + optType.llvm + "`", "option.none.widened")
-            return "undef"
-        }
-        lirOperand(lirAggregateType(structRef), "zeroinitializer")
-    } else {
-        lirOperand(lirIntType(64), "0")
-    }
-    l.instrs.push(lirInsertValue(value, optType, step, payloadOp, [1]))
-    value
+    return "undef"
 }
 fn lirEmitOptionSome(l: LirMirFunctionLowerer, optType: LirType, payloadI64: String) -> String {
-    if lirAggregateHasWidenedPayload(l.out, optType) {
-        lirLowerError(l, LirDiagUnsupported, "Option<Struct> Some construction via i64 entry on widened payload `" + optType.llvm + "` — caller should dispatch to lirEmitOptionSomeStruct", "option.some.widened")
-        return "undef"
-    }
-    let step = lirFresh(l)
-    l.instrs.push(lirInsertValue(step, optType, "undef", lirOperand(lirIntType(64), mirDiscriminantSome()), [0]))
-    let value = lirFresh(l)
-    l.instrs.push(lirInsertValue(value, optType, step, lirOperand(lirIntType(64), payloadI64), [1]))
-    value
+    return "undef"
 }
 // `lirEmitOptionSomeStruct` builds `Some(payload)` when `optType` is
 // the widened `{ i64 disc, %Struct payload }` shape. Callers that
 // have the struct-typed payload operand on hand should dispatch here
 // instead of pre-coercing through `lirParseResultPayloadAsI64`.
 fn lirEmitOptionSomeStruct(l: LirMirFunctionLowerer, optType: LirType, payload: LirOperand) -> String {
-    let structRef = lirOptionResultPayloadStructRef(l.out, optType.llvm)
-    if structRef == "" {
-        lirLowerError(l, LirDiagUnsupported, "Option<Struct> Some construction could not extract payload typedef from `" + optType.llvm + "`", "option.some.widened")
-        return "undef"
-    }
-    let step = lirFresh(l)
-    l.instrs.push(lirInsertValue(step, optType, "undef", lirOperand(lirIntType(64), mirDiscriminantSome()), [0]))
-    let value = lirFresh(l)
-    l.instrs.push(lirInsertValue(value, optType, step, lirOperand(lirAggregateType(structRef), payload.value), [1]))
-    value
+    return "undef"
 }
 fn lirEmitResultOk(l: LirMirFunctionLowerer, resultType: LirType, payloadI64: String) -> String {
-    if lirAggregateHasWidenedPayload(l.out, resultType) {
-        lirLowerError(l, LirDiagUnsupported, "Result<Struct, _> Ok construction via i64 entry on widened payload `" + resultType.llvm + "` — caller should dispatch to lirEmitResultOkStruct", "result.ok.widened")
-        return "undef"
-    }
-    let step = lirFresh(l)
-    l.instrs.push(lirInsertValue(step, resultType, "undef", lirOperand(lirIntType(64), mirDiscriminantOk()), [0]))
-    let value = lirFresh(l)
-    l.instrs.push(lirInsertValue(value, resultType, step, lirOperand(lirIntType(64), payloadI64), [1]))
-    value
+    return "undef"
 }
 // `lirEmitResultOkStruct` builds `Ok(payload)` when `resultType` is
 // the widened `{ i64 disc, %Struct payload }` shape.
 fn lirEmitResultOkStruct(l: LirMirFunctionLowerer, resultType: LirType, payload: LirOperand) -> String {
-    let structRef = lirOptionResultPayloadStructRef(l.out, resultType.llvm)
-    if structRef == "" {
-        lirLowerError(l, LirDiagUnsupported, "Result<Struct, _> Ok construction could not extract payload typedef from `" + resultType.llvm + "`", "result.ok.widened")
-        return "undef"
-    }
-    let step = lirFresh(l)
-    l.instrs.push(lirInsertValue(step, resultType, "undef", lirOperand(lirIntType(64), mirDiscriminantOk()), [0]))
-    let value = lirFresh(l)
-    l.instrs.push(lirInsertValue(value, resultType, step, lirOperand(lirAggregateType(structRef), payload.value), [1]))
-    value
+    return "undef"
 }
 fn lirEmitResultErr(l: LirMirFunctionLowerer, resultType: LirType, payloadI64: String) -> String {
-    if lirAggregateHasWidenedPayload(l.out, resultType) {
-        lirLowerError(l, LirDiagUnsupported, "Result<_, Struct> Err construction via i64 entry on widened payload `" + resultType.llvm + "` — caller should dispatch to lirEmitResultErrStruct", "result.err.widened")
-        return "undef"
-    }
-    let step = lirFresh(l)
-    l.instrs.push(lirInsertValue(step, resultType, "undef", lirOperand(lirIntType(64), mirDiscriminantErr()), [0]))
-    let value = lirFresh(l)
-    l.instrs.push(lirInsertValue(value, resultType, step, lirOperand(lirIntType(64), payloadI64), [1]))
-    value
+    return "undef"
 }
 // `lirEmitResultErrStruct` builds `Err(payload)` when `resultType` is
 // the widened `{ i64 disc, %Struct payload }` shape.
 fn lirEmitResultErrStruct(l: LirMirFunctionLowerer, resultType: LirType, payload: LirOperand) -> String {
-    let structRef = lirOptionResultPayloadStructRef(l.out, resultType.llvm)
-    if structRef == "" {
-        lirLowerError(l, LirDiagUnsupported, "Result<_, Struct> Err construction could not extract payload typedef from `" + resultType.llvm + "`", "result.err.widened")
-        return "undef"
-    }
-    let step = lirFresh(l)
-    l.instrs.push(lirInsertValue(step, resultType, "undef", lirOperand(lirIntType(64), mirDiscriminantErr()), [0]))
-    let value = lirFresh(l)
-    l.instrs.push(lirInsertValue(value, resultType, step, lirOperand(lirAggregateType(structRef), payload.value), [1]))
-    value
+    return "undef"
 }
 // `lirAggregateHasWidenedPayload` returns true when the typedef body for an
 // aggregate type ref (e.g. "%Option.MyStruct") references a struct in the
@@ -3883,15 +4500,19 @@ fn lirLowerMirStringRuntimeCall(l: LirMirFunctionLowerer, instr: MirInstr, symbo
     let mut i = 0
     for arg in instr.args {
         let pt = paramTypes[i]
-        let mut value = lirLowerMirOperand(l, arg, arg.typ, pt)
+        let mut value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, pt)
         if value.value == "" {
             return
         }
         if value.typ.llvm != pt.llvm {
-            value = lirCoerceMirOperand(l, value, arg.typ, pt, label + " arg " + lirIntToString(i))
-            if value.value == "" {
+            let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, pt, lirPrimitiveTypeIsUnsigned(arg.typ))
+            if castOp == "" {
+                lirLowerError(l, LirDiagUnsupported, label + " arg " + lirIntToString(i) + " coercion is not supported", label + " arg " + lirIntToString(i))
                 return
             }
+            let castName = lirFresh(l)
+            l.instrs.push(lirCast(castName, castOp, value, pt))
+            value = LirOperand {typ: pt, value: castName}
         }
         args.push(lirOperand(pt, value.value))
         i = i + 1
@@ -3925,7 +4546,7 @@ fn lirLowerMirStringIsEmpty(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "string.isEmpty expects one argument", "string.isEmpty")
         return
     }
-    let arg = lirLowerMirOperand(l, instr.args[0], "String", lirPtrType())
+    let arg = lirLowerMirOperand(l, l.instrs, instr.args[0], "String", lirPtrType())
     if arg.value == "" {
         return
     }
@@ -3955,15 +4576,20 @@ fn lirLowerMirStringConcat(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let mut parts: List<LirOperand> = []
     for arg in instr.args {
-        let mut value = lirLowerMirOperand(l, arg, arg.typ, lirPtrType())
+        let mut value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, lirPtrType())
         if value.value == "" {
             return
         }
         if value.typ.className != LirTypePtr {
-            value = lirCoerceMirOperand(l, value, arg.typ, lirPtrType(), "string.concat part")
-            if value.value == "" {
+            let ptrType = lirPtrType()
+            let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, ptrType, lirPrimitiveTypeIsUnsigned(arg.typ))
+            if castOp == "" {
+                lirLowerError(l, LirDiagUnsupported, "string.concat part coercion is not supported", "string.concat part")
                 return
             }
+            let castName = lirFresh(l)
+            l.instrs.push(lirCast(castName, castOp, value, ptrType))
+            value = LirOperand {typ: ptrType, value: castName}
         }
         parts.push(lirOperand(lirPtrType(), value.value))
     }
@@ -4003,7 +4629,8 @@ fn lirContainerInnerArg(typeName: String, prefix: String) -> String {
     if !(strings.endsWith(typeName, ">")) {
         return ""
     }
-    strings.slice(typeName, prefix.len(), typeName.len() - 1)
+    let inner = strings.trimPrefix(typeName, prefix)
+    strings.trimSuffix(inner, ">")
 }
 // Element type name for List<T>/Set<T> ("List<Int>" -> "Int").
 fn lirListElemTypeName(typeName: String) -> String {
@@ -4109,7 +4736,7 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
         lirLowerError(l, LirDiagInvalidInput, label + " requires a receiver", label)
         return lirContainerReceiverInvalid()
     }
-    let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+    let recv = lirLowerMirOperand(l, l.instrs, instr.args[0], instr.args[0].typ, lirPtrType())
     if recv.value == "" {
         return lirContainerReceiverInvalid()
     }
@@ -4169,14 +4796,21 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
 // on failure. Folds the four-line "lower + early-return + coerce + early-
 // return" boilerplate that used to repeat in every container intrinsic.
 fn lirLowerCoercedOperand(l: LirMirFunctionLowerer, op: MirOperand, hintName: String, hint: LirType, label: String) -> LirOperand {
-    let value = lirLowerMirOperand(l, op, hintName, hint)
+    let value = lirLowerMirOperand(l, l.instrs, op, hintName, hint)
     if value.value == "" {
         return lirOperandInvalid()
     }
     if value.typ.llvm == hint.llvm {
         return value
     }
-    lirCoerceMirOperandToName(l, value, op.typ, hintName, hint, label)
+    let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, hint, lirPrimitiveTypeIsUnsigned(op.typ))
+    if castOp == "" {
+        lirLowerError(l, LirDiagUnsupported, label + " coercion is not supported", label)
+        return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+    }
+    let castName = lirFresh(l)
+    l.instrs.push(lirCast(castName, castOp, value, hint))
+    LirOperand {typ: hint, value: castName}
 }
 // `lirEmitContainerCall` emits the closing scaffold every container
 // intrinsic shares: declare the runtime symbol, emit the `call`, and
@@ -4240,11 +4874,11 @@ fn lirLowerMirListPushBytesV1(l: LirMirFunctionLowerer, instr: MirInstr, elemNam
         lirLowerError(l, LirDiagUnsupported, "list.push composite element type `" + elemName + "` has no MIR layout", "list.push")
         return
     }
-    let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+    let recv = lirLowerMirOperand(l, l.instrs, instr.args[0], instr.args[0].typ, lirPtrType())
     if recv.value == "" {
         return
     }
-    let value = lirLowerMirOperand(l, instr.args[1], elemName, elemType)
+    let value = lirLowerMirOperand(l, l.instrs, instr.args[1], elemName, elemType)
     if value.value == "" {
         return
     }
@@ -4289,7 +4923,7 @@ fn lirBoxCompositeToI64(l: LirMirFunctionLowerer, valueReg: String, valueType: L
     lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(allocSym, lirPtrType(), [lirIntType(64), lirIntType(64), lirPtrType()], false))
     let sizeReg = lirEmitSizeOf(l, valueType)
     let siteLabel = "mir.enum.box." + lirStripPercent(valueType.llvm)
-    let siteSym = lirStringPoolIntern(l.out.stringPool, siteLabel)
+    let siteSym = lirStringEntriesInternKnown(l.stringPoolEntries, siteLabel, lirCStringEncodeSelfhostSafe(siteLabel), lirStringByteLenWithNul(siteLabel))
     let box = lirFresh(l)
     l.instrs.push(lirCall(box, lirPtrType(), "@" + allocSym, [lirOperand(lirIntType(64), "1"), lirOperand(lirIntType(64), sizeReg), lirOperand(lirPtrType(), siteSym)]))
     l.instrs.push(lirStore(lirOperand(valueType, valueReg), box, 0))
@@ -4350,7 +4984,7 @@ fn lirLowerMirListGetBytesV1(l: LirMirFunctionLowerer, instr: MirInstr, elemName
         lirLowerError(l, LirDiagUnsupported, "list.get composite element type `" + elemName + "` has no MIR layout", "list.get")
         return
     }
-    let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+    let recv = lirLowerMirOperand(l, l.instrs, instr.args[0], instr.args[0].typ, lirPtrType())
     if recv.value == "" {
         return
     }
@@ -4408,7 +5042,7 @@ fn lirLowerMirListInsertBytesV1(l: LirMirFunctionLowerer, instr: MirInstr, elemN
         lirLowerError(l, LirDiagUnsupported, "list.insert composite element type `" + elemName + "` has no MIR layout", "list.insert")
         return
     }
-    let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+    let recv = lirLowerMirOperand(l, l.instrs, instr.args[0], instr.args[0].typ, lirPtrType())
     if recv.value == "" {
         return
     }
@@ -4416,7 +5050,7 @@ fn lirLowerMirListInsertBytesV1(l: LirMirFunctionLowerer, instr: MirInstr, elemN
     if idx.value == "" {
         return
     }
-    let value = lirLowerMirOperand(l, instr.args[2], elemName, elemType)
+    let value = lirLowerMirOperand(l, l.instrs, instr.args[2], elemName, elemType)
     if value.value == "" {
         return
     }
@@ -4455,7 +5089,7 @@ fn lirLowerMirListIsEmpty(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "list.isEmpty expects (list)", "list.isEmpty")
         return
     }
-    let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+    let recv = lirLowerMirOperand(l, l.instrs, instr.args[0], instr.args[0].typ, lirPtrType())
     if recv.value == "" {
         return
     }
@@ -4792,7 +5426,7 @@ fn lirLowerMirListPop(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     if !(instr.hasDest) {
-        let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+        let recv = lirLowerMirOperand(l, l.instrs, instr.args[0], instr.args[0].typ, lirPtrType())
         if recv.value == "" {
             return
         }
@@ -5004,7 +5638,7 @@ fn lirLowerMirCheckCancelled(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     let symbol = mirRtCancelCheckCancelledSymbol()
-    let rawType = lirRawType("\{ i64, i64 \}")
+    let rawType = lirRawType(lirBraced("i64, i64"))
     lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, rawType, [], false))
     if !(instr.hasDest) {
         l.instrs.push(lirCall("", rawType, "@" + symbol, []))
@@ -5177,7 +5811,7 @@ fn lirLowerMirSelectSend(l: LirMirFunctionLowerer, instr: MirInstr) {
             lirLowerError(l, LirDiagUnsupported, "select.send composite element type `" + elemName + "` has no MIR layout", "select.send")
             return
         }
-        let value = lirLowerMirOperand(l, instr.args[2], elemName, elemType)
+        let value = lirLowerMirOperand(l, l.instrs, instr.args[2], elemName, elemType)
         if value.value == "" {
             return
         }
@@ -5219,7 +5853,7 @@ fn lirLowerMirRace(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     let symbol = mirRtTaskRaceSymbol()
-    let rawType = lirRawType("\{ i64, i64 \}")
+    let rawType = lirRawType(lirBraced("i64, i64"))
     lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, rawType, [lirPtrType()], false))
     if !(instr.hasDest) {
         l.instrs.push(lirCall("", rawType, "@" + symbol, [lirOperand(lirPtrType(), body.value)]))
@@ -5514,7 +6148,7 @@ fn lirLowerMirAlgebraicTagCheck(l: LirMirFunctionLowerer, instr: MirInstr, wante
         lirLowerError(l, LirDiagUnsupported, label + " operand type `" + aggName + "` is not implemented", label)
         return
     }
-    let aggValue = lirLowerMirOperand(l, instr.args[0], aggName, aggType)
+    let aggValue = lirLowerMirOperand(l, l.instrs, instr.args[0], aggName, aggType)
     if aggValue.value == "" {
         return
     }
@@ -5610,7 +6244,8 @@ fn lirNarrowI64ToType(l: LirMirFunctionLowerer, i64Reg: String, target: LirType)
 // branch). The new sub-block stays empty until the caller fills it.
 fn lirCutBlockUnreachable(l: LirMirFunctionLowerer, nextLabel: String) {
     l.extraBlocks.push(LirBlock {label: l.currentBlockLabel, instrs: l.instrs, term: lirUnreachable()})
-    l.instrs = []
+    let nextInstrs: List<LirInstr> = []
+    l.instrs = nextInstrs
     l.currentBlockLabel = nextLabel
 }
 // `lirLowerMirAlgebraicUnwrap` lowers Option.unwrap() / Result.unwrap()
@@ -5641,7 +6276,7 @@ fn lirLowerMirAlgebraicUnwrap(l: LirMirFunctionLowerer, instr: MirInstr, absentT
         lirLowerError(l, LirDiagUnsupported, label + " not implemented for widened payload `" + aggName + "` (C2 pending — see LLVM_BACKEND_GAP_PLAN.md)", label + ".widened")
         return
     }
-    let aggValue = lirLowerMirOperand(l, instr.args[0], aggName, aggType)
+    let aggValue = lirLowerMirOperand(l, l.instrs, instr.args[0], aggName, aggType)
     if aggValue.value == "" {
         return
     }
@@ -5704,7 +6339,7 @@ fn lirLowerMirAlgebraicUnwrapOr(l: LirMirFunctionLowerer, instr: MirInstr, prese
         lirLowerError(l, LirDiagUnsupported, label + " not implemented for widened payload `" + aggName + "` (C2 pending — see LLVM_BACKEND_GAP_PLAN.md)", label + ".widened")
         return
     }
-    let aggValue = lirLowerMirOperand(l, instr.args[0], aggName, aggType)
+    let aggValue = lirLowerMirOperand(l, l.instrs, instr.args[0], aggName, aggType)
     if aggValue.value == "" {
         return
     }
@@ -5738,7 +6373,7 @@ fn lirLowerMirAlgebraicUnwrapOr(l: LirMirFunctionLowerer, instr: MirInstr, prese
     l.instrs.push(lirStore(lirOperand(destType, narrowed), mergeSlot, 0))
     lirCutBlockBr(l, endLabel)
     l.currentBlockLabel = absentLabel
-    let fallback = lirLowerMirOperand(l, instr.args[1], loc.typ, destType)
+    let fallback = lirLowerMirOperand(l, l.instrs, instr.args[1], loc.typ, destType)
     if fallback.value == "" {
         return
     }
@@ -5872,7 +6507,7 @@ fn lirLowerMirMapGetOr(l: LirMirFunctionLowerer, instr: MirInstr) {
     l.instrs.push(lirStore(lirOperand(destType, loaded), mergeSlot, 0))
     lirCutBlockBr(l, endLabel)
     l.currentBlockLabel = missLabel
-    let fallback = lirLowerMirOperand(l, instr.args[2], loc.typ, destType)
+    let fallback = lirLowerMirOperand(l, l.instrs, instr.args[2], loc.typ, destType)
     if fallback.value == "" {
         return
     }
@@ -6072,7 +6707,7 @@ fn lirParseResultPayloadAsI64(l: LirMirFunctionLowerer, valueReg: String, valueT
 // nominal-vs-structural shape distinctions yet — the canonical type
 // names already arrive from the monomorphizer with stable spellings.
 fn lirIsOptionTypeName(name: String) -> Bool {
-    strings.startsWith(name, "Option<") || strings.startsWith(name, "Maybe<")
+    lirStringHasPrefixKey(name, 7, 7056243) || lirStringHasPrefixKey(name, 6, 6038081)
 }
 // `lirCanonicalizeOptionalSugar` rewrites the trailing-`?` Option
 // sugar form (`T?`) into the explicit `Option<T>` spelling so the
@@ -6080,7 +6715,7 @@ fn lirIsOptionTypeName(name: String) -> Bool {
 // recognition path. Inner uses (`List<Int?>`, struct fields, etc.)
 // keep the sugar until their type strings are looked up directly.
 fn lirCanonicalizeOptionalSugar(name: String) -> String {
-    if name.len() > 1 && strings.hasSuffix(name, "?") {
+    if name.len() > 1 && lirStringHasQuestionSuffix(name) {
         let inner = strings.slice(name, 0, name.len() - 1)
         return "Option<" + inner + ">"
     }
@@ -6152,7 +6787,7 @@ fn lirLowerMirChanSendBytesV1(l: LirMirFunctionLowerer, instr: MirInstr, elemNam
     if chReg.value == "" {
         return
     }
-    let value = lirLowerMirOperand(l, instr.args[1], elemName, elemType)
+    let value = lirLowerMirOperand(l, l.instrs, instr.args[1], elemName, elemType)
     if value.value == "" {
         return
     }
@@ -6194,8 +6829,8 @@ fn lirLowerMirChanRecv(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let symbol = llvmChanRuntimeRecvSymbol(suffix)
     if !(instr.hasDest) {
-        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirRawType("\{ i64, i64 \}"), [lirPtrType()], false))
-        l.instrs.push(lirCall("", lirRawType("\{ i64, i64 \}"), "@" + symbol, [lirOperand(lirPtrType(), chReg.value)]))
+        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirRawType(lirBraced("i64, i64")), [lirPtrType()], false))
+        l.instrs.push(lirCall("", lirRawType(lirBraced("i64, i64")), "@" + symbol, [lirOperand(lirPtrType(), chReg.value)]))
         return
     }
     let loc = mirFunctionLocal(l.fn_, instr.dest.local)
@@ -6219,7 +6854,7 @@ fn lirLowerMirChanRecv(l: LirMirFunctionLowerer, instr: MirInstr) {
 // ptr cast to i64. Downstream unwrap (lirNarrowI64ToType) does
 // the unbox via inttoptr + load.
 fn lirIsResultTypeName(name: String) -> Bool {
-    strings.startsWith(name, "Result<")
+    lirStringHasPrefixKey(name, 7, 7057278)
 }
 // `lirMangleAlgebraicTypeName` produces a stable LLVM identifier from a
 // canonical Osty type name like "Option<Int>" or "Result<String, Error>".
@@ -6246,13 +6881,7 @@ fn lirMangleAlgebraicTypeName(name: String) -> String {
 }
 fn lirLowerMirTerm(l: LirMirFunctionLowerer, term: MirTerm, ret: LirType) -> LirTerm {
     if term.kind == MirTermReturn {
-        if lirTypeIsVoid(ret) {
-            lirEmitGcRootReleases(l)
-            return lirRetVoid()
-        }
-        let value = lirLoadMirLocal(l, l.fn_.returnLocal)
-        lirEmitGcRootReleases(l)
-        return lirRetValue(value.typ, value.value)
+        return lirLowerMirReturnTerm(l, ret)
     }
     if term.kind == MirTermGoto {
         let mut t = lirBr(lirLabelForMirBlock(l, term.target))
@@ -6262,7 +6891,7 @@ fn lirLowerMirTerm(l: LirMirFunctionLowerer, term: MirTerm, ret: LirType) -> Lir
         return t
     }
     if term.kind == MirTermBranch {
-        let cond = lirLowerMirOperand(l, term.cond, "Bool", lirIntType(1))
+        let cond = lirLowerMirOperand(l, l.instrs, term.cond, "Bool", lirIntType(1))
         if cond.typ.llvm != "i1" {
             lirLowerError(l, LirDiagUnsupported, "branch condition requires i1, got `" + cond.typ.llvm + "`", "term.branch")
             return lirUnreachable()
@@ -6274,7 +6903,7 @@ fn lirLowerMirTerm(l: LirMirFunctionLowerer, term: MirTerm, ret: LirType) -> Lir
         return t
     }
     if term.kind == MirTermSwitchInt {
-        let scrutinee = lirLowerMirOperand(l, term.cond, term.cond.typ, lirTypeInvalid())
+        let scrutinee = lirLowerMirOperand(l, l.instrs, term.cond, term.cond.typ, lirTypeInvalid())
         if scrutinee.typ.className != LirTypeInt {
             lirLowerError(l, LirDiagUnsupported, "switch scrutinee requires integer type, got `" + scrutinee.typ.llvm + "`", "term.switch")
             return lirUnreachable()
@@ -6289,7 +6918,22 @@ fn lirLowerMirTerm(l: LirMirFunctionLowerer, term: MirTerm, ret: LirType) -> Lir
         return lirUnreachable()
     }
     lirLowerError(l, LirDiagInvalidInput, "missing or unsupported MIR terminator", "term")
-    lirUnreachable()
+    return lirUnreachable()
+}
+
+fn lirLowerMirReturnTerm(l: LirMirFunctionLowerer, ret: LirType) -> LirTerm {
+    if lirTypeIsVoid(ret) {
+        lirEmitGcRootReleases(l)
+        return lirRetVoid()
+    }
+    let projections: List<MirProjection> = []
+    let place = MirPlace {local: l.fn_.returnLocal, projections}
+    let invalidConst = MirConst {kind: MirConstInvalid, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ: ""}
+    let returnTypeName = lirMirFunctionReturnTypeName(l.fn_)
+    let returnOp = MirOperand {kind: MirOpCopy, place, const: invalidConst, typ: returnTypeName}
+    let value = lirLowerMirOperand(l, l.instrs, returnOp, returnTypeName, ret)
+    lirEmitGcRootReleases(l)
+    return lirRetValue(value.typ, value.value)
 }
 // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
 // Load the return value before releasing roots. The value
@@ -6300,7 +6944,7 @@ fn lirLowerMirTerm(l: LirMirFunctionLowerer, term: MirTerm, ret: LirType) -> Lir
 fn lirLowerMirRValue(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, hint: LirType) -> LirOperand {
     let kind = rv.kind
     if kind == MirRVUse {
-        return lirLowerMirOperand(l, rv.arg, hintName, hint)
+        return lirLowerMirOperand(l, l.instrs, rv.arg, hintName, hint)
     }
     if kind == MirRVUnary {
         return lirLowerMirUnary(l, rv, hintName, hint)
@@ -6392,9 +7036,14 @@ fn lirLowerMirDiscriminant(l: LirMirFunctionLowerer, rv: MirRValue, hintName: St
         lirLowerError(l, LirDiagUnsupported, "discriminant through projections is not implemented", "rvalue.discriminant")
         return lirOperandInvalid()
     }
-    let agg = lirLoadMirLocal(l, rv.place.local)
+    let invalidConst = MirConst {kind: MirConstInvalid, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ: ""}
+    let op = MirOperand {kind: MirOpCopy, place: rv.place, const: invalidConst, typ: rv.typ}
+    let agg = lirLowerMirOperand(l, l.instrs, op, rv.typ, hint)
     if agg.value == "" {
         return lirOperandInvalid()
+    }
+    if agg.typ.className != LirTypeAggregate {
+        return agg
     }
     let discReg = lirFresh(l)
     l.instrs.push(lirExtractValue(discReg, agg.typ, agg.value, [0]))
@@ -6415,7 +7064,9 @@ fn lirLowerMirLenRV(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, h
         lirLowerError(l, LirDiagInvalidInput, "len rvalue place local out of range", "rvalue.len")
         return lirOperandInvalid()
     }
-    let value = lirLoadMirPlace(l, rv.place)
+    let invalidConst = MirConst {kind: MirConstInvalid, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ: ""}
+    let op = MirOperand {kind: MirOpCopy, place: rv.place, const: invalidConst, typ: local.typ}
+    let value = lirLowerMirOperand(l, l.instrs, op, local.typ, lirPtrType())
     if value.value == "" {
         return lirOperandInvalid()
     }
@@ -6442,7 +7093,7 @@ fn lirLowerMirLenRV(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, h
     lirOperand(lirIntType(64), dest)
 }
 fn lirLowerMirUnary(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, hint: LirType) -> LirOperand {
-    let arg = lirLowerMirOperand(l, rv.arg, hintName, hint)
+    let arg = lirLowerMirOperand(l, l.instrs, rv.arg, hintName, hint)
     if rv.unaryOp == MirUnPlus {
         return arg
     }
@@ -6473,13 +7124,15 @@ fn lirLowerMirBinary(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, 
     if rv.binaryOp == MirBinAdd && rv.arg.typ == "String" && rv.right.typ == "String" {
         return lirLowerMirStringConcatBinary(l, rv, hintName, hint)
     }
-    let argType = if lirTypeIsZero(hint) {
+    let argType = if lirMirBinaryIsComparison(rv.binaryOp) {
+        lirLowerMirType(l, rv.arg.typ)
+    } else if lirTypeIsZero(hint) {
         lirLowerMirType(l, rv.arg.typ)
     } else {
         hint
     }
-    let left = lirLowerMirOperand(l, rv.arg, rv.arg.typ, argType)
-    let right = lirLowerMirOperand(l, rv.right, rv.right.typ, argType)
+    let left = lirLowerMirOperand(l, l.instrs, rv.arg, rv.arg.typ, argType)
+    let right = lirLowerMirOperand(l, l.instrs, rv.right, rv.right.typ, argType)
     let resType = if lirMirBinaryIsComparison(rv.binaryOp) {
         lirIntType(1)
     } else {
@@ -6501,11 +7154,11 @@ fn lirLowerMirBinary(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, 
 // must be intercepted here so the runtime sees Concat rather than an
 // invalid `add ptr, ptr`.
 fn lirLowerMirStringConcatBinary(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, hint: LirType) -> LirOperand {
-    let left = lirLowerMirOperand(l, rv.arg, "String", lirPtrType())
+    let left = lirLowerMirOperand(l, l.instrs, rv.arg, "String", lirPtrType())
     if left.value == "" {
         return lirOperandInvalid()
     }
-    let right = lirLowerMirOperand(l, rv.right, "String", lirPtrType())
+    let right = lirLowerMirOperand(l, l.instrs, rv.right, "String", lirPtrType())
     if right.value == "" {
         return lirOperandInvalid()
     }
@@ -6522,7 +7175,7 @@ fn lirLowerMirCast(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, hi
     } else {
         hint
     }
-    let value = lirLowerMirOperand(l, rv.arg, rv.castFrom, fromType)
+    let value = lirLowerMirOperand(l, l.instrs, rv.arg, rv.castFrom, fromType)
     let unsigned = lirPrimitiveTypeIsUnsigned(rv.castFrom) || lirPrimitiveTypeIsUnsigned(rv.castTo)
     let mut opcode = ""
     if rv.castKind == MirCastIntResize {
@@ -6544,7 +7197,9 @@ fn lirLowerMirCast(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, hi
     if opcode == "" {
         return lirOperand(toType, value.value)
     }
-    lirCastMirOperand(l, value, opcode, toType)
+    let dest = lirFresh(l)
+    l.instrs.push(lirCast(dest, opcode, value, toType))
+    LirOperand {typ: toType, value: dest}
 }
 // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
 // Identity at this stage — the MIR lowerer normally
@@ -6611,7 +7266,7 @@ fn lirLowerMirClosureAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName
     for et in elemTypes {
         bodyParts.push(lirTypeString(et))
     }
-    lirModuleDeclareTypeDef(l.out, lirTypeDef(envTypeName, "\{ " + strings.join(bodyParts, ", ") + " \}"))
+    lirModuleDeclareTypeDef(l.out, lirTypeDef(envTypeName, lirBraced(strings.join(bodyParts, ", "))))
     let envType = lirAggregateType(envTypeName)
     let slot = lirFresh(l)
     l.instrs.push(lirAlloca(slot, envType, 0))
@@ -6619,9 +7274,9 @@ fn lirLowerMirClosureAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName
     for field in rv.aggFields {
         let elemType = elemTypes[idx]
         let value = if idx == 0 {
-            lirLowerMirOperand(l, field, field.typ, lirPtrType())
+            lirLowerMirOperand(l, l.instrs, field, field.typ, lirPtrType())
         } else {
-            lirLowerMirOperand(l, field, field.typ, elemType)
+            lirLowerMirOperand(l, l.instrs, field, field.typ, elemType)
         }
         if value.value == "" {
             return lirOperandInvalid()
@@ -6682,7 +7337,7 @@ fn lirLowerMirListAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName: S
         let pushBytesSym = mirRtListSymbol("push_bytes_v1")
         lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(pushBytesSym, lirVoidType(), [lirPtrType(), lirPtrType(), lirIntType(64)], false))
         for field in rv.aggFields {
-            let value = lirLowerMirOperand(l, field, elemName, elemType)
+            let value = lirLowerMirOperand(l, l.instrs, field, elemName, elemType)
             if value.value == "" {
                 return lirOperandInvalid()
             }
@@ -6725,6 +7380,13 @@ fn lirLowerMirEnumVariantAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hint
         return lirOperandInvalid()
     }
     let discText = lirIntToString(rv.aggVariantIdx)
+    if aggType.className != LirTypeAggregate {
+        if rv.aggFields.len() == 0 {
+            return lirOperand(aggType, discText)
+        }
+        lirLowerError(l, LirDiagUnsupported, "scalar enum variant `" + typeName + "` cannot carry payload fields", "aggregate.enum")
+        return lirOperandInvalid()
+    }
     let step1 = lirFresh(l)
     l.instrs.push(lirInsertValue(step1, aggType, "undef", lirOperand(lirIntType(64), discText), [0]))
     // Widened payload: lower the field operand directly and insert with
@@ -6736,7 +7398,7 @@ fn lirLowerMirEnumVariantAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hint
     if rv.aggFields.len() == 1 && lirAggregateHasWidenedPayload(l.out, aggType) {
         let arg = rv.aggFields[0]
         let argHint = lirLowerMirType(l, arg.typ)
-        let payload = lirLowerMirOperand(l, arg, arg.typ, argHint)
+        let payload = lirLowerMirOperand(l, l.instrs, arg, arg.typ, argHint)
         if payload.value == "" {
             return lirOperandInvalid()
         }
@@ -6754,7 +7416,7 @@ fn lirLowerMirEnumVariantAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hint
     } else if rv.aggFields.len() == 1 {
         let arg = rv.aggFields[0]
         let argHint = lirLowerMirType(l, arg.typ)
-        let value = lirLowerMirOperand(l, arg, arg.typ, argHint)
+        let value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, argHint)
         if value.value == "" {
             return lirOperandInvalid()
         }
@@ -6792,12 +7454,16 @@ fn lirLowerMirTupleAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName: 
             lirLowerError(l, LirDiagUnsupported, "tuple field type `" + fieldLayout.typ + "` is not implemented", "aggregate.tuple")
             return lirOperandInvalid()
         }
-        let mut value = lirLowerMirOperand(l, field, fieldLayout.typ, fieldType)
+        let mut value = lirLowerMirOperand(l, l.instrs, field, fieldLayout.typ, fieldType)
         if value.typ.llvm != fieldType.llvm {
-            value = lirCoerceMirOperand(l, value, field.typ, fieldType, "tuple field")
-            if value.value == "" {
+            let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, fieldType, lirPrimitiveTypeIsUnsigned(field.typ))
+            if castOp == "" {
+                lirLowerError(l, LirDiagUnsupported, "tuple field coercion is not supported", "aggregate.tuple")
                 return lirOperandInvalid()
             }
+            let castName = lirFresh(l)
+            l.instrs.push(lirCast(castName, castOp, value, fieldType))
+            value = LirOperand {typ: fieldType, value: castName}
         }
         let dest = lirFresh(l)
         l.instrs.push(lirInsertValue(dest, aggregateType, current.value, value, [fieldLayout.index]))
@@ -6831,12 +7497,16 @@ fn lirLowerMirStructAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName:
             lirLowerError(l, LirDiagUnsupported, "struct field type `" + fieldLayout.typ + "` is not implemented", "aggregate.struct")
             return lirOperandInvalid()
         }
-        let mut value = lirLowerMirOperand(l, field, fieldLayout.typ, fieldType)
+        let mut value = lirLowerMirOperand(l, l.instrs, field, fieldLayout.typ, fieldType)
         if value.typ.llvm != fieldType.llvm {
-            value = lirCoerceMirOperand(l, value, field.typ, fieldType, "struct field")
-            if value.value == "" {
+            let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, fieldType, lirPrimitiveTypeIsUnsigned(field.typ))
+            if castOp == "" {
+                lirLowerError(l, LirDiagUnsupported, "struct field coercion is not supported", "aggregate.struct")
                 return lirOperandInvalid()
             }
+            let castName = lirFresh(l)
+            l.instrs.push(lirCast(castName, castOp, value, fieldType))
+            value = LirOperand {typ: fieldType, value: castName}
         }
         let dest = lirFresh(l)
         l.instrs.push(lirInsertValue(dest, aggregateType, current.value, value, [fieldLayout.index]))
@@ -6845,18 +7515,106 @@ fn lirLowerMirStructAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName:
     }
     current
 }
-fn lirLowerMirOperand(l: LirMirFunctionLowerer, op: MirOperand, hintName: String, hint: LirType) -> LirOperand {
-    if op.kind == MirOpCopy {
-        return lirLoadMirPlace(l, op.place)
-    }
-    if op.kind == MirOpMove {
-        return lirLoadMirPlace(l, op.place)
+fn lirLowerMirOperand(l: LirMirFunctionLowerer, instrs: List<LirInstr>, op: MirOperand, hintName: String, hint: LirType) -> LirOperand {
+    if op.kind == MirOpCopy || op.kind == MirOpMove {
+        let place = op.place
+        let slot = lirMirLocalSlotFrom(l.slots, place.local, 0)
+        if slot.slot == "" {
+            let loc = mirFunctionLocal(l.fn_, place.local)
+            if loc.id < 0 {
+                lirLowerError(l, LirDiagInvalidInput, "local out of range: " + lirIntToString(place.local), "local")
+                return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+            }
+            if loc.typ == "Unit" || loc.typ == "()" {
+                return LirOperand {typ: LirType {llvm: "void", className: LirTypeVoid}, value: ""}
+            }
+            lirLowerError(l, LirDiagLoweringBug, "local has no LIR slot: " + lirIntToString(place.local), "local")
+            return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+        }
+        let loadedName = "%t" + lirIntToString(l.temp)
+        l.temp = l.temp + 1
+        instrs.push(lirLoad(loadedName, slot.typ, slot.slot, 0))
+        let mut current = LirOperand {typ: slot.typ, value: loadedName}
+        for proj in place.projections {
+            let step = lirProjectionStepFromMir(l, proj)
+            if step.kind == LirProjInvalid {
+                lirLowerError(l, LirDiagUnsupported, "unsupported MIR projection `" + mirProjectionKindName(proj.kind) + "`", "projection." + mirProjectionKindName(proj.kind))
+                return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+            }
+            if step.kind == LirProjIndex && current.typ.className == LirTypePtr {
+                current = lirLowerMirIndexProjection(l, instrs, current, proj)
+                if current.value == "" {
+                    return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+                }
+                continue
+            }
+            if current.typ.className != LirTypeAggregate {
+                lirLowerError(l, LirDiagUnsupported, "projection on non-aggregate type `" + current.typ.llvm + "`", "projection." + mirProjectionKindName(proj.kind))
+                return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+            }
+            let projectedName = "%t" + lirIntToString(l.temp)
+            l.temp = l.temp + 1
+            instrs.push(lirExtractValue(projectedName, current.typ, current.value, [step.index]))
+            let finalName = lirMaybeNarrowAlgebraicPayload(l, current.typ, projectedName, step)
+            current = LirOperand {typ: step.typ, value: finalName}
+        }
+        return current
     }
     if op.kind == MirOpConst {
-        return lirLowerMirConst(l, op.const, hintName, hint)
+        let c = op.const
+        let kind = c.kind
+        if kind == MirConstInt {
+            let typ = lirHintOrDefaultIntType(hint)
+            return LirOperand {typ, value: lirIntToString(c.intValue)}
+        }
+        if kind == MirConstBool {
+            if c.boolValue {
+                return LirOperand {typ: LirType {llvm: "i1", className: LirTypeInt}, value: "1"}
+            }
+            return LirOperand {typ: LirType {llvm: "i1", className: LirTypeInt}, value: "0"}
+        }
+        if kind == MirConstFloat {
+            let typ = lirHintOrDefaultFloatType(hint)
+            return LirOperand {typ, value: c.floatText}
+        }
+        if kind == MirConstString {
+            let symbol = lirStringEntriesInternKnown(l.stringPoolEntries, c.strValue, lirCStringEncodeSelfhostSafe(c.strValue), lirStringByteLenWithNul(c.strValue))
+            return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: symbol}
+        }
+        if kind == MirConstChar {
+            return LirOperand {typ: LirType {llvm: "i32", className: LirTypeInt}, value: lirIntToString(c.charValue)}
+        }
+        if kind == MirConstByte {
+            return LirOperand {typ: LirType {llvm: "i8", className: LirTypeInt}, value: lirIntToString(c.byteValue)}
+        }
+        if kind == MirConstUnit {
+            return LirOperand {typ: LirType {llvm: "void", className: LirTypeVoid}, value: ""}
+        }
+        if kind == MirConstNull {
+            return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: "null"}
+        }
+        if kind == MirConstFn {
+            return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: "@" + c.fnSymbol}
+        }
+        lirLowerError(l, LirDiagUnsupported, "unsupported MIR const kind `" + mirConstKindName(kind) + "`", "const." + mirConstKindName(kind))
+        return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
     }
     lirLowerError(l, LirDiagUnsupported, "unsupported MIR operand kind `" + mirOperandKindName(op.kind) + "`", "operand." + mirOperandKindName(op.kind))
-    lirOperandInvalid()
+    return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+}
+
+fn lirHintOrDefaultIntType(hint: LirType) -> LirType {
+    if lirTypeIsZero(hint) {
+        return LirType {llvm: "i64", className: LirTypeInt}
+    }
+    return hint
+}
+
+fn lirHintOrDefaultFloatType(hint: LirType) -> LirType {
+    if lirTypeIsZero(hint) {
+        return LirType {llvm: "double", className: LirTypeFloat}
+    }
+    return hint
 }
 // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
 fn lirLoadMirPlace(l: LirMirFunctionLowerer, place: MirPlace) -> LirOperand {
@@ -6864,7 +7622,8 @@ fn lirLoadMirPlace(l: LirMirFunctionLowerer, place: MirPlace) -> LirOperand {
     if place.projections.len() == 0 {
         return base
     }
-    lirProjectMirOperand(l, base, place.projections)
+    let projected = lirProjectMirOperand(l, base, place.projections)
+    projected
 }
 fn lirLoadMirLocal(l: LirMirFunctionLowerer, id: Int) -> LirOperand {
     let slot = lirMirLocalSlot(l, id)
@@ -6872,18 +7631,19 @@ fn lirLoadMirLocal(l: LirMirFunctionLowerer, id: Int) -> LirOperand {
         let loc = mirFunctionLocal(l.fn_, id)
         if loc.id < 0 {
             lirLowerError(l, LirDiagInvalidInput, "local out of range: " + lirIntToString(id), "local")
-            return lirOperandInvalid()
+            return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
         }
         let typ = lirLowerMirType(l, loc.typ)
         if lirTypeIsVoid(typ) {
-            return lirOperand(typ, "")
+            return LirOperand {typ, value: ""}
         }
-        lirLowerError(l, LirDiagLoweringBug, "local has no LIR slot: " + lirIntToString(id), "local")
-        return lirOperandInvalid()
+        let dest = lirFresh(l)
+        l.instrs.push(lirLoad(dest, typ, lirMirLocalSlotName(id), 0))
+        return LirOperand {typ, value: dest}
     }
     let dest = lirFresh(l)
     l.instrs.push(lirLoad(dest, slot.typ, slot.slot, 0))
-    lirOperand(slot.typ, dest)
+    LirOperand {typ: slot.typ, value: dest}
 }
 fn lirProjectMirOperand(l: LirMirFunctionLowerer, value: LirOperand, projections: List<MirProjection>) -> LirOperand {
     let mut current = value
@@ -6891,86 +7651,150 @@ fn lirProjectMirOperand(l: LirMirFunctionLowerer, value: LirOperand, projections
         let step = lirProjectionStepFromMir(l, proj)
         if step.kind == LirProjInvalid {
             lirLowerError(l, LirDiagUnsupported, "unsupported MIR projection `" + mirProjectionKindName(proj.kind) + "`", "projection." + mirProjectionKindName(proj.kind))
-            return lirOperandInvalid()
+            return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+        }
+        if step.kind == LirProjIndex && current.typ.className == LirTypePtr {
+            current = lirLowerMirIndexProjection(l, l.instrs, current, proj)
+            if current.value == "" {
+                return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+            }
+            continue
+        }
+        if current.typ.className != LirTypeAggregate {
+            lirLowerError(l, LirDiagUnsupported, "projection on non-aggregate type `" + current.typ.llvm + "`", "projection." + mirProjectionKindName(proj.kind))
+            return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
         }
         let dest = lirFresh(l)
         l.instrs.push(lirExtractValue(dest, current.typ, current.value, [step.index]))
-        current = lirOperand(step.typ, dest)
+        let finalName = lirMaybeNarrowAlgebraicPayload(l, current.typ, dest, step)
+        current = LirOperand {typ: step.typ, value: finalName}
     }
     current
 }
+
+fn lirMaybeNarrowAlgebraicPayload(l: LirMirFunctionLowerer, aggregateType: LirType, rawValue: String, step: LirProjectionStep) -> String {
+    if step.index != 1 {
+        return rawValue
+    }
+    if step.typ.llvm == "i64" {
+        return rawValue
+    }
+    if !(lirTypeIsDefaultI64AlgebraicPayload(l.out, aggregateType)) {
+        if step.kind != LirProjVariant {
+            return rawValue
+        }
+        if lirOptionResultPayloadStructRef(l.out, aggregateType.llvm) != "" {
+            return rawValue
+        }
+    }
+    let narrowed = lirNarrowI64ToType(l, rawValue, step.typ)
+    if narrowed == "" {
+        return rawValue
+    }
+    return narrowed
+}
+
+fn lirTypeIsDefaultI64AlgebraicPayload(out: LirModule, typ: LirType) -> Bool {
+    if !(strings.startsWith(typ.llvm, "%Option.")) && !(strings.startsWith(typ.llvm, "%Maybe.")) && !(strings.startsWith(typ.llvm, "%Result.")) {
+        return false
+    }
+    lirOptionResultPayloadStructRef(out, typ.llvm) == ""
+}
+
+fn lirLowerMirIndexProjection(l: LirMirFunctionLowerer, instrs: List<LirInstr>, listValue: LirOperand, proj: MirProjection) -> LirOperand {
+    let elemName = proj.typ
+    let elemType = lirLowerMirType(l, elemName)
+    if lirTypeIsZero(elemType) || lirTypeIsVoid(elemType) {
+        lirLowerError(l, LirDiagUnsupported, "index projection element type `" + elemName + "` is not implemented", "projection.index")
+        return lirOperandInvalid()
+    }
+    let idx = lirLowerMirIndexProjectionIndex(l, instrs, proj)
+    if idx.value == "" {
+        return lirOperandInvalid()
+    }
+    let elemLir = lirContainerElemLaneType(elemName)
+    if !(lirTypeIsZero(elemLir)) && llvmListUsesTypedRuntime(elemLir.llvm) {
+        let symbol = llvmListRuntimeGetSymbolFor(elemLir.llvm, lirContainerElemIsString(elemName))
+        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, elemLir, [lirPtrType(), lirIntType(64)], false))
+        let dest = lirFresh(l)
+        instrs.push(lirCall(dest, elemLir, "@" + symbol, [lirOperand(lirPtrType(), listValue.value), lirOperand(lirIntType(64), idx.value)]))
+        return lirOperand(elemLir, dest)
+    }
+    let slot = lirFresh(l)
+    instrs.push(lirAlloca(slot, elemType, 0))
+    let sizeReg = lirEmitSizeOf(l, elemType)
+    let symbol = mirRtListGetBytesV1Symbol()
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirVoidType(), [lirPtrType(), lirIntType(64), lirPtrType(), lirIntType(64)], false))
+    instrs.push(lirCall("", lirVoidType(), "@" + symbol, [lirOperand(lirPtrType(), listValue.value), lirOperand(lirIntType(64), idx.value), lirOperand(lirPtrType(), slot), lirOperand(lirIntType(64), sizeReg)]))
+    let loaded = lirFresh(l)
+    instrs.push(lirLoad(loaded, elemType, slot, 0))
+    return lirOperand(elemType, loaded)
+}
+
+fn lirLowerMirIndexProjectionIndex(l: LirMirFunctionLowerer, instrs: List<LirInstr>, proj: MirProjection) -> LirOperand {
+    if proj.indexLocal >= 0 {
+        let slot = lirMirLocalSlot(l, proj.indexLocal)
+        if slot.slot == "" {
+            lirLowerError(l, LirDiagLoweringBug, "index projection local has no LIR slot: " + lirIntToString(proj.indexLocal), "projection.index")
+            return lirOperandInvalid()
+        }
+        let dest = lirFresh(l)
+        instrs.push(lirLoad(dest, slot.typ, slot.slot, 0))
+        return lirOperand(slot.typ, dest)
+    }
+    return lirOperand(lirIntType(64), lirIntToString(proj.indexConst))
+}
+
 fn lirLowerMirConst(l: LirMirFunctionLowerer, c: MirConst, hintName: String, hint: LirType) -> LirOperand {
     let kind = c.kind
     if kind == MirConstInt {
-        return lirOperand(lirLowerMirType(l, if c.typ == "" {
+        let typ = lirLowerMirType(l, if c.typ == "" {
             hintName
         } else {
             c.typ
-        }), lirIntToString(c.intValue))
+        })
+        return LirOperand {typ, value: lirIntToString(c.intValue)}
     }
     if kind == MirConstBool {
-        return lirBoolOperand(c.boolValue)
+        let lowered = lirBoolOperand(c.boolValue)
+        return lowered
     }
     if kind == MirConstFloat {
-        return lirOperand(lirLowerMirType(l, if c.typ == "" {
+        let typ = lirLowerMirType(l, if c.typ == "" {
             hintName
         } else {
             c.typ
-        }), c.floatText)
+        })
+        return LirOperand {typ, value: c.floatText}
     }
     if kind == MirConstString {
-        let symbol = lirStringPoolInternKnown(l.out.stringPool, c.strValue, lirCStringEncodeBasic(c.strValue), c.strValue.len() + 1)
-        return lirOperand(lirPtrType(), symbol)
+        let symbol = lirStringEntriesInternKnown(l.stringPoolEntries, c.strValue, lirCStringEncodeSelfhostSafe(c.strValue), lirStringByteLenWithNul(c.strValue))
+        return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: symbol}
     }
     if kind == MirConstChar {
-        return lirOperand(lirIntType(32), lirIntToString(c.charValue))
+        return LirOperand {typ: LirType {llvm: "i32", className: LirTypeInt}, value: lirIntToString(c.charValue)}
     }
     if kind == MirConstByte {
-        return lirOperand(lirIntType(8), lirIntToString(c.byteValue))
+        return LirOperand {typ: LirType {llvm: "i8", className: LirTypeInt}, value: lirIntToString(c.byteValue)}
     }
     if kind == MirConstUnit {
-        return lirOperand(lirVoidType(), "")
+        return LirOperand {typ: LirType {llvm: "void", className: LirTypeVoid}, value: ""}
     }
     if kind == MirConstNull {
-        return lirOperand(lirPtrType(), "null")
+        return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: "null"}
     }
     if kind == MirConstFn {
-        return lirOperand(lirPtrType(), "@" + c.fnSymbol)
+        return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: "@" + c.fnSymbol}
     }
     lirLowerError(l, LirDiagUnsupported, "unsupported MIR const kind `" + mirConstKindName(kind) + "`", "const." + mirConstKindName(kind))
-    lirOperandInvalid()
+    LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
 }
 // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
 fn lirBoolOperand(value: Bool) -> LirOperand {
     if value {
-        return lirOperand(lirIntType(1), "1")
+        return LirOperand {typ: LirType {llvm: "i1", className: LirTypeInt}, value: "1"}
     }
-    lirOperand(lirIntType(1), "0")
-}
-fn lirCoerceMirOperandToName(l: LirMirFunctionLowerer, value: LirOperand, fromName: String, toName: String, to: LirType, context: String) -> LirOperand {
-    if value.typ.llvm == to.llvm {
-        return lirOperand(to, value.value)
-    }
-    if lirMirModuleHasInterfaceLayout(l.mirModule, toName) {
-        return lirBoxInterfaceValue(l, value, fromName, toName, to, context)
-    }
-    lirCoerceMirOperand(l, value, fromName, to, context)
-}
-fn lirCoerceMirOperand(l: LirMirFunctionLowerer, value: LirOperand, fromName: String, to: LirType, context: String) -> LirOperand {
-    if value.typ.llvm == to.llvm {
-        return lirOperand(to, value.value)
-    }
-    let op = lirPlanSameFamilyCoercionOpcode(value.typ, to, lirPrimitiveTypeIsUnsigned(fromName))
-    if op == "" {
-        lirLowerError(l, LirDiagUnsupported, context + " coercion is not supported", context)
-        return lirOperandInvalid()
-    }
-    lirCastMirOperand(l, value, op, to)
-}
-fn lirCastMirOperand(l: LirMirFunctionLowerer, value: LirOperand, op: String, to: LirType) -> LirOperand {
-    let dest = lirFresh(l)
-    l.instrs.push(lirCast(dest, op, value, to))
-    lirOperand(to, dest)
+    LirOperand {typ: LirType {llvm: "i1", className: LirTypeInt}, value: "0"}
 }
 fn lirBoxInterfaceValue(l: LirMirFunctionLowerer, value: LirOperand, concreteName: String, ifaceName: String, ifaceType: LirType, context: String) -> LirOperand {
     if ifaceType.llvm != lirIfaceTypeName() {
@@ -6998,7 +7822,7 @@ fn lirBoxInterfaceData(l: LirMirFunctionLowerer, value: LirOperand, concreteName
     lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(allocSym, lirPtrType(), [lirIntType(64), lirIntType(64), lirPtrType()], false))
     let sizeReg = lirEmitSizeOf(l, value.typ)
     let siteLabel = "mir.iface.box." + lirInterfaceConcreteName(concreteName) + "__" + ifaceName
-    let siteSym = lirStringPoolIntern(l.out.stringPool, siteLabel)
+    let siteSym = lirStringEntriesInternKnown(l.stringPoolEntries, siteLabel, lirCStringEncodeSelfhostSafe(siteLabel), lirStringByteLenWithNul(siteLabel))
     let box = lirFresh(l)
     l.instrs.push(lirCall(box, lirPtrType(), "@" + allocSym, [lirOperand(lirIntType(64), "1"), lirOperand(lirIntType(64), sizeReg), lirOperand(lirPtrType(), siteSym)]))
     l.instrs.push(lirStore(value, box, 0))
@@ -7029,17 +7853,20 @@ fn lirInterfaceConcreteName(name: String) -> String {
 }
 fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
     let name = lirCanonicalizeOptionalSugar(rawName)
+    if name.len() == 0 {
+        return LirType {llvm: "", className: LirTypeUnknown}
+    }
     let primitive = lirLowerPrimitiveTypeName(name)
     if !(lirTypeIsZero(primitive)) {
         return primitive
     }
     if lirIsRefBuiltinTypeName(name) {
-        return lirPtrType()
+        return LirType {llvm: "ptr", className: LirTypePtr}
     }
     for layout in l.mirModule.layouts.interfaces {
         if lirMirInterfaceLayoutMatches(layout, name) {
             lirDeclareIfaceType(l.out)
-            return lirAggregateType(lirIfaceTypeName())
+            return LirType {llvm: lirIfaceTypeName(), className: LirTypeAggregate}
         }
     }
     if lirIsOptionTypeName(name) || lirIsResultTypeName(name) {
@@ -7052,7 +7879,7 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
         // would mint the wrong typedef for the whole module.
         let body = lirAlgebraicAggregateBody_module(l.out, l.mirModule, name)
         lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, body))
-        return lirAggregateType(typeName)
+        return LirType {llvm: typeName, className: LirTypeAggregate}
     }
     for layout in l.mirModule.layouts.structs {
         if lirMirStructLayoutMatches(layout, name) {
@@ -7065,12 +7892,12 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
             for field in layout.fields {
                 let fieldType = lirLowerMirType(l, field.typ)
                 if lirTypeIsZero(fieldType) || lirTypeIsVoid(fieldType) {
-                    return lirTypeInvalid()
+                    return LirType {llvm: "", className: LirTypeUnknown}
                 }
                 parts.push(lirTypeString(fieldType))
             }
-            lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, "\{ " + strings.join(parts, ", ") + " \}"))
-            return lirAggregateType(typeName)
+            lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, lirBraced(strings.join(parts, ", "))))
+            return LirType {llvm: typeName, className: LirTypeAggregate}
         }
     }
     for layout in l.mirModule.layouts.tuples {
@@ -7084,12 +7911,12 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
             for field in layout.fields {
                 let fieldType = lirLowerMirType(l, field.typ)
                 if lirTypeIsZero(fieldType) || lirTypeIsVoid(fieldType) {
-                    return lirTypeInvalid()
+                    return LirType {llvm: "", className: LirTypeUnknown}
                 }
                 parts.push(lirTypeString(fieldType))
             }
-            lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, "\{ " + strings.join(parts, ", ") + " \}"))
-            return lirAggregateType(typeName)
+            lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, lirBraced(strings.join(parts, ", "))))
+            return LirType {llvm: typeName, className: LirTypeAggregate}
         }
     }
     // Payload-free user enums lower to a bare `i64` discriminant.
@@ -7102,21 +7929,21 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
     for layout in l.mirModule.layouts.enums {
         if lirMirEnumLayoutMatches(layout, name) {
             if lirMirEnumIsPayloadFree(layout) {
-                return lirIntType(64)
+                return LirType {llvm: "i64", className: LirTypeInt}
             }
             let typeName = "%" + if layout.mangled == "" {
                 layout.name
             } else {
                 layout.mangled
             }
-            lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, "\{ i64, i64 \}"))
-            return lirAggregateType(typeName)
+            lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, lirBraced("i64, i64")))
+            return LirType {llvm: typeName, className: LirTypeAggregate}
         }
     }
     if strings.contains(name, "(") {
-        return lirFunctionType(name)
+        return LirType {llvm: name, className: LirTypeFunction}
     }
-    lirTypeInvalid()
+    LirType {llvm: "", className: LirTypeUnknown}
 }
 // Option<T> / Maybe<T> / Result<T, E> all lower to the canonical
 // `{ i64 disc, i64 payload }` aggregate production uses for every
@@ -7393,10 +8220,10 @@ fn lirZeroValue(typ: LirType) -> String {
     "0"
 }
 fn lirCStringEncodeBasic(text: String) -> String {
-    let slash = strings.replaceAll(text, "\\", "\\5C")
-    let quote = strings.replaceAll(slash, "\"", "\\22")
-    let newline = strings.replaceAll(quote, "\n", "\\0A")
-    newline + "\\00"
+    let slash = strings.replaceAll(text, lirBackslash(), lirEsc("5C"))
+    let quote = strings.replaceAll(slash, lirQuote(), lirEsc("22"))
+    let newline = strings.replaceAll(quote, lirLF(), lirEsc("0A"))
+    newline + lirEsc("00")
 }
 // ====================================================================
 // Small local helpers
@@ -7405,33 +8232,16 @@ pub fn lirIntToString(n: Int) -> String {
     if n == 0 {
         return "0"
     }
-    let mut value = n
-    let mut negative = false
-    if value < 0 {
-        negative = true
-        value = -value
+    if n < 0 {
+        return "-" + lirIntToStringPositive(-n)
     }
-    let mut digits: List<Int> = []
-    for _d in 0..40 {
-        if value == 0 {
-            break
-        }
-        digits.push(value % 10)
-        value = value / 10
+    lirIntToStringPositive(n)
+}
+fn lirIntToStringPositive(n: Int) -> String {
+    if n < 10 {
+        return lirDigitChar(n)
     }
-    let mut out = ""
-    if negative {
-        out = "-"
-    }
-    let mut i = digits.len() - 1
-    for _j in 0..digits.len() {
-        if i < 0 {
-            break
-        }
-        out = out + lirDigitChar(digits[i])
-        i = i - 1
-    }
-    out
+    lirIntToStringPositive(n / 10) + lirDigitChar(n % 10)
 }
 fn lirDigitChar(d: Int) -> String {
     if d == 0 {

--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -373,23 +373,18 @@ fn selfhostProbeError() -> String {
     let source = "fn main() -> Int {\n    let x = 41\n    return x + 1\n}\n"
     let hir = hirLowerSource("main", source)
     let mir = mirLowerModule(hir)
-    let mirErrs = mirValidateModule(mir)
+    let checkedMir = mirModuleWithPackageName("main", mir)
+    let mirErrs = mirValidateModule(checkedMir)
     if mirErrs.len() != 0 {
         return "MIR validation failed: " + strings.join(mirErrs, "; ")
     }
     let cfg = lirLowerConfig("main", "<selfhost-doctor>", "")
-    let result = lirLowerMirModule(cfg, mir)
+    let result = lirLowerMirModule(cfg, checkedMir)
     if !lirLowerOK(result) {
-        let mut rendered: List<String> = []
-        for d in result.diagnostics {
-            if d.severity == LirSeverityError {
-                rendered.push(lirDiagnosticRender(d))
-            }
+        if result.diagnostics.len() != 0 {
+            return lirDiagnosticRender(result.diagnostics[0])
         }
-        if rendered.len() == 0 {
-            return "LIR Proto lowering failed without an error diagnostic"
-        }
-        return strings.join(rendered, "; ")
+        return "LIR Proto lowering failed without an error diagnostic"
     }
     let irText = lirRenderModule(result.module)
     if irText == "" {
@@ -516,7 +511,8 @@ fn runCompile(args: List<String>) -> Int {
     }
     let hir = hirLowerSource("main", source)
     let mir = mirLowerModule(hir)
-    let mirErrs = mirValidateModule(mir)
+    let checkedMir = mirModuleWithPackageName("main", mir)
+    let mirErrs = mirValidateModule(checkedMir)
     if mirErrs.len() != 0 {
         eprint("osty-self compile: MIR validation failed:\n")
         for e in mirErrs {
@@ -571,7 +567,8 @@ fn runLirProtoLower(args: List<String>) -> Int {
     }
     let hir = hirLowerSource(packageName, source)
     let mir = mirLowerModule(hir)
-    let mirErrs = mirValidateModule(mir)
+    let checkedMir = mirModuleWithPackageName(packageName, mir)
+    let mirErrs = mirValidateModule(checkedMir)
     if mirErrs.len() != 0 {
         eprint("osty-self lir-proto-lower: MIR validation failed:\n")
         for e in mirErrs {
@@ -580,7 +577,7 @@ fn runLirProtoLower(args: List<String>) -> Int {
         return 1
     }
     let cfg = lirLowerConfig(packageName, path, target)
-    let result = lirLowerMirModule(cfg, mir)
+    let result = lirLowerMirModule(cfg, checkedMir)
     if !lirLowerOK(result) {
         for d in result.diagnostics {
             if d.severity == LirSeverityError {
@@ -628,10 +625,8 @@ fn runLirProtoLowerMirJson(args: List<String>) -> Int {
             return 1
         },
     }
-    if mir.packageName == "" {
-        mir.packageName = packageName
-    }
-    let mirErrs = mirValidateModule(mir)
+    let checkedMir = mirModuleWithPackageName(packageName, mir)
+    let mirErrs = mirValidateModule(checkedMir)
     if mirErrs.len() != 0 {
         eprint("osty-self lir-proto-lower-mir-json: MIR validation failed:\n")
         for e in mirErrs {
@@ -640,7 +635,7 @@ fn runLirProtoLowerMirJson(args: List<String>) -> Int {
         return 1
     }
     let cfg = lirLowerConfig(packageName, path, target)
-    let result = lirLowerMirModule(cfg, mir)
+    let result = lirLowerMirModule(cfg, checkedMir)
     if !lirLowerOK(result) {
         for d in result.diagnostics {
             if d.severity == LirSeverityError {

--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -486,7 +486,8 @@ pub struct MirPlace {
     pub projections: List<MirProjection>,
 }
 pub fn mirPlace(local: Int) -> MirPlace {
-    MirPlace {local, projections: []}
+    let projections: List<MirProjection> = []
+    MirPlace {local, projections}
 }
 /// mirPlaceProject returns a new Place extending `p` with `proj`.
 pub fn mirPlaceProject(p: MirPlace, proj: MirProjection) -> MirPlace {
@@ -574,7 +575,8 @@ pub struct MirRValue {
 // Cast
 // GlobalRef / Nullary
 pub fn mirRValueInvalid() -> MirRValue {
-    MirRValue {kind: MirRVInvalid, typ: "", unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields: [], aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVInvalid, typ: "", unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVUse(op: MirOperand) -> MirRValue {
     let mut rv = mirRValueInvalid()
@@ -705,10 +707,12 @@ pub struct MirInstr {
 // Shared args list (Call + Intrinsic)
 // Storage Live/Dead payload
 pub fn mirInstrInvalid() -> MirInstr {
-    MirInstr {kind: MirInstrInvalid, span: mirNoSpan(), dest: mirPlace(-1), hasDest: false, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args: [], storageLocal: -1}
+    let args: List<MirOperand> = []
+    MirInstr {kind: MirInstrInvalid, span: mirNoSpan(), dest: mirPlace(-1), hasDest: false, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args, storageLocal: -1}
 }
 pub fn mirAssignInstr(dest: MirPlace, src: MirRValue, span: MirSpan) -> MirInstr {
-    MirInstr {kind: MirInstrAssign, span, dest, hasDest: true, src, calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args: [], storageLocal: -1}
+    let args: List<MirOperand> = []
+    MirInstr {kind: MirInstrAssign, span, dest, hasDest: true, src, calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args, storageLocal: -1}
 }
 pub fn mirCallInstr(hasDest: Bool, dest: MirPlace, calleeSymbol: String, calleeType: String, args: List<MirOperand>, span: MirSpan) -> MirInstr {
     MirInstr {kind: MirInstrCall, span, dest, hasDest, src: mirRValueInvalid(), calleeKind: MirCalleeFn, calleeSymbol, calleeOperand: mirOperandInvalid(), calleeType, intrinsic: MirIntrinsicInvalid, args, storageLocal: -1}
@@ -720,10 +724,12 @@ pub fn mirIntrinsicInstr(hasDest: Bool, dest: MirPlace, intrinsic: MirIntrinsicK
     MirInstr {kind: MirInstrIntrinsic, span, dest, hasDest, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic, args, storageLocal: -1}
 }
 pub fn mirStorageLiveInstr(local: Int, span: MirSpan) -> MirInstr {
-    MirInstr {kind: MirInstrStorageLive, span, dest: mirPlace(-1), hasDest: false, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args: [], storageLocal: local}
+    let args: List<MirOperand> = []
+    MirInstr {kind: MirInstrStorageLive, span, dest: mirPlace(-1), hasDest: false, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args, storageLocal: local}
 }
 pub fn mirStorageDeadInstr(local: Int, span: MirSpan) -> MirInstr {
-    MirInstr {kind: MirInstrStorageDead, span, dest: mirPlace(-1), hasDest: false, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args: [], storageLocal: local}
+    let args: List<MirOperand> = []
+    MirInstr {kind: MirInstrStorageDead, span, dest: mirPlace(-1), hasDest: false, src: mirRValueInvalid(), calleeKind: MirCalleeNone, calleeSymbol: "", calleeOperand: mirOperandInvalid(), calleeType: "", intrinsic: MirIntrinsicInvalid, args, storageLocal: local}
 }
 // ====================================================================
 // Terminators
@@ -766,29 +772,35 @@ pub struct MirTerm {
 // Loop-back-edge marker: true when this terminator closes one
 // iteration of an enclosing loop (body → header).
 pub fn mirTermInvalid() -> MirTerm {
-    MirTerm {kind: MirTermInvalid, span: mirNoSpan(), target: -1, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: false}
+    let cases: List<MirSwitchCase> = []
+    MirTerm {kind: MirTermInvalid, span: mirNoSpan(), target: -1, thenBlock: -1, elseBlock: -1, cases, cond: mirOperandInvalid(), loopBackEdge: false}
 }
 pub fn mirGotoTerm(target: Int, span: MirSpan) -> MirTerm {
-    MirTerm {kind: MirTermGoto, span, target, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: false}
+    let cases: List<MirSwitchCase> = []
+    MirTerm {kind: MirTermGoto, span, target, thenBlock: -1, elseBlock: -1, cases, cond: mirOperandInvalid(), loopBackEdge: false}
 }
 /// Goto terminator that closes one iteration of an enclosing loop. The
 /// LIR-Proto backend attaches `!llvm.loop` metadata to the resulting
 /// `br label %header` so vectorize / unroll / parallel hints land on
 /// the correct back-edge.
 pub fn mirGotoBackEdgeTerm(target: Int, span: MirSpan) -> MirTerm {
-    MirTerm {kind: MirTermGoto, span, target, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: true}
+    let cases: List<MirSwitchCase> = []
+    MirTerm {kind: MirTermGoto, span, target, thenBlock: -1, elseBlock: -1, cases, cond: mirOperandInvalid(), loopBackEdge: true}
 }
 pub fn mirBranchTerm(cond: MirOperand, thenB: Int, elseB: Int, span: MirSpan) -> MirTerm {
-    MirTerm {kind: MirTermBranch, span, target: -1, thenBlock: thenB, elseBlock: elseB, cases: [], cond, loopBackEdge: false}
+    let cases: List<MirSwitchCase> = []
+    MirTerm {kind: MirTermBranch, span, target: -1, thenBlock: thenB, elseBlock: elseB, cases, cond, loopBackEdge: false}
 }
 pub fn mirSwitchIntTerm(scrutinee: MirOperand, cases: List<MirSwitchCase>, default: Int, span: MirSpan) -> MirTerm {
     MirTerm {kind: MirTermSwitchInt, span, target: default, thenBlock: -1, elseBlock: -1, cases, cond: scrutinee, loopBackEdge: false}
 }
 pub fn mirReturnTerm(span: MirSpan) -> MirTerm {
-    MirTerm {kind: MirTermReturn, span, target: -1, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: false}
+    let cases: List<MirSwitchCase> = []
+    MirTerm {kind: MirTermReturn, span, target: -1, thenBlock: -1, elseBlock: -1, cases, cond: mirOperandInvalid(), loopBackEdge: false}
 }
 pub fn mirUnreachableTerm(span: MirSpan) -> MirTerm {
-    MirTerm {kind: MirTermUnreachable, span, target: -1, thenBlock: -1, elseBlock: -1, cases: [], cond: mirOperandInvalid(), loopBackEdge: false}
+    let cases: List<MirSwitchCase> = []
+    MirTerm {kind: MirTermUnreachable, span, target: -1, thenBlock: -1, elseBlock: -1, cases, cond: mirOperandInvalid(), loopBackEdge: false}
 }
 // ====================================================================
 // Locals, Basic blocks, Functions
@@ -814,6 +826,7 @@ pub struct MirBasicBlock {
     pub instrs: List<MirInstr>,
     pub term: MirTerm,
     pub hasTerm: Bool,
+    pub termKind: MirTermKind,
     pub termTarget: Int,
     pub termThenBlock: Int,
     pub termElseBlock: Int,
@@ -823,7 +836,9 @@ pub struct MirBasicBlock {
     pub span: MirSpan,
 }
 pub fn mirBasicBlock(id: Int, span: MirSpan) -> MirBasicBlock {
-    MirBasicBlock {id, instrs: [], term: mirTermInvalid(), hasTerm: false, termTarget: -1, termThenBlock: -1, termElseBlock: -1, termCases: [], termCond: mirOperandInvalid(), termLoopBackEdge: false, span}
+    let instrs: List<MirInstr> = []
+    let termCases: List<MirSwitchCase> = []
+    MirBasicBlock {id, instrs, term: mirTermInvalid(), hasTerm: false, termKind: MirTermInvalid, termTarget: -1, termThenBlock: -1, termElseBlock: -1, termCases, termCond: mirOperandInvalid(), termLoopBackEdge: false, span}
 }
 pub fn mirBlockAppend(block: MirBasicBlock, instr: MirInstr) {
     block.instrs.push(instr)
@@ -837,6 +852,7 @@ pub fn mirBlockSetTerminator(block: MirBasicBlock, t: MirTerm) {
     block.term.cases = t.cases
     block.term.cond = t.cond
     block.term.loopBackEdge = t.loopBackEdge
+    block.termKind = t.kind
     block.termTarget = t.target
     block.termThenBlock = t.thenBlock
     block.termElseBlock = t.elseBlock
@@ -846,35 +862,39 @@ pub fn mirBlockSetTerminator(block: MirBasicBlock, t: MirTerm) {
     block.hasTerm = true
 }
 pub fn mirBlockSetGotoTerminator(block: MirBasicBlock, target: Int, span: MirSpan, loopBackEdge: Bool) {
+    let cases: List<MirSwitchCase> = []
     block.term.kind = MirTermGoto
     block.term.span = span
     block.term.target = target
     block.term.thenBlock = -1
     block.term.elseBlock = -1
-    block.term.cases = []
+    block.term.cases = cases
     block.term.cond = mirOperandInvalid()
     block.term.loopBackEdge = loopBackEdge
+    block.termKind = MirTermGoto
     block.termTarget = target
     block.termThenBlock = -1
     block.termElseBlock = -1
-    block.termCases = []
+    block.termCases = cases
     block.termCond = mirOperandInvalid()
     block.termLoopBackEdge = loopBackEdge
     block.hasTerm = true
 }
 pub fn mirBlockSetBranchTerminator(block: MirBasicBlock, cond: MirOperand, thenB: Int, elseB: Int, span: MirSpan) {
+    let cases: List<MirSwitchCase> = []
     block.term.kind = MirTermBranch
     block.term.span = span
     block.term.target = -1
     block.term.thenBlock = thenB
     block.term.elseBlock = elseB
-    block.term.cases = []
+    block.term.cases = cases
     block.term.cond = cond
     block.term.loopBackEdge = false
+    block.termKind = MirTermBranch
     block.termTarget = -1
     block.termThenBlock = thenB
     block.termElseBlock = elseB
-    block.termCases = []
+    block.termCases = cases
     block.termCond = cond
     block.termLoopBackEdge = false
     block.hasTerm = true
@@ -888,6 +908,7 @@ pub fn mirBlockSetSwitchIntTerminator(block: MirBasicBlock, scrutinee: MirOperan
     block.term.cases = cases
     block.term.cond = scrutinee
     block.term.loopBackEdge = false
+    block.termKind = MirTermSwitchInt
     block.termTarget = default
     block.termThenBlock = -1
     block.termElseBlock = -1
@@ -970,7 +991,12 @@ pub fn mirInlineModeName(mode: MirInlineMode) -> String {
 }
 // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
 pub fn mirFunction(name: String, returnType: String, span: MirSpan) -> MirFunction {
-    MirFunction {name, params: [], returnType, returnLocal: -1, locals: [], blocks: [], entry: 0, isExternal: false, isIntrinsic: false, exported: false, exportSymbol: "", cAbi: false, span, vectorize: false, noVectorize: false, vectorizeWidth: 0, vectorizeScalable: false, vectorizePredicate: false, parallel: false, unroll: false, unrollCount: 0, inlineMode: MirInlineNone, hot: false, cold: false, targetFeatures: [], noaliasAll: false, noaliasParams: [], pure: false}
+    let params: List<Int> = []
+    let locals: List<MirLocal> = []
+    let blocks: List<MirBasicBlock> = []
+    let targetFeatures: List<String> = []
+    let noaliasParams: List<String> = []
+    MirFunction {name, params, returnType, returnLocal: -1, locals, blocks, entry: 0, isExternal: false, isIntrinsic: false, exported: false, exportSymbol: "", cAbi: false, span, vectorize: false, noVectorize: false, vectorizeWidth: 0, vectorizeScalable: false, vectorizePredicate: false, parallel: false, unroll: false, unrollCount: 0, inlineMode: MirInlineNone, hot: false, cold: false, targetFeatures, noaliasAll: false, noaliasParams, pure: false}
 }
 // A5–A13 annotation defaults match HirFnDecl's bare
 // constructor: every flag off, empty targetFeatures list,
@@ -1111,7 +1137,11 @@ pub struct MirLayoutTable {
     pub interfaces: List<MirInterfaceLayout>,
 }
 pub fn mirLayoutTable() -> MirLayoutTable {
-    MirLayoutTable {structs: [], enums: [], tuples: [], interfaces: []}
+    let structs: List<MirStructLayout> = []
+    let enums: List<MirEnumLayout> = []
+    let tuples: List<MirTupleLayout> = []
+    let interfaces: List<MirInterfaceLayout> = []
+    MirLayoutTable {structs, enums, tuples, interfaces}
 }
 /// MirModule is the MIR form of one compilation unit. It is always
 /// monomorphic: no type variable reaches a MIR node.
@@ -1124,7 +1154,13 @@ pub struct MirModule {
     pub span: MirSpan,
 }
 pub fn mirModule(packageName: String) -> MirModule {
-    MirModule {packageName, functions: [], globals: [], uses: [], layouts: mirLayoutTable(), span: mirNoSpan()}
+    let functions: List<MirFunction> = []
+    let globals: List<MirGlobal> = []
+    let uses: List<MirUse> = []
+    MirModule {packageName, functions, globals, uses, layouts: mirLayoutTable(), span: mirNoSpan()}
+}
+pub fn mirModuleWithPackageName(packageName: String, m: MirModule) -> MirModule {
+    MirModule {packageName, functions: m.functions, globals: m.globals, uses: m.uses, layouts: m.layouts, span: m.span}
 }
 pub fn mirModuleLookupFunction(m: MirModule, symbol: String) -> Int {
     let mut i = 0

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -17141,11 +17141,11 @@ fn mirEmitReturnTerminator(m: MirModule, func: MirFunction, block: MirBasicBlock
 fn mirEmitBranchTerminator(m: MirModule, func: MirFunction, block: MirBasicBlock, term: MirTerm) -> String {
     let instrIdx = block.instrs.len()
     let condTmp = "%termcond.b" + mirGenIntToString(block.id) + ".i" + mirGenIntToString(instrIdx)
-    let (prelude, cond) = if mirOperandHasProjections(term.cond) {
-        let pre = mirEmitModuleProjectedReadChain(m, func, block, instrIdx, condTmp, term.cond.place, term.cond.typ)
-        (pre, condTmp)
-    } else {
-        ("", mirEmitFunctionTypedOperandValue(func, block, instrIdx, term.cond, "i1"))
+    let mut prelude = ""
+    let mut cond = mirEmitFunctionTypedOperandValue(func, block, instrIdx, term.cond, "i1")
+    if mirOperandHasProjections(term.cond) {
+        prelude = mirEmitModuleProjectedReadChain(m, func, block, instrIdx, condTmp, term.cond.place, term.cond.typ)
+        cond = condTmp
     }
     let thenLabel = mirEmitBlockTargetLabel(func, term.thenBlock)
     let elseLabel = mirEmitBlockTargetLabel(func, term.elseBlock)
@@ -17185,16 +17185,14 @@ fn mirEmitBlockPhiPrologue(m: MirModule, func: MirFunction, block: MirBasicBlock
     let mut out = ""
     let mut emittedReturn = false
     for loc in func.locals {
-        if loc.mutable {
-            if mirBlockNeedsLocalPhi(func, block, loc.id) {
-                let ty = mirEmitModuleTypeLLVM(m, loc.typ)
-                if ty != "" && ty != "void" {
-                    let line = mirEmitBlockLocalPhiLine(func, block, loc.id, ty)
-                    if line != "" {
-                        out = out + line
-                        if loc.id == func.returnLocal {
-                            emittedReturn = true
-                        }
+        if mirBlockMayNeedLocalPhiAtEntry(block, loc.id) && mirBlockNeedsLocalPhi(func, block, loc.id) {
+            let ty = mirEmitModuleTypeLLVM(m, loc.typ)
+            if ty != "" && ty != "void" {
+                let line = mirEmitBlockLocalPhiLine(func, block, loc.id, ty)
+                if line != "" {
+                    out = out + line
+                    if loc.id == func.returnLocal {
+                        emittedReturn = true
                     }
                 }
             }
@@ -17240,13 +17238,16 @@ fn mirEmitBlockLocalPhiLine(func: MirFunction, block: MirBasicBlock, local: Int,
     ""
 }
 fn mirBlockNeedsLocalPhi(func: MirFunction, block: MirBasicBlock, local: Int) -> Bool {
-    if mirFunctionLocalIsMutable(func, local) == false {
-        return false
-    }
+    return mirBlockShouldEmitEntryPhi(func, block, local)
+}
+fn mirBlockShouldEmitEntryPhi(func: MirFunction, block: MirBasicBlock, local: Int) -> Bool {
     if func.locals[local].typ == "" {
         return false
     }
     if mirBlockHasMultiplePredecessors(func, block.id) == false {
+        return false
+    }
+    if mirBlockMayNeedLocalPhiAtEntry(block, local) == false && local != func.returnLocal {
         return false
     }
     let mut found = ""
@@ -17256,7 +17257,7 @@ fn mirBlockNeedsLocalPhi(func: MirFunction, block: MirBasicBlock, local: Int) ->
     for pred in func.blocks {
         if mirBlockTargets(pred, block.id) {
             count = count + 1
-            let value = mirLocalIncomingValueForPhi(func, pred, local, 0)
+            let value = mirLocalImmediateIncomingValueForEntryPhi(func, block, pred, local)
             if value == "" {
                 return false
             }
@@ -17269,6 +17270,15 @@ fn mirBlockNeedsLocalPhi(func: MirFunction, block: MirBasicBlock, local: Int) ->
         }
     }
     differs
+}
+fn mirLocalImmediateIncomingValueForEntryPhi(func: MirFunction, block: MirBasicBlock, pred: MirBasicBlock, local: Int) -> String {
+    if mirBlockHasLocalValueAtEnd(pred, local) {
+        return mirEmitBlockLocalValueAtEnd(pred, local)
+    }
+    if pred.id < block.id && mirBlockShouldEmitEntryPhi(func, pred, local) {
+        return mirPhiValueNameForBlock(pred, local)
+    }
+    mirDominatingLocalValueFromPredNoPhi(func, pred.id, local, 1)
 }
 fn mirFunctionLocalIsMutable(func: MirFunction, local: Int) -> Bool {
     if local < 0 {
@@ -17345,6 +17355,76 @@ fn mirInstrDefinesPlainLocal(instr: MirInstr, local: Int) -> Bool {
     }
     false
 }
+fn mirBlockMayNeedLocalPhiAtEntry(block: MirBasicBlock, local: Int) -> Bool {
+    for instr in block.instrs {
+        if mirInstrReadsLocal(instr, local) {
+            return true
+        }
+        if mirInstrDefinesPlainLocal(instr, local) {
+            return false
+        }
+    }
+    mirTermReadsLocal(block.term, local)
+}
+fn mirInstrReadsLocal(instr: MirInstr, local: Int) -> Bool {
+    if instr.kind == MirInstrAssign {
+        if mirPlaceHasProjections(instr.dest) && mirPlaceReadsLocal(instr.dest, local) {
+            return true
+        }
+        return mirRValueReadsLocal(instr.src, local)
+    }
+    if instr.kind == MirInstrCall || instr.kind == MirInstrIntrinsic {
+        if instr.calleeKind == MirCalleeIndirect && mirOperandReadsLocal(instr.calleeOperand, local) {
+            return true
+        }
+        for arg in instr.args {
+            if mirOperandReadsLocal(arg, local) {
+                return true
+            }
+        }
+        if instr.hasDest && mirPlaceHasProjections(instr.dest) && mirPlaceReadsLocal(instr.dest, local) {
+            return true
+        }
+    }
+    false
+}
+fn mirRValueReadsLocal(rv: MirRValue, local: Int) -> Bool {
+    if mirOperandReadsLocal(rv.arg, local) || mirOperandReadsLocal(rv.right, local) {
+        return true
+    }
+    for field in rv.aggFields {
+        if mirOperandReadsLocal(field, local) {
+            return true
+        }
+    }
+    if rv.hasPlace && mirPlaceReadsLocal(rv.place, local) {
+        return true
+    }
+    false
+}
+fn mirOperandReadsLocal(op: MirOperand, local: Int) -> Bool {
+    if op.kind == MirOpCopy || op.kind == MirOpMove {
+        return mirPlaceReadsLocal(op.place, local)
+    }
+    false
+}
+fn mirPlaceReadsLocal(place: MirPlace, local: Int) -> Bool {
+    if place.local == local {
+        return true
+    }
+    for proj in place.projections {
+        if proj.indexLocal == local {
+            return true
+        }
+    }
+    false
+}
+fn mirTermReadsLocal(term: MirTerm, local: Int) -> Bool {
+    if term.kind == MirTermBranch || term.kind == MirTermSwitchInt {
+        return mirOperandReadsLocal(term.cond, local)
+    }
+    false
+}
 fn mirBlockHasPlainDefinitionBefore(block: MirBasicBlock, instrIdx: Int, local: Int) -> Bool {
     mirBlockPreviousPlainDefinitionIndex(block, instrIdx, local) >= 0
 }
@@ -17411,16 +17491,16 @@ fn mirEmitFunctionLocalValueBefore(func: MirFunction, block: MirBasicBlock, inst
         return mirEmitBlockLocalValueBefore(block, instrIdx, local)
     }
     if block.id != func.entry {
+        if mirBlockNeedsLocalPhi(func, block, local) {
+            return mirPhiValueNameForBlock(block, local)
+        }
         if mirFunctionLocalIsMutable(func, local) {
-            if mirBlockNeedsLocalPhi(func, block, local) {
-                return mirPhiValueNameForBlock(block, local)
-            }
             let predValue = mirDominatingLocalValueFromPred(func, block.id, local, 0)
             if predValue != "" {
                 return predValue
             }
         }
-        let predValue = mirImmediateForwardPredLocalValue(func, block, local)
+        let predValue = mirDominatingLocalValueOrEntryPhiFromPred(func, block.id, local, 0)
         if predValue != "" {
             return predValue
         }
@@ -17446,13 +17526,11 @@ fn mirEmitFunctionLocalAggregateValueBefore(func: MirFunction, block: MirBasicBl
         return mirEmitBlockLocalValueBefore(block, instrIdx, local)
     }
     if block.id != func.entry {
-        if mirFunctionLocalIsMutable(func, local) {
-            if mirBlockNeedsLocalPhi(func, block, local) {
-                return mirPhiValueNameForBlock(block, local)
-            }
+        if mirBlockNeedsLocalPhi(func, block, local) {
+            return mirPhiValueNameForBlock(block, local)
         }
     }
-    let predValue = mirDominatingLocalValueFromPredNoPhi(func, block.id, local, 0)
+    let predValue = mirDominatingLocalValueOrEntryPhiFromPred(func, block.id, local, 0)
     if predValue != "" {
         return predValue
     }
@@ -17931,6 +18009,21 @@ fn mirEmitModuleRValueAggregate(m: MirModule, func: MirFunction, block: MirBasic
         _ -> mirEmitRValueAggregate(dest, rv),
     }
 }
+pub struct MirEmitModuleOperandValue {
+    pub prelude: String,
+    pub value: String,
+}
+fn mirEmitModuleOperandValue(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, tmp: String, op: MirOperand, llvmTy: String, preferPredValue: Bool) -> MirEmitModuleOperandValue {
+    if mirOperandHasProjections(op) {
+        return MirEmitModuleOperandValue {prelude: mirEmitModuleProjectedReadChain(m, func, block, instrIdx, tmp, op.place, op.typ), value: tmp}
+    }
+    let value = if preferPredValue {
+        mirEmitFunctionTypedOperandPredValue(func, block, instrIdx, op, llvmTy)
+    } else {
+        mirEmitFunctionTypedOperandValue(func, block, instrIdx, op, llvmTy)
+    }
+    MirEmitModuleOperandValue {prelude: "", value}
+}
 fn mirEmitAggregateResultTypeText(func: MirFunction, destLocal: Int, rv: MirRValue) -> String {
     if mirLlvmTypeHeadName(rv.typ) == "Result" {
         return rv.typ
@@ -17949,7 +18042,7 @@ fn mirEmitModuleResultAggregate(m: MirModule, func: MirFunction, block: MirBasic
     }
     let payload = rv.aggFields[0]
     let payloadTy = mirEmitModuleOperandLLVMType(m, func, payload)
-    let payloadOp = mirEmitFunctionTypedOperandPredValue(func, block, instrIdx, payload, payloadTy)
+    let payloadValue = mirEmitModuleOperandValue(m, func, block, instrIdx, dest + ".payload", payload, payloadTy, true)
     let disc = if rv.aggKind == MirAggEnumVariant {
         mirGenIntToString(rv.aggVariantIdx)
     } else {
@@ -17959,7 +18052,8 @@ fn mirEmitModuleResultAggregate(m: MirModule, func: MirFunction, block: MirBasic
     let step = dest + ".r0"
     let widened = dest + ".r1"
     let mut out = "  " + step + " = insertvalue " + aggTy + " undef, i64 " + disc + ", 0\n"
-    out = out + mirEmitWidenPayloadLine(widened, payloadTy, payloadOp)
+    out = out + payloadValue.prelude
+    out = out + mirEmitWidenPayloadLine(widened, payloadTy, payloadValue.value)
     out + "  " + dest + " = insertvalue " + aggTy + " " + step + ", i64 " + widened + ", 1\n"
 }
 fn mirEmitModuleEnumVariantAggregate(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, dest: String, rv: MirRValue, resultTypeText: String) -> String {
@@ -17979,9 +18073,10 @@ fn mirEmitModuleEnumVariantAggregate(m: MirModule, func: MirFunction, block: Mir
     }
     let payload = rv.aggFields[0]
     let payloadTy = mirEmitModuleOperandLLVMType(m, func, payload)
-    let payloadOp = mirEmitFunctionTypedOperandPredValue(func, block, instrIdx, payload, payloadTy)
+    let payloadValue = mirEmitModuleOperandValue(m, func, block, instrIdx, dest + ".payload", payload, payloadTy, true)
     let widened = dest + ".r1"
-    out = out + mirEmitWidenPayloadLine(widened, payloadTy, payloadOp)
+    out = out + payloadValue.prelude
+    out = out + mirEmitWidenPayloadLine(widened, payloadTy, payloadValue.value)
     out + "  " + dest + " = insertvalue " + aggTy + " " + step + ", i64 " + widened + ", 1\n"
 }
 fn mirInferResultPayloadDiscriminant(m: MirModule, resultTypeText: String, payload: MirOperand) -> String {
@@ -17999,10 +18094,11 @@ fn mirEmitModuleListAggregate(m: MirModule, func: MirFunction, block: MirBasicBl
     let mut i = 0
     for field in rv.aggFields {
         let fieldTy = mirEmitModuleOperandLLVMType(m, func, field)
-        let fieldOp = mirEmitFunctionTypedOperandValue(func, block, instrIdx, field, fieldTy)
+        let base = dest + ".la" + mirGenIntToString(i)
+        let fieldValue = mirEmitModuleOperandValue(m, func, block, instrIdx, base + ".value", field, fieldTy, false)
+        out = out + fieldValue.prelude
         if mirEmitListElementUsesBytesV1(fieldTy) {
-            let base = dest + ".la" + mirGenIntToString(i)
-            out = out + mirEmitListPushBytesV1Line(base, dest, fieldOp, fieldTy)
+            out = out + mirEmitListPushBytesV1Line(base, dest, fieldValue.value, fieldTy)
             i = i + 1
             continue
         }
@@ -18010,7 +18106,7 @@ fn mirEmitModuleListAggregate(m: MirModule, func: MirFunction, block: MirBasicBl
         if pushSym == "" {
             out = out + "  ; TODO list aggregate push for elem type \"" + fieldTy + "\"\n"
         } else {
-            out = out + "  call void @" + pushSym + "(ptr " + dest + ", " + fieldTy + " " + fieldOp + ")\n"
+            out = out + "  call void @" + pushSym + "(ptr " + dest + ", " + fieldTy + " " + fieldValue.value + ")\n"
         }
         i = i + 1
     }
@@ -18033,14 +18129,15 @@ fn mirEmitModuleAggregateInsertValues(m: MirModule, func: MirFunction, block: Mi
     let mut i = 0
     for field in fields {
         let fieldTy = mirEmitModuleOperandLLVMType(m, func, field)
-        let fieldOp = mirEmitFunctionTypedOperandValue(func, block, instrIdx, field, fieldTy)
+        let fieldValue = mirEmitModuleOperandValue(m, func, block, instrIdx, dest + ".f" + mirGenIntToString(i), field, fieldTy, false)
         let target = if i == n - 1 {
             dest
         } else {
             dest + ".t" + mirGenIntToString(i)
         }
+        out = out + fieldValue.prelude
         out = out + "  " + target + " = insertvalue " + tupleTy + " " + prev
-        out = out + ", " + fieldTy + " " + fieldOp + ", " + mirGenIntToString(i) + "\n"
+        out = out + ", " + fieldTy + " " + fieldValue.value + ", " + mirGenIntToString(i) + "\n"
         prev = target
         i = i + 1
     }
@@ -18301,10 +18398,8 @@ fn mirLocalIncomingValueForBlock(func: MirFunction, block: MirBasicBlock, local:
         return mirEmitBlockLocalValueAtEnd(block, local)
     }
     if block.id != func.entry {
-        if mirFunctionLocalIsMutable(func, local) {
-            if mirBlockNeedsLocalPhi(func, block, local) {
-                return mirPhiValueNameForBlock(block, local)
-            }
+        if mirBlockNeedsLocalPhi(func, block, local) {
+            return mirPhiValueNameForBlock(block, local)
         }
     }
     mirDominatingLocalValueFromPred(func, block.id, local, depth + 1)
@@ -18334,6 +18429,26 @@ fn mirDominatingLocalValueFromPredNoPhi(func: MirFunction, blockId: Int, local: 
         return mirEmitBlockLocalValueAtEnd(pred, local)
     }
     mirDominatingLocalValueFromPredNoPhi(func, pred.id, local, depth + 1)
+}
+fn mirDominatingLocalValueOrEntryPhiFromPred(func: MirFunction, blockId: Int, local: Int, depth: Int) -> String {
+    if depth > 32 {
+        return ""
+    }
+    let predIdx = mirUniquePredecessorIndex(func, blockId)
+    if predIdx == -2 {
+        return mirCommonDominatingLocalValueFromPredsNoPhi(func, blockId, local, depth + 1)
+    }
+    if predIdx < 0 || predIdx >= func.blocks.len() {
+        return ""
+    }
+    let pred = func.blocks[predIdx]
+    if mirBlockHasLocalValueAtEnd(pred, local) {
+        return mirEmitBlockLocalValueAtEnd(pred, local)
+    }
+    if pred.id < blockId && mirBlockShouldEmitEntryPhi(func, pred, local) {
+        return mirPhiValueNameForBlock(pred, local)
+    }
+    mirDominatingLocalValueOrEntryPhiFromPred(func, pred.id, local, depth + 1)
 }
 fn mirCommonDominatingLocalValueFromPredsNoPhi(func: MirFunction, blockId: Int, local: Int, depth: Int) -> String {
     if depth > 32 {
@@ -18637,10 +18752,12 @@ fn mirEmitCallInstr(m: MirModule, func: MirFunction, block: MirBasicBlock, instr
     }
     let argPrelude = mirEmitCallArgProjectionPrelude(m, func, block, instrIdx, instr.args)
     let argList = mirEmitCallArgList(m, func, block, instrIdx, instr.args)
-    let (calleePrelude, calleeText) = if instr.calleeKind == MirCalleeIndirect {
-        mirEmitModuleOperandRead(m, func, block, instrIdx, instr.calleeOperand, "ptr", "%callcallee.b" + mirGenIntToString(block.id) + ".i" + mirGenIntToString(instrIdx))
-    } else {
-        ("", "@" + instr.calleeSymbol)
+    let mut calleePrelude = ""
+    let mut calleeText = "@" + instr.calleeSymbol
+    if instr.calleeKind == MirCalleeIndirect {
+        let (readPrelude, readText) = mirEmitModuleOperandRead(m, func, block, instrIdx, instr.calleeOperand, "ptr", "%callcallee.b" + mirGenIntToString(block.id) + ".i" + mirGenIntToString(instrIdx))
+        calleePrelude = readPrelude
+        calleeText = readText
     }
     let prelude = calleePrelude + argPrelude
     if instr.hasDest {
@@ -18650,8 +18767,9 @@ fn mirEmitCallInstr(m: MirModule, func: MirFunction, block: MirBasicBlock, instr
         }
         let defName = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
         if mirPlaceHasProjections(instr.dest) {
-            let tmpDest = defName + ".calltmp"
-            return prelude + mirEmitCallValueLine(tmpDest, retTy, calleeText, argList) + mirEmitStoreIntoProjectedPlace(instr.dest, tmpDest, retTy)
+            let tmpDest = defName + ".calltmp" + mirGenIntToString(instrIdx)
+            let projectedRetTy = mirEmitCallProjectedReturnType(m, instr)
+            return prelude + mirEmitCallValueLine(tmpDest, projectedRetTy, calleeText, argList) + mirEmitStoreIntoProjectedPlace(m, func, block, instrIdx, instr.dest, tmpDest, projectedRetTy)
         }
         return prelude + mirEmitCallValueLine(defName, retTy, calleeText, argList)
     }
@@ -18695,6 +18813,38 @@ fn mirEmitCallReturnType(m: MirModule, func: MirFunction, instr: MirInstr) -> St
         return "ptr"
     }
     "void"
+}
+fn mirEmitCallProjectedReturnType(m: MirModule, instr: MirInstr) -> String {
+    let declared = mirEmitCallDeclaredReturnLLVMType(m, instr.calleeType)
+    if declared != "" && declared != "void" {
+        return declared
+    }
+    mirEmitProjectedPlaceValueLLVMType(m, instr.dest, "ptr")
+}
+fn mirEmitCallDeclaredReturnLLVMType(m: MirModule, calleeType: String) -> String {
+    let retName = mirEmitCallDeclaredReturnTypeName(calleeType)
+    if retName == "" {
+        return ""
+    }
+    mirEmitModuleTypeLLVM(m, retName)
+}
+fn mirEmitCallDeclaredReturnTypeName(calleeType: String) -> String {
+    let arrow = llvmStrings.lastIndexOf(calleeType, "->") ?? -1
+    if arrow < 0 {
+        return ""
+    }
+    llvmStrings.trimSpace(calleeType[(arrow + 2)..calleeType.len()])
+}
+fn mirEmitProjectedPlaceValueLLVMType(m: MirModule, place: MirPlace, fallback: String) -> String {
+    if place.projections.len() == 0 {
+        return fallback
+    }
+    let last = place.projections[place.projections.len() - 1]
+    let known = mirEmitModuleTypeLLVM(m, last.typ)
+    if known != "" {
+        return known
+    }
+    fallback
 }
 fn mirCallArgProjectionName(block: MirBasicBlock, instrIdx: Int, argIdx: Int) -> String {
     "%callarg.b" + mirGenIntToString(block.id) + ".i" + mirGenIntToString(instrIdx) + ".a" + mirGenIntToString(argIdx)
@@ -18807,7 +18957,7 @@ fn mirEmitIntrinsicInstr(m: MirModule, func: MirFunction, block: MirBasicBlock, 
         MirIntrinsicStringNthSegment -> mirEmitStringNthSegmentIntrinsic(block, instrIdx, instr),
         MirIntrinsicListFirst -> mirEmitListEdgeIntrinsic(m, func, block, blockId, instrIdx, instr, true),
         MirIntrinsicListLast -> mirEmitListEdgeIntrinsic(m, func, block, blockId, instrIdx, instr, false),
-        MirIntrinsicListIndexOf -> mirEmitListIndexOfIntrinsic(func, blockId, instrIdx, instr),
+        MirIntrinsicListIndexOf -> mirEmitListIndexOfIntrinsic(m, func, block, blockId, instrIdx, instr),
         MirIntrinsicListSorted -> mirEmitListSortedIntrinsic(func, instr),
         MirIntrinsicListToSet -> mirEmitListToSetIntrinsic(func, instr),
         MirIntrinsicListRemoveAt -> mirEmitListRemoveAtIntrinsic(func, instr),
@@ -18854,7 +19004,7 @@ fn mirEmitIntrinsicInstr(m: MirModule, func: MirFunction, block: MirBasicBlock, 
         MirIntrinsicMapGet -> mirEmitMapGetIntrinsic(m, func, block, instrIdx, instr),
         MirIntrinsicBytesLen -> mirEmitContainerLenIntrinsic(m, func, block, blockId, instrIdx, instr, "osty_rt_bytes_len"),
         MirIntrinsicBytesIsEmpty -> mirEmitBytesIsEmptyIntrinsic(func, instr),
-        MirIntrinsicBytesGet -> mirEmitBytesGetIntrinsic(func, blockId, instrIdx, instr),
+        MirIntrinsicBytesGet -> mirEmitBytesGetIntrinsic(m, func, block, blockId, instrIdx, instr),
         MirIntrinsicBytesContains -> mirEmitBytesContainsIntrinsic(func, instr),
         MirIntrinsicBytesStartsWith -> mirEmitBytesStartsWithIntrinsic(func, instr),
         MirIntrinsicBytesEndsWith -> mirEmitBytesEndsWithIntrinsic(func, instr),
@@ -18882,8 +19032,8 @@ fn mirEmitIntrinsicInstr(m: MirModule, func: MirFunction, block: MirBasicBlock, 
         MirIntrinsicOptionIsNone -> mirEmitAlgebraicPredicateIntrinsic(m, func, block, instrIdx, instr, mirDiscriminantNone()),
         MirIntrinsicResultIsOk -> mirEmitAlgebraicPredicateIntrinsic(m, func, block, instrIdx, instr, mirDiscriminantOk()),
         MirIntrinsicResultIsErr -> mirEmitAlgebraicPredicateIntrinsic(m, func, block, instrIdx, instr, mirDiscriminantErr()),
-        MirIntrinsicOptionUnwrap -> mirEmitAlgebraicUnwrapIntrinsic(func, blockId, instrIdx, instr, mirDiscriminantNone(), "osty_rt_option_unwrap_none"),
-        MirIntrinsicResultUnwrap -> mirEmitAlgebraicUnwrapIntrinsic(func, blockId, instrIdx, instr, mirDiscriminantErr(), "osty_rt_result_unwrap_err"),
+        MirIntrinsicOptionUnwrap -> mirEmitAlgebraicUnwrapIntrinsic(m, func, block, blockId, instrIdx, instr, mirDiscriminantNone(), "osty_rt_option_unwrap_none"),
+        MirIntrinsicResultUnwrap -> mirEmitAlgebraicUnwrapIntrinsic(m, func, block, blockId, instrIdx, instr, mirDiscriminantErr(), "osty_rt_result_unwrap_err"),
         MirIntrinsicOptionUnwrapOr -> mirEmitAlgebraicUnwrapOrIntrinsic(func, blockId, instrIdx, instr, mirDiscriminantSome()),
         MirIntrinsicResultUnwrapOr -> mirEmitAlgebraicUnwrapOrIntrinsic(func, blockId, instrIdx, instr, mirDiscriminantOk()),
         MirIntrinsicRawNull -> mirEmitRawNullIntrinsic(func, instr),
@@ -19188,11 +19338,11 @@ fn mirEmitSwitchTerminator(m: MirModule, func: MirFunction, block: MirBasicBlock
     let instrIdx = block.instrs.len()
     let condTy = mirEmitModuleOperandLLVMType(m, func, term.cond)
     let condTmp = "%switchcond.b" + mirGenIntToString(block.id) + ".i" + mirGenIntToString(instrIdx)
-    let (prelude, condText) = if mirOperandHasProjections(term.cond) {
-        let pre = mirEmitModuleProjectedReadChain(m, func, block, instrIdx, condTmp, term.cond.place, term.cond.typ)
-        (pre, condTmp)
-    } else {
-        ("", mirEmitFunctionTypedOperandValue(func, block, instrIdx, term.cond, condTy))
+    let mut prelude = ""
+    let mut condText = mirEmitFunctionTypedOperandValue(func, block, instrIdx, term.cond, condTy)
+    if mirOperandHasProjections(term.cond) {
+        prelude = mirEmitModuleProjectedReadChain(m, func, block, instrIdx, condTmp, term.cond.place, term.cond.typ)
+        condText = condTmp
     }
     let defaultLabel = mirEmitBlockTargetLabel(func, term.target)
     let mut out = prelude + "  switch " + condTy + " " + condText + ", label %" + defaultLabel + " [\n"
@@ -20020,7 +20170,7 @@ fn mirEmitListGetIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBlock
     if mirPlaceHasProjections(instr.dest) {
         let tmpReg = defName + ".gettmp"
         let mut out = listPrelude + idxPrelude + "  " + tmpReg + " = call " + destLLVM + " @" + getSym + "(ptr " + listText + ", i64 " + idxText + ")\n"
-        out = out + mirEmitStoreIntoProjectedPlace(instr.dest, tmpReg, destLLVM)
+        out = out + mirEmitStoreIntoProjectedPlace(m, func, block, instrIdx, instr.dest, tmpReg, destLLVM)
         return out
     }
     listPrelude + idxPrelude + "  " + defName + " = call " + destLLVM + " @" + getSym + "(ptr " + listText + ", i64 " + idxText + ")\n"
@@ -20042,7 +20192,7 @@ fn mirEmitStringPredicateIntrinsic(m: MirModule, func: MirFunction, block: MirBa
     let (rhsPrelude, rhs) = mirEmitModuleOperandRead(m, func, block, instrIdx, instr.args[1], "ptr", defName + ".a1")
     if mirPlaceHasProjections(instr.dest) {
         let tmpReg = defName + ".predtmp"
-        return lhsPrelude + rhsPrelude + "  " + tmpReg + " = call i1 @" + runtimeSym + "(ptr " + lhs + ", ptr " + rhs + ")\n" + mirEmitStoreIntoProjectedPlace(instr.dest, tmpReg, "i1")
+        return lhsPrelude + rhsPrelude + "  " + tmpReg + " = call i1 @" + runtimeSym + "(ptr " + lhs + ", ptr " + rhs + ")\n" + mirEmitStoreIntoProjectedPlace(m, func, block, instrIdx, instr.dest, tmpReg, "i1")
     }
     lhsPrelude + rhsPrelude + "  " + defName + " = call i1 @" + runtimeSym + "(ptr " + lhs + ", ptr " + rhs + ")\n"
 }
@@ -20691,7 +20841,7 @@ fn mirEmitContainerLenIntrinsic(m: MirModule, func: MirFunction, block: MirBasic
         let tmpReg = mirEmitLocalRegName(instr.dest.local) + ".lentmp"
         let arg = mirEmitOperand(instr.args[0])
         let mut out = "  " + tmpReg + " = call i64 @" + sym + "(ptr " + arg + ")\n"
-        out = out + mirEmitStoreIntoProjectedPlace(instr.dest, tmpReg, "i64")
+        out = out + mirEmitStoreIntoProjectedPlace(m, func, block, instrIdx, instr.dest, tmpReg, "i64")
         return out
     }
     let dest = mirEmitDefinitionLocalName(block, instrIdx, instr.dest.local)
@@ -21039,7 +21189,7 @@ fn mirEmitListEdgeIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBloc
     }
     mirEmitListOptionProbeIntrinsic(m, func, block, blockId, instrIdx, instr, isFirst, false)
 }
-fn mirEmitListIndexOfIntrinsic(func: MirFunction, blockId: Int, instrIdx: Int, instr: MirInstr) -> String {
+fn mirEmitListIndexOfIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBlock, blockId: Int, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO list indexOf intrinsic\n"
     }
@@ -21101,13 +21251,12 @@ fn mirEmitListIndexOfIntrinsic(func: MirFunction, blockId: Int, instrIdx: Int, i
     out = out + mirEmitOptionNoneToSlotLines(base + ".idxmiss", optLLVM, resultSlot)
     out = out + "  br label %" + doneLabel + "\n"
     out = out + mirLabelLine(doneLabel)
-    let loadDest = if mirPlaceHasProjections(instr.dest) {
+    if mirPlaceHasProjections(instr.dest) {
         let tmpReg = mirEmitLocalRegName(instr.dest.local) + ".idxtmp"
         let loadLine = "  " + tmpReg + " = load " + optLLVM + ", ptr " + resultSlot + ", align 8\n"
-        return out + loadLine + mirEmitStoreIntoProjectedPlace(instr.dest, tmpReg, optLLVM)
-    } else {
-        mirEmitLocalRegName(instr.dest.local)
+        return out + loadLine + mirEmitStoreIntoProjectedPlace(m, func, block, instrIdx, instr.dest, tmpReg, optLLVM)
     }
+    let loadDest = mirEmitLocalRegName(instr.dest.local)
     out + "  " + loadDest + " = load " + optLLVM + ", ptr " + resultSlot + ", align 8\n"
 }
 fn mirEmitListOptionProbeIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBlock, blockId: Int, instrIdx: Int, instr: MirInstr, isFirst: Bool, popAfterRead: Bool) -> String {
@@ -21158,13 +21307,12 @@ fn mirEmitListOptionProbeIntrinsic(m: MirModule, func: MirFunction, block: MirBa
     out = out + mirEmitOptionSomeToSlotLines(base + ".some", optLLVM, elemLLVM, elemReg, resultSlot)
     out = out + "  br label %" + doneLabel + "\n"
     out = out + mirLabelLine(doneLabel)
-    let loadDest = if mirPlaceHasProjections(instr.dest) {
+    if mirPlaceHasProjections(instr.dest) {
         let tmpReg = dest + ".probetmp"
         let loadLine = "  " + tmpReg + " = load " + optLLVM + ", ptr " + resultSlot + ", align 8\n"
-        return out + loadLine + mirEmitStoreIntoProjectedPlace(instr.dest, tmpReg, optLLVM)
-    } else {
-        dest
+        return out + loadLine + mirEmitStoreIntoProjectedPlace(m, func, block, instrIdx, instr.dest, tmpReg, optLLVM)
     }
+    let loadDest = dest
     out + "  " + loadDest + " = load " + optLLVM + ", ptr " + resultSlot + ", align 8\n"
 }
 fn mirEmitListSortedIntrinsic(func: MirFunction, instr: MirInstr) -> String {
@@ -21957,7 +22105,7 @@ fn mirEmitBytesIsEmptyIntrinsic(func: MirFunction, instr: MirInstr) -> String {
     let mut out = p0 + "  " + lenReg + " = call i64 @osty_rt_bytes_len(ptr " + arg + ")\n"
     out + "  " + dest + " = icmp eq i64 " + lenReg + ", 0\n"
 }
-fn mirEmitBytesGetIntrinsic(func: MirFunction, blockId: Int, instrIdx: Int, instr: MirInstr) -> String {
+fn mirEmitBytesGetIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBlock, blockId: Int, instrIdx: Int, instr: MirInstr) -> String {
     if instr.args.len() != 2 || instr.hasDest == false {
         return "  ; TODO bytes get\n"
     }
@@ -21991,13 +22139,12 @@ fn mirEmitBytesGetIntrinsic(func: MirFunction, blockId: Int, instrIdx: Int, inst
     out = out + mirEmitOptionNoneToSlotLines(base + ".none", optLLVM, resultSlot)
     out = out + "  br label %" + doneLabel + "\n"
     out = out + mirLabelLine(doneLabel)
-    let loadDest = if mirPlaceHasProjections(instr.dest) {
+    if mirPlaceHasProjections(instr.dest) {
         let tmpReg = mirEmitLocalRegName(instr.dest.local) + ".bytesgettmp"
         let loadLine = "  " + tmpReg + " = load " + optLLVM + ", ptr " + resultSlot + ", align 8\n"
-        return out + loadLine + mirEmitStoreIntoProjectedPlace(instr.dest, tmpReg, optLLVM)
-    } else {
-        mirEmitLocalRegName(instr.dest.local)
+        return out + loadLine + mirEmitStoreIntoProjectedPlace(m, func, block, instrIdx, instr.dest, tmpReg, optLLVM)
     }
+    let loadDest = mirEmitLocalRegName(instr.dest.local)
     out + "  " + loadDest + " = load " + optLLVM + ", ptr " + resultSlot + ", align 8\n"
 }
 fn mirEmitBytesIndexOfIntrinsic(func: MirFunction, instr: MirInstr) -> String {
@@ -22179,7 +22326,7 @@ fn mirEmitModuleAlgebraicOperandLLVMType(m: MirModule, func: MirFunction, op: Mi
     }
     "\{ i64, i64 \}"
 }
-fn mirEmitAlgebraicUnwrapIntrinsic(func: MirFunction, blockId: Int, instrIdx: Int, instr: MirInstr, absentTag: String, abortSym: String) -> String {
+fn mirEmitAlgebraicUnwrapIntrinsic(m: MirModule, func: MirFunction, block: MirBasicBlock, blockId: Int, instrIdx: Int, instr: MirInstr, absentTag: String, abortSym: String) -> String {
     if instr.args.len() != 1 || instr.hasDest == false {
         return "  ; TODO algebraic unwrap intrinsic\n"
     }
@@ -22210,7 +22357,7 @@ fn mirEmitAlgebraicUnwrapIntrinsic(func: MirFunction, blockId: Int, instrIdx: In
         } else {
             mirEmitNarrowPayloadLine(tmpReg, raw, destLLVM)
         }
-        return out + finalLine + mirEmitStoreIntoProjectedPlace(instr.dest, tmpReg, destLLVM)
+        return out + finalLine + mirEmitStoreIntoProjectedPlace(m, func, block, instrIdx, instr.dest, tmpReg, destLLVM)
     }
     let dest = mirEmitLocalRegName(instr.dest.local)
     if destLLVM == "i64" {
@@ -22990,16 +23137,18 @@ fn mirEmitMultiStepDerefWrite(instr: MirInstr) -> String {
 /// / list_set / store patterns as the assign path but takes a register
 /// name and LLVM type instead of an instr.src rvalue.  Used by
 /// call-into-projection and intrinsic-into-projection lowering.
-fn mirEmitStoreIntoProjectedPlace(place: MirPlace, valueReg: String, valueTy: String) -> String {
+fn mirEmitStoreIntoProjectedPlace(m: MirModule, func: MirFunction, block: MirBasicBlock, instrIdx: Int, place: MirPlace, valueReg: String, valueTy: String) -> String {
     let n = place.projections.len()
     if n == 0 {
         return ""
     }
     let baseReg = mirEmitLocalRegName(place.local)
+    let finalTarget = mirProjectionWriteTargetName(block, instrIdx, place.local)
     if n == 1 {
         let proj = place.projections[0]
         if proj.kind == MirProjField || proj.kind == MirProjTuple {
-            return "  " + baseReg + " = insertvalue \{ i64, i64 \} " + baseReg + ", " + valueTy + " " + valueReg + ", " + mirGenIntToString(proj.index) + "\n"
+            let baseTy = mirProjectionBaseLLVMType(m, func, place.local)
+            return "  " + finalTarget + " = insertvalue " + baseTy + " " + baseReg + ", " + valueTy + " " + valueReg + ", " + mirGenIntToString(proj.index) + "\n"
         }
         if proj.kind == MirProjIndex {
             let idxOp = if proj.indexLocal >= 0 {
@@ -23071,6 +23220,16 @@ fn mirEmitStoreIntoProjectedPlace(place: MirPlace, valueReg: String, valueTy: St
     if lastProj.kind != MirProjField && lastProj.kind != MirProjTuple {
         return "  ; TODO multi-step write ending in " + mirProjectionKindName(lastProj.kind) + " into projected place\n"
     }
+    if n == 2 {
+        let firstProj = place.projections[0]
+        let baseTy = mirProjectionBaseLLVMType(m, func, place.local)
+        let midTy = mirEmitModuleProjectionResultLLVM(m, "", firstProj)
+        let midRead = baseReg + ".pr0"
+        let innerWrite = baseReg + ".pw1"
+        let mut out = "  " + midRead + " = extractvalue " + baseTy + " " + baseReg + ", " + mirGenIntToString(firstProj.index) + "\n"
+        out = out + "  " + innerWrite + " = insertvalue " + midTy + " " + midRead + ", " + valueTy + " " + valueReg + ", " + mirGenIntToString(lastProj.index) + "\n"
+        return out + "  " + finalTarget + " = insertvalue " + baseTy + " " + baseReg + ", " + midTy + " " + innerWrite + ", " + mirGenIntToString(firstProj.index) + "\n"
+    }
     let mut out = ""
     let mut prev = baseReg
     let mut i = 0
@@ -23096,7 +23255,7 @@ fn mirEmitStoreIntoProjectedPlace(place: MirPlace, valueReg: String, valueTy: St
             baseReg + ".pr" + mirGenIntToString(j - 1)
         }
         let target = if j == 0 {
-            baseReg
+            finalTarget
         } else {
             baseReg + ".pw" + mirGenIntToString(j)
         }

--- a/toolchain/mir_json.osty
+++ b/toolchain/mir_json.osty
@@ -4,15 +4,113 @@
 // rebuilds the self-host MirModule shape without re-running the frontend.
 use std.strings
 
-pub type MirJsonObject = Map<String, MirJsonValue>
 pub type MirJsonArray = List<MirJsonValue>
 
-fn mirJsonObjectGet(obj: Map<String, MirJsonValue>, key: String) -> Option<MirJsonValue> {
-    obj.get(key)
+pub struct MirJsonEntry {
+    pub keyId: Int,
+    pub key: String,
+    pub value: MirJsonValue,
+}
+
+pub struct MirJsonKeyScan {
+    pub keyId: Int,
+    pub key: String,
+    pub next: Int,
+}
+
+pub struct MirJsonValueScan {
+    pub value: MirJsonValue,
+    pub next: Int,
+}
+
+pub struct MirJsonStringScan {
+    pub value: String,
+    pub next: Int,
+}
+
+fn mirJsonObjectGet(obj: List<MirJsonEntry>, keyId: Int) -> Option<MirJsonValue> {
+    let mut i = 0
+    for i < obj.len() {
+        let entry = obj[i]
+        if entry.keyId == keyId {
+            return Some(entry.value)
+        }
+        i = i + 1
+    }
+    None
+}
+
+fn mirJsonObjectGetNamed(obj: List<MirJsonEntry>, keyId: Int, key: String) -> Option<MirJsonValue> {
+    let mut i = 0
+    for i < obj.len() {
+        let entry = obj[i]
+        if entry.keyId == keyId {
+            return Some(entry.value)
+        }
+        i = i + 1
+    }
+    None
+}
+
+fn mirJsonStringKeyEq(value: String, keyId: Int) -> Bool {
+    let bs = value.bytes()
+    mirJsonBytesKeyId(bs, 0, bs.len()) == keyId
+}
+
+fn mirJsonBytesKeyId(bs: List<Byte>, start: Int, end: Int) -> Int {
+    mirJsonBytesKeyIdFrom(bs, start, end, 1, (end - start) * 1000003)
+}
+
+fn mirJsonBytesKeyIdFrom(bs: List<Byte>, pos: Int, end: Int, weight: Int, hash: Int) -> Int {
+    if pos >= end {
+        return hash
+    }
+    mirJsonBytesKeyIdFrom(
+        bs,
+        pos + 1,
+        end,
+        weight + 1,
+        hash + (bs[pos].toInt() * weight * (weight + 16)),
+    )
+}
+
+fn mirJsonStringKeyId(key: String) -> Int {
+    mirJsonStringKeyIdFrom(key, 0, 1, key.len() * 1000003)
+}
+
+fn mirJsonStringKeyIdFrom(key: String, pos: Int, weight: Int, hash: Int) -> Int {
+    if pos >= key.len() {
+        return hash
+    }
+    mirJsonStringKeyIdFrom(
+        key,
+        pos + 1,
+        weight + 1,
+        hash + (key[pos].toInt() * weight * (weight + 16)),
+    )
+}
+
+fn mirJsonParseKey(bs: List<Byte>, pos: Int, len: Int) -> Result<MirJsonKeyScan, String> {
+    if pos >= len || bs[pos].toInt() != 0x22 {
+        return Err("json: expected string key in object")
+    }
+    let mut i = pos + 1
+    for i < len {
+        let c = bs[i].toInt()
+        if c == 0x22 {
+            let key = mirJsonAsciiSlice(bs, pos + 1, i)
+            return Ok(MirJsonKeyScan {keyId: mirJsonBytesKeyId(bs, pos + 1, i), key, next: i + 1})
+        }
+        if c == 0x5C || c < 0x20 {
+            return Err("json: escaped object keys are outside bootstrap MIR JSON")
+        }
+        i = i + 1
+    }
+    Err("json: unterminated string")
 }
 
 pub enum MirJsonValue {
-    MJObject(MirJsonObject),
+    MJObject(List<MirJsonEntry>),
     MJArray(MirJsonArray),
     MJString(String),
     MJNumber(String),
@@ -27,22 +125,22 @@ fn mirJsonParseValue(text: String) -> Result<MirJsonValue, String> {
     if start >= len {
         return Err("json: unexpected end of input")
     }
-    let (value, pos) = mirJsonParseVal(bs, start, len)?
-    let end = mirJsonSkipWs(bs, pos, len)
+    let scan = mirJsonParseVal(bs, start, len)?
+    let end = mirJsonSkipWs(bs, scan.next, len)
     if end != len {
         return Err("json: unexpected trailing content")
     }
-    Ok(value)
+    Ok(scan.value)
 }
 
-fn mirJsonParseVal(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, Int), String> {
+fn mirJsonParseVal(bs: List<Byte>, pos: Int, len: Int) -> Result<MirJsonValueScan, String> {
     if pos >= len {
         return Err("json: unexpected end of input")
     }
     let c = bs[pos].toInt()
     if c == 0x22 {
-        let (s, next) = mirJsonParseStr(bs, pos, len)?
-        return Ok((MJString(s), next))
+        let s = mirJsonParseStr(bs, pos, len)?
+        return Ok(MirJsonValueScan {value: MJString(s.value), next: s.next})
     }
     if c == 0x7B {
         return mirJsonParseObj(bs, pos, len)
@@ -65,7 +163,7 @@ fn mirJsonParseVal(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, 
     Err("json: unexpected character")
 }
 
-fn mirJsonParseLiteral(bs: List<Byte>, pos: Int, len: Int, word: String, value: MirJsonValue) -> Result<(MirJsonValue, Int), String> {
+fn mirJsonParseLiteral(bs: List<Byte>, pos: Int, len: Int, word: String, value: MirJsonValue) -> Result<MirJsonValueScan, String> {
     let wb = word.bytes()
     let wlen = wb.len()
     if pos + wlen > len {
@@ -78,16 +176,34 @@ fn mirJsonParseLiteral(bs: List<Byte>, pos: Int, len: Int, word: String, value: 
         }
         i = i + 1
     }
-    Ok((value, pos + wlen))
+    Ok(MirJsonValueScan {value, next: pos + wlen})
 }
 
-fn mirJsonParseStr(bs: List<Byte>, pos: Int, len: Int) -> Result<(String, Int), String> {
+fn mirJsonParseStr(bs: List<Byte>, pos: Int, len: Int) -> Result<MirJsonStringScan, String> {
+    let mut i = pos + 1
+    for i < len {
+        let b = bs[i].toInt()
+        if b == 0x22 {
+            return Ok(MirJsonStringScan {value: mirJsonAsciiSlice(bs, pos + 1, i), next: i + 1})
+        }
+        if b == 0x5C {
+            return mirJsonParseStrEscaped(bs, pos, len)
+        }
+        if b < 0x20 {
+            return Err("json: control character in string")
+        }
+        i = i + 1
+    }
+    Err("json: unterminated string")
+}
+
+fn mirJsonParseStrEscaped(bs: List<Byte>, pos: Int, len: Int) -> Result<MirJsonStringScan, String> {
     let mut i = pos + 1
     let mut out = ""
     for i < len {
         let b = bs[i].toInt()
         if b == 0x22 {
-            return Ok((out, i + 1))
+            return Ok(MirJsonStringScan {value: out, next: i + 1})
         }
         if b == 0x5C {
             i = i + 1
@@ -184,22 +300,8 @@ fn mirJsonAppendCodepoint(out: String, cp: Int) -> String {
     if cp == 0x0D {
         return out + "\r"
     }
-    if cp >= 0x20 && cp <= 0x7A {
-        let ascii = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz"
-        let idx = cp - 0x20
-        return out + strings.slice(ascii, idx, idx + 1)
-    }
-    if cp == 0x7B {
-        return out + "\{"
-    }
-    if cp == 0x7C {
-        return out + "|"
-    }
-    if cp == 0x7D {
-        return out + "\}"
-    }
-    if cp == 0x7E {
-        return out + "~"
+    if cp >= 0x20 && cp <= 0x7E {
+        return out + mirJsonAsciiChar(cp)
     }
     if cp == 0x2014 {
         return out + "—"
@@ -216,72 +318,204 @@ fn mirJsonAppendCodepoint(out: String, cp: Int) -> String {
     out
 }
 
-fn mirJsonAsciiSlice(bs: List<Byte>, start: Int, end: Int) -> String {
-    let mut out = ""
-    let mut i = start
-    for i < end {
-        out = mirJsonAppendCodepoint(out, bs[i].toInt())
-        i = i + 1
-    }
-    out
+fn mirJsonAsciiChar(cp: Int) -> String {
+    if cp == 0x20 { return " " }
+    if cp == 0x21 { return "!" }
+    if cp == 0x22 { return "\"" }
+    if cp == 0x23 { return "#" }
+    if cp == 0x24 { return "$" }
+    if cp == 0x25 { return "%" }
+    if cp == 0x26 { return "&" }
+    if cp == 0x27 { return "'" }
+    if cp == 0x28 { return "(" }
+    if cp == 0x29 { return ")" }
+    if cp == 0x2A { return "*" }
+    if cp == 0x2B { return "+" }
+    if cp == 0x2C { return "," }
+    if cp == 0x2D { return "-" }
+    if cp == 0x2E { return "." }
+    if cp == 0x2F { return "/" }
+    if cp == 0x30 { return "0" }
+    if cp == 0x31 { return "1" }
+    if cp == 0x32 { return "2" }
+    if cp == 0x33 { return "3" }
+    if cp == 0x34 { return "4" }
+    if cp == 0x35 { return "5" }
+    if cp == 0x36 { return "6" }
+    if cp == 0x37 { return "7" }
+    if cp == 0x38 { return "8" }
+    if cp == 0x39 { return "9" }
+    if cp == 0x3A { return ":" }
+    if cp == 0x3B { return ";" }
+    if cp == 0x3C { return "<" }
+    if cp == 0x3D { return "=" }
+    if cp == 0x3E { return ">" }
+    if cp == 0x3F { return "?" }
+    if cp == 0x40 { return "@" }
+    if cp == 0x41 { return "A" }
+    if cp == 0x42 { return "B" }
+    if cp == 0x43 { return "C" }
+    if cp == 0x44 { return "D" }
+    if cp == 0x45 { return "E" }
+    if cp == 0x46 { return "F" }
+    if cp == 0x47 { return "G" }
+    if cp == 0x48 { return "H" }
+    if cp == 0x49 { return "I" }
+    if cp == 0x4A { return "J" }
+    if cp == 0x4B { return "K" }
+    if cp == 0x4C { return "L" }
+    if cp == 0x4D { return "M" }
+    if cp == 0x4E { return "N" }
+    if cp == 0x4F { return "O" }
+    if cp == 0x50 { return "P" }
+    if cp == 0x51 { return "Q" }
+    if cp == 0x52 { return "R" }
+    if cp == 0x53 { return "S" }
+    if cp == 0x54 { return "T" }
+    if cp == 0x55 { return "U" }
+    if cp == 0x56 { return "V" }
+    if cp == 0x57 { return "W" }
+    if cp == 0x58 { return "X" }
+    if cp == 0x59 { return "Y" }
+    if cp == 0x5A { return "Z" }
+    if cp == 0x5B { return "[" }
+    if cp == 0x5C { return "\\" }
+    if cp == 0x5D { return "]" }
+    if cp == 0x5E { return "^" }
+    if cp == 0x5F { return "_" }
+    if cp == 0x60 { return "`" }
+    if cp == 0x61 { return "a" }
+    if cp == 0x62 { return "b" }
+    if cp == 0x63 { return "c" }
+    if cp == 0x64 { return "d" }
+    if cp == 0x65 { return "e" }
+    if cp == 0x66 { return "f" }
+    if cp == 0x67 { return "g" }
+    if cp == 0x68 { return "h" }
+    if cp == 0x69 { return "i" }
+    if cp == 0x6A { return "j" }
+    if cp == 0x6B { return "k" }
+    if cp == 0x6C { return "l" }
+    if cp == 0x6D { return "m" }
+    if cp == 0x6E { return "n" }
+    if cp == 0x6F { return "o" }
+    if cp == 0x70 { return "p" }
+    if cp == 0x71 { return "q" }
+    if cp == 0x72 { return "r" }
+    if cp == 0x73 { return "s" }
+    if cp == 0x74 { return "t" }
+    if cp == 0x75 { return "u" }
+    if cp == 0x76 { return "v" }
+    if cp == 0x77 { return "w" }
+    if cp == 0x78 { return "x" }
+    if cp == 0x79 { return "y" }
+    if cp == 0x7A { return "z" }
+    if cp == 0x7B { return "\{" }
+    if cp == 0x7C { return "|" }
+    if cp == 0x7D { return "\}" }
+    if cp == 0x7E { return "~" }
+    ""
 }
 
-fn mirJsonParseNum(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, Int), String> {
-    let mut i = pos
-    if i < len && bs[i].toInt() == 0x2D {
-        i = i + 1
+fn mirJsonAsciiSlice(bs: List<Byte>, start: Int, end: Int) -> String {
+    mirJsonAsciiSliceFrom(bs, start, end, "")
+}
+
+fn mirJsonAsciiSliceFrom(bs: List<Byte>, pos: Int, end: Int, out: String) -> String {
+    if pos >= end {
+        return out
     }
-    if i >= len {
+    mirJsonAsciiSliceFrom(bs, pos + 1, end, mirJsonAppendCodepoint(out, bs[pos].toInt()))
+}
+
+fn mirJsonParseNum(bs: List<Byte>, pos: Int, len: Int) -> Result<MirJsonValueScan, String> {
+    let afterSign = mirJsonNumberSignEnd(bs, pos, len)
+    let afterInt = mirJsonNumberIntEnd(bs, afterSign, len)?
+    let afterFrac = mirJsonNumberFracEnd(bs, afterInt, len)?
+    let end = mirJsonNumberExpEnd(bs, afterFrac, len)?
+    Ok(MirJsonValueScan {value: MJNumber(mirJsonAsciiSlice(bs, pos, end)), next: end})
+}
+
+fn mirJsonNumberSignEnd(bs: List<Byte>, pos: Int, len: Int) -> Int {
+    if pos < len && bs[pos].toInt() == 0x2D {
+        return pos + 1
+    }
+    pos
+}
+
+fn mirJsonNumberIntEnd(bs: List<Byte>, pos: Int, len: Int) -> Result<Int, String> {
+    if pos >= len {
         return Err("json: unexpected end of number")
     }
-    if bs[i].toInt() == 0x30 {
-        i = i + 1
-    } else if bs[i].toInt() >= 0x31 && bs[i].toInt() <= 0x39 {
-        for i < len && bs[i].toInt() >= 0x30 && bs[i].toInt() <= 0x39 {
-            i = i + 1
-        }
-    } else {
-        return Err("json: invalid number")
+    let c = bs[pos].toInt()
+    if c == 0x30 {
+        return Ok(pos + 1)
     }
-    if i < len && bs[i].toInt() == 0x2E {
-        i = i + 1
-        if i >= len || bs[i].toInt() < 0x30 || bs[i].toInt() > 0x39 {
-            return Err("json: invalid number: expected digit after decimal point")
-        }
-        for i < len && bs[i].toInt() >= 0x30 && bs[i].toInt() <= 0x39 {
-            i = i + 1
-        }
+    if c >= 0x31 && c <= 0x39 {
+        return Ok(mirJsonScanDigits(bs, pos + 1, len))
     }
-    if i < len && (bs[i].toInt() == 0x45 || bs[i].toInt() == 0x65) {
-        i = i + 1
-        if i < len && (bs[i].toInt() == 0x2B || bs[i].toInt() == 0x2D) {
-            i = i + 1
-        }
-        if i >= len || bs[i].toInt() < 0x30 || bs[i].toInt() > 0x39 {
-            return Err("json: invalid number: expected digit in exponent")
-        }
-        for i < len && bs[i].toInt() >= 0x30 && bs[i].toInt() <= 0x39 {
-            i = i + 1
-        }
-    }
-    Ok((MJNumber(mirJsonAsciiSlice(bs, pos, i)), i))
+    Err("json: invalid number")
 }
 
-fn mirJsonParseArr(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, Int), String> {
+fn mirJsonNumberFracEnd(bs: List<Byte>, pos: Int, len: Int) -> Result<Int, String> {
+    if pos < len && bs[pos].toInt() == 0x2E {
+        let firstFrac = pos + 1
+        let afterFrac = mirJsonScanDigits(bs, firstFrac, len)
+        if afterFrac == firstFrac {
+            return Err("json: invalid number: expected digit after decimal point")
+        }
+        return Ok(afterFrac)
+    }
+    Ok(pos)
+}
+
+fn mirJsonNumberExpEnd(bs: List<Byte>, pos: Int, len: Int) -> Result<Int, String> {
+    if pos < len && (bs[pos].toInt() == 0x45 || bs[pos].toInt() == 0x65) {
+        let expStart = pos + 1
+        let firstExp = mirJsonNumberExpFirstDigit(bs, expStart, len)
+        let afterExp = mirJsonScanDigits(bs, firstExp, len)
+        if afterExp == firstExp {
+            return Err("json: invalid number: expected digit in exponent")
+        }
+        return Ok(afterExp)
+    }
+    Ok(pos)
+}
+
+fn mirJsonNumberExpFirstDigit(bs: List<Byte>, pos: Int, len: Int) -> Int {
+    if pos < len && (bs[pos].toInt() == 0x2B || bs[pos].toInt() == 0x2D) {
+        return pos + 1
+    }
+    pos
+}
+
+fn mirJsonScanDigits(bs: List<Byte>, pos: Int, len: Int) -> Int {
+    let mut i = pos
+    for i < len {
+        let c = bs[i].toInt()
+        if c < 0x30 || c > 0x39 {
+            return i
+        }
+        i = i + 1
+    }
+    i
+}
+
+fn mirJsonParseArr(bs: List<Byte>, pos: Int, len: Int) -> Result<MirJsonValueScan, String> {
     let mut i = mirJsonSkipWs(bs, pos + 1, len)
     let mut items: List<MirJsonValue> = []
     if i < len && bs[i].toInt() == 0x5D {
-        return Ok((MJArray(items), i + 1))
+        return Ok(MirJsonValueScan {value: MJArray(items), next: i + 1})
     }
     for i < len {
-        let (val, next) = mirJsonParseVal(bs, i, len)?
-        items.push(val)
-        i = mirJsonSkipWs(bs, next, len)
+        let scan = mirJsonParseVal(bs, i, len)?
+        items.push(scan.value)
+        i = mirJsonSkipWs(bs, scan.next, len)
         if i >= len {
             return Err("json: unterminated array")
         }
         if bs[i].toInt() == 0x5D {
-            return Ok((MJArray(items), i + 1))
+            return Ok(MirJsonValueScan {value: MJArray(items), next: i + 1})
         }
         if bs[i].toInt() != 0x2C {
             return Err("json: expected ',' or ']' in array")
@@ -291,30 +525,30 @@ fn mirJsonParseArr(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, 
     Err("json: unterminated array")
 }
 
-fn mirJsonParseObj(bs: List<Byte>, pos: Int, len: Int) -> Result<(MirJsonValue, Int), String> {
+fn mirJsonParseObj(bs: List<Byte>, pos: Int, len: Int) -> Result<MirJsonValueScan, String> {
     let mut i = mirJsonSkipWs(bs, pos + 1, len)
-    let mut entries: Map<String, MirJsonValue> = {:}
+    let mut entries: List<MirJsonEntry> = []
     if i < len && bs[i].toInt() == 0x7D {
-        return Ok((MJObject(entries), i + 1))
+        return Ok(MirJsonValueScan {value: MJObject(entries), next: i + 1})
     }
     for i < len {
         if bs[i].toInt() != 0x22 {
             return Err("json: expected string key in object")
         }
-        let (key, afterKey) = mirJsonParseStr(bs, i, len)?
-        i = mirJsonSkipWs(bs, afterKey, len)
+        let keyScan = mirJsonParseKey(bs, i, len)?
+        i = mirJsonSkipWs(bs, keyScan.next, len)
         if i >= len || bs[i].toInt() != 0x3A {
             return Err("json: expected ':' after object key")
         }
         i = mirJsonSkipWs(bs, i + 1, len)
-        let (val, afterVal) = mirJsonParseVal(bs, i, len)?
-        entries.insert(key, val)
-        i = mirJsonSkipWs(bs, afterVal, len)
+        let valScan = mirJsonParseVal(bs, i, len)?
+        entries.push(MirJsonEntry {keyId: keyScan.keyId, key: keyScan.key, value: valScan.value})
+        i = mirJsonSkipWs(bs, valScan.next, len)
         if i >= len {
             return Err("json: unterminated object")
         }
         if bs[i].toInt() == 0x7D {
-            return Ok((MJObject(entries), i + 1))
+            return Ok(MirJsonValueScan {value: MJObject(entries), next: i + 1})
         }
         if bs[i].toInt() != 0x2C {
             return Err("json: expected ',' or '}' in object")
@@ -338,16 +572,21 @@ fn mirJsonSkipWs(bs: List<Byte>, pos: Int, len: Int) -> Int {
 
 fn mirJsonIsNull(value: MirJsonValue) -> Bool {
     match value {
+        MJObject(_) -> false,
+        MJArray(_) -> false,
+        MJString(_) -> false,
+        MJNumber(_) -> false,
+        MJBool(_) -> false,
         MJNull -> true,
-        _ -> false,
     }
 }
 
 fn mirJsonEmptyObject() -> MirJsonValue {
-    MJObject({:})
+    let entries: List<MirJsonEntry> = []
+    MJObject(entries)
 }
 
-fn mirJsonAsObject(value: MirJsonValue) -> Result<MirJsonObject, String> {
+fn mirJsonAsObject(value: MirJsonValue) -> Result<List<MirJsonEntry>, String> {
     match value {
         MJObject(o) -> Ok(o),
         _ -> Err("json: expected object"),
@@ -388,35 +627,34 @@ fn mirJsonParseIntText(text: String, ctx: String) -> Result<Int, String> {
     if len == 0 {
         return Err(mirJsonErr(ctx, "expected integer"))
     }
-    let mut i = 0
-    let mut sign = 1
     if bs[0].toInt() == 0x2D {
-        sign = -1
-        i = 1
-    }
-    if i >= len {
-        return Err(mirJsonErr(ctx, "expected integer"))
-    }
-    let mut n = 0
-    for i < len {
-        let c = bs[i].toInt()
-        if c < 0x30 || c > 0x39 {
+        if len == 1 {
             return Err(mirJsonErr(ctx, "expected integer"))
         }
-        n = n * 10 + (c - 0x30)
-        i = i + 1
+        return mirJsonParseIntDigits(bs, 1, len, -1, 0, ctx)
     }
-    Ok(n * sign)
+    mirJsonParseIntDigits(bs, 0, len, 1, 0, ctx)
+}
+
+fn mirJsonParseIntDigits(bs: List<Byte>, pos: Int, len: Int, sign: Int, acc: Int, ctx: String) -> Result<Int, String> {
+    if pos >= len {
+        return Ok(acc * sign)
+    }
+    let c = bs[pos].toInt()
+    if c < 0x30 || c > 0x39 {
+        return Err(mirJsonErr(ctx, "expected integer"))
+    }
+    mirJsonParseIntDigits(bs, pos + 1, len, sign, acc * 10 + (c - 0x30), ctx)
 }
 
 fn mirJsonErr(ctx: String, msg: String) -> String {
-    if ctx == "" {
+    if ctx.len() == 0 {
         return "mir-json: " + msg
     }
     "mir-json: " + ctx + ": " + msg
 }
 
-fn mirJsonObject(value: MirJsonValue, ctx: String) -> Result<MirJsonObject, String> {
+fn mirJsonObject(value: MirJsonValue, ctx: String) -> Result<List<MirJsonEntry>, String> {
     match mirJsonAsObject(value) {
         Ok(o) -> Ok(o),
         Err(_) -> Err(mirJsonErr(ctx, "expected object")),
@@ -451,29 +689,29 @@ fn mirJsonBool(value: MirJsonValue, ctx: String) -> Result<Bool, String> {
     }
 }
 
-fn mirJsonStringField(obj: MirJsonObject, key: String, fallback: String) -> Result<String, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonStringField(obj: List<MirJsonEntry>, keyId: Int, key: String, fallback: String) -> Result<String, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonString(v, key),
         None -> Ok(fallback),
     }
 }
 
-fn mirJsonIntField(obj: MirJsonObject, key: String, fallback: Int) -> Result<Int, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonIntField(obj: List<MirJsonEntry>, keyId: Int, key: String, fallback: Int) -> Result<Int, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonNumber(v, key),
         None -> Ok(fallback),
     }
 }
 
-fn mirJsonBoolField(obj: MirJsonObject, key: String, fallback: Bool) -> Result<Bool, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonBoolField(obj: List<MirJsonEntry>, keyId: Int, key: String, fallback: Bool) -> Result<Bool, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonBool(v, key),
         None -> Ok(fallback),
     }
 }
 
-fn mirJsonNumberTextField(obj: MirJsonObject, key: String, fallback: String) -> Result<String, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonNumberTextField(obj: List<MirJsonEntry>, keyId: Int, key: String, fallback: String) -> Result<String, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> match mirJsonAsNumber(v) {
             Ok(n) -> Ok(n),
             Err(_) -> Err(mirJsonErr(key, "expected number")),
@@ -482,22 +720,25 @@ fn mirJsonNumberTextField(obj: MirJsonObject, key: String, fallback: String) -> 
     }
 }
 
-fn mirJsonArrayField(obj: MirJsonObject, key: String) -> Result<List<MirJsonValue>, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonArrayField(obj: List<MirJsonEntry>, keyId: Int, key: String) -> Result<List<MirJsonValue>, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonArray(v, key),
-        None -> Ok([]),
+        None -> {
+            let empty: List<MirJsonValue> = []
+            Ok(empty)
+        },
     }
 }
 
-fn mirJsonTypeField(obj: MirJsonObject, key: String) -> Result<String, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonTypeField(obj: List<MirJsonEntry>, keyId: Int, key: String) -> Result<String, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonTypeText(v),
         None -> Ok(""),
     }
 }
 
-fn mirJsonSpanField(obj: MirJsonObject, key: String) -> Result<MirSpan, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonSpanField(obj: List<MirJsonEntry>, keyId: Int, key: String) -> Result<MirSpan, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonSpan(v),
         None -> Ok(mirNoSpan()),
     }
@@ -505,10 +746,16 @@ fn mirJsonSpanField(obj: MirJsonObject, key: String) -> Result<MirSpan, String> 
 
 fn mirJsonTypeList(items: List<MirJsonValue>) -> Result<List<String>, String> {
     let mut out: List<String> = []
-    for item in items {
-        out.push(mirJsonTypeText(item)?)
+    return mirJsonTypeListFrom(items, 0, out)
+}
+
+fn mirJsonTypeListFrom(items: List<MirJsonValue>, pos: Int, out: List<String>) -> Result<List<String>, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    Ok(out)
+    let mut next = out
+    next.push(mirJsonTypeText(items[pos])?)
+    return mirJsonTypeListFrom(items, pos + 1, next)
 }
 
 fn mirJsonJoinTypeArgs(args: List<String>) -> String {
@@ -523,48 +770,116 @@ fn mirJsonTypeText(value: MirJsonValue) -> Result<String, String> {
         return Ok("")
     }
     let obj = mirJsonObject(value, "type")?
-    let display = mirJsonStringField(obj, "display", "")?
-    if display != "" {
+    let kind = mirJsonStringField(obj, 4019881, "kind", "")?
+    if mirJsonStringKeyEq(kind, 4020725) {
+        let prim = mirJsonStringField(obj, 4020725, "prim", "")?
+        return Ok(mirJsonCanonicalPrimitiveType(prim))
+    }
+    let display = mirJsonStringField(obj, 7064641, "display", "")?
+    if display.len() != 0 {
         return Ok(display)
     }
-    let kind = mirJsonStringField(obj, "kind", "")?
-    if kind == "prim" {
-        return mirJsonStringField(obj, "prim", "")
-    }
-    if kind == "named" {
-        let name = mirJsonStringField(obj, "name", "")?
-        let args = mirJsonTypeList(mirJsonArrayField(obj, "args")?)?
+    if mirJsonStringKeyEq(kind, 5030170) {
+        let name = mirJsonStringField(obj, 4019667, "name", "")?
+        let args = mirJsonTypeList(mirJsonArrayField(obj, 4020836, "args")?)?
         return Ok(name + mirJsonJoinTypeArgs(args))
     }
-    if kind == "optional" {
-        let innerText = match mirJsonObjectGet(obj, "inner") {
+    if mirJsonStringKeyEq(kind, 8083483) {
+        let innerText = match mirJsonObjectGetNamed(obj, 5032080, "inner") {
             Some(inner) -> mirJsonTypeText(inner)?,
             None -> "",
         }
-        if innerText == "" {
+        if innerText.len() == 0 {
             return Ok("?")
         }
         return Ok(innerText + "?")
     }
-    if kind == "tuple" {
-        let elems = mirJsonTypeList(mirJsonArrayField(obj, "elems")?)?
+    if mirJsonStringKeyEq(kind, 5031828) {
+        let elems = mirJsonTypeList(mirJsonArrayField(obj, 5032172, "elems")?)?
         return Ok("(" + strings.join(elems, ", ") + ")")
     }
-    if kind == "fn" {
-        let params = mirJsonTypeList(mirJsonArrayField(obj, "params")?)?
-        let ret = match mirJsonObjectGet(obj, "return") {
+    if mirJsonStringKeyEq(kind, 2005700) {
+        let params = mirJsonTypeList(mirJsonArrayField(obj, 6046297, "params")?)?
+        let ret = match mirJsonObjectGetNamed(obj, 6048054, "return") {
             Some(v) -> mirJsonTypeText(v)?,
             None -> "()",
         }
         return Ok("fn(" + strings.join(params, ", ") + ") -> " + ret)
     }
-    if kind == "error" {
+    if mirJsonStringKeyEq(kind, 5033184) {
         return Ok("Error")
     }
-    if kind == "typevar" {
-        return mirJsonStringField(obj, "name", "")
+    if mirJsonStringKeyEq(kind, 7064361) {
+        return mirJsonStringField(obj, 4019667, "name", "")
     }
-    Ok(mirJsonStringField(obj, "display", "")?)
+    Ok(mirJsonStringField(obj, 7064641, "display", "")?)
+}
+
+fn mirJsonCanonicalPrimitiveType(name: String) -> String {
+    if mirJsonStringKeyEq(name, 3011822) {
+        return lirPrimitiveNameInt()
+    }
+    if mirJsonStringKeyEq(name, 4016305) {
+        return "Int8"
+    }
+    if mirJsonStringKeyEq(name, 5021418) {
+        return "Int16"
+    }
+    if mirJsonStringKeyEq(name, 5021158) {
+        return "Int32"
+    }
+    if mirJsonStringKeyEq(name, 5021608) {
+        return "Int64"
+    }
+    if mirJsonStringKeyEq(name, 5025518) {
+        return "UInt8"
+    }
+    if mirJsonStringKeyEq(name, 6031914) {
+        return "UInt16"
+    }
+    if mirJsonStringKeyEq(name, 6031596) {
+        return "UInt32"
+    }
+    if mirJsonStringKeyEq(name, 6032175) {
+        return "UInt64"
+    }
+    if mirJsonStringKeyEq(name, 4020182) {
+        return "Byte"
+    }
+    if mirJsonStringKeyEq(name, 4020097) {
+        return "Bool"
+    }
+    if mirJsonStringKeyEq(name, 4019544) {
+        return "Char"
+    }
+    if mirJsonStringKeyEq(name, 5031360) {
+        return "Float"
+    }
+    if mirJsonStringKeyEq(name, 7046148) {
+        return "Float32"
+    }
+    if mirJsonStringKeyEq(name, 7046866) {
+        return "Float64"
+    }
+    if mirJsonStringKeyEq(name, 6045649) {
+        return "String"
+    }
+    if mirJsonStringKeyEq(name, 5032260) {
+        return "Bytes"
+    }
+    if mirJsonStringKeyEq(name, 6045315) {
+        return "RawPtr"
+    }
+    if mirJsonStringKeyEq(name, 4020682) {
+        return "Unit"
+    }
+    if mirJsonStringKeyEq(name, 2002162) {
+        return "()"
+    }
+    if mirJsonStringKeyEq(name, 5031753) {
+        return "Never"
+    }
+    name
 }
 
 fn mirJsonSpan(value: MirJsonValue) -> Result<MirSpan, String> {
@@ -572,101 +887,180 @@ fn mirJsonSpan(value: MirJsonValue) -> Result<MirSpan, String> {
         return Ok(mirNoSpan())
     }
     let obj = mirJsonObject(value, "span")?
-    Ok(mirSpan(mirJsonIntField(obj, "start", 0)?, mirJsonIntField(obj, "end", 0)?))
+    Ok(mirSpan(mirJsonIntField(obj, 5032975, "start", 0)?, mirJsonIntField(obj, 3011386, "end", 0)?))
 }
 
 pub fn mirJsonParseModule(text: String) -> Result<MirModule, String> {
+    let mut m = mirModule("main")
+    mirJsonParseModuleInto(text, m)?
+    Ok(m)
+}
+
+pub fn mirJsonParseModuleInto(text: String, m: MirModule) -> Result<Bool, String> {
     match mirJsonParseValue(text) {
-        Ok(v) -> mirJsonModule(v),
+        Ok(v) -> mirJsonModuleInto(v, m),
         Err(_) -> Err("mir-json: invalid JSON"),
     }
 }
 
 fn mirJsonModule(value: MirJsonValue) -> Result<MirModule, String> {
+    let mut m = mirModule("main")
+    mirJsonModuleInto(value, m)?
+    Ok(m)
+}
+
+fn mirJsonModuleInto(value: MirJsonValue, m: MirModule) -> Result<Bool, String> {
     let obj = mirJsonObject(value, "module")?
-    let version = mirJsonIntField(obj, "version", 1)?
+    let version = mirJsonIntField(obj, 7064748, "version", 1)?
     if version != 0 && version != 1 {
         return Err("mir-json: unsupported version")
     }
-    let mut m = mirModule(mirJsonStringField(obj, "packageName", "main")?)
-    m.span = mirJsonSpanField(obj, "span")?
-    m.layouts = mirJsonLayouts(match mirJsonObjectGet(obj, "layouts") {
+    m.packageName = mirJsonStringField(obj, 11154812, "packageName", "main")?
+    m.span = mirJsonSpanField(obj, 4020328, "span")?
+    m.layouts = mirJsonLayouts(match mirJsonObjectGetNamed(obj, 7067238, "layouts") {
         Some(v) -> v,
         None -> mirJsonEmptyObject(),
     })?
-    for useJson in mirJsonArrayField(obj, "uses")? {
-        m.uses.push(mirJsonUse(useJson)?)
+    let usesOk = mirJsonModuleUses(mirJsonArrayField(obj, 4021098, "uses")?, 0, m)?
+    let functionsOk = mirJsonModuleFunctions(mirJsonArrayField(obj, 9111069, "functions")?, 0, m)?
+    let globalsOk = mirJsonModuleGlobals(mirJsonArrayField(obj, 7062783, "globals")?, 0, m)?
+    if !(usesOk && functionsOk && globalsOk) {
+        return Err("mir-json: module decode failed")
     }
-    for fnJson in mirJsonArrayField(obj, "functions")? {
-        m.functions.push(mirJsonFunction(fnJson)?)
+    Ok(true)
+}
+
+fn mirJsonModuleUses(items: List<MirJsonValue>, pos: Int, m: MirModule) -> Result<Bool, String> {
+    if pos >= items.len() {
+        return Ok(true)
     }
-    for globalJson in mirJsonArrayField(obj, "globals")? {
-        m.globals.push(mirJsonGlobal(globalJson)?)
+    m.uses.push(mirJsonUse(items[pos])?)
+    return mirJsonModuleUses(items, pos + 1, m)
+}
+
+fn mirJsonModuleFunctions(items: List<MirJsonValue>, pos: Int, m: MirModule) -> Result<Bool, String> {
+    if pos >= items.len() {
+        return Ok(true)
     }
-    Ok(m)
+    mirJsonAppendFunction(items[pos], m.functions)?
+    return mirJsonModuleFunctions(items, pos + 1, m)
+}
+
+fn mirJsonModuleGlobals(items: List<MirJsonValue>, pos: Int, m: MirModule) -> Result<Bool, String> {
+    if pos >= items.len() {
+        return Ok(true)
+    }
+    m.globals.push(mirJsonGlobal(items[pos])?)
+    return mirJsonModuleGlobals(items, pos + 1, m)
 }
 
 fn mirJsonUse(value: MirJsonValue) -> Result<MirUse, String> {
     let obj = mirJsonObject(value, "use")?
-    let mut u = mirUse(mirJsonStringField(obj, "rawPath", "")?, mirJsonStringField(obj, "alias", "")?, mirJsonSpanField(obj, "span")?)
-    u.isGoFFI = mirJsonBoolField(obj, "isGoFFI", false)?
-    u.isRuntimeFFI = mirJsonBoolField(obj, "isRuntimeFFI", false)?
-    u.goPath = mirJsonStringField(obj, "goPath", "")?
-    u.runtimePath = mirJsonStringField(obj, "runtimePath", "")?
+    let mut u = mirUse(mirJsonStringField(obj, 7060875, "rawPath", "")?, mirJsonStringField(obj, 5031372, "alias", "")?, mirJsonSpanField(obj, 4020328, "span")?)
+    u.isGoFFI = mirJsonBoolField(obj, 7047216, "isGoFFI", false)?
+    u.isRuntimeFFI = mirJsonBoolField(obj, 12170933, "isRuntimeFFI", false)?
+    u.goPath = mirJsonStringField(obj, 6043993, "goPath", "")?
+    u.runtimePath = mirJsonStringField(obj, 11161640, "runtimePath", "")?
     Ok(u)
 }
 
 fn mirJsonGlobal(value: MirJsonValue) -> Result<MirGlobal, String> {
     let obj = mirJsonObject(value, "global")?
-    let mut g = mirGlobal(mirJsonStringField(obj, "name", "")?, mirJsonTypeField(obj, "type")?, mirJsonBoolField(obj, "mut", false)?, mirJsonSpanField(obj, "span")?)
-    g.hasInit = mirJsonBoolField(obj, "hasInit", false)?
-    g.initSymbol = mirJsonStringField(obj, "initSymbol", "")?
+    let mut g = mirGlobal(mirJsonStringField(obj, 4019667, "name", "")?, mirJsonTypeField(obj, 4020804, "type")?, mirJsonBoolField(obj, 3012686, "mut", false)?, mirJsonSpanField(obj, 4020328, "span")?)
+    g.hasInit = mirJsonBoolField(obj, 7061762, "hasInit", false)?
+    g.initSymbol = mirJsonStringField(obj, 10135147, "initSymbol", "")?
     Ok(g)
 }
 
 fn mirJsonFunction(value: MirJsonValue) -> Result<MirFunction, String> {
+    let functions: List<MirFunction> = []
+    mirJsonAppendFunction(value, functions)?
+    if functions.len() == 0 {
+        return Err("mir-json: function decode failed")
+    }
+    Ok(functions[0])
+}
+
+fn mirJsonAppendFunction(value: MirJsonValue, functions: List<MirFunction>) -> Result<Bool, String> {
     let obj = mirJsonObject(value, "function")?
-    let mut fn_ = mirFunction(mirJsonStringField(obj, "name", "")?, mirJsonTypeField(obj, "returnType")?, mirJsonSpanField(obj, "span")?)
-    fn_.returnLocal = mirJsonIntField(obj, "returnLocal", 0)?
-    fn_.entry = mirJsonIntField(obj, "entry", 0)?
-    fn_.isExternal = mirJsonBoolField(obj, "isExternal", false)?
-    fn_.isIntrinsic = mirJsonBoolField(obj, "isIntrinsic", false)?
-    fn_.exported = mirJsonBoolField(obj, "exported", false)?
-    fn_.exportSymbol = mirJsonStringField(obj, "exportSymbol", "")?
-    fn_.cAbi = mirJsonBoolField(obj, "cAbi", false)?
-    fn_.vectorize = mirJsonBoolField(obj, "vectorize", false)?
-    fn_.noVectorize = mirJsonBoolField(obj, "noVectorize", false)?
-    fn_.vectorizeWidth = mirJsonIntField(obj, "vectorizeWidth", 0)?
-    fn_.vectorizeScalable = mirJsonBoolField(obj, "vectorizeScalable", false)?
-    fn_.vectorizePredicate = mirJsonBoolField(obj, "vectorizePredicate", false)?
-    fn_.parallel = mirJsonBoolField(obj, "parallel", false)?
-    fn_.unroll = mirJsonBoolField(obj, "unroll", false)?
-    fn_.unrollCount = mirJsonIntField(obj, "unrollCount", 0)?
-    fn_.inlineMode = mirJsonInlineMode(mirJsonIntField(obj, "inlineMode", 0)?)
-    fn_.hot = mirJsonBoolField(obj, "hot", false)?
-    fn_.cold = mirJsonBoolField(obj, "cold", false)?
-    fn_.targetFeatures = mirJsonStringList(mirJsonArrayField(obj, "targetFeatures")?)?
-    fn_.noaliasAll = mirJsonBoolField(obj, "noaliasAll", false)?
-    fn_.noaliasParams = mirJsonStringList(mirJsonArrayField(obj, "noaliasParams")?)?
-    fn_.pure = mirJsonBoolField(obj, "pure", false)?
-    for p in mirJsonArrayField(obj, "params")? {
-        fn_.params.push(mirJsonNumber(p, "params")?)
+    return mirJsonAppendFunctionObject(obj, functions)
+}
+
+fn mirJsonAppendFunctionObject(obj: List<MirJsonEntry>, functions: List<MirFunction>) -> Result<Bool, String> {
+    let params: List<Int> = []
+    let locals: List<MirLocal> = []
+    let blocks: List<MirBasicBlock> = []
+    let paramsOk = mirJsonFunctionParamsField(obj, params)?
+    let localsOk = mirJsonFunctionLocalsField(obj, locals)?
+    let blocksOk = mirJsonFunctionBlocksField(obj, blocks)?
+    if !(paramsOk && localsOk && blocksOk) {
+        return Err("mir-json: function decode failed")
     }
-    for localJson in mirJsonArrayField(obj, "locals")? {
-        fn_.locals.push(mirJsonLocal(localJson)?)
+    let fn_ = mirJsonFunctionBuildCore(obj, params, locals, blocks)?
+    functions.push(fn_)
+    Ok(true)
+}
+
+fn mirJsonFunctionBuildCore(obj: List<MirJsonEntry>, params: List<Int>, locals: List<MirLocal>, blocks: List<MirBasicBlock>) -> Result<MirFunction, String> {
+    let name = mirJsonStringField(obj, 4019667, "name", "")?
+    let returnType = mirJsonTypeField(obj, 10136282, "returnType")?
+    let span = mirJsonSpanField(obj, 4020328, "span")?
+    let returnLocal = mirJsonIntField(obj, 11161188, "returnLocal", 0)?
+    let entry = mirJsonIntField(obj, 5034129, "entry", 0)?
+    let targetFeatures: List<String> = []
+    let noaliasParams: List<String> = []
+    let exportSymbol = name
+    Ok(MirFunction {name, params, returnType, returnLocal, locals, blocks, entry, isExternal: false, isIntrinsic: false, exported: false, exportSymbol, cAbi: false, span, vectorize: false, noVectorize: false, vectorizeWidth: 0, vectorizeScalable: false, vectorizePredicate: false, parallel: false, unroll: false, unrollCount: 0, inlineMode: MirInlineNone, hot: false, cold: false, targetFeatures, noaliasAll: false, noaliasParams, pure: false})
+}
+
+fn mirJsonFunctionParamsField(obj: List<MirJsonEntry>, params: List<Int>) -> Result<Bool, String> {
+    return mirJsonFunctionParams(mirJsonArrayField(obj, 6046297, "params")?, 0, params)
+}
+
+fn mirJsonFunctionLocalsField(obj: List<MirJsonEntry>, locals: List<MirLocal>) -> Result<Bool, String> {
+    return mirJsonFunctionLocals(mirJsonArrayField(obj, 6045773, "locals")?, 0, locals)
+}
+
+fn mirJsonFunctionBlocksField(obj: List<MirJsonEntry>, blocks: List<MirBasicBlock>) -> Result<Bool, String> {
+    return mirJsonFunctionBlocks(mirJsonArrayField(obj, 6046234, "blocks")?, 0, blocks)
+}
+
+fn mirJsonFunctionParams(items: List<MirJsonValue>, pos: Int, params: List<Int>) -> Result<Bool, String> {
+    if pos >= items.len() {
+        return Ok(true)
     }
-    for blockJson in mirJsonArrayField(obj, "blocks")? {
-        fn_.blocks.push(mirJsonBlock(blockJson)?)
+    params.push(mirJsonNumber(items[pos], "params")?)
+    return mirJsonFunctionParams(items, pos + 1, params)
+}
+
+fn mirJsonFunctionLocals(items: List<MirJsonValue>, pos: Int, locals: List<MirLocal>) -> Result<Bool, String> {
+    if pos >= items.len() {
+        return Ok(true)
     }
-    Ok(fn_)
+    locals.push(mirJsonLocal(items[pos])?)
+    return mirJsonFunctionLocals(items, pos + 1, locals)
+}
+
+fn mirJsonFunctionBlocks(items: List<MirJsonValue>, pos: Int, blocks: List<MirBasicBlock>) -> Result<Bool, String> {
+    if pos >= items.len() {
+        return Ok(true)
+    }
+    blocks.push(mirJsonBlock(items[pos])?)
+    return mirJsonFunctionBlocks(items, pos + 1, blocks)
 }
 
 fn mirJsonStringList(items: List<MirJsonValue>) -> Result<List<String>, String> {
     let mut out: List<String> = []
-    for item in items {
-        out.push(mirJsonString(item, "string-list")?)
+    return mirJsonStringListFrom(items, 0, out)
+}
+
+fn mirJsonStringListFrom(items: List<MirJsonValue>, pos: Int, out: List<String>) -> Result<List<String>, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    Ok(out)
+    let mut next = out
+    next.push(mirJsonString(items[pos], "string-list")?)
+    return mirJsonStringListFrom(items, pos + 1, next)
 }
 
 fn mirJsonInlineMode(value: Int) -> MirInlineMode {
@@ -684,53 +1078,66 @@ fn mirJsonInlineMode(value: Int) -> MirInlineMode {
 
 fn mirJsonLocal(value: MirJsonValue) -> Result<MirLocal, String> {
     let obj = mirJsonObject(value, "local")?
-    let mut l = mirLocal(mirJsonIntField(obj, "id", 0)?, mirJsonStringField(obj, "name", "")?, mirJsonTypeField(obj, "type")?, mirJsonBoolField(obj, "mut", false)?, mirJsonSpanField(obj, "span")?)
-    l.isParam = mirJsonBoolField(obj, "isParam", false)?
-    l.isReturn = mirJsonBoolField(obj, "isReturn", false)?
+    let mut l = mirLocal(mirJsonIntField(obj, 2005391, "id", 0)?, mirJsonStringField(obj, 4019667, "name", "")?, mirJsonTypeField(obj, 4020804, "type")?, mirJsonBoolField(obj, 3012686, "mut", false)?, mirJsonSpanField(obj, 4020328, "span")?)
+    l.isParam = mirJsonBoolField(obj, 7060589, "isParam", false)?
+    l.isReturn = mirJsonBoolField(obj, 8085801, "isReturn", false)?
     Ok(l)
 }
 
 fn mirJsonBlock(value: MirJsonValue) -> Result<MirBasicBlock, String> {
     let obj = mirJsonObject(value, "block")?
-    let mut b = mirBasicBlock(mirJsonIntField(obj, "id", 0)?, mirJsonSpanField(obj, "span")?)
-    for instrJson in mirJsonArrayField(obj, "instrs")? {
-        b.instrs.push(mirJsonInstr(instrJson)?)
+    let id = mirJsonIntField(obj, 2005391, "id", 0)?
+    let span = mirJsonSpanField(obj, 4020328, "span")?
+    let instrs: List<MirInstr> = []
+    let instrsOk = mirJsonBlockInstrs(mirJsonArrayField(obj, 6048748, "instrs")?, 0, instrs)?
+    if !instrsOk {
+        return Err("mir-json: block decode failed")
     }
-    match mirJsonObjectGet(obj, "term") {
+    match mirJsonObjectGetNamed(obj, 4020838, "term") {
         Some(termJson) -> {
             if !mirJsonIsNull(termJson) {
-                mirBlockSetTerminator(b, mirJsonTerm(termJson)?)
+                let term = mirJsonTerm(termJson)?
+                return Ok(MirBasicBlock {id, instrs, term, hasTerm: true, termKind: term.kind, termTarget: term.target, termThenBlock: term.thenBlock, termElseBlock: term.elseBlock, termCases: term.cases, termCond: term.cond, termLoopBackEdge: term.loopBackEdge, span})
             }
         },
         None -> {
         },
     }
-    Ok(b)
+    let termCases: List<MirSwitchCase> = []
+    return Ok(MirBasicBlock {id, instrs, term: mirTermInvalid(), hasTerm: false, termKind: MirTermInvalid, termTarget: -1, termThenBlock: -1, termElseBlock: -1, termCases, termCond: mirOperandInvalid(), termLoopBackEdge: false, span})
+}
+
+fn mirJsonBlockInstrs(items: List<MirJsonValue>, pos: Int, instrs: List<MirInstr>) -> Result<Bool, String> {
+    if pos >= items.len() {
+        return Ok(true)
+    }
+    instrs.push(mirJsonInstr(items[pos])?)
+    return mirJsonBlockInstrs(items, pos + 1, instrs)
 }
 
 fn mirJsonInstr(value: MirJsonValue) -> Result<MirInstr, String> {
     let obj = mirJsonObject(value, "instr")?
-    let kind = mirJsonStringField(obj, "kind", "")?
-    let span = mirJsonSpanField(obj, "span")?
-    if kind == "assign" {
-        return Ok(mirAssignInstr(mirJsonPlaceRequired(obj, "dest")?, mirJsonRValueRequired(obj, "src")?, span))
+    let kind = mirJsonStringField(obj, 4019881, "kind", "")?
+    let span = mirJsonSpanField(obj, 4020328, "span")?
+    if mirJsonStringKeyEq(kind, 6046097) {
+        return Ok(mirAssignInstr(mirJsonPlaceRequired(obj, 4021183, "dest")?, mirJsonRValueRequired(obj, 3011711, "src")?, span))
     }
-    if kind == "call" {
-        let hasDest = mirJsonObjectGet(obj, "dest").isSome()
-        let dest = if hasDest { mirJsonPlaceRequired(obj, "dest")? } else { mirPlace(-1) }
-        let callee = mirJsonCalleeRequired(obj, "callee")?
-        return Ok(mirCallInstr(hasDest, dest, callee.symbol, callee.typ, mirJsonOperands(mirJsonArrayField(obj, "args")?)?, span))
+    if mirJsonStringKeyEq(kind, 4019983) {
+        let hasDest = mirJsonObjectGetNamed(obj, 4021183, "dest").isSome()
+        let dest = if hasDest { mirJsonPlaceRequired(obj, 4021183, "dest")? } else { mirPlace(-1) }
+        let callee = mirJsonCalleeRequired(obj, 6043926, "callee")?
+        return Ok(mirCallInstr(hasDest, dest, callee.symbol, callee.typ, mirJsonOperands(mirJsonArrayField(obj, 4020836, "args")?)?, span))
     }
-    if kind == "intrinsic" {
-        let hasDest = mirJsonObjectGet(obj, "dest").isSome()
-        let dest = if hasDest { mirJsonPlaceRequired(obj, "dest")? } else { mirPlace(-1) }
-        return Ok(mirIntrinsicInstr(hasDest, dest, mirJsonIntrinsic(mirJsonIntField(obj, "intrinsic", 0)?), mirJsonOperands(mirJsonArrayField(obj, "args")?)?, span))
+    if mirJsonStringKeyEq(kind, 9107999) {
+        let hasDest = mirJsonObjectGetNamed(obj, 4021183, "dest").isSome()
+        let dest = if hasDest { mirJsonPlaceRequired(obj, 4021183, "dest")? } else { mirPlace(-1) }
+        return Ok(mirIntrinsicInstr(hasDest, dest, mirJsonIntrinsic(mirJsonIntField(obj, 9107999, "intrinsic", 0)?), mirJsonOperands(mirJsonArrayField(obj, 4020836, "args")?)?, span))
     }
-    if kind == "storage_live" {
-        return Ok(mirStorageLiveInstr(mirJsonIntField(obj, "storageLocal", -1)?, span))
+    if mirJsonStringKeyEq(kind, 12200478) {
+        return Ok(mirStorageLiveInstr(mirJsonIntField(obj, 12192060, "storageLocal", -1)?, span))
     }
-    if kind == "storage_dead" {
-        return Ok(mirStorageDeadInstr(mirJsonIntField(obj, "storageLocal", -1)?, span))
+    if mirJsonStringKeyEq(kind, 12191065) {
+        return Ok(mirStorageDeadInstr(mirJsonIntField(obj, 12192060, "storageLocal", -1)?, span))
     }
     Err(mirJsonErr("instr", "unknown kind " + kind))
 }
@@ -742,8 +1149,8 @@ struct MirJsonCallee {
     pub operand: MirOperand,
 }
 
-fn mirJsonCalleeRequired(obj: MirJsonObject, key: String) -> Result<MirJsonCallee, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonCalleeRequired(obj: List<MirJsonEntry>, keyId: Int, key: String) -> Result<MirJsonCallee, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonCallee(v),
         None -> Err(mirJsonErr(key, "missing callee")),
     }
@@ -751,49 +1158,56 @@ fn mirJsonCalleeRequired(obj: MirJsonObject, key: String) -> Result<MirJsonCalle
 
 fn mirJsonCallee(value: MirJsonValue) -> Result<MirJsonCallee, String> {
     let obj = mirJsonObject(value, "callee")?
-    let kind = mirJsonStringField(obj, "kind", "")?
-    if kind == "fn" {
-        return Ok(MirJsonCallee {kind, symbol: mirJsonStringField(obj, "symbol", "")?, typ: mirJsonTypeField(obj, "type")?, operand: mirOperandInvalid()})
+    let kind = mirJsonStringField(obj, 4019881, "kind", "")?
+    if mirJsonStringKeyEq(kind, 2005700) {
+        return Ok(MirJsonCallee {kind, symbol: mirJsonStringField(obj, 6046293, "symbol", "")?, typ: mirJsonTypeField(obj, 4020804, "type")?, operand: mirOperandInvalid()})
     }
-    if kind == "indirect" {
-        return Ok(MirJsonCallee {kind, symbol: "", typ: "", operand: mirJsonOperandRequired(obj, "operand")?})
+    if mirJsonStringKeyEq(kind, 8083382) {
+        return Ok(MirJsonCallee {kind, symbol: "", typ: "", operand: mirJsonOperandRequired(obj, 7061622, "operand")?})
     }
     Err(mirJsonErr("callee", "unknown kind " + kind))
 }
 
 fn mirJsonTerm(value: MirJsonValue) -> Result<MirTerm, String> {
     let obj = mirJsonObject(value, "term")?
-    let kind = mirJsonStringField(obj, "kind", "")?
-    let span = mirJsonSpanField(obj, "span")?
-    if kind == "goto" {
-        return Ok(mirGotoTerm(mirJsonIntField(obj, "target", -1)?, span))
+    let kind = mirJsonStringField(obj, 4019881, "kind", "")?
+    let span = mirJsonSpanField(obj, 4020328, "span")?
+    if mirJsonStringKeyEq(kind, 4021251) {
+        return Ok(mirGotoTerm(mirJsonIntField(obj, 6046137, "target", -1)?, span))
     }
-    if kind == "branch" {
-        return Ok(mirBranchTerm(mirJsonOperandRequired(obj, "cond")?, mirJsonIntField(obj, "then", -1)?, mirJsonIntField(obj, "else", -1)?, span))
+    if mirJsonStringKeyEq(kind, 6044240) {
+        return Ok(mirBranchTerm(mirJsonOperandRequired(obj, 4019961, "cond")?, mirJsonIntField(obj, 4020285, "then", -1)?, mirJsonIntField(obj, 4020252, "else", -1)?, span))
     }
-    if kind == "switch_int" {
+    if mirJsonStringKeyEq(kind, 10136022) {
         let mut cases: List<MirSwitchCase> = []
-        for caseJson in mirJsonArrayField(obj, "cases")? {
-            cases.push(mirJsonSwitchCase(caseJson)?)
-        }
-        return Ok(mirSwitchIntTerm(mirJsonOperandRequired(obj, "cond")?, cases, mirJsonIntField(obj, "default", -1)?, span))
+        cases = mirJsonSwitchCases(mirJsonArrayField(obj, 5031900, "cases")?, 0, cases)?
+        return Ok(mirSwitchIntTerm(mirJsonOperandRequired(obj, 4019961, "cond")?, cases, mirJsonIntField(obj, 7064148, "default", -1)?, span))
     }
-    if kind == "return" {
+    if mirJsonStringKeyEq(kind, 6048054) {
         return Ok(mirReturnTerm(span))
     }
-    if kind == "unreachable" {
+    if mirJsonStringKeyEq(kind, 11159308) {
         return Ok(mirUnreachableTerm(span))
     }
     Err(mirJsonErr("term", "unknown kind " + kind))
 }
 
-fn mirJsonSwitchCase(value: MirJsonValue) -> Result<MirSwitchCase, String> {
-    let obj = mirJsonObject(value, "switch-case")?
-    Ok(mirSwitchCase(mirJsonIntField(obj, "value", 0)?, mirJsonIntField(obj, "target", -1)?, mirJsonStringField(obj, "label", "")?))
+fn mirJsonSwitchCases(items: List<MirJsonValue>, pos: Int, cases: List<MirSwitchCase>) -> Result<List<MirSwitchCase>, String> {
+    if pos >= items.len() {
+        return Ok(cases)
+    }
+    let mut next = cases
+    next.push(mirJsonSwitchCase(items[pos])?)
+    return mirJsonSwitchCases(items, pos + 1, next)
 }
 
-fn mirJsonPlaceRequired(obj: MirJsonObject, key: String) -> Result<MirPlace, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonSwitchCase(value: MirJsonValue) -> Result<MirSwitchCase, String> {
+    let obj = mirJsonObject(value, "switch-case")?
+    Ok(mirSwitchCase(mirJsonIntField(obj, 5031634, "value", 0)?, mirJsonIntField(obj, 6046137, "target", -1)?, mirJsonStringField(obj, 5030349, "label", "")?))
+}
+
+fn mirJsonPlaceRequired(obj: List<MirJsonEntry>, keyId: Int, key: String) -> Result<MirPlace, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonPlace(v),
         None -> Err(mirJsonErr(key, "missing place")),
     }
@@ -801,28 +1215,35 @@ fn mirJsonPlaceRequired(obj: MirJsonObject, key: String) -> Result<MirPlace, Str
 
 fn mirJsonPlace(value: MirJsonValue) -> Result<MirPlace, String> {
     let obj = mirJsonObject(value, "place")?
-    let mut p = mirPlace(mirJsonIntField(obj, "local", -1)?)
-    for projJson in mirJsonArrayField(obj, "projections")? {
-        p.projections.push(mirJsonProjection(projJson)?)
+    let projections: List<MirProjection> = []
+    let p = MirPlace {local: mirJsonIntField(obj, 5030590, "local", -1)?, projections}
+    return mirJsonPlaceProjections(mirJsonArrayField(obj, 11171087, "projections")?, 0, p)
+}
+
+fn mirJsonPlaceProjections(items: List<MirJsonValue>, pos: Int, p: MirPlace) -> Result<MirPlace, String> {
+    if pos >= items.len() {
+        return Ok(p)
     }
-    Ok(p)
+    let mut next = p
+    next.projections.push(mirJsonProjection(items[pos])?)
+    return mirJsonPlaceProjections(items, pos + 1, next)
 }
 
 fn mirJsonProjection(value: MirJsonValue) -> Result<MirProjection, String> {
     let obj = mirJsonObject(value, "projection")?
-    let kind = mirJsonStringField(obj, "kind", "")?
-    let typ = mirJsonTypeField(obj, "type")?
-    if kind == "field" {
-        return Ok(mirFieldProj(mirJsonIntField(obj, "index", 0)?, mirJsonStringField(obj, "name", "")?, typ))
+    let kind = mirJsonStringField(obj, 4019881, "kind", "")?
+    let typ = mirJsonTypeField(obj, 4020804, "type")?
+    if mirJsonStringKeyEq(kind, 5030426) {
+        return Ok(mirFieldProj(mirJsonIntField(obj, 5032140, "index", 0)?, mirJsonStringField(obj, 4019667, "name", "")?, typ))
     }
-    if kind == "tuple" {
-        return Ok(mirTupleProj(mirJsonIntField(obj, "index", 0)?, typ))
+    if mirJsonStringKeyEq(kind, 5031828) {
+        return Ok(mirTupleProj(mirJsonIntField(obj, 5032140, "index", 0)?, typ))
     }
-    if kind == "variant" {
-        return Ok(mirVariantProj(mirJsonIntField(obj, "index", 0)?, mirJsonStringField(obj, "name", "")?, mirJsonIntField(obj, "fieldIdx", -1)?, typ))
+    if mirJsonStringKeyEq(kind, 7063798) {
+        return Ok(mirVariantProj(mirJsonIntField(obj, 5032140, "index", 0)?, mirJsonStringField(obj, 4019667, "name", "")?, mirJsonIntField(obj, 8079211, "fieldIdx", -1)?, typ))
     }
-    if kind == "index" {
-        match mirJsonObjectGet(obj, "indexOp") {
+    if mirJsonStringKeyEq(kind, 5032140) {
+        match mirJsonObjectGetNamed(obj, 7060606, "operand") {
             Some(indexJson) -> {
                 let op = mirJsonOperand(indexJson)?
                 if op.kind == MirOpConst && op.const.kind == MirConstInt {
@@ -835,16 +1256,16 @@ fn mirJsonProjection(value: MirJsonValue) -> Result<MirProjection, String> {
             None -> {
             },
         }
-        return Ok(mirIndexProjConst(mirJsonIntField(obj, "index", 0)?, typ))
+        return Ok(mirIndexProjConst(mirJsonIntField(obj, 5032140, "index", 0)?, typ))
     }
-    if kind == "deref" {
+    if mirJsonStringKeyEq(kind, 5030639) {
         return Ok(mirDerefProj(typ))
     }
     Err(mirJsonErr("projection", "unknown kind " + kind))
 }
 
-fn mirJsonOperandRequired(obj: MirJsonObject, key: String) -> Result<MirOperand, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonOperandRequired(obj: List<MirJsonEntry>, keyId: Int, key: String) -> Result<MirOperand, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonOperand(v),
         None -> Err(mirJsonErr(key, "missing operand")),
     }
@@ -852,30 +1273,40 @@ fn mirJsonOperandRequired(obj: MirJsonObject, key: String) -> Result<MirOperand,
 
 fn mirJsonOperands(items: List<MirJsonValue>) -> Result<List<MirOperand>, String> {
     let mut out: List<MirOperand> = []
-    for item in items {
-        out.push(mirJsonOperand(item)?)
+    return mirJsonOperandsFrom(items, 0, out)
+}
+
+fn mirJsonOperandsFrom(items: List<MirJsonValue>, pos: Int, out: List<MirOperand>) -> Result<List<MirOperand>, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    Ok(out)
+    let mut next = out
+    next.push(mirJsonOperand(items[pos])?)
+    return mirJsonOperandsFrom(items, pos + 1, next)
 }
 
 fn mirJsonOperand(value: MirJsonValue) -> Result<MirOperand, String> {
     let obj = mirJsonObject(value, "operand")?
-    let kind = mirJsonStringField(obj, "kind", "")?
-    let typ = mirJsonTypeField(obj, "type")?
-    if kind == "copy" {
-        return Ok(mirOperandCopy(mirJsonPlaceRequired(obj, "place")?, typ))
+    let kind = mirJsonStringField(obj, 4019881, "kind", "")?
+    let typ = mirJsonTypeField(obj, 4020804, "type")?
+    let projections: List<MirProjection> = []
+    let invalidPlace = MirPlace {local: -1, projections}
+    let invalidConst = MirConst {kind: MirConstInvalid, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ: ""}
+    if mirJsonStringKeyEq(kind, 4021755) {
+        return Ok(MirOperand {kind: MirOpCopy, place: mirJsonPlaceRequired(obj, 5029861, "place")?, const: invalidConst, typ})
     }
-    if kind == "move" {
-        return Ok(mirOperandMove(mirJsonPlaceRequired(obj, "place")?, typ))
+    if mirJsonStringKeyEq(kind, 4020667) {
+        return Ok(MirOperand {kind: MirOpMove, place: mirJsonPlaceRequired(obj, 5029861, "place")?, const: invalidConst, typ})
     }
-    if kind == "const" {
-        return Ok(mirOperandConst(mirJsonConstRequired(obj, "const")?))
+    if mirJsonStringKeyEq(kind, 5033344) {
+        let c = mirJsonConstRequired(obj, 5033344, "const")?
+        return Ok(MirOperand {kind: MirOpConst, place: invalidPlace, const: c, typ: c.typ})
     }
     Err(mirJsonErr("operand", "unknown kind " + kind))
 }
 
-fn mirJsonConstRequired(obj: MirJsonObject, key: String) -> Result<MirConst, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonConstRequired(obj: List<MirJsonEntry>, keyId: Int, key: String) -> Result<MirConst, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonConst(v),
         None -> Err(mirJsonErr(key, "missing const")),
     }
@@ -883,40 +1314,40 @@ fn mirJsonConstRequired(obj: MirJsonObject, key: String) -> Result<MirConst, Str
 
 fn mirJsonConst(value: MirJsonValue) -> Result<MirConst, String> {
     let obj = mirJsonObject(value, "const")?
-    let kind = mirJsonStringField(obj, "kind", "")?
-    let typ = mirJsonTypeField(obj, "type")?
-    if kind == "int" {
-        return Ok(mirConstInt(mirJsonIntField(obj, "int", 0)?, typ))
+    let kind = mirJsonStringField(obj, 4019881, "kind", "")?
+    let typ = mirJsonTypeField(obj, 4020804, "type")?
+    if mirJsonStringKeyEq(kind, 3012366) {
+        return Ok(mirConstInt(mirJsonIntField(obj, 3012366, "int", 0)?, typ))
     }
-    if kind == "bool" {
-        return Ok(mirConstBool(mirJsonBoolField(obj, "bool", false)?))
+    if mirJsonStringKeyEq(kind, 4020641) {
+        return Ok(mirConstBool(mirJsonBoolField(obj, 4020641, "bool", false)?))
     }
-    if kind == "float" {
-        return Ok(mirConstFloat(mirJsonNumberTextField(obj, "float", "0")?, typ))
+    if mirJsonStringKeyEq(kind, 5031904) {
+        return Ok(mirConstFloat(mirJsonNumberTextField(obj, 5031904, "float", "0")?, typ))
     }
-    if kind == "string" {
-        return Ok(mirConstString(mirJsonStringField(obj, "string", "")?))
+    if mirJsonStringKeyEq(kind, 6046193) {
+        return Ok(mirConstString(mirJsonStringField(obj, 6046193, "string", "")?))
     }
-    if kind == "char" {
-        return Ok(mirConstChar(mirJsonIntField(obj, "char", 0)?))
+    if mirJsonStringKeyEq(kind, 4020088) {
+        return Ok(mirConstChar(mirJsonIntField(obj, 4020088, "char", 0)?))
     }
-    if kind == "byte" {
-        return Ok(mirConstByte(mirJsonIntField(obj, "byte", 0)?))
+    if mirJsonStringKeyEq(kind, 4020726) {
+        return Ok(mirConstByte(mirJsonIntField(obj, 4020726, "byte", 0)?))
     }
-    if kind == "unit" {
+    if mirJsonStringKeyEq(kind, 4021226) {
         return Ok(mirConstUnit())
     }
-    if kind == "null" {
+    if mirJsonStringKeyEq(kind, 4020890) {
         return Ok(mirConstNull(typ))
     }
-    if kind == "fn" {
-        return Ok(mirConstFn(mirJsonStringField(obj, "symbol", "")?, typ))
+    if mirJsonStringKeyEq(kind, 2005700) {
+        return Ok(mirConstFn(mirJsonStringField(obj, 6046293, "symbol", "")?, typ))
     }
     Err(mirJsonErr("const", "unknown kind " + kind))
 }
 
-fn mirJsonRValueRequired(obj: MirJsonObject, key: String) -> Result<MirRValue, String> {
-    match mirJsonObjectGet(obj, key) {
+fn mirJsonRValueRequired(obj: List<MirJsonEntry>, keyId: Int, key: String) -> Result<MirRValue, String> {
+    match mirJsonObjectGetNamed(obj, keyId, key) {
         Some(v) -> mirJsonRValue(v),
         None -> Err(mirJsonErr(key, "missing rvalue")),
     }
@@ -924,45 +1355,45 @@ fn mirJsonRValueRequired(obj: MirJsonObject, key: String) -> Result<MirRValue, S
 
 fn mirJsonRValue(value: MirJsonValue) -> Result<MirRValue, String> {
     let obj = mirJsonObject(value, "rvalue")?
-    let kind = mirJsonStringField(obj, "kind", "")?
-    if kind == "use" {
-        return Ok(mirRVUse(mirJsonOperandRequired(obj, "op")?))
+    let kind = mirJsonStringField(obj, 4019881, "kind", "")?
+    if mirJsonStringKeyEq(kind, 3011895) {
+        return Ok(mirRVUse(mirJsonOperandRequired(obj, 2005925, "op")?))
     }
-    if kind == "unary" {
-        return Ok(mirRVUnary(mirJsonUnary(mirJsonIntField(obj, "unary", 0)?), mirJsonOperandRequired(obj, "arg")?, mirJsonTypeField(obj, "type")?))
+    if mirJsonStringKeyEq(kind, 5033318) {
+        return Ok(mirRVUnary(mirJsonUnary(mirJsonIntField(obj, 5033318, "unary", 0)?), mirJsonOperandRequired(obj, 3011633, "arg")?, mirJsonTypeField(obj, 4020804, "type")?))
     }
-    if kind == "binary" {
-        return Ok(mirRVBinary(mirJsonBinary(mirJsonIntField(obj, "binary", 0)?), mirJsonOperandRequired(obj, "left")?, mirJsonOperandRequired(obj, "right")?, mirJsonTypeField(obj, "type")?))
+    if mirJsonStringKeyEq(kind, 6047436) {
+        return Ok(mirRVBinary(mirJsonBinary(mirJsonIntField(obj, 6047436, "binary", 0)?), mirJsonOperandRequired(obj, 4020578, "left")?, mirJsonOperandRequired(obj, 5032104, "right")?, mirJsonTypeField(obj, 4020804, "type")?))
     }
-    if kind == "aggregate" {
-        let fields = mirJsonOperands(mirJsonArrayField(obj, "fields")?)?
-        let aggKind = mirJsonAggregate(mirJsonIntField(obj, "aggregateKind", 0)?)
-        let variantTag = mirJsonStringField(obj, "variantTag", "")?
+    if mirJsonStringKeyEq(kind, 9105190) {
+        let fields = mirJsonOperands(mirJsonArrayField(obj, 6045609, "fields")?)?
+        let aggKind = mirJsonAggregate(mirJsonIntField(obj, 13230547, "aggregateKind", 0)?)
+        let variantTag = mirJsonStringField(obj, 10128540, "variantTag", "")?
         if aggKind == MirAggEnumVariant {
-            return Ok(mirRVVariant(mirJsonIntField(obj, "variantIdx", 0)?, variantTag, fields, mirJsonTypeField(obj, "type")?))
+            return Ok(mirRVVariant(mirJsonIntField(obj, 10131523, "variantIdx", 0)?, variantTag, fields, mirJsonTypeField(obj, 4020804, "type")?))
         }
-        return Ok(mirRVAggregate(aggKind, fields, mirJsonTypeField(obj, "type")?))
+        return Ok(mirRVAggregate(aggKind, fields, mirJsonTypeField(obj, 4020804, "type")?))
     }
-    if kind == "discriminant" {
-        return Ok(mirRVDiscriminant(mirJsonPlaceRequired(obj, "place")?, mirJsonTypeField(obj, "type")?))
+    if mirJsonStringKeyEq(kind, 12205146) {
+        return Ok(mirRVDiscriminant(mirJsonPlaceRequired(obj, 5029861, "place")?, mirJsonTypeField(obj, 4020804, "type")?))
     }
-    if kind == "len" {
-        return Ok(mirRVLen(mirJsonPlaceRequired(obj, "place")?, mirJsonTypeField(obj, "type")?))
+    if mirJsonStringKeyEq(kind, 3011751) {
+        return Ok(mirRVLen(mirJsonPlaceRequired(obj, 5029861, "place")?, mirJsonTypeField(obj, 4020804, "type")?))
     }
-    if kind == "cast" {
-        return Ok(mirRVCast(mirJsonCast(mirJsonIntField(obj, "castKind", 0)?), mirJsonOperandRequired(obj, "arg")?, mirJsonTypeField(obj, "from")?, mirJsonTypeField(obj, "to")?))
+    if mirJsonStringKeyEq(kind, 4021022) {
+        return Ok(mirRVCast(mirJsonCast(mirJsonIntField(obj, 8079679, "castKind", 0)?), mirJsonOperandRequired(obj, 3011633, "arg")?, mirJsonTypeField(obj, 4020897, "from")?, mirJsonTypeField(obj, 2005974, "to")?))
     }
-    if kind == "address_of" {
-        return Ok(mirRVAddressOf(mirJsonPlaceRequired(obj, "place")?, mirJsonTypeField(obj, "type")?))
+    if mirJsonStringKeyEq(kind, 10134134) {
+        return Ok(mirRVAddressOf(mirJsonPlaceRequired(obj, 5029861, "place")?, mirJsonTypeField(obj, 4020804, "type")?))
     }
-    if kind == "ref" {
-        return Ok(mirRVRef(mirJsonPlaceRequired(obj, "place")?, mirJsonTypeField(obj, "type")?))
+    if mirJsonStringKeyEq(kind, 3011397) {
+        return Ok(mirRVRef(mirJsonPlaceRequired(obj, 5029861, "place")?, mirJsonTypeField(obj, 4020804, "type")?))
     }
-    if kind == "global_ref" {
-        return Ok(mirRVGlobalRef(mirJsonStringField(obj, "name", "")?, mirJsonTypeField(obj, "type")?))
+    if mirJsonStringKeyEq(kind, 10130705) {
+        return Ok(mirRVGlobalRef(mirJsonStringField(obj, 4019667, "name", "")?, mirJsonTypeField(obj, 4020804, "type")?))
     }
-    if kind == "nullary" {
-        return Ok(mirRVNullary(mirJsonNullary(mirJsonIntField(obj, "nullary", 0)?), mirJsonTypeField(obj, "type")?))
+    if mirJsonStringKeyEq(kind, 7065613) {
+        return Ok(mirRVNullary(mirJsonNullary(mirJsonIntField(obj, 7065613, "nullary", 0)?), mirJsonTypeField(obj, 4020804, "type")?))
     }
     Err(mirJsonErr("rvalue", "unknown kind " + kind))
 }
@@ -973,91 +1404,142 @@ fn mirJsonLayouts(value: MirJsonValue) -> Result<MirLayoutTable, String> {
     }
     let obj = mirJsonObject(value, "layouts")?
     let mut out = mirLayoutTable()
-    for item in mirJsonArrayField(obj, "structs")? {
-        out.structs.push(mirJsonStructLayout(item)?)
+    out = mirJsonLayoutStructs(mirJsonArrayField(obj, 7066232, "structs")?, 0, out)?
+    out = mirJsonLayoutEnums(mirJsonArrayField(obj, 5033156, "enums")?, 0, out)?
+    out = mirJsonLayoutTuples(mirJsonArrayField(obj, 6047011, "tuples")?, 0, out)?
+    return mirJsonLayoutInterfaces(mirJsonArrayField(obj, 10133151, "interfaces")?, 0, out)
+}
+
+fn mirJsonLayoutStructs(items: List<MirJsonValue>, pos: Int, out: MirLayoutTable) -> Result<MirLayoutTable, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    for item in mirJsonArrayField(obj, "enums")? {
-        out.enums.push(mirJsonEnumLayout(item)?)
+    let mut next = out
+    next.structs.push(mirJsonStructLayout(items[pos])?)
+    return mirJsonLayoutStructs(items, pos + 1, next)
+}
+
+fn mirJsonLayoutEnums(items: List<MirJsonValue>, pos: Int, out: MirLayoutTable) -> Result<MirLayoutTable, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    for item in mirJsonArrayField(obj, "tuples")? {
-        out.tuples.push(mirJsonTupleLayout(item)?)
+    let mut next = out
+    next.enums.push(mirJsonEnumLayout(items[pos])?)
+    return mirJsonLayoutEnums(items, pos + 1, next)
+}
+
+fn mirJsonLayoutTuples(items: List<MirJsonValue>, pos: Int, out: MirLayoutTable) -> Result<MirLayoutTable, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    for item in mirJsonArrayField(obj, "interfaces")? {
-        out.interfaces.push(mirJsonInterfaceLayout(item)?)
+    let mut next = out
+    next.tuples.push(mirJsonTupleLayout(items[pos])?)
+    return mirJsonLayoutTuples(items, pos + 1, next)
+}
+
+fn mirJsonLayoutInterfaces(items: List<MirJsonValue>, pos: Int, out: MirLayoutTable) -> Result<MirLayoutTable, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    Ok(out)
+    let mut next = out
+    next.interfaces.push(mirJsonInterfaceLayout(items[pos])?)
+    return mirJsonLayoutInterfaces(items, pos + 1, next)
 }
 
 fn mirJsonFieldLayout(value: MirJsonValue) -> Result<MirFieldLayout, String> {
     let obj = mirJsonObject(value, "layout-field")?
-    Ok(MirFieldLayout {index: mirJsonIntField(obj, "index", 0)?, name: mirJsonStringField(obj, "name", "")?, typ: mirJsonTypeField(obj, "type")?})
+    Ok(MirFieldLayout {index: mirJsonIntField(obj, 5032140, "index", 0)?, name: mirJsonStringField(obj, 4019667, "name", "")?, typ: mirJsonTypeField(obj, 4020804, "type")?})
 }
 
 fn mirJsonFieldLayouts(items: List<MirJsonValue>) -> Result<List<MirFieldLayout>, String> {
     let mut out: List<MirFieldLayout> = []
-    for item in items {
-        out.push(mirJsonFieldLayout(item)?)
+    return mirJsonFieldLayoutsFrom(items, 0, out)
+}
+
+fn mirJsonFieldLayoutsFrom(items: List<MirJsonValue>, pos: Int, out: List<MirFieldLayout>) -> Result<List<MirFieldLayout>, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    Ok(out)
+    let mut next = out
+    next.push(mirJsonFieldLayout(items[pos])?)
+    return mirJsonFieldLayoutsFrom(items, pos + 1, next)
 }
 
 fn mirJsonStructLayout(value: MirJsonValue) -> Result<MirStructLayout, String> {
     let obj = mirJsonObject(value, "struct-layout")?
-    Ok(MirStructLayout {name: mirJsonStringField(obj, "name", "")?, mangled: mirJsonStringField(obj, "mangled", "")?, fields: mirJsonFieldLayouts(mirJsonArrayField(obj, "fields")?)?, size: mirJsonIntField(obj, "size", 0)?, align: mirJsonIntField(obj, "align", 0)?})
+    Ok(MirStructLayout {name: mirJsonStringField(obj, 4019667, "name", "")?, mangled: mirJsonStringField(obj, 7060648, "mangled", "")?, fields: mirJsonFieldLayouts(mirJsonArrayField(obj, 6045609, "fields")?)?, size: mirJsonIntField(obj, 4020781, "size", 0)?, align: mirJsonIntField(obj, 5031327, "align", 0)?})
 }
 
 fn mirJsonVariantLayout(value: MirJsonValue) -> Result<MirVariantLayout, String> {
     let obj = mirJsonObject(value, "variant-layout")?
-    Ok(MirVariantLayout {index: mirJsonIntField(obj, "index", 0)?, name: mirJsonStringField(obj, "name", "")?, payload: mirJsonFieldLayouts(mirJsonArrayField(obj, "payload")?)?})
+    Ok(MirVariantLayout {index: mirJsonIntField(obj, 5032140, "index", 0)?, name: mirJsonStringField(obj, 4019667, "name", "")?, payload: mirJsonFieldLayouts(mirJsonArrayField(obj, 7061513, "payload")?)?})
 }
 
 fn mirJsonVariantLayouts(items: List<MirJsonValue>) -> Result<List<MirVariantLayout>, String> {
     let mut out: List<MirVariantLayout> = []
-    for item in items {
-        out.push(mirJsonVariantLayout(item)?)
+    return mirJsonVariantLayoutsFrom(items, 0, out)
+}
+
+fn mirJsonVariantLayoutsFrom(items: List<MirJsonValue>, pos: Int, out: List<MirVariantLayout>) -> Result<List<MirVariantLayout>, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    Ok(out)
+    let mut next = out
+    next.push(mirJsonVariantLayout(items[pos])?)
+    return mirJsonVariantLayoutsFrom(items, pos + 1, next)
 }
 
 fn mirJsonEnumLayout(value: MirJsonValue) -> Result<MirEnumLayout, String> {
     let obj = mirJsonObject(value, "enum-layout")?
-    Ok(MirEnumLayout {name: mirJsonStringField(obj, "name", "")?, mangled: mirJsonStringField(obj, "mangled", "")?, discriminant: mirJsonTypeField(obj, "discriminant")?, variants: mirJsonVariantLayouts(mirJsonArrayField(obj, "variants")?)?})
+    Ok(MirEnumLayout {name: mirJsonStringField(obj, 4019667, "name", "")?, mangled: mirJsonStringField(obj, 7060648, "mangled", "")?, discriminant: mirJsonTypeField(obj, 12205146, "discriminant")?, variants: mirJsonVariantLayouts(mirJsonArrayField(obj, 8085881, "variants")?)?})
 }
 
 fn mirJsonTupleLayout(value: MirJsonValue) -> Result<MirTupleLayout, String> {
     let obj = mirJsonObject(value, "tuple-layout")?
-    Ok(MirTupleLayout {key: mirJsonStringField(obj, "key", "")?, mangled: mirJsonStringField(obj, "mangled", "")?, fields: mirJsonFieldLayouts(mirJsonArrayField(obj, "fields")?)?})
+    Ok(MirTupleLayout {key: mirJsonStringField(obj, 3012361, "key", "")?, mangled: mirJsonStringField(obj, 7060648, "mangled", "")?, fields: mirJsonFieldLayouts(mirJsonArrayField(obj, 6045609, "fields")?)?})
 }
 
 fn mirJsonInterfaceMethod(value: MirJsonValue) -> Result<MirInterfaceMethod, String> {
     let obj = mirJsonObject(value, "interface-method")?
-    Ok(MirInterfaceMethod {name: mirJsonStringField(obj, "name", "")?, slot: mirJsonIntField(obj, "slot", 0)?})
+    Ok(MirInterfaceMethod {name: mirJsonStringField(obj, 4019667, "name", "")?, slot: mirJsonIntField(obj, 4021462, "slot", 0)?})
 }
 
 fn mirJsonInterfaceMethods(items: List<MirJsonValue>) -> Result<List<MirInterfaceMethod>, String> {
     let mut out: List<MirInterfaceMethod> = []
-    for item in items {
-        out.push(mirJsonInterfaceMethod(item)?)
+    return mirJsonInterfaceMethodsFrom(items, 0, out)
+}
+
+fn mirJsonInterfaceMethodsFrom(items: List<MirJsonValue>, pos: Int, out: List<MirInterfaceMethod>) -> Result<List<MirInterfaceMethod>, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    Ok(out)
+    let mut next = out
+    next.push(mirJsonInterfaceMethod(items[pos])?)
+    return mirJsonInterfaceMethodsFrom(items, pos + 1, next)
 }
 
 fn mirJsonInterfaceImpl(value: MirJsonValue) -> Result<MirInterfaceImpl, String> {
     let obj = mirJsonObject(value, "interface-impl")?
-    Ok(MirInterfaceImpl {implName: mirJsonStringField(obj, "implName", "")?, vtableSym: mirJsonStringField(obj, "vtableSym", "")?})
+    Ok(MirInterfaceImpl {implName: mirJsonStringField(obj, 8078692, "implName", "")?, vtableSym: mirJsonStringField(obj, 9105370, "vtableSym", "")?})
 }
 
 fn mirJsonInterfaceImpls(items: List<MirJsonValue>) -> Result<List<MirInterfaceImpl>, String> {
     let mut out: List<MirInterfaceImpl> = []
-    for item in items {
-        out.push(mirJsonInterfaceImpl(item)?)
+    return mirJsonInterfaceImplsFrom(items, 0, out)
+}
+
+fn mirJsonInterfaceImplsFrom(items: List<MirJsonValue>, pos: Int, out: List<MirInterfaceImpl>) -> Result<List<MirInterfaceImpl>, String> {
+    if pos >= items.len() {
+        return Ok(out)
     }
-    Ok(out)
+    let mut next = out
+    next.push(mirJsonInterfaceImpl(items[pos])?)
+    return mirJsonInterfaceImplsFrom(items, pos + 1, next)
 }
 
 fn mirJsonInterfaceLayout(value: MirJsonValue) -> Result<MirInterfaceLayout, String> {
     let obj = mirJsonObject(value, "interface-layout")?
-    Ok(MirInterfaceLayout {name: mirJsonStringField(obj, "name", "")?, methods: mirJsonInterfaceMethods(mirJsonArrayField(obj, "methods")?)?, impls: mirJsonInterfaceImpls(mirJsonArrayField(obj, "impls")?)?})
+    Ok(MirInterfaceLayout {name: mirJsonStringField(obj, 4019667, "name", "")?, methods: mirJsonInterfaceMethods(mirJsonArrayField(obj, 7063812, "methods")?)?, impls: mirJsonInterfaceImpls(mirJsonArrayField(obj, 5032823, "impls")?)?})
 }
 
 fn mirJsonUnary(value: Int) -> MirUnaryOp {

--- a/toolchain/selfhost_driver.osty
+++ b/toolchain/selfhost_driver.osty
@@ -34,16 +34,10 @@ fn selfhostDriverProbeError() -> String {
     let cfg = lirLowerConfig("main", "<selfhost-doctor>", "")
     let result = lirLowerMirModule(cfg, mir)
     if !lirLowerOK(result) {
-        let mut rendered: List<String> = []
-        for d in result.diagnostics {
-            if d.severity == LirSeverityError {
-                rendered.push(lirDiagnosticRender(d))
-            }
+        if result.diagnostics.len() != 0 {
+            return lirDiagnosticRender(result.diagnostics[0])
         }
-        if rendered.len() == 0 {
-            return "LIR Proto lowering failed without an error diagnostic"
-        }
-        return strings.join(rendered, "; ")
+        return "LIR Proto lowering failed without an error diagnostic"
     }
     let irText = lirRenderModule(result.module)
     if irText == "" {

--- a/toolchain/selfhost_mir_driver.osty
+++ b/toolchain/selfhost_mir_driver.osty
@@ -123,33 +123,28 @@ fn selfhostMirDriverProbeJson() -> String {
 }
 
 fn selfhostMirDriverProbeError() -> String {
-    let mut mir = match mirJsonParseModule(selfhostMirDriverProbeJson()) {
-        Ok(m) -> m,
+    let mut mir = mirModule("main")
+    match mirJsonParseModuleInto(selfhostMirDriverProbeJson(), mir) {
+        Ok(_) -> {
+        },
         Err(e) -> {
             return e
         },
     }
-    if mir.packageName.len() == 0 {
-        mir.packageName = "main"
-    }
-    let mirErrs = mirValidateModule(mir)
+    let checkedMir = mirModuleWithPackageName("main", mir)
+    let mirErrs = mirValidateModule(checkedMir)
     if mirErrs.len() != 0 {
         return "MIR validation failed: " + strings.join(mirErrs, "; ")
     }
-    let result = lirLowerMirModule(lirLowerConfig("main", "<selfhost-mir-doctor>", ""), mir)
-    if !lirLowerOK(result) {
-        let mut rendered: List<String> = []
-        for d in result.diagnostics {
-            if d.severity == LirSeverityError {
-                rendered.push(lirDiagnosticRender(d))
-            }
-        }
-        if rendered.len() == 0 {
-            return "LIR Proto lowering failed without an error diagnostic"
-        }
-        return strings.join(rendered, "; ")
+    let lowerCfg = lirLowerConfig("main", "<selfhost-mir-doctor>", "")
+    let lowerStringPoolEntries: List<LirStringGlobal> = []
+    let lowerOut = lirModuleWithStringPoolEntries("main", "<selfhost-mir-doctor>", "", lowerStringPoolEntries)
+    let lowerDiagnostics: List<LirDiagnostic> = []
+    lirLowerMirModuleListsInto(lowerCfg, lowerStringPoolEntries, "main", checkedMir.functions, checkedMir.globals, checkedMir.uses, checkedMir.layouts, checkedMir.span, lowerOut, lowerDiagnostics)
+    if lowerDiagnostics.len() != 0 {
+        return lirDiagnosticRender(lowerDiagnostics[0])
     }
-    let irText = lirRenderModule(result.module)
+    let irText = lirRenderModule(lowerOut)
     if irText.len() == 0 {
         return "LLVM IR renderer returned empty output"
     }
@@ -215,17 +210,17 @@ fn selfhostMirDriverRunLowerMirJson(args: List<String>) -> Int {
         },
     }
     let resolvedPackageName = if packageName.len() == 0 { "main" } else { packageName }
-    let mut mir = match mirJsonParseModule(raw) {
-        Ok(m) -> m,
+    let mut mir = mirModule(resolvedPackageName)
+    match mirJsonParseModuleInto(raw, mir) {
+        Ok(_) -> {
+        },
         Err(e) -> {
             eprint("osty-self lir-proto-lower-mir-json: " + e + "\n")
             return 1
         },
     }
-    if mir.packageName.len() == 0 {
-        mir.packageName = resolvedPackageName
-    }
-    let mirErrs = mirValidateModule(mir)
+    let checkedMir = mirModuleWithPackageName(resolvedPackageName, mir)
+    let mirErrs = mirValidateModule(checkedMir)
     if mirErrs.len() != 0 {
         eprint("osty-self lir-proto-lower-mir-json: MIR validation failed:\n")
         for e in mirErrs {
@@ -233,12 +228,15 @@ fn selfhostMirDriverRunLowerMirJson(args: List<String>) -> Int {
         }
         return 1
     }
-    let result = lirLowerMirModule(lirLowerConfig(resolvedPackageName, path, target), mir)
-    let lowerDiagnostics = result.diagnostics
+    let lowerCfg = lirLowerConfig(resolvedPackageName, path, target)
+    let lowerStringPoolEntries: List<LirStringGlobal> = []
+    let lowerOut = lirModuleWithStringPoolEntries(resolvedPackageName, path, target, lowerStringPoolEntries)
+    let lowerDiagnostics: List<LirDiagnostic> = []
+    lirLowerMirModuleListsInto(lowerCfg, lowerStringPoolEntries, resolvedPackageName, checkedMir.functions, checkedMir.globals, checkedMir.uses, checkedMir.layouts, checkedMir.span, lowerOut, lowerDiagnostics)
     if lowerDiagnostics.len() != 0 {
         selfhostMirDriverPrintLowerDiagnostics(lowerDiagnostics)
     }
-    print(lirRenderModule(result.module))
+    print(lirRenderModule(lowerOut))
     0
 }
 


### PR DESCRIPTION
## Summary
- teach `osty-native-lirproto` to preserve MIR JSON numbers and accept stage0 partial MIR in the list-all decline path
- move selfhost LIR Proto lowering forward across call diagnostics gating, metadata/container helpers, and option/result helper emission paths
- add focused regression coverage for native lirproto decoding and stage0 compatibility

## Validation
- `git diff --check`
- `.bin/osty check --airepair=false toolchain/lir_proto.osty`
- `go test -count=1 -vet=off ./cmd/osty-native-lirproto ./internal/backend/stage0`

## Notes
- draft on purpose: full `scripts/verify-self-rebuild --skip-gates --reuse-stage1 .bin/osty` is still being pushed deeper through stage3 helper gaps