### PR TITLE
feat: PR1a — osty-native-checker LLVM walking skeleton (stub)

### DIFF
--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -1,0 +1,3 @@
+fn main() {
+    println("osty-native-checker-llvm: stub")
+}

--- a/cmd/osty-native-checker/osty.toml
+++ b/cmd/osty-native-checker/osty.toml
@@ -1,0 +1,14 @@
+[package]
+name = "osty-native-checker"
+version = "0.1.0"
+edition = "0.5"
+description = "LLVM self-build target — osty-native-checker (Osty entry point)."
+
+[bin]
+name = "osty-native-checker-llvm"
+path = "main.osty"
+
+[capabilities]
+runtime = true
+
+[dependencies]


### PR DESCRIPTION
## Summary

`docs/llvm-selfhost-plan.md` §6 PR1 의 **가장 작은 형태** — `osty build --backend llvm cmd/osty-native-checker/` 가 통과하고 binary 가 동작하는 minimum walking skeleton.

```sh
$ OSTY_STAGE0_FALLBACK=1 .bin/osty build --backend llvm cmd/osty-native-checker/
Built .osty/out/debug/llvm/osty-native-checker-llvm

$ ./cmd/osty-native-checker/.osty/out/debug/llvm/osty-native-checker-llvm
osty-native-checker-llvm: stub
```

## 신규 파일

| 파일 | LOC | 역할 |
|---|---|---|
| `cmd/osty-native-checker/osty.toml` | 12 | manifest + `[bin] name="osty-native-checker-llvm" path="main.osty"` |
| `cmd/osty-native-checker/main.osty` | 3 | stub `fn main() { println("...") }` |

## 확인된 spike open question

- **Q6**: `cmd/osty-native-checker/` 에 `main.go` (Go shell) + `main.osty` (LLVM entry) 공존? → **YES**. `osty build` 가 `.go` 파일 무시.

## 분할 — 이 PR 의 비-목표

이 PR 은 plan §6 PR1 의 **build + runs only** 부분. 다음 PR 들로 분할:

- **PR1b** — `std.io.stdin().readAll()` helper + `osty_rt_io_read_all` C runtime
- **PR1c** — stub JSON echo (stdin 받아 dummy CheckResult JSON 출력)
- **PR2** — manual `parseCheckRequest` + `stringifyCheckResult` (plan §6 PR2)
- **PR3** — 진짜 checker 호출 + L1 byte parity (plan §6 PR3)

분할 이유: 각 단계가 mergeable 한 단위로 작아져 review 부담 ↓ + 차단 시점 명확.

## Test plan

- [x] `just prepush` 로컬 통과
- [x] LLVM-built binary 실행 확인 (`stage0 fallback` 경유)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)