### PR TITLE
docs: PR3-A — cross-package module resolution spec 명확화 + SPEC_GAP

### DIFF
--- a/LANG_SPEC_v0.5/05-modules-and-packages.md
+++ b/LANG_SPEC_v0.5/05-modules-and-packages.md
@@ -42,6 +42,20 @@ use go "net/http" {
 re-export cycles are `E0552`. `use go "<path>" { ... }` imports a Go
 package via FFI (see §12).
 
+**Module access path resolution.** Given `use dep_or_pkg`, the imported
+name binds the *package itself*. To access a top-level item from a
+sub-module file within that package, write `dep_or_pkg.module.item`
+(e.g., `use toolchain; toolchain.elab.elabFile(cx)`). Equivalently, the
+shorter form `use dep_or_pkg.module` binds the *module file*, and items
+are accessed as `module.item` (e.g., `use toolchain.elab; elab.elabFile(cx)`).
+`use dep_or_pkg.module as alias` binds the alias to the module. A
+single-segment alias to a *package* (`use toolchain as tc`) is permitted
+and accesses items as `tc.module.item`; the alias never collapses module
+boundaries. Implementations must distinguish module bindings from type
+bindings — applying `<module>.<item>` to a non-module produces `E0703`
+(method-on-type) which currently leaks for cross-package `use` and is
+tracked in `SPEC_GAPS.md` under `cross-pkg-module-resolution`.
+
 ### 5.3 Visibility
 
 Declarations are package-private by default. `pub` exports:

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -4,8 +4,10 @@
 - **Type**: Decision log
   `LANG_SPEC_v0.5/` + `OSTY_GRAMMAR_v0.5.md` 기준.
 
-**현재 open gap: 없음.** v0.4 사용 코퍼스에서 관찰된 15 개
-개선점(G20-G34) 을 v0.5 에서 일괄 결정했고, vectorize-hint 트랙의
+**현재 open gap: 1.** `cross-pkg-module-resolution` (이 PR 에서 등록) —
+LLVM self-host trajectory 의 PR3 (`cmd/osty-native-checker` 가 toolchain
+crate dep 의 함수를 호출) 진입 시 발견. v0.4 사용 코퍼스에서 관찰된 15
+개 개선점(G20-G34) 을 v0.5 에서 일괄 결정했고, vectorize-hint 트랙의
 마지막 gap (iterator-protocol 루프) 도 PR #1632/#1642 로 해소됐다.
 
 스펙은 v0.2 부터 폴더 구조이다. §X (X = 1..19) 는 `LANG_SPEC_v0.5/NN-*.md`
@@ -219,6 +221,27 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 의 struct 정의에서 그대로 흡수.
 
 **관련 PR**: TBD (이번 작업).
+
+### `cross-pkg-module-resolution` — `use <dep>.<module>` 가 module 이 아니라 type 으로 해석됨
+
+**Scope**: LANG_SPEC §5.2 ([modules-and-packages](LANG_SPEC_v0.5/05-modules-and-packages.md)) + 컴파일러 구현.
+
+**관찰**: `osty.toml` 의 `[dependencies]` 로 path-dep 가 resolve 되고 `use toolchain` alone 은 통과하나, `use toolchain.check` 또는 `use toolchain.check as tc` + `tc.frontInvalidTypeRepr()` 호출 시 native checker 가 `E0703: no method 'frontInvalidTypeRepr' on type 'check'` 발화. 즉 `check` (module binding) 가 type 으로 잘못 해석됨.
+
+**진단**: `examples/` 와 `toolchain/` 의 모든 `.osty` 가 `use std.*` 만 사용 — `std` 가 prelude-special-cased 라 일반 cross-package use path 와 다른 경로로 resolve 되는 듯. 사용자-level cross-package import 의 정통 예시가 코퍼스에 0건이라 실제 동작이 검증된 적 없음.
+
+**spec 의 의미**: LANG_SPEC §5.2 의 module access path resolution 단락 (2026-05-16 추가) 이 "module bindings 와 type bindings 의 구분 필요" 를 명시. 본 gap 은 구현이 그 spec 을 따르지 않는 상태.
+
+**영향**: LLVM self-host plan ([docs/llvm-selfhost-plan.md](docs/llvm-selfhost-plan.md)) 의 PR3 ([docs/llvm-selfhost-plan-pr3-design.md](docs/llvm-selfhost-plan-pr3-design.md)) 가 이 gap 의 해결을 선행 조건으로 함. `cmd/osty-native-checker/main.osty` 가 `toolchain.elab.elabFile` 등을 호출하려면 native checker 가 module path 를 인식해야.
+
+**해결 path**:
+1. `toolchain/resolve.osty` + `toolchain/elab.osty` 의 cross-package use 처리 — 현재 prelude-special-case 만 cover, 일반 path 추가
+2. `[lib]` crate 가 dep 로 import 될 때 module file → `Module` symbol 등록 (현재 type 등록으로 fallback)
+3. `<module>.<symbol>` access 가 method-lookup 가 아니라 module-scoped symbol lookup 으로 dispatch
+
+**관련 PR**: TBD (다음 세션 PR3-B/C).
+
+**관련 doc**: [docs/llvm-selfhost-plan-pr3-attempt.md](docs/llvm-selfhost-plan-pr3-attempt.md), [docs/llvm-selfhost-plan-pr3-design.md](docs/llvm-selfhost-plan-pr3-design.md).
 
 ### ~~`default-arg-resolve`~~ — defaulted parameter 가 함수 scope 에 등록 안 됨 — **해소됨 (2026-05-05)**
 


### PR DESCRIPTION
## Summary

[PR3 design](docs/llvm-selfhost-plan-pr3-design.md) ([#1831](https://github.com/choiceoh/osty/pull/1831)) 의 PR3-A — spec 명확화 단계.

## 변경

| 파일 | 변경 |
|---|---|
| `LANG_SPEC_v0.5/05-modules-and-packages.md` | §5.2 에 module access path resolution 단락 추가 — `use <dep>` / `use <dep>.<module>` / `use <dep>.<module> as alias` 세 형태의 의미 + module vs type binding 구분 |
| `SPEC_GAPS.md` | `cross-pkg-module-resolution` open gap 등록 — 현재 open gap 0 → 1 |

## 관찰

- `osty.toml [dependencies] path-dep` resolve 통과
- `use toolchain` alone build 통과
- `use toolchain.check; check.fn()` → `E0703 no method on type 'check'` (module → type 오해석)
- `examples/` 와 `toolchain/` 의 모든 `.osty` 가 `use std.*` 만 — **cross-package 사용자 import 정통 예시 0건**, `std` 가 prelude-special-case 가능성

## 영향

LLVM self-host plan ([docs/llvm-selfhost-plan.md](docs/llvm-selfhost-plan.md)) 의 **PR3-B ~ PR3-F 의 선행 조건**. 이 gap 의 해결 없이는 `cmd/osty-native-checker/main.osty` 가 `toolchain.elab.elabFile` 등 호출 불가.

## 해결 path (구현 PR — PR3-B/C/D/E/F)

1. `toolchain/resolve.osty` + `toolchain/elab.osty` 의 일반 cross-package path 처리 추가
2. `[lib]` crate dep 시 module file → `Module` symbol 등록 (현재 type fallback)
3. `<module>.<symbol>` access 가 module-scoped lookup

## 누적 (이 세션, 13 PR 머지 예정)

| # | PR | milestone |
|---|---|---|
| 1–8 | (PR0 ~ PR1c 진짜 stdin) | ✓ |
| 9 | [#1827](https://github.com/choiceoh/osty/pull/1827) | PR2 attempt |
| 10 | [#1829](https://github.com/choiceoh/osty/pull/1829) | **PR2 manual parser** |
| 11 | [#1830](https://github.com/choiceoh/osty/pull/1830) | PR3 attempt |
| 12 | [#1831](https://github.com/choiceoh/osty/pull/1831) | PR3 design |
| 13 | (this) | **PR3-A spec 명확화** |

## Test plan

- [x] `just prepush` 통과
- [x] LANG_SPEC + SPEC_GAPS 일치 확인
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)