### PR TITLE
fix: ?.field flattens when field type is already optional

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -4602,15 +4602,21 @@ func (l *lowerer) recoverFieldType(receiverType Type, fieldName string) Type {
 	// Optional chaining: `b?.n` where `b: Box?` lowers as a single
 	// FieldExpr{Optional:true} whose receiver type is `Box?`. The
 	// checker often doesn't record a type for it, and the canonical
-	// struct-field lookup expects a NamedType. Unwrap the option
-	// here, look up the field on the inner nominal, and re-wrap so
-	// the optional-chaining shape `Option<fieldType>` survives —
-	// callers that need the unwrapped type (raw `.field` recovery
-	// after the checker missed it) still see the right shape on
-	// the next branch.
+	// struct-field lookup expects a NamedType. Unwrap the option,
+	// look up the field on the inner nominal, and propagate the
+	// None-short-circuit semantics: the result is Option<fieldType>
+	// unless the field is *already* optional (`Outer.inner: Inner?`),
+	// in which case `?.` flattens — chained `outer?.inner?.value`
+	// must produce `Int?`, not `Int??`. Without the flatten, MIR
+	// builds an extra Option wrapper whose None branch falls back
+	// to `none <error>` because the synthesised type can't be
+	// inferred two levels down.
 	if ot, ok := receiverType.(*OptionalType); ok && ot != nil {
 		if innerNT, ok := ot.Inner.(*NamedType); ok && innerNT != nil && !innerNT.Builtin {
 			if t := l.lookupStructFieldType(innerNT.Name, fieldName); t != nil {
+				if _, alreadyOpt := t.(*OptionalType); alreadyOpt {
+					return t
+				}
 				return &OptionalType{Inner: t}
 			}
 		}

--- a/internal/mir/optional_chain_flatten_test.go
+++ b/internal/mir/optional_chain_flatten_test.go
@@ -1,0 +1,61 @@
+package mir
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLowerOptionalChainFlattensWhenFieldIsAlreadyOption covers
+// chained `?.field` where an intermediate field is itself
+// declared optional, e.g.:
+//
+//	struct Outer { inner: Inner? }
+//	struct Inner { value: Int }
+//
+//	o?.inner?.value ?? -1   // o: Outer?
+//
+// The `?.` operator short-circuits on None and returns the field
+// value as-is. When the field type is already `T?`, the chained
+// `?.` MUST flatten — `o?.inner` is `Inner?`, not `Inner??` — so
+// the next `?.value` projects through a single Option layer to
+// produce `Int?`. Without flattening, MIR builds an extra Option
+// wrapper whose None branch falls back to `none <error>` because
+// the synthesised type can't be inferred two levels down.
+//
+// This complements the simpler `?.field` shape covered in
+// `TestLowerOptionalStructPayloadProjectsThroughVariant` (PR
+// #1818). See CLAUDE.md §A.6:
+//
+//	user?.address?.city ?? "unknown"
+//
+// canonical pattern — `address: Address?` field on a `user: User?`
+// receiver returns the city as `String?` (single Option), not
+// `String??`.
+func TestLowerOptionalChainFlattensWhenFieldIsAlreadyOption(t *testing.T) {
+	src := `struct Outer { inner: Inner? }
+struct Inner { value: Int }
+
+fn deep(o: Outer?) -> Int {
+    o?.inner?.value ?? -1
+}
+`
+	mirText := lowerSourceToMIR(t, src)
+	// First-hop type: o?.inner has type Inner? (NOT Inner??).
+	// Without the flatten, the intermediate slot was `Inner??`
+	// and the second hop's None case carried `<error>`.
+	if !strings.Contains(mirText, "Inner?  // _opt") {
+		t.Errorf("expected first-hop slot typed `Inner?  // _opt` (flat), got:\n%s", mirText)
+	}
+	if strings.Contains(mirText, "Inner??  // _opt") {
+		t.Errorf("first-hop slot incorrectly typed `Inner??  // _opt` — `?.` should flatten when field is already optional:\n%s", mirText)
+	}
+	// Final coalesce target is `Int?` (the second hop produces
+	// Option<Int> by projecting `.value` on an `Inner` from
+	// Some-arm; coalesce default `-1` is Int).
+	if !strings.Contains(mirText, "Int?  // _coalesce") {
+		t.Errorf("expected coalesce slot `Int?  // _coalesce`, got:\n%s", mirText)
+	}
+	if strings.Contains(mirText, "<error>") {
+		t.Errorf("ErrTypeVal leaked into MIR:\n%s", mirText)
+	}
+}


### PR DESCRIPTION
## Summary

Chained `?.field` 가 중간 필드가 이미 `T?` 인 경우 한 레벨만 Option 을 유지하도록 `recoverFieldType` 의 flatten 분기 추가.

CLAUDE.md §A.6 canonical 패턴:

```osty
user?.address?.city ?? "unknown"
```

`address: Address?` 필드에 대해 `user?.address` 는 `Address?` 를 반환해야 한다 (Address?? 아님). 그 다음 `?.city` 가 `String?` 를 만들고 coalesce 가 `String` 으로 unwrap.

## Root cause

PR #1818 의 `recoverFieldType` 가 OptionalType 수신자에 대해 항상 `Option<fieldType>` 로 래핑:

```go
if ot, ok := receiverType.(*OptionalType); ok && ot != nil {
    if innerNT, ok := ot.Inner.(*NamedType); ok && innerNT != nil && !innerNT.Builtin {
        if t := l.lookupStructFieldType(innerNT.Name, fieldName); t != nil {
            return &OptionalType{Inner: t}  // 이중 래핑
        }
    }
    return nil
}
```

필드가 이미 Option 이면 결과가 `Option<Option<T>>` — MIR 가 이중 Option 의 inner None 분기에서 `none <error>` 폴백을 emit 했다 (synthesised None constructor 가 두 레벨 깊이 타입을 추론 못 함).

## Fix

`recoverFieldType` 가 field type 을 조회한 뒤, 이미 OptionalType 이면 그대로 반환 (flatten), 그렇지 않으면 OptionalType 으로 래핑:

```go
if t := l.lookupStructFieldType(innerNT.Name, fieldName); t != nil {
    if _, alreadyOpt := t.(*OptionalType); alreadyOpt {
        return t  // flatten
    }
    return &OptionalType{Inner: t}
}
```

## Coverage

`TestLowerOptionalChainFlattensWhenFieldIsAlreadyOption` 가 `o?.inner?.value ?? -1` 의 MIR 출력을 잠근다:
- 첫 hop 슬롯이 `Inner?  // _opt` (flatten 됨)
- 첫 hop 슬롯이 `Inner??  // _opt` 가 아님 (이중 래핑 금지)
- coalesce 슬롯이 `Int?  // _coalesce`
- `<error>` 누설 부재

## Test plan

- [x] 새 `TestLowerOptionalChainFlattensWhenFieldIsAlreadyOption` 통과
- [x] PR #1818 의 `?.field` 회귀락 (`TestLowerOptionalStructPayloadProjectsThroughVariant`) 통과 — 단일 hop 케이스 영향 없음
- [x] PR #1820 의 if-let payload 회귀락 통과
- [x] PR #1822 의 Result 회귀락 통과
- [x] `./internal/{ir,mir,backend}` short suite 통과

https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT

---
_Generated by [Claude Code](https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT)_