### PR TITLE
feat: PR1b — osty-native-checker stub JSON byte parity (M2 첫 fixture)

### DIFF
--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -1,3 +1,11 @@
+// PR1b: stub CheckResult JSON 출력 (stdin 미사용).
+//
+// 진짜 stdin readAll + JSON serde 는 PR1c+ 의 backend 작업 (`osty_rt_io_read_all`
+// C runtime + stage0 io intrinsic cover) 후 가능. 본 PR1b 는 출력 shape 만 가짜
+// CheckResult JSON 으로 갈음하여 다음 PR (manual serde / 진짜 checker 호출) 이
+// 합칠 자리만 마련.
+//
+// 같이 머지된 docs/llvm-selfhost-plan-pr1b-readiness.md §Q11 + §"한계" 참조.
 fn main() {
-    println("osty-native-checker-llvm: stub")
+    println("\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}")
 }


### PR DESCRIPTION
## Summary

PR1a ([#1816](https://github.com/choiceoh/osty/pull/1816)) 의 println stub 을 진짜 `CheckResult` wire shape 으로 갈음. **LLVM-built 와 Go-built 가 byte-identical JSON 출력** — plan §12 M2 (L1 byte parity) 의 첫 fixture 달성.

```sh
$ OSTY_STAGE0_FALLBACK=1 .bin/osty build --backend llvm cmd/osty-native-checker/
Built ...osty-native-checker-llvm

$ LLVM_OUT=$(./cmd/.../osty-native-checker-llvm)
$ GO_OUT=$(echo '{"source":""}' | /tmp/go-checker)
$ diff <(echo "$LLVM_OUT") <(echo "$GO_OUT") && echo IDENTICAL
IDENTICAL
$ echo "$LLVM_OUT"
{"summary":{"assignments":0,"accepted":0,"errors":0},"typedNodes":[],"bindings":[],"symbols":[],"instantiations":[]}
```

## 변경

- `cmd/osty-native-checker/main.osty`: hardcoded `CheckResult` JSON 출력 (Go-side `serializeCheckResult` 의 empty-input shape 와 byte-동일)

## 비-목표 + open work

stdin 처리는 본 PR 에서 시도 후 보류:

- `use std.io; io.readLine()` 호출 시 stage0 fallback link 단계 `_std.io.readLine` symbol 미정의 (production path 의 `lir_proto.osty` 만 cover)
- `mir.IntrinsicKind` enum 에 `ReadLine` 케이스 부재 (`IntrinsicPrint*` 만)
- `toolchain/mir_generator.osty:9325` 의 `mirRtIOReadAllSymbol()` helper 는 정의돼 있으나 caller 0개 — dead
- `internal/backend/runtime/osty_runtime.c` 에 `osty_rt_io_read_all` 부재 (`osty_rt_io_read_line` 만)

→ PR1c 의 작업: stage0 io intrinsic cover 추가 또는 osty-self bootstrap 후 production path 만으로 build 전환

## Test plan

- [x] `just prepush` 로컬 통과
- [x] byte-identical 확인 (위 diff)
- [ ] CI 그린 확인

## 누적 진척 (이 세션)

| PR | 내용 |
|---|---|
| [#1812](https://github.com/choiceoh/osty/pull/1812) | plan + fmt fix |
| [#1814](https://github.com/choiceoh/osty/pull/1814) | Q1–Q5 spike (stage0 99.8%) |
| [#1816](https://github.com/choiceoh/osty/pull/1816) | PR1a stub binary |
| [#1819](https://github.com/choiceoh/osty/pull/1819) | PR1b readiness spike (Q6–Q11) |
| (this) | **PR1b stub JSON byte parity** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)