### PR TITLE
fix: closure inference for return-position + let-FnType-annotation

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -257,7 +257,45 @@ func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
 	if fn.Body != nil {
 		out.Body = l.lowerBlock(fn.Body)
 	}
+	// Return-position closure inference: `fn f() -> fn(Int) -> Int { |x| x + 1 }`
+	// — the trailing-expression closure inherits its expected
+	// signature from the declared return type. Without this,
+	// the closure's `Params[i].Type` stays nil and the body's
+	// Idents reading those params lower with ErrTypeVal.
+	// `lowerClosure` already handles the equivalent let-with-
+	// annotation case via `out.T = l.exprType(c)` when the
+	// checker captures it, but the return-position case is
+	// usually missing because the checker doesn't run on the
+	// builtin-routed Closure node.
+	if fnT, ok := out.Return.(*FnType); ok && fnT != nil {
+		backfillTrailingClosure(out.Body, fnT)
+	}
 	return out
+}
+
+// backfillTrailingClosure refines a function body's trailing
+// closure expression with an expected fn signature. The trailing
+// closure can live in either `Block.Result` (when the body's
+// final expression is captured as the block's implicit result)
+// or the last `ExprStmt` of `Block.Stmts` (when the parser
+// preserved it as a statement-position trailing expression — the
+// common case for single-expr `fn` bodies). Both shapes lower to
+// the same closure value; both need the backfill.
+func backfillTrailingClosure(body *Block, expected *FnType) {
+	if body == nil || expected == nil {
+		return
+	}
+	if cl, ok := body.Result.(*Closure); ok && cl != nil {
+		backfillClosure(cl, expected)
+		return
+	}
+	if n := len(body.Stmts); n > 0 {
+		if es, ok := body.Stmts[n-1].(*ExprStmt); ok && es != nil {
+			if cl, ok := es.X.(*Closure); ok && cl != nil {
+				backfillClosure(cl, expected)
+			}
+		}
+	}
 }
 
 // extractInlineMode reads the v0.6 A8 `#[inline]` family off the
@@ -1787,6 +1825,20 @@ func (l *lowerer) lowerLetStmt(s *ast.LetStmt) Stmt {
 		out.Value = l.lowerExpr(s.Value)
 		if out.Type == nil {
 			out.Type = out.Value.Type()
+		}
+		// Closure-from-annotation backfill: `let f: fn(Int) ->
+		// Int = |x| x + 1` carries the closure's expected
+		// signature in the LetStmt's type annotation. Propagate
+		// it back into the Closure value so its un-annotated
+		// param/Return slots resolve before the body's Idents
+		// poison downstream lowering.
+		if cl, ok := out.Value.(*Closure); ok && cl != nil {
+			if fnT, ok := out.Type.(*FnType); ok && fnT != nil {
+				backfillClosure(cl, fnT)
+				if out.Value.Type() == nil || out.Value.Type() == ErrTypeVal {
+					out.Type = cl.T
+				}
+			}
 		}
 	}
 	if !usableRecoveredType(out.Type) {

--- a/internal/mir/canonical_patterns_lower_test.go
+++ b/internal/mir/canonical_patterns_lower_test.go
@@ -121,16 +121,12 @@ fn cityOf(u: User?) -> String {
     pairs.len()
 }`,
 		},
-		// `closure_capture_int` (`|x| x + n` as the return value
-		// of `fn makeAdder(n: Int) -> fn(Int) -> Int`) requires
-		// return-position closure inference — the expected
-		// signature comes from the enclosing fn's return type, not
-		// from a method-call arg slot. The method-arg backfill
-		// (`backfillClosureArgsFromMethodCall`) doesn't see it.
-		// Tracked as future work; the LIR Proto
-		// `source_closure_int_capture` fixture exercises the
-		// LLVM-side shape and the checker may already infer it
-		// in some configurations.
+		{
+			name: "closure_capture_int",
+			src: `fn makeAdder(n: Int) -> fn(Int) -> Int {
+    |x| x + n
+}`,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/mir/closure_return_position_test.go
+++ b/internal/mir/closure_return_position_test.go
@@ -1,0 +1,94 @@
+package mir
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLowerClosureBackfillsFromReturnAndAnnotation locks in the
+// IR-lowering hand-off for closures whose expected signature
+// comes from somewhere other than a method-call arg slot —
+// follow-up to PR #1828 (which handled method-arg closure
+// inference) and PR #1836 (which fixed chain return type
+// recovery).
+//
+// Two surfaces, both routed through `backfillClosure` after the
+// initial lowering:
+//
+//  1. **Return-position closure** —
+//
+//     ```osty
+//     fn makeAdder(n: Int) -> fn(Int) -> Int {
+//         |x| x + n
+//     }
+//     ```
+//
+//     The trailing-expression closure inherits its signature
+//     from the declared return type. `backfillTrailingClosure`
+//     walks Block.Result and the last ExprStmt of Block.Stmts
+//     because the parser keeps single-expression bodies as
+//     statement-position trailing expressions.
+//
+//  2. **LetStmt-with-FnType-annotation** —
+//
+//     ```osty
+//     let f: fn(Int) -> Int = |x| x + 1
+//     ```
+//
+//     The annotation on the binding propagates back into the
+//     Closure value so its un-annotated params resolve.
+//
+// Without these, the closure's `Params[i].Type` stays nil and
+// every Ident reading the param lowers as ErrTypeVal, poisoning
+// the closure body and any consuming expression.
+//
+// Asserts: (a) closure body fn signature is concrete (no
+// `_<idx>: <error>` slots in the lifted closure fn), (b) no
+// `<error>` leaks anywhere in the MIR.
+func TestLowerClosureBackfillsFromReturnAndAnnotation(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			"return_position_capture_int",
+			`fn makeAdder(n: Int) -> fn(Int) -> Int {
+    |x| x + n
+}`,
+		},
+		{
+			"return_position_bool_predicate",
+			`fn gt(n: Int) -> fn(Int) -> Bool {
+    |x| x > n
+}`,
+		},
+		{
+			"return_position_no_capture",
+			`fn inc() -> fn(Int) -> Int {
+    |x| x + 1
+}`,
+		},
+		{
+			"let_binding_with_annotation",
+			`fn main() {
+    let f: fn(Int) -> Int = |x| x + 1
+    let _ = f(5)
+}`,
+		},
+		{
+			"let_binding_with_bool_predicate",
+			`fn main() {
+    let pred: fn(Int) -> Bool = |n| n > 0
+    let _ = pred(5)
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mirText := lowerSourceToMIR(t, c.src)
+			if strings.Contains(mirText, "<error>") {
+				t.Errorf("<error> leaked into MIR for %s:\n%s", c.name, mirText)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

PR #1828/#1836 의 follow-up: method-call arg 가 아닌 두 surface 에서 closure 의 expected fn signature 를 propagate.

## 두 surface

### 1. Return-position closure

```osty
fn makeAdder(n: Int) -> fn(Int) -> Int {
    |x| x + n
}
```

trailing-expression closure 가 declared return type 으로부터 signature 를 받음. 새 `backfillTrailingClosure` helper 가 `Block.Result` 와 `Block.Stmts` 의 마지막 ExprStmt 양쪽을 확인 — parser 가 single-expression body 를 statement-position trailing expr 로 두는 경우를 처리.

### 2. LetStmt-with-FnType-annotation

```osty
let f: fn(Int) -> Int = |x| x + 1
```

binding annotation 에서 closure 의 unannotated param 슬롯 채움. `lowerLetStmt` 끝에서 Value 가 Closure 이고 Type 이 FnType 이면 `backfillClosure` 호출.

## Before/After

Before:
```
fn makeAdder__closure1(_1: ClosureEnv, _2: <error>) -> () {
    let _2: <error>  // _
    ...
}
fn makeAdder(_1: Int) -> fn(Int) -> Int {
    let _2: <error>  // _
    ...
}
```

After:
```
fn makeAdder__closure1(_1: ClosureEnv, _2: Int) -> Int {
    let return _0: Int  // _return
    let _3: Int  // n
    bb0:
        _3 = use _1.*.1
        _0 = _2 + _3
        return
}
fn makeAdder(_1: Int) -> fn(Int) -> Int {
    let _2: fn(Int) -> Int  // _
    bb0:
        _2 = aggregate closure(const fn makeAdder__closure1, _1)
        ...
}
```

## Test plan

- [x] 새 `TestLowerClosureBackfillsFromReturnAndAnnotation` 5/5 통과 (capture int / bool predicate / no capture / let-annot arith / let-annot predicate)
- [x] PR #1836 의 `TestCanonicalPatternsLowerWithoutErrorLeaks` 에서 future work 로 주석 처리되어 있던 `closure_capture_int` 케이스도 이제 통과 — 9/9 → 10/10
- [x] PR #1811/#1815/#1818/#1820/#1822/#1824/#1828/#1833/#1836 의 기존 회귀락 모두 통과
- [x] `./internal/{ir,mir,backend}` short suite 통과

https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT

---
_Generated by [Claude Code](https://claude.ai/code/session_011MAu47znuDS4KCTd87qPHT)_