### PR TITLE
feat: PR3-B — [lib]-only manifest decline 진단 + spec gap 확장

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -238,6 +238,7 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 1. `toolchain/resolve.osty` + `toolchain/elab.osty` 의 cross-package use 처리 — 현재 prelude-special-case 만 cover, 일반 path 추가
 2. `[lib]` crate 가 dep 로 import 될 때 module file → `Module` symbol 등록 (현재 type 등록으로 fallback)
 3. `<module>.<symbol>` access 가 method-lookup 가 아니라 module-scoped symbol lookup 으로 dispatch
+4. `cmd/osty/build.go::emitViaQuery` 가 `m.Lib != nil` 인 manifest 를 library object + export meta 산출 path 로 route. **현재 manifest.go 가 `[lib]` parse + render 하나 cmd/osty 의 build 가 활용 0건** — 2026-05-16 PR 에서 explicit decline 진단으로 surface.
 
 **관련 PR**: TBD (다음 세션 PR3-B/C).
 

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -461,6 +461,17 @@ func emitAndBuildViaQuery(root string, m *manifest.Manifest, eng *ostyquery.Engi
 
 func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyquery.Engine, lower ostyquery.LowerKey, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode, binName string) *backend.Result {
 	commandName := "osty " + command
+	// Library-only manifest (`[lib]` without `[bin]`): currently the cmd/osty
+	// build pipeline only knows how to emit binaries, so a library crate's
+	// object/export-meta path is not yet wired. Surface the gap to the user
+	// instead of silently skipping. Tracked in
+	// SPEC_GAPS.md::cross-pkg-module-resolution and the LLVM self-host plan's
+	// PR3-E. Library entry handling will fold into this path once
+	// docs/llvm-selfhost-plan-pr3-design.md PR3-E lands.
+	if m != nil && m.Lib != nil && m.Bin == nil {
+		fmt.Fprintf(os.Stderr, "%s: library-only manifest ([lib] without [bin]) is not yet supported by the LLVM build path; see SPEC_GAPS.md::cross-pkg-module-resolution\n", commandName)
+		return nil
+	}
 	entryRel := "main.osty"
 	if m != nil && m.Bin != nil && m.Bin.Path != "" {
 		entryRel = m.Bin.Path


### PR DESCRIPTION
## Summary

PR3-A ([#1832](https://github.com/choiceoh/osty/pull/1832)) 의 후속 — `[lib]` manifest 처리의 현 상태 측정 + 사용자 surface 진단 추가.

## 측정

| layer | `[lib]` 처리 |
|---|---|
| `internal/manifest/manifest.go` | parse + `m.Lib *LibTarget` + render. 정상 |
| `cmd/osty/build.go` | `m.Lib` reference **0건**. silently skip |

즉 manifest 차원에서 `[lib]` 인지 + spec §13.2 에 schema 명시 됐으나 cmd/osty 의 build path 가 활용 안 함.

## 변경

| 파일 | 변경 |
|---|---|
| `cmd/osty/build.go::emitViaQuery` | `[lib]`-only manifest (`[lib]` without `[bin]`) build 시 explicit decline 진단 추가 |
| `SPEC_GAPS.md::cross-pkg-module-resolution` | gap 의 해결 path 에 #4 추가 (cmd/osty build path 의 m.Lib 미활용) |

```
$ osty build path/to/lib-only-pkg/
osty build: library-only manifest ([lib] without [bin]) is not yet
supported by the LLVM build path; see SPEC_GAPS.md::cross-pkg-module-resolution
```

## 비-목표

진짜 lib build path (object + export meta 산출, dep linker integration) 는 **PR3-E** 의 범위. 본 PR 은 wall 의 user-visible surface 만.

`[bin] + [lib]` 공존 케이스 (rust-style library + binary 동시): spec §13.2 가 둘 다 optional 로 정의 — coexist 가능. 본 PR 의 decline 은 `[lib]`-only 케이스에만 적용.

## 누적 (이 세션, 14 PR 머지 예정)

| # | PR |
|---|---|
| 1–13 | (PR0 ~ PR3-A) |
| 14 | (this) PR3-B [lib]-only decline |

## Test plan

- [x] `just prepush` 통과
- [x] [lib]-only manifest decline 메시지 확인
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)