### PR TITLE
docs: PR3-C 측정 — toolchain/resolve.osty 의 use-decl path 추적 부재

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -239,6 +239,7 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 2. `[lib]` crate 가 dep 로 import 될 때 module file → `Module` symbol 등록 (현재 type 등록으로 fallback)
 3. `<module>.<symbol>` access 가 method-lookup 가 아니라 module-scoped symbol lookup 으로 dispatch
 4. `cmd/osty/build.go::emitViaQuery` 가 `m.Lib != nil` 인 manifest 를 library object + export meta 산출 path 로 route. **현재 manifest.go 가 `[lib]` parse + render 하나 cmd/osty 의 build 가 활용 0건** — 2026-05-16 PR 에서 explicit decline 진단으로 surface.
+5. **`toolchain/resolve.osty:499` — use-decl 처리 시 alias 만 `"package"` kind 의 symbol 로 등록, full import path 미저장**. 즉 `use toolchain.check as tc` 시 `tc` 는 알려지지만 어떤 module 인지 추적 없음 → `tc.frontInvalidTypeRepr()` 호출 시 method-on-package 인지 못 하고 method-on-type 으로 fallback → E0703. 진짜 fix = `SelfSymbol` 에 import-path 필드 추가 + module-scoped lookup arm (`elab.osty` 의 method-call dispatch 에 새 분기). 추정 ~150 LOC + 다수 사이트 회귀 검증.
 
 **관련 PR**: TBD (다음 세션 PR3-B/C).
 


### PR DESCRIPTION
PR3-attempt + PR3-B 확장 분석. toolchain/resolve.osty:499 (srAstCollectDecl 의 AstNUseDecl 처리) 측정:

  out = srAddUseSymbol(out, selfSymbolAtNode(
    alias, "package", "", 0, 0, node.start, node.end, ...))

즉 use-decl 처리 시 alias 만 "package" kind 의 symbol 로 등록. full import path (예: "toolchain.check") 미저장. 그래서:

  use toolchain.check as tc
  let _ = tc.frontInvalidTypeRepr()  // E0703

→ tc 가 package kind 알려졌으나 어떤 module 인지 추적 0건. method-call 시 module-scoped lookup 분기 부재 → method-on-type 으로 fallback → E0703.

진짜 fix:
- SelfSymbol 에 import-path 필드 추가
- elab.osty 의 method-call dispatch 에 새 분기 (module-scoped lookup)
- 추정 ~150 LOC + 다수 사이트 회귀 검증

SPEC_GAPS.md::cross-pkg-module-resolution gap 의 해결 path 에 #5 추가.

본 PR 은 측정 doc 갱신만. 진짜 구현 변경은 PR3-C-impl 별도.