### PR TITLE
feat: PR2 — manual naive JSON parser (옵션 3', backend 의존 0)

### DIFF
--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -1,13 +1,37 @@
-// PR1c: stdin readLine + stub CheckResult JSON echo.
+// PR2: stdin → manual naive JSON parse → stub CheckResult JSON echo.
 //
-// internal/mir/lower.go::rewriteStdlibSymbolToRuntime 가 std.io.readLine →
-// osty_rt_io_read_line 로 rewrite. stage0 fallback 과 production path (lir_proto)
-// 가 같은 symbol 을 보게 되어 link 단계에서 osty_runtime.c 의 함수에 resolve.
+// std.json.* 호출이 stage0 fallback 에서 막힘 (cf. docs/llvm-selfhost-plan-
+// pr2-attempt.md). 우회로: primitive strings.indexOf / strings.slice 만 사용
+// 한 naive "source" field 추출. L1 corpus 의 escape-free fixture (예:
+// `{"source":"fn main(){}"}`) 가정.
+//
+// 정확성 한계:
+// - "source" key 의 `\"` escape, value 안 `\"` escape 미처리
+// - newline / unicode 미처리
+// - 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지
+// PR3 의 진짜 checker 호출 + L2/L3 corpus 진행 시 std.json 으로 교체.
 use std.io
+use std.strings
+
+fn naiveExtractSource(text: String) -> String {
+    let openMarker = "\"source\":\""
+    if let Some(i) = strings.indexOf(text, openMarker) {
+        let startIdx = i + strings.len(openMarker)
+        let rest = strings.slice(text, startIdx, strings.len(text))
+        if let Some(endRel) = strings.indexOf(rest, "\"") {
+            return strings.slice(rest, 0, endRel)
+        }
+    }
+    ""
+}
+
+fn emptyCheckResultJson() -> String {
+    "\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}"
+}
 
 fn main() {
     let input = io.readLine()
-    if input.len() >= 0 {
-        println("\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}")
-    }
+    let _source = naiveExtractSource(input)
+    // 진짜 checker 호출은 PR3 — 현재는 모든 source 입력에 empty CheckResult.
+    println(emptyCheckResultJson())
 }


### PR DESCRIPTION
## Summary

PR2 attempt ([#1827](https://github.com/choiceoh/osty/pull/1827)) 의 std.json wall 우회. primitive `strings.indexOf` / `strings.slice` 만 사용해서 input 의 `source` 필드 추출.

```osty
fn naiveExtractSource(text: String) -> String {
    let openMarker = "\"source\":\""
    if let Some(i) = strings.indexOf(text, openMarker) {
        let startIdx = i + strings.len(openMarker)
        let rest = strings.slice(text, startIdx, strings.len(text))
        if let Some(endRel) = strings.indexOf(rest, "\"") {
            return strings.slice(rest, 0, endRel)
        }
    }
    ""
}
```

## 검증

```sh
$ echo '{"source":""}' | LLVM-built
{"summary":{"assignments":0,"accepted":0,"errors":0},"typedNodes":[],...}

$ echo '{"source":""}' | Go-built
{"summary":{"assignments":0,"accepted":0,"errors":0},"typedNodes":[],...}

diff: IDENTICAL ✓

$ echo '{"source":"fn main(){}"}' | LLVM-built  vs  | Go-built
diff: DIFFER ✗ (예상 — PR3 의 진짜 checker 호출 대기)
```

## 분량

- ~10 LOC 추가 (PR2 attempt doc 의 예상 ~150 보다 훨씬 적음 — `strings.indexOf` 의 `Option<Int>` 처리가 `if let Some` 패턴으로 깔끔)
- 1 파일 (`cmd/osty-native-checker/main.osty`)

## 옵션 3' 채택 이유 ([#1827](https://github.com/choiceoh/osty/pull/1827) §4)

| # | 접근 | LOC | 위험 |
|---|---|---|---|
| 옵션 1' | std.json.* symbol rewrite | ~20 | C Result/aggregate ABI wrapper 필요 |
| 옵션 2' | stdlib body 단순화 | 수 일~수 주 | 큰 |
| **옵션 3'** | **manual parser** | **~10** | **backend 의존 0** |
| 옵션 4 | stage0 stdlib pattern cover | ~100 backend | 중간 |

## 한계 (다음 PR 에서 해결)

- `"source"` key 의 `\"` escape, value 의 `\"` escape 미처리
- newline / unicode 미처리
- 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지

L1 corpus 의 escape-free fixture 만 cover. L2/L3 진행 시 std.json 으로 교체.

## 다음 (PR3) — 진짜 checker 호출

- `selfhostBuildPackageAst(files)` → `(file, layout)`
- `newElabCx(file, None)`
- `selfhostInstallImportSurfaces(env, imports)`
- `elabFile(cx)`
- `serializeCheckResult(cx)`
- `adaptCheckResultWithTokenLayout(raw, layout)` (Go side, Osty 이식 필요 — N8)

PR3 의 추가 wall: toolchain crate dep 의 multi-package build (osty.toml `[dependencies]` 로 toolchain 추가 가능 여부 미지).

## 누적 (이 세션, 10 PR 머지 예정)

| # | PR |
|---|---|
| 1 | [#1812](https://github.com/choiceoh/osty/pull/1812) PR0 plan |
| 2 | [#1814](https://github.com/choiceoh/osty/pull/1814) Spike 1 |
| 3 | [#1816](https://github.com/choiceoh/osty/pull/1816) M1 stub binary |
| 4 | [#1819](https://github.com/choiceoh/osty/pull/1819) Spike 2 |
| 5 | [#1821](https://github.com/choiceoh/osty/pull/1821) M2 stub byte parity |
| 6 | [#1823](https://github.com/choiceoh/osty/pull/1823) PR1c blockers |
| 7 | [#1825](https://github.com/choiceoh/osty/pull/1825) PR1c-1 negative |
| 8 | [#1826](https://github.com/choiceoh/osty/pull/1826) **PR1c 진짜 stdin** |
| 9 | [#1827](https://github.com/choiceoh/osty/pull/1827) PR2 attempt |
| 10 | (this) **PR2 manual parser** |

## Test plan

- [x] `just prepush` 통과
- [x] empty source fixture: byte-identical ✓
- [x] non-empty source: DIFFER 예상 확인 (PR3 대기)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)