### PR TITLE
fix: builtin Option/Result variant payload type for if-let pattern bind

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -1187,9 +1187,9 @@ func (bs *bodyState) bindPattern(pat ir.Pattern, scrutinee Place, scrutineeT Typ
 		// after a decision-tree branch).
 		layout := bs.l.variantLayout(p.Enum, p.Variant)
 		for i, arg := range p.Args {
-			pt := variantPayloadType(layout, i)
+			pt := resolveVariantPayloadType(layout, scrutineeT, p.Variant, i)
 			proj := &VariantProj{
-				Variant:  variantIndex(layout),
+				Variant:  resolveVariantIndex(layout, scrutineeT, p.Variant),
 				Name:     p.Variant,
 				FieldIdx: i,
 				Type:     pt,
@@ -4650,8 +4650,8 @@ func (bs *bodyState) lowerIfLetVariant(ife *ir.IfLetExpr, dest Place, destT Type
 	// Bind payload elements.
 	layout := bs.l.variantLayout(vp.Enum, vp.Variant)
 	for i, arg := range vp.Args {
-		pt := variantPayloadType(layout, i)
-		proj := &VariantProj{Variant: variantIndex(layout), Name: vp.Variant, FieldIdx: i, Type: pt}
+		pt := resolveVariantPayloadType(layout, scrutT, vp.Variant, i)
+		proj := &VariantProj{Variant: resolveVariantIndex(layout, scrutT, vp.Variant), Name: vp.Variant, FieldIdx: i, Type: pt}
 		child := Place{Local: scrutLocal}.Project(proj)
 		bs.bindPattern(arg, child, pt, ife.SpanV)
 	}
@@ -7939,6 +7939,97 @@ func variantPayloadType(info *variantInfo, i int) Type {
 		return ir.ErrTypeVal
 	}
 	return info.variant.Payload[i]
+}
+
+// builtinVariantPayloadType derives the i-th payload type for a
+// prelude Option<T> / Result<T, E> variant when `variantLayout`
+// returns nil (builtin path: the enum declaration lives in stdlib
+// rather than the user module, so the IR's variantInfo map can't
+// find it).
+//
+// Without this, `if let Some(box) = b: Box?` lowers the bound
+// `box` with `<error>` type — the pattern position knows the
+// payload structurally (Some has one payload of type Box) but the
+// fallback in `variantPayloadType` just returned ErrTypeVal.
+// Downstream consumers (struct field projection, ToString
+// dispatch, …) then poison the local.
+//
+// Returns ir.ErrTypeVal if the scrutinee is not a recognised
+// prelude shape or the variant / index doesn't match.
+func builtinVariantPayloadType(scrutT Type, variantName string, idx int) Type {
+	if scrutT == nil {
+		return ir.ErrTypeVal
+	}
+	if ot, ok := scrutT.(*ir.OptionalType); ok && ot != nil {
+		switch variantName {
+		case "Some":
+			if idx == 0 && ot.Inner != nil {
+				return ot.Inner
+			}
+		case "None":
+			// No payload.
+		}
+		return ir.ErrTypeVal
+	}
+	nt, ok := scrutT.(*ir.NamedType)
+	if !ok || nt == nil || !nt.Builtin {
+		return ir.ErrTypeVal
+	}
+	switch nt.Name {
+	case "Option", "Maybe":
+		if variantName == "Some" && idx == 0 && len(nt.Args) >= 1 {
+			return nt.Args[0]
+		}
+	case "Result":
+		switch variantName {
+		case "Ok":
+			if idx == 0 && len(nt.Args) >= 1 {
+				return nt.Args[0]
+			}
+		case "Err":
+			if idx == 0 && len(nt.Args) >= 2 {
+				return nt.Args[1]
+			}
+		}
+	}
+	return ir.ErrTypeVal
+}
+
+// builtinVariantIndex returns the canonical tag index for a
+// prelude Option / Result variant — matches the layout
+// `Some/Ok = 0`, `None/Err = 1` documented in the LIR Proto
+// fixtures (`source_optional_field_chain` etc.). Used when
+// `variantLayout` returns nil for the builtin shapes so the
+// projection's tag index is meaningful rather than the default 0.
+func builtinVariantIndex(scrutT Type, variantName string) int {
+	switch variantName {
+	case "Some", "Ok":
+		return 0
+	case "None", "Err":
+		return 1
+	}
+	return 0
+}
+
+// resolveVariantPayloadType returns the variant's i-th payload
+// type, falling back to the builtin Option / Result synthesis when
+// the user-side `variantInfo` lookup didn't find a matching enum.
+// scrutT supplies the receiver type for the builtin fallback.
+func resolveVariantPayloadType(info *variantInfo, scrutT Type, variantName string, idx int) Type {
+	if info != nil && info.variant != nil {
+		return variantPayloadType(info, idx)
+	}
+	return builtinVariantPayloadType(scrutT, variantName, idx)
+}
+
+// resolveVariantIndex returns the variant tag index, falling back
+// to the builtin Option / Result canonical mapping when the
+// user-side lookup is nil.
+func resolveVariantIndex(info *variantInfo, scrutT Type, variantName string) int {
+	if info != nil {
+		return info.index
+	}
+	return builtinVariantIndex(scrutT, variantName)
 }
 
 // projectionToPlace turns a HIR decision-tree projection chain into a

--- a/internal/mir/optional_aggregate_lowering_test.go
+++ b/internal/mir/optional_aggregate_lowering_test.go
@@ -32,11 +32,10 @@ import (
 //     chaining return type through.
 func TestLowerOptionalStructPayloadProjectsThroughVariant(t *testing.T) {
 	cases := []struct {
-		name           string
-		src            string
-		wantMIR        []string
-		dontWant       []string
-		allowErrorType bool
+		name     string
+		src      string
+		wantMIR  []string
+		dontWant []string
 	}{
 		{
 			name: "question_field_chain_with_default",
@@ -127,19 +126,19 @@ fn print(b: Box?) -> Int {
 				// `if let Some(box) = b` lowers to a discriminant
 				// probe + Some-arm payload bind, same shape as a
 				// 2-arm match. The bound `box` reaches the body as
-				// a payload projection (`_<x>@Some.0`).
+				// a payload projection (`_<x>@Some.0`) typed as the
+				// inner payload (`Box`), derived from the receiver
+				// `Box?` via `builtinVariantPayloadType` for prelude
+				// Option whose enum decl doesn't live in the user
+				// module.
 				"@Some.0",
 				"discriminant",
 				".n",
+				// Locking the recovered payload type — without the
+				// builtin variant lookup fallback this slot would
+				// read `<error>  // box`.
+				"Box  // box",
 			},
-			// The if-let payload binding's declared type currently
-			// still reaches MIR as `<error>` because the checker
-			// doesn't always thread the pattern position type
-			// down to the binding — tracked separately from this
-			// PR's `?.field` fix. The structural projection is
-			// correct (`_x@Some.0` + `.n`) and downstream lowering
-			// reads the field from the payload directly.
-			allowErrorType: true,
 		},
 	}
 	for _, c := range cases {
@@ -158,7 +157,7 @@ fn print(b: Box?) -> Int {
 					t.Errorf("GAP-INSTR-006 marker %q in MIR:\n%s", b, mirText)
 				}
 			}
-			if !c.allowErrorType && strings.Contains(mirText, "<error>") {
+			if strings.Contains(mirText, "<error>") {
 				t.Errorf("ErrTypeVal leaked into MIR for %s:\n%s", c.name, mirText)
 			}
 			for _, dw := range c.dontWant {


### PR DESCRIPTION
## Summary

`if let Some(box) = b` 에서 `b: Box?` 일 때 MIR 가 binding `box` 를 `let _4: <error>  // box` 로 lower 하던 follow-up. PR #1818 이 `?.field` chain 의 ErrTypeVal 누설을 막았지만, if-let pattern bind 경로는 여전히 ErrTypeVal 로 떨어졌다.

## Root cause

```go
layout := bs.l.variantLayout(vp.Enum, vp.Variant)
// builtin Option/Result 는 nil 반환 (스텁 enum decl 이 user module 에 없음)
for i, arg := range vp.Args {
    pt := variantPayloadType(layout, i)  // -> ErrTypeVal
    ...
    bs.bindPattern(arg, child, pt, ife.SpanV)  // box: <error>
}
```

`variantLayout` 의 코멘트:
> Builtin (Option/Result) — fall back to synthesised layout.

`return nil` 만 있고 synthesised layout 은 없었다.

## Fix

`builtinVariantPayloadType(scrutT, variantName, idx)` + `builtinVariantIndex(scrutT, variantName)` helper 를 새로 추가. `resolveVariantPayloadType` / `resolveVariantIndex` 가 variantLayout 이 nil 일 때 두 helper 로 폴백한다.

매핑:

| receiver | variant | idx | payload |
|---|---|---|---|
| `T?` / `Option<T>` | Some | 0 | T |
| `T?` / `Option<T>` | None | — | — |
| `Result<T, E>` | Ok | 0 | T |
| `Result<T, E>` | Err | 0 | E |

Index convention: Some/Ok = 0, None/Err = 1 — LIR Proto fixture `source_optional_field_chain` 의 tag 와 일치.

Call sites updated:
- `bindPattern` 의 `*ir.VariantPat` 분기 (line ~1184)
- `lowerIfLetVariant` 의 payload bind 루프 (line ~4651)

Before:
```
let _4: <error>  // box
_4 = use _2@Some.0
_0 = use _4.n
```

After:
```
let _4: Box  // box
_4 = use _2@Some.0
_0 = use _4.n
```

## Test plan

- [x] `TestLowerOptionalStructPayloadProjectsThroughVariant` 의 if-let case 에서 `allowErrorType` softening 제거 + `Box  // box` 명시 매칭 추가, 5/5 통과
- [x] PR #1818 의 `?.field` 회귀락 통과 (no regression)
- [x] `./internal/{ir,mir,lexer,parser,resolve,check,diag,backend}` short suite 통과
- [ ] LLVM-측 추가 영향은 osty-self 환경에서만 가시화

https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT

---
_Generated by [Claude Code](https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT)_