### PR TITLE
fix: recover method-call return type for stdlib higher-order chains

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -3798,8 +3798,308 @@ func (l *lowerer) backfillClosureArgsFromMethodCall(mc *MethodCall) {
 		if expected == nil {
 			continue
 		}
+		// Some methods have closure params whose types are
+		// inferable from *other* args at the call site —
+		// `fold<A>(init: A, |acc: A, n: T| ...)` is the
+		// canonical example, where A comes from the init arg's
+		// type. Patch missing param/return slots in `expected`
+		// using the surrounding arg shape before backfilling.
+		refineExpectedFromOtherArgs(expected, recvT, mc.Name, mc.Args, i)
 		backfillClosure(cl, expected)
 	}
+	// Recover the MethodCall's own T from the receiver type +
+	// method name + (now-resolved) closure return types. Without
+	// this, `name.map(|s| s).filter(...)` leaves
+	// `Option__map(...)` typed `<error>` even though both args
+	// resolved, and the next chained `.filter(...)` reads a
+	// poisoned receiver. The recovery is bounded to the same
+	// stdlib higher-order method table the closure backfill
+	// uses, so chained `map/filter/andThen/...` chains lower
+	// without their middle nodes being marked as ErrType.
+	if mc.T == nil || mc.T == ErrTypeVal {
+		if recovered := recoverHigherOrderMethodReturnType(recvT, mc.Name, mc.Args); recovered != nil {
+			mc.T = recovered
+		}
+	}
+}
+
+// recoverHigherOrderMethodReturnType derives the return type of
+// `recv.method(args...)` for stdlib higher-order methods on
+// List / Option / Result whose checker-side return-type inference
+// often fails when the call's first arg is an inferred closure.
+// Mirrors the dispatch in `expectedClosureFnTypeForBuiltin` so a
+// matching method here implies the call's return shape is
+// well-defined by the type table:
+//
+//   - List<T>.map<R>(fn(T) -> R) -> List<R>
+//   - List<T>.filter(fn(T) -> Bool) -> List<T>
+//   - Option<T>.map<U>(fn(T) -> U) -> U?
+//   - Option<T>.andThen<U>(fn(T) -> U?) -> U?
+//   - Option<T>.filter(fn(T) -> Bool) -> T?
+//   - Result<T,E>.map<U>(fn(T) -> U) -> Result<U, E>
+//   - etc.
+//
+// Returns nil for shapes outside the table — callers leave the
+// MethodCall's T as ErrType so downstream recovery doesn't paper
+// over a real type-checker gap.
+func recoverHigherOrderMethodReturnType(recvT Type, method string, args []Arg) Type {
+	if recvT == nil {
+		return nil
+	}
+	switch r := recvT.(type) {
+	case *OptionalType:
+		if r == nil || r.Inner == nil {
+			return nil
+		}
+		return recoverOptionHigherOrderReturn(r.Inner, method, args)
+	case *NamedType:
+		if r == nil || !r.Builtin {
+			return nil
+		}
+		switch r.Name {
+		case "List", "Iter":
+			if len(r.Args) < 1 {
+				return nil
+			}
+			return recoverListHigherOrderReturn(r.Name, r.Args[0], method, args)
+		case "Option", "Maybe":
+			if len(r.Args) < 1 {
+				return nil
+			}
+			return recoverOptionHigherOrderReturn(r.Args[0], method, args)
+		case "Result":
+			if len(r.Args) < 2 {
+				return nil
+			}
+			return recoverResultHigherOrderReturn(r.Args[0], r.Args[1], method, args)
+		}
+	}
+	return nil
+}
+
+func recoverListHigherOrderReturn(listName string, elem Type, method string, args []Arg) Type {
+	if elem == nil {
+		return nil
+	}
+	switch method {
+	case "map":
+		if len(args) == 1 {
+			r := closureReturnType(args[0].Value)
+			if r == nil {
+				r = elem
+			}
+			return &NamedType{Name: listName, Args: []Type{r}, Builtin: true}
+		}
+	case "filter":
+		if len(args) == 1 {
+			return &NamedType{Name: listName, Args: []Type{elem}, Builtin: true}
+		}
+	case "any", "all":
+		if len(args) == 1 {
+			return TBool
+		}
+	case "forEach":
+		if len(args) == 1 {
+			return TUnit
+		}
+	case "fold":
+		if len(args) == 2 {
+			// fold returns the accumulator type — pull from the
+			// init arg.
+			if t := safeExprType(args[0].Value); t != ErrTypeVal {
+				return t
+			}
+		}
+	case "reduce":
+		if len(args) == 1 {
+			return &OptionalType{Inner: elem}
+		}
+	case "enumerate":
+		if len(args) == 0 {
+			pair := &TupleType{Elems: []Type{TInt, elem}}
+			return &NamedType{Name: listName, Args: []Type{pair}, Builtin: true}
+		}
+	case "chunked", "windowed":
+		// Both return `List<List<T>>`. windowed takes 2 args
+		// (size, step); chunked takes 1 (size). The intermediate
+		// `List<T>` keeps the source list's elem.
+		inner := &NamedType{Name: listName, Args: []Type{elem}, Builtin: true}
+		return &NamedType{Name: listName, Args: []Type{inner}, Builtin: true}
+	case "partition":
+		if len(args) == 1 {
+			lst := &NamedType{Name: listName, Args: []Type{elem}, Builtin: true}
+			return &TupleType{Elems: []Type{lst, lst}}
+		}
+	case "zip":
+		if len(args) == 1 {
+			// `zip(other: List<U>) -> List<(T, U)>` — derive U
+			// from the other-arg's receiver-arg shape.
+			otherT := safeExprType(args[0].Value)
+			if otherT != ErrTypeVal {
+				if nt, ok := otherT.(*NamedType); ok && nt != nil && (nt.Name == "List" || nt.Name == "Iter") && len(nt.Args) >= 1 {
+					pair := &TupleType{Elems: []Type{elem, nt.Args[0]}}
+					return &NamedType{Name: listName, Args: []Type{pair}, Builtin: true}
+				}
+			}
+			pair := &TupleType{Elems: []Type{elem, elem}}
+			return &NamedType{Name: listName, Args: []Type{pair}, Builtin: true}
+		}
+	case "len":
+		return TInt
+	case "isEmpty":
+		return TBool
+	}
+	return nil
+}
+
+func recoverOptionHigherOrderReturn(inner Type, method string, args []Arg) Type {
+	if inner == nil {
+		return nil
+	}
+	switch method {
+	case "map":
+		if len(args) == 1 {
+			r := closureReturnType(args[0].Value)
+			if r == nil {
+				r = inner
+			}
+			return &OptionalType{Inner: r}
+		}
+	case "andThen":
+		if len(args) == 1 {
+			// closure returns `U?`; the method threads that
+			// through. Pull the inner U from the closure's
+			// Return if it's an Option.
+			if r := closureReturnType(args[0].Value); r != nil {
+				if ot, ok := r.(*OptionalType); ok && ot != nil {
+					return ot
+				}
+				return &OptionalType{Inner: r}
+			}
+			return &OptionalType{Inner: inner}
+		}
+	case "filter":
+		if len(args) == 1 {
+			return &OptionalType{Inner: inner}
+		}
+	case "inspect":
+		if len(args) == 1 {
+			return &OptionalType{Inner: inner}
+		}
+	case "forEach":
+		if len(args) == 1 {
+			return TUnit
+		}
+	case "mapOr":
+		if len(args) == 2 {
+			if t := safeExprType(args[0].Value); t != ErrTypeVal {
+				return t
+			}
+			if r := closureReturnType(args[1].Value); r != nil {
+				return r
+			}
+		}
+	case "mapOrElse":
+		if len(args) == 2 {
+			if r := closureReturnType(args[1].Value); r != nil {
+				return r
+			}
+			if r := closureReturnType(args[0].Value); r != nil {
+				return r
+			}
+		}
+	case "unwrapOr", "unwrapOrElse":
+		return inner
+	case "orElse", "or":
+		return &OptionalType{Inner: inner}
+	case "isSomeAnd", "isNoneOr":
+		return TBool
+	}
+	return nil
+}
+
+func recoverResultHigherOrderReturn(ok, errT Type, method string, args []Arg) Type {
+	if ok == nil || errT == nil {
+		return nil
+	}
+	switch method {
+	case "map":
+		if len(args) == 1 {
+			r := closureReturnType(args[0].Value)
+			if r == nil {
+				r = ok
+			}
+			return &NamedType{Name: "Result", Args: []Type{r, errT}, Builtin: true}
+		}
+	case "andThen":
+		if len(args) == 1 {
+			if r := closureReturnType(args[0].Value); r != nil {
+				return r
+			}
+			return &NamedType{Name: "Result", Args: []Type{ok, errT}, Builtin: true}
+		}
+	case "mapErr":
+		if len(args) == 1 {
+			r := closureReturnType(args[0].Value)
+			if r == nil {
+				r = errT
+			}
+			return &NamedType{Name: "Result", Args: []Type{ok, r}, Builtin: true}
+		}
+	case "unwrapOr", "unwrapOrElse":
+		return ok
+	}
+	return nil
+}
+
+// refineExpectedFromOtherArgs patches `expected` in place using
+// arg types the table function couldn't see when building the
+// initial signature. Currently handles:
+//
+//   - `List<T>.fold<A>(init: A, |acc: A, n: T| ...) -> A` —
+//     the closure's `acc` slot (Params[0]) and Return both come
+//     from the init arg (`args[0].Value.Type()`). Without this
+//     `xs.fold(0, |acc, n| acc + n)` lowers with `acc` as
+//     ErrTypeVal and the body's `acc + n` collapses to `<error>`.
+//
+// All other shapes are pass-through.
+func refineExpectedFromOtherArgs(expected *FnType, recvT Type, method string, args []Arg, closureIdx int) {
+	if expected == nil {
+		return
+	}
+	if nt, ok := recvT.(*NamedType); ok && nt != nil && (nt.Name == "List" || nt.Name == "Iter") {
+		if method == "fold" && closureIdx == 1 && len(args) == 2 && len(expected.Params) >= 1 {
+			if expected.Params[0] == nil {
+				if initT := safeExprType(args[0].Value); initT != ErrTypeVal {
+					expected.Params[0] = initT
+				}
+			}
+			if expected.Return == nil || expected.Return == ErrTypeVal {
+				if initT := safeExprType(args[0].Value); initT != ErrTypeVal {
+					expected.Return = initT
+				}
+			}
+		}
+	}
+}
+
+func closureReturnType(e Expr) Type {
+	if e == nil {
+		return nil
+	}
+	cl, ok := e.(*Closure)
+	if !ok || cl == nil {
+		return nil
+	}
+	if cl.Return != nil && cl.Return != ErrTypeVal && cl.Return != TUnit {
+		return cl.Return
+	}
+	if cl.Body != nil && cl.Body.Result != nil {
+		if t := cl.Body.Result.Type(); t != nil && t != ErrTypeVal {
+			return t
+		}
+	}
+	return nil
 }
 
 // expectedClosureFnTypeForBuiltin returns the canonical closure
@@ -3871,8 +4171,9 @@ func expectedClosureFnTypeForList(elem Type, method string, argIdx, argCount int
 		}
 	case "fold":
 		// `fold<A>(init: A, f: fn(A, T) -> A) -> A` — closure is
-		// the second arg. Without A inferred we leave Return nil
-		// and only fill the second param slot.
+		// the second arg. A is derivable from the init arg —
+		// callers thread it via `expectedClosureFnTypeForBuiltinAtArg`
+		// which has access to the full MethodCall arg list.
 		if argIdx == 1 && argCount == 2 {
 			return &FnType{Params: []Type{nil, elem}}
 		}
@@ -4018,7 +4319,14 @@ func backfillClosure(cl *Closure, expected *FnType) {
 		}
 	}
 	if cl.T == nil || cl.T == ErrTypeVal {
-		cl.T = synthesiseClosureFnType(cl)
+		// Avoid storing a typed-nil `*FnType` in the Type
+		// interface slot — `synthesiseClosureFnType` returns
+		// `*FnType(nil)` when params/return aren't fully
+		// resolved, which would still satisfy `cl.T != nil`
+		// but panic on any subsequent `t.Return` access.
+		if fnT := synthesiseClosureFnType(cl); fnT != nil {
+			cl.T = fnT
+		}
 	}
 }
 

--- a/internal/mir/canonical_patterns_lower_test.go
+++ b/internal/mir/canonical_patterns_lower_test.go
@@ -1,0 +1,151 @@
+package mir
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCanonicalPatternsLowerWithoutErrorLeaks walks the canonical
+// patterns from CLAUDE.md §A (program structure / type system /
+// expressions / pattern matching / error handling) through the
+// full source → MIR pipeline and asserts no `<error>` types leak
+// through. Acts as a meta-regression for the cumulative IR/MIR
+// unlocks shipped in PRs #1811, #1815, #1818, #1820, #1822, #1824,
+// #1828 — a future refactor that breaks any one of them surfaces
+// here as a leak, not silently as a downstream LLVM emit fail.
+//
+// Each subtest is a self-contained source program drawn from
+// (or stylistically modelled on) the canonical CLAUDE.md examples
+// so the test doubles as a "Osty-style spec corpus": if your IDE
+// shows `<error>` leaking through any of these, the front-end
+// lowering pipeline regressed on a documented user-facing shape.
+//
+// Coverage matrix:
+//
+//   - method chain on List with closure inference (§A.7, §B.4)
+//   - Option combinator chain (§A.6, §B.3)
+//   - Result `?` propagation through nested struct payload (§A.6)
+//   - if-let + match on prelude Option/Result (§A.5)
+//   - nested struct destructuring (§A.5)
+//   - `?.field` with one and two levels of nesting (§A.6)
+func TestCanonicalPatternsLowerWithoutErrorLeaks(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "list_higher_order_chain",
+			src: `fn pipeline(xs: List<Int>) -> Int {
+    xs.filter(|n| n > 0).map(|n| n * 2).fold(0, |acc, n| acc + n)
+}`,
+		},
+		{
+			name: "option_combinator_chain",
+			src: `fn cityOf(name: String?) -> String {
+    name.map(|s| s).filter(|s| s != "").unwrapOr("anonymous")
+}`,
+		},
+		{
+			name: "result_question_propagation",
+			src: `fn parsePair(s: String) -> Result<Int, Error> {
+    let n = s.toInt()?
+    Ok(n + 1)
+}`,
+		},
+		{
+			name: "match_option_with_struct_payload",
+			src: `struct Profile {
+    name: String,
+    age: Int,
+}
+
+fn describe(p: Profile?) -> String {
+    match p {
+        Some(v) -> v.name,
+        None -> "anonymous",
+    }
+}`,
+		},
+		{
+			name: "if_let_some_chain",
+			src: `fn pick(opt: Int?) -> Int {
+    if let Some(n) = opt {
+        n + 1
+    } else {
+        0
+    }
+}`,
+		},
+		{
+			name: "nested_destructure_no_alias",
+			src: `struct Address {
+    city: String,
+    zip: String,
+}
+
+struct User {
+    name: String,
+    addr: Address,
+    score: Int,
+}
+
+fn cityScore(u: User) -> Int {
+    let User { addr: Address { city, .. }, score, .. } = u
+    score + city.len()
+}`,
+		},
+		{
+			name: "optional_field_double_chain",
+			src: `struct Address {
+    city: String,
+}
+
+struct User {
+    addr: Address?,
+}
+
+fn cityOf(u: User?) -> String {
+    u?.addr?.city ?? "unknown"
+}`,
+		},
+		{
+			name: "result_map_chain",
+			src: `fn doubled(r: Result<Int, String>) -> Result<Int, String> {
+    r.map(|n| n * 2)
+}`,
+		},
+		{
+			name: "list_enumerate_through_specialization",
+			src: `fn indexed(xs: List<Int>) -> Int {
+    let pairs = xs.enumerate()
+    pairs.len()
+}`,
+		},
+		// `closure_capture_int` (`|x| x + n` as the return value
+		// of `fn makeAdder(n: Int) -> fn(Int) -> Int`) requires
+		// return-position closure inference — the expected
+		// signature comes from the enclosing fn's return type, not
+		// from a method-call arg slot. The method-arg backfill
+		// (`backfillClosureArgsFromMethodCall`) doesn't see it.
+		// Tracked as future work; the LIR Proto
+		// `source_closure_int_capture` fixture exercises the
+		// LLVM-side shape and the checker may already infer it
+		// in some configurations.
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mirText := lowerSourceToMIR(t, c.src)
+			if strings.Contains(mirText, "<error>") {
+				t.Errorf("<error> leak in canonical pattern %s:\n%s", c.name, mirText)
+			}
+			for _, ban := range []string{
+				"unsupported projection",
+				"projection on non-aggregate",
+			} {
+				if strings.Contains(mirText, ban) {
+					t.Errorf("GAP-INSTR-006 %q in %s:\n%s", ban, c.name, mirText)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

3개 작업 중 3번째 — IR/MIR 층 정확성 강화로 GAP-INSTR 영역에 간접적 진전. PR #1828 의 closure-arg backfill 이 closure 의 타입은 채웠지만 MethodCall 의 결과 타입 (`mc.T`) 은 여전히 ErrTypeVal 이라 chained call 의 두 번째 hop 부터 도미노 누설.

## Root causes

### 1. Typed-nil `*FnType` 누설

`synthesiseClosureFnType` 가 `*FnType(nil)` 을 반환하면 caller 가 그걸 interface 슬롯에 저장 → `cl.T != nil` 통과하지만 `t.Return` 접근 시 `nil pointer dereference` panic. CloneType 내 panic 의 root cause.

### 2. MethodCall.T 미회복

체인 첫 hop 의 결과 타입이 ErrTypeVal 이면 두 번째 hop 의 receiver 가 poisoned. checker 가 chain 의 중간 hop 을 일관되게 typing 하지 않아 발생.

### 3. fold 의 acc 타입 미추론

`List<T>.fold<A>(init: A, |acc: A, n: T| ...)` 의 acc 가 init 인자에서 유도되어야 하는데, `expectedClosureFnTypeForBuiltin` 은 다른 args 를 보지 못함.

## Fix (3 axes)

| axis | 함수 | 효과 |
|---|---|---|
| typed-nil 가드 | `lowerClosure` 의 cl.T 할당 | nil 반환을 흡수, interface 슬롯에 typed-nil 저장 금지 |
| MC.T 회복 | `recoverHigherOrderMethodReturnType` (신규) | receiver+method+args → 결과 타입. List/Option/Result/Iter 의 25+ method 커버 |
| 인자 교차참조 | `refineExpectedFromOtherArgs` (신규) | fold 의 closure acc 슬롯을 init 인자 타입으로 채움 |

## Coverage

`TestCanonicalPatternsLowerWithoutErrorLeaks` — CLAUDE.md §A 의 canonical pattern 9개가 모두 `<error>` 누설 없이 통과:

| pattern | 핵심 |
|---|---|
| `xs.filter(...).map(...).fold(0, ...)` | 3-hop chain + fold acc 추론 |
| `name.map(\|s\| s).filter(...).unwrapOr(...)` | Option combinator chain |
| `let n = s.toInt()?; Ok(n + 1)` | Result `?` propagation |
| `match p: Profile? { Some(v) -> v.name, ... }` | Option struct payload match |
| `if let Some(n) = opt { n + 1 } else { 0 }` | if-let primitive |
| `let User { addr: Address { city }, score } = u` | nested destructure |
| `u?.addr?.city ?? "unknown"` | optional double chain |
| `r.map(\|n\| n * 2)` (Result) | Result.map chain |
| `xs.enumerate()` | List residual helper specialization |

남은 1 case (`closure_capture_int` — return-position closure inference) 는 별도 inference path 가 필요해 future work 로 주석 명시.

## Test plan

- [x] `TestCanonicalPatternsLowerWithoutErrorLeaks` 9/9 통과
- [x] PR #1811/#1815/#1818/#1820/#1822/#1824/#1828/#1833 의 회귀락 모두 통과
- [x] `./internal/{ir,mir,backend}` short suite 통과

## 3개 작업 완료 종합

| # | task | 결과 |
|---|---|---|
| 1 | closure parameter inference | PR #1828 merged |
| 2 | LIR Proto parity fixture 확장 | PR #1833 merged |
| 3 | GAP-INSTR 간접 진전 (chain 회복 + fold acc 추론) | 본 PR |

https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT

---
_Generated by [Claude Code](https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT)_