### PR TITLE
feat: Option/Result combinator closure monomorphization

### DIFF
--- a/internal/backend/llvm_option_result_higher_order_test.go
+++ b/internal/backend/llvm_option_result_higher_order_test.go
@@ -1,0 +1,173 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+)
+
+// TestInjectReachableStdlibBodiesPicksUpOptionAndResultCombinators
+// covers the closure-taking combinators on prelude `Option<T>` /
+// `Result<T, E>` values. Before `BuiltinTypeOwningModule` registered
+// these owners, `opt.map(|x| ...)`-style call sites stayed as
+// MethodCall nodes through monomorph and MIR — the LLVM backend
+// then fell back to the per-intrinsic dispatch in
+// `toolchain/mir_generator.osty`, which only handled `isSome` /
+// `isNone` / `unwrap` and walled on any combinator carrying a
+// closure argument or method-local generic.
+//
+// With the owners registered, the method body lands as a free fn
+// `osty_std_option__Option__map(self: Option<T>, f: fn(T) -> U) -> U?`
+// (and analogously for Result), and the user-side call site is
+// rewritten in place into a CallExpr against that mangled symbol
+// with the receiver prepended as the first positional argument —
+// exactly the shape `TestLLVMBackendEmitListHigherOrder` asserts
+// for `List<T>.map`.
+//
+// Asserts:
+//  1. the relevant `osty_std_option__Option__<m>` and
+//     `osty_std_result__Result__<m>` free fns are produced;
+//  2. they carry an explicit `self` first param of the owning
+//     NamedType (so monomorph can substitute the receiver's
+//     concrete generics into the body's `match self`);
+//  3. the rewritten call sites in `main` no longer carry
+//     MethodCall nodes for those methods — they're CallExprs
+//     against the mangled names.
+func TestInjectReachableStdlibBodiesPicksUpOptionAndResultCombinators(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+	src := `fn main() {
+    let opt = Some(5)
+    let doubled = opt.map(|x| x * 2)
+    let filtered = doubled.filter(|x| x > 0)
+    let chained = filtered.andThen(|x| Some(x + 1))
+    println(chained.unwrapOr(0))
+
+    let r: Result<Int, String> = Ok(10)
+    let r2 = r.map(|x| x + 1)
+    let r3 = r2.andThen(|x| Ok(x * 2))
+    println(r3.unwrapOr(0))
+}`
+	file, res, chk := parseBackendFile(t, src)
+	entry, err := LowerEntryIR("main", "main.osty", file, res, chk)
+	if err != nil {
+		t.Fatalf("LowerEntryIR: %v", err)
+	}
+	mod := entry.IR
+	if mod == nil {
+		t.Fatal("nil module")
+	}
+
+	// Each injected method is rewritten by Monomorphize into a
+	// `_Z<len><mangled>I<type-codes>E…` Itanium-style symbol — the
+	// stable substring is the source-name infix `osty_std_<module>__<Type>__<method>`.
+	// We assert the infix appears so the test stays stable across
+	// future mangling tweaks while still proving the method's body
+	// reached the output module.
+	want := []string{
+		"osty_std_option__Option__map",
+		"osty_std_option__Option__filter",
+		"osty_std_option__Option__andThen",
+		"osty_std_result__Result__map",
+		"osty_std_result__Result__andThen",
+	}
+	have := map[string]bool{}
+	var mainFn *ir.FnDecl
+	for _, d := range mod.Decls {
+		fn, ok := d.(*ir.FnDecl)
+		if !ok {
+			continue
+		}
+		if fn.Name == "main" {
+			mainFn = fn
+			continue
+		}
+		have[fn.Name] = true
+		if !strings.Contains(fn.Name, "osty_std_option__Option__") &&
+			!strings.Contains(fn.Name, "osty_std_result__Result__") {
+			continue
+		}
+		if len(fn.Params) == 0 || fn.Params[0].Name != "self" {
+			t.Errorf("%s: first param = %+v, want self", fn.Name, fn.Params)
+			continue
+		}
+		if len(fn.Generics) != 0 {
+			t.Errorf("%s: post-monomorph generics = %d, want 0 (fully specialized)", fn.Name, len(fn.Generics))
+		}
+		nt, ok := fn.Params[0].Type.(*ir.NamedType)
+		if !ok {
+			t.Errorf("%s: self.Type = %T, want *NamedType", fn.Name, fn.Params[0].Type)
+			continue
+		}
+		switch {
+		case strings.Contains(fn.Name, "osty_std_option__Option__"):
+			// After monomorph the self type is the specialization's
+			// mangled `_ZTS…Option…` nominal, not the source
+			// `option.Option`. Accept either: the substring
+			// "Option" survives both encodings.
+			if !strings.Contains(nt.Name, "Option") {
+				t.Errorf("%s: self.Type.Name = %q, want substring Option", fn.Name, nt.Name)
+			}
+		case strings.Contains(fn.Name, "osty_std_result__Result__"):
+			if !strings.Contains(nt.Name, "Result") {
+				t.Errorf("%s: self.Type.Name = %q, want substring Result", fn.Name, nt.Name)
+			}
+		}
+	}
+	for _, w := range want {
+		found := false
+		for k := range have {
+			if strings.Contains(k, w) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing injected free fn whose name contains %q (have %v)", w, sortedKeys(have))
+		}
+	}
+
+	if mainFn == nil {
+		t.Fatal("no main fn in module")
+	}
+	rewrittenCombinators := []string{"map", "filter", "andThen"}
+	leftAsMethodCall := map[string]bool{}
+	rewrittenAsCallExpr := map[string]bool{}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		switch x := n.(type) {
+		case *ir.MethodCall:
+			for _, m := range rewrittenCombinators {
+				if x.Name == m {
+					leftAsMethodCall[m] = true
+				}
+			}
+		case *ir.CallExpr:
+			id, ok := x.Callee.(*ir.Ident)
+			if !ok {
+				return true
+			}
+			for _, m := range rewrittenCombinators {
+				if strings.Contains(id.Name, "__Option__"+m) || strings.Contains(id.Name, "__Result__"+m) {
+					rewrittenAsCallExpr[m] = true
+				}
+			}
+		}
+		return true
+	}), mainFn)
+	for _, m := range rewrittenCombinators {
+		if leftAsMethodCall[m] {
+			t.Errorf("main contains unrewritten MethodCall.%s — Option/Result owner mapping not picked up", m)
+		}
+		if !rewrittenAsCallExpr[m] {
+			t.Errorf("main missing CallExpr against mangled Option/Result %s — call-site rewrite did not run", m)
+		}
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/backend/stdlib_mangle.go
+++ b/internal/backend/stdlib_mangle.go
@@ -216,23 +216,22 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 				return true
 			}
 		}
-		named, ok := mc.Receiver.Type().(*ir.NamedType)
-		if !ok || named == nil || named.Name == "" {
-			return true
-		}
 		// Builtin generic types (`List<T>`, `Map<K, V>`, `Set<T>`,
 		// `Option<T>`, `Result<T, E>`) reach the IR with `Builtin:
-		// true` but `Package: ""`. Discovery in `ir.ReachMethods`
-		// patches the package to the canonical owning module; do
-		// the same here so the rewrite finds its match.
-		module := named.Package
-		if module == "" && named.Builtin {
-			module = ir.BuiltinTypeOwningModule(named.Name)
-		}
-		if module == "" {
+		// true` but `Package: ""`, and `T?` reaches as
+		// `OptionalType` — Option<T>'s surface form. Discovery in
+		// `ir.ReachMethods` normalises both into the canonical
+		// owning module via `stdlibReceiverOwner`; mirror it here
+		// so the rewrite finds its match for chained combinator
+		// shapes like `opt.map(...).filter(...)` whose second hop
+		// is typed `Int?` rather than `Option<Int>`.
+		recvTy := mc.Receiver.Type()
+		module, typeName, ok := stdlibReceiverOwnerForRewrite(recvTy)
+		if !ok {
 			return true
 		}
-		mangled, hit := set[key{module: module, typeName: named.Name, method: mc.Name}]
+		named, _ := recvTy.(*ir.NamedType)
+		mangled, hit := set[key{module: module, typeName: typeName, method: mc.Name}]
 		if !hit {
 			return true
 		}
@@ -247,6 +246,29 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 			SpanV: mc.SpanV,
 		})
 		args = append(args, mc.Args...)
+		// `methodToFreeFn` prepends the owner's generic params onto the
+		// free fn's Generics list (so `Option<T>.map<U>` becomes a
+		// `[T, U]`-generic free fn). The user-side MethodCall only
+		// carries the method-local `TypeArgs` the checker recorded
+		// (commonly empty for combinators where the method generic is
+		// inferred from a closure return), so monomorph's `request`
+		// would fail the arity check and silently leave the call
+		// against a generic symbol that gets dropped from the output
+		// module. Prepend the receiver's concrete owner args
+		// (`Option<Int>` → `[Int]`, `Int?` → `[Int]`) so the
+		// rewritten call carries `[ownerArgs..., methodArgs...]` and
+		// the arity matches.
+		ownerArgs := stdlibReceiverOwnerArgs(recvTy)
+		typeArgs := mc.TypeArgs
+		if len(ownerArgs) > 0 {
+			combined := make([]ir.Type, 0, len(ownerArgs)+len(typeArgs))
+			for _, a := range ownerArgs {
+				combined = append(combined, ir.CloneType(a))
+			}
+			combined = append(combined, typeArgs...)
+			typeArgs = combined
+		}
+		_ = named
 		swap[mc] = &ir.CallExpr{
 			Callee: &ir.Ident{
 				Name:  mangled,
@@ -254,7 +276,7 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 				T:     stdlibFnType(args, mc.T),
 				SpanV: mc.SpanV,
 			},
-			TypeArgs: mc.TypeArgs,
+			TypeArgs: typeArgs,
 			Args:     args,
 			T:        mc.T,
 			SpanV:    mc.SpanV,
@@ -267,6 +289,62 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 	rw := &stdlibMethodCallsiteSpliceVisitor{swap: swap}
 	ir.Walk(rw, mod)
 	return valueRewriteCount + rw.count
+}
+
+// stdlibReceiverOwnerForRewrite mirrors `ir.stdlibReceiverOwner` for
+// the call-site rewriter — kept inline here so the rewriter does not
+// need to import an unexported helper. Returns the (module, type)
+// pair the method-body injector keyed under, or false when no stdlib
+// owner applies.
+//
+// Accepts `NamedType` (including Builtin types with empty Package
+// fields) and `OptionalType` (the surface form of `Option<T>` —
+// chained combinators like `opt.map(...).filter(...)` are typed
+// `Int?` on the second hop and must still resolve to
+// `option.Option`).
+func stdlibReceiverOwnerForRewrite(t ir.Type) (module string, typeName string, ok bool) {
+	switch x := t.(type) {
+	case *ir.NamedType:
+		if x == nil || x.Name == "" {
+			return "", "", false
+		}
+		module = x.Package
+		if module == "" && x.Builtin {
+			module = ir.BuiltinTypeOwningModule(x.Name)
+		}
+		if module == "" {
+			return "", "", false
+		}
+		return module, x.Name, true
+	case *ir.OptionalType:
+		if x == nil {
+			return "", "", false
+		}
+		return "option", "Option", true
+	}
+	return "", "", false
+}
+
+// stdlibReceiverOwnerArgs returns the concrete type arguments that
+// should be prepended onto a method call's TypeArgs to satisfy the
+// owner-prefix slot of the synthesised free fn. For a NamedType this
+// is the type's Args; for an OptionalType (`Int?`), it is the inner
+// type lifted into a single-element slice so it matches Option<T>'s
+// generic shape.
+func stdlibReceiverOwnerArgs(t ir.Type) []ir.Type {
+	switch x := t.(type) {
+	case *ir.NamedType:
+		if x == nil {
+			return nil
+		}
+		return x.Args
+	case *ir.OptionalType:
+		if x == nil || x.Inner == nil {
+			return nil
+		}
+		return []ir.Type{x.Inner}
+	}
+	return nil
 }
 
 func stdlibFnType(args []ir.Arg, ret ir.Type) ir.Type {

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -1806,7 +1806,22 @@ func (s *monoState) scanExpr(e Expr) {
 	switch e := e.(type) {
 	case *CallExpr:
 		// Rewrite generic call to mangled specialization.
-		if len(e.TypeArgs) > 0 {
+		//
+		// CallExpr.TypeArgs is sourced from the checker's instantiation
+		// table. For most user-side generic calls it carries the full
+		// list. For stdlib method-body calls rewritten via
+		// `RewriteStdlibMethodCallsites` (`opt.map(|x| ...)` →
+		// `osty_std_option__Option__map(opt, |x| ...)`), the receiver's
+		// concrete owner args are already prepended, but the closure-
+		// returning combinators commonly leave method-local generics
+		// (e.g. `map<U>`'s `U`) implicit — the checker records no
+		// turbofish for them and we have to derive them from the
+		// concrete arg types at rewrite time. Without that fallback,
+		// the call site silently leaves `osty_std_option__Option__map`
+		// unspecialized, the generic template gets dropped from the
+		// output module, and downstream lowering walls on the
+		// unresolved symbol.
+		if len(e.TypeArgs) > 0 || s.callCalleeIsGenericFn(e) {
 			s.rewriteGenericCall(e)
 			// After monomorphization the backend contract is fully
 			// concrete: any remaining CallExpr.TypeArgs are just
@@ -1924,10 +1939,40 @@ func (s *monoState) scanExpr(e Expr) {
 	}
 }
 
+// callCalleeIsGenericFn reports whether c.Callee references a known
+// generic free fn in this module. Used to admit `osty_std_…` stdlib
+// method-body calls into `rewriteGenericCall` even when the checker
+// did not record any method-local type args — `rewriteGenericCall`
+// then derives the missing args by unifying the concrete arg types
+// against the generic param types. Without this admission, the
+// `len(e.TypeArgs) > 0` gate in `scanExpr` would leave those calls
+// pointing at a generic symbol that gets dropped in Pass 2.
+func (s *monoState) callCalleeIsGenericFn(c *CallExpr) bool {
+	if s == nil || c == nil {
+		return false
+	}
+	id, ok := c.Callee.(*Ident)
+	if !ok || id == nil || id.Name == "" {
+		return false
+	}
+	_, ok = s.genericsByName[id.Name]
+	return ok
+}
+
 // rewriteGenericCall translates a generic free-fn call site into its
 // mangled specialization. Only calls whose callee resolves to a
 // top-level generic FnDecl are rewritten; others are left alone (the
 // checker should have rejected anything else, but we stay defensive).
+//
+// When `c.TypeArgs` is shorter than `orig.Generics` (the common shape
+// after `RewriteStdlibMethodCallsites` for closure-taking combinators
+// like `opt.map(|x| ...)` — the receiver's owner args are prepended
+// but the method-local generics are left for inference), the missing
+// suffix is derived by unifying each param's structural type against
+// the matching arg's concrete type. Each generic param is resolved
+// by the first param position that mentions it; this is sufficient
+// for Option/Result/List combinators where every method generic
+// flows through a closure return or a pair-typed param.
 func (s *monoState) rewriteGenericCall(c *CallExpr) {
 	id, ok := c.Callee.(*Ident)
 	if !ok {
@@ -1937,10 +1982,15 @@ func (s *monoState) rewriteGenericCall(c *CallExpr) {
 	if !ok {
 		return
 	}
-	mangled := s.request(orig, c.TypeArgs)
+	typeArgs := c.TypeArgs
+	if len(typeArgs) < len(orig.Generics) {
+		typeArgs = s.inferMissingGenericArgs(orig, c, typeArgs)
+	}
+	mangled := s.request(orig, typeArgs)
 	if mangled == "" {
 		return
 	}
+	c.TypeArgs = typeArgs
 	// Substitute the call's return type and the callee identifier's
 	// FnType using the same env `request` used to mangle the symbol.
 	// Without this, downstream IR/MIR lowering sees `let r = first(xs)`
@@ -1962,6 +2012,135 @@ func (s *monoState) rewriteGenericCall(c *CallExpr) {
 	id.Name = mangled
 	id.TypeArgs = nil
 	c.TypeArgs = nil
+}
+
+// inferMissingGenericArgs fills out a short c.TypeArgs by unifying
+// each remaining generic param against the concrete arg type at the
+// first param position that mentions it. Returns the original
+// `provided` unchanged if no progress can be made (a still-short
+// result trips `request`'s arity check and reports a normal warning).
+//
+// The unification is structural and unidirectional: walk param type
+// and arg type together, and whenever we see a `TypeVar{Name: G}` in
+// the param while standing over a concrete subtype in the arg,
+// record `G → arg-subtype`. Nested NamedType / OptionalType /
+// TupleType / FnType shapes recurse; mismatched constructors abort
+// the walk for that arg position (leaving G unbound for now). The
+// closure-taking combinators on Option/Result/List/Iter satisfy this
+// — e.g. `map<U>(self: Option<T>, f: fn(T) -> U)` resolves `U` from
+// arg[1] = `fn(Int) -> Int` by walking into the FnType's Return.
+func (s *monoState) inferMissingGenericArgs(fn *FnDecl, c *CallExpr, provided []Type) []Type {
+	if fn == nil || c == nil {
+		return provided
+	}
+	out := make([]Type, len(fn.Generics))
+	for i := range fn.Generics {
+		if i < len(provided) {
+			out[i] = provided[i]
+		}
+	}
+	env := SubstEnv{}
+	for i, p := range fn.Generics {
+		if p != nil && out[i] != nil {
+			env[p.Name] = out[i]
+		}
+	}
+	for argIdx, arg := range c.Args {
+		if argIdx >= len(fn.Params) || fn.Params[argIdx] == nil {
+			break
+		}
+		paramTy := fn.Params[argIdx].Type
+		if paramTy == nil || arg.Value == nil {
+			continue
+		}
+		argTy := arg.Value.Type()
+		if argTy == nil || argTy == ErrTypeVal {
+			continue
+		}
+		unifyTypeVarSlots(paramTy, argTy, env)
+	}
+	for i, p := range fn.Generics {
+		if p == nil || out[i] != nil {
+			continue
+		}
+		if bound, ok := env[p.Name]; ok && !containsTypeVar(bound) {
+			out[i] = bound
+		}
+	}
+	for _, t := range out {
+		if t == nil {
+			return provided
+		}
+	}
+	return out
+}
+
+// unifyTypeVarSlots walks paramTy and argTy structurally, recording
+// `TypeVar.Name → concrete subtype` pairs into env. Used to derive
+// implicit method-local generics for stdlib combinator call sites.
+// Mismatched shapes silently stop their subtree — the caller falls
+// back to the existing arity check when env doesn't cover every
+// generic param.
+func unifyTypeVarSlots(paramTy, argTy Type, env SubstEnv) {
+	if paramTy == nil || argTy == nil {
+		return
+	}
+	switch p := paramTy.(type) {
+	case *TypeVar:
+		if p.Name == "" {
+			return
+		}
+		if _, seen := env[p.Name]; seen {
+			return
+		}
+		env[p.Name] = CloneType(argTy)
+		return
+	case *NamedType:
+		// A bare `NamedType{Name: G}` with no args is the IR
+		// lowerer's alternate encoding for a type parameter. Treat
+		// it like *TypeVar.
+		if len(p.Args) == 0 && p.Package == "" && !p.Builtin {
+			if _, seen := env[p.Name]; !seen {
+				env[p.Name] = CloneType(argTy)
+			}
+			return
+		}
+		a, ok := argTy.(*NamedType)
+		if !ok || a == nil || a.Name != p.Name || len(a.Args) != len(p.Args) {
+			return
+		}
+		for i := range p.Args {
+			unifyTypeVarSlots(p.Args[i], a.Args[i], env)
+		}
+	case *OptionalType:
+		if a, ok := argTy.(*OptionalType); ok && a != nil {
+			unifyTypeVarSlots(p.Inner, a.Inner, env)
+			return
+		}
+		// `Option<T>` (NamedType) and `T?` (OptionalType) are
+		// surface synonyms; cross-match when the arg uses the
+		// expanded form.
+		if a, ok := argTy.(*NamedType); ok && a != nil && a.Name == "Option" && len(a.Args) == 1 {
+			unifyTypeVarSlots(p.Inner, a.Args[0], env)
+		}
+	case *TupleType:
+		a, ok := argTy.(*TupleType)
+		if !ok || a == nil || len(a.Elems) != len(p.Elems) {
+			return
+		}
+		for i := range p.Elems {
+			unifyTypeVarSlots(p.Elems[i], a.Elems[i], env)
+		}
+	case *FnType:
+		a, ok := argTy.(*FnType)
+		if !ok || a == nil || len(a.Params) != len(p.Params) {
+			return
+		}
+		for i := range p.Params {
+			unifyTypeVarSlots(p.Params[i], a.Params[i], env)
+		}
+		unifyTypeVarSlots(p.Return, a.Return, env)
+	}
 }
 
 // ==== Helpers ====

--- a/internal/ir/reach.go
+++ b/internal/ir/reach.go
@@ -96,19 +96,52 @@ func (r methodReachVisitor) Visit(n Node) Visitor {
 	if !ok || call == nil || call.Receiver == nil || call.Name == "" {
 		return r
 	}
-	named, ok := call.Receiver.Type().(*NamedType)
-	if !ok || named == nil || named.Name == "" {
+	module, typeName, ok := stdlibReceiverOwner(call.Receiver.Type())
+	if !ok {
 		return r
 	}
-	module := named.Package
-	if module == "" && named.Builtin {
-		module = BuiltinTypeOwningModule(named.Name)
-	}
-	if module == "" {
-		return r
-	}
-	r[MethodRef{Module: module, Type: named.Name, Method: call.Name}] = struct{}{}
+	r[MethodRef{Module: module, Type: typeName, Method: call.Name}] = struct{}{}
 	return r
+}
+
+// stdlibReceiverOwner normalises a method-call receiver type into the
+// (module, type-name) pair the body-injector uses to look up the
+// method declaration. Handles:
+//
+//   - `NamedType{Package: "encoding", Name: "Hex"}` — module-qualified
+//     stdlib type, the canonical shape.
+//   - `NamedType{Builtin: true, Name: "List"|"Iter"|"Option"|"Result"}`
+//     — prelude-bound generic types whose owning module comes from
+//     `BuiltinTypeOwningModule`.
+//   - `OptionalType{Inner: ...}` — surface form of `Option<T>`. The
+//     IR keeps `T?` and `Option<T>` as separate constructors but
+//     they share the same method declarations, so a chained
+//     combinator (`opt.map(...).filter(...)`) typed as `Int?` on
+//     the second hop still needs to reach `option.Option.filter`.
+//
+// Returns `("", "", false)` when no stdlib owner applies — user
+// methods on user types must not pollute the reach set.
+func stdlibReceiverOwner(t Type) (module string, name string, ok bool) {
+	switch x := t.(type) {
+	case *NamedType:
+		if x == nil || x.Name == "" {
+			return "", "", false
+		}
+		module = x.Package
+		if module == "" && x.Builtin {
+			module = BuiltinTypeOwningModule(x.Name)
+		}
+		if module == "" {
+			return "", "", false
+		}
+		return module, x.Name, true
+	case *OptionalType:
+		if x == nil {
+			return "", "", false
+		}
+		return "option", "Option", true
+	}
+	return "", "", false
 }
 
 // BuiltinTypeOwningModule returns the stdlib module that owns the
@@ -116,23 +149,40 @@ func (r methodReachVisitor) Visit(n Node) Visitor {
 // in this table fall through and contribute no method references —
 // the body-injector treats them like user-defined types.
 //
-// Today only `List<T>` is whitelisted: its higher-order methods
-// (`map`, `filter`, `fold`, `reduce`, etc.) are bodied helpers that
-// the LLVM backend can lower end-to-end through the standard
-// injection path. `Map<K,V>` / `Set<T>` are intentionally left out
-// because their primitive operations (`get`, `insert`, `remove`,
-// `len`) route through dedicated runtime intrinsics
-// (`osty_rt_map_*`, `osty_rt_set_*`); pulling their bodied helpers
-// (`containsKey` calls `get(...).isSome()`, etc.) into injection
-// double-lowers the same call site and trips the monomorph
-// substitution. `Option`/`Result` already have working
-// per-intrinsic dispatch in `mir_generator.go`.
+// `List<T>` and `Iter<T>` route their higher-order methods
+// (`map`, `filter`, `fold`, `reduce`, etc.) through the standard
+// injection path so the LLVM backend lowers them end-to-end.
+//
+// `Option<T>` / `Result<T, E>` route their combinator methods
+// (`map`, `andThen`, `filter`, `mapOr`, `unwrapOrElse`, …) through
+// the same path. The combinators carry method-local generics
+// (`map<U>`, `andThen<U>`) and closure parameters, so MIR's
+// per-method intrinsic dispatch in `toolchain/mir_generator.osty`
+// cannot lower them in isolation; they need the same
+// methodToFreeFn → monomorphize-method-clone pipeline that List
+// uses. The simpler probes (`isSome`, `isNone`, `unwrap`, …) had
+// a parallel MIR intrinsic dispatch but the IR-level rewrite
+// turns each `recv.method(...)` into a free `CallExpr` against the
+// mangled body, so MIR sees no MethodCall to short-circuit —
+// match-on-Option in the injected body produces the same MIR
+// shape the old intrinsic generated.
+//
+// `Map<K,V>` / `Set<T>` are intentionally left out because their
+// primitive operations (`get`, `insert`, `remove`, `len`) route
+// through dedicated runtime intrinsics (`osty_rt_map_*`,
+// `osty_rt_set_*`); pulling their bodied helpers (`containsKey`
+// calls `get(...).isSome()`, etc.) into injection double-lowers
+// the same call site and trips the monomorph substitution.
 func BuiltinTypeOwningModule(name string) string {
-	if name == "List" {
+	switch name {
+	case "List":
 		return "collections"
-	}
-	if name == "Iter" {
+	case "Iter":
 		return "iter"
+	case "Option":
+		return "option"
+	case "Result":
+		return "result"
 	}
 	return ""
 }

--- a/internal/ir/reach_test.go
+++ b/internal/ir/reach_test.go
@@ -227,6 +227,61 @@ func TestReachAndReachMethodsAreIndependent(t *testing.T) {
 	}
 }
 
+func TestBuiltinTypeOwningModuleResolvesGenericCollectionTypes(t *testing.T) {
+	cases := []struct {
+		name, want string
+	}{
+		{"List", "collections"},
+		{"Iter", "iter"},
+		{"Option", "option"},
+		{"Result", "result"},
+		{"Map", ""},
+		{"Set", ""},
+		{"NotAType", ""},
+	}
+	for _, c := range cases {
+		if got := BuiltinTypeOwningModule(c.name); got != c.want {
+			t.Errorf("BuiltinTypeOwningModule(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestReachMethodsPicksUpBuiltinOptionAndResultMethods(t *testing.T) {
+	// Receivers carrying `Builtin: true` with an empty Package — the
+	// shape `ir.Lower` emits for prelude `Option<T>` / `Result<T,E>`
+	// values — must route through `BuiltinTypeOwningModule` so the
+	// body-injection pipeline can pull in their bodied combinators
+	// (`map`, `andThen`, `filter`, …). Before Option/Result were
+	// registered in the table, these MethodCalls were silently
+	// dropped from the reach set and `xs.map(|x| ...)`-style
+	// combinator chains stayed unrewritten through MIR/LLVM.
+	optTy := &NamedType{Builtin: true, Name: "Option", Args: []Type{TInt}}
+	resTy := &NamedType{Builtin: true, Name: "Result", Args: []Type{TInt, TString}}
+	mod := &Module{
+		Package: "main",
+		Script: []Stmt{
+			&ExprStmt{X: &MethodCall{
+				Receiver: &Ident{Name: "opt", T: optTy},
+				Name:     "map",
+			}},
+			&ExprStmt{X: &MethodCall{
+				Receiver: &Ident{Name: "res", T: resTy},
+				Name:     "andThen",
+			}},
+		},
+	}
+	got := ReachMethods(mod)
+	want := []MethodRef{
+		{Module: "option", Type: "Option", Method: "map"},
+		{Module: "result", Type: "Result", Method: "andThen"},
+	}
+	for _, w := range want {
+		if _, ok := got[w]; !ok {
+			t.Errorf("ReachMethods() missing %v; got %v", w, got)
+		}
+	}
+}
+
 func TestReachSkipsFieldAccessOnNonIdent(t *testing.T) {
 	// (getObj.load()).compare(a) — outer receiver is CallExpr, not Ident.
 	inner := &CallExpr{


### PR DESCRIPTION
## Summary

Option<T>·Result<T,E>의 closure-받는 combinator (`.map` / `.filter` / `.andThen` / `.mapOr` / `.unwrapOrElse` …) 가 stdlib body-injection + monomorphization 파이프라인을 `List<T>` / `Iter<T>` 와 같은 방식으로 통과한다. 결과적으로 stage2 binary 가 `opt.map(|x| ...)` 체인을 LLVM-route 에서 lower 할 수 있게 되어 더 넓은 stdlib 표면이 native 로 들어온다.

이전에는 `BuiltinTypeOwningModule` 이 Option/Result 를 "" 로 반환 → reach 스캔이 MethodCall 을 드롭 → MIR 의 per-method intrinsic dispatch (`mir_generator.osty`) 만이 dispatch surface 였다. 이 dispatch 는 `isSome` / `isNone` / `unwrap` 같은 단순 probe 만 lower 했고 closure 받는 combinator 는 wall 에 부딪혔다.

## Changes

내부 변경 3축:

1. **Owner mapping**: `BuiltinTypeOwningModule` 에 `Option → "option"` / `Result → "result"` 매핑 추가. `opt.map(...)` MethodCall 이 reach 스캔에 잡혀 `methodToFreeFn` 가 `osty_std_option__Option__map(self, f)` 자유 함수로 변환한다. (`internal/ir/reach.go`)

2. **OptionalType normalisation**: 새 helper `stdlibReceiverOwner` / `stdlibReceiverOwnerForRewrite` 가 `T?` (OptionalType) 수신자를 `Option<T>` 와 동일하게 정규화. `opt.map(...).filter(...)` 같은 체인의 두번째 hop 이 `Int?` 로 typed 되어도 owner 가 `option.Option` 로 풀린다. (`internal/ir/reach.go`, `internal/backend/stdlib_mangle.go`)

3. **Implicit method-generic inference**: `RewriteStdlibMethodCallsites` 가 수신자의 concrete owner args 를 `TypeArgs` 에 prepend (`Option<Int>.map<U>` → `[Int, U]`), `rewriteGenericCall` 은 부족한 method-local generic 을 param/arg 타입 구조적 unification 으로 채운다. `map<U>` 의 `U` 같은 closure-return-inferred 제네릭은 turbofish 없이도 specialize 된다. (`internal/ir/monomorph.go`, `internal/backend/stdlib_mangle.go`)

검증된 동작:
- `opt.map(|x| x * 2)` → IR 모듈에 `_Z28osty_std_option__Option__mapIllE...`-mangled 자유 함수가 specialize 되어 들어간다 (자동 검증, `TestInjectReachableStdlibBodiesPicksUpOptionAndResultCombinators`).
- 체인된 `opt.map(...).filter(...).andThen(...)` 각 hop 이 모두 mangled CallExpr 로 rewrite 된다.
- `Result<Int, String>` 에서도 동일하게 동작 (`map<U>`, `andThen<U>`, `unwrapOr` specialize).

## Test plan

- [x] `TestBuiltinTypeOwningModuleResolvesGenericCollectionTypes` 추가
- [x] `TestReachMethodsPicksUpBuiltinOptionAndResultMethods` 추가
- [x] `TestInjectReachableStdlibBodiesPicksUpOptionAndResultCombinators` 추가
- [x] 기존 `TestLLVMBackendEmitListHigherOrder` 통과 (회귀 없음)
- [x] `./internal/{ir,lexer,parser,resolve,check,diag,mir,format,stdlib,llvmabi,nativellvmgen,toolchain}` 통과
- [x] `./cmd/...` 통과
- [x] 단축 backend 테스트 통과 (사전부터 깨져 있던 `TestBundledRuntimeListReserveBacktraceIsOptional` 제외)
- [ ] `osty-self` 가 필요한 full-emit 테스트는 환경 부재로 skip (CI 에서 검증 필요)

https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT

---
_Generated by [Claude Code](https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT)_