### PR TITLE
feat: PR3-C-impl-go step 1+2 — ResolvedSymbol.ImportPath post-processing

### DIFF
--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -545,20 +545,25 @@ type ResolveSummary struct {
 }
 
 // ResolvedSymbol records one symbol declared by the self-host resolver.
+// When Kind == "package", ImportPath carries the full use-decl path
+// (e.g. "toolchain.check") populated by adaptResolveResult's post-processing
+// pass. Empty for all other kinds. Consumers that want module-scoped lookup
+// can branch on `ImportPath != ""`.
 type ResolvedSymbol struct {
-	ID        string    `json:"symbolId,omitempty"`
-	PackageID string    `json:"packageId,omitempty"`
-	DeclID    string    `json:"declId,omitempty"`
-	Node      int       `json:"node"`
-	Name      string    `json:"name"`
-	Kind      string    `json:"kind"`
-	Type      *TypeRepr `json:"type"`
-	Arity     int       `json:"arity"`
-	Depth     int       `json:"depth"`
-	Start     int       `json:"start"`
-	End       int       `json:"end"`
-	Public    bool      `json:"public"`
-	File      string    `json:"file,omitempty"`
+	ID         string    `json:"symbolId,omitempty"`
+	PackageID  string    `json:"packageId,omitempty"`
+	DeclID     string    `json:"declId,omitempty"`
+	Node       int       `json:"node"`
+	Name       string    `json:"name"`
+	Kind       string    `json:"kind"`
+	Type       *TypeRepr `json:"type"`
+	Arity      int       `json:"arity"`
+	Depth      int       `json:"depth"`
+	Start      int       `json:"start"`
+	End        int       `json:"end"`
+	Public     bool      `json:"public"`
+	File       string    `json:"file,omitempty"`
+	ImportPath string    `json:"importPath,omitempty"`
 }
 
 // ResolvedRef records one value/name reference plus its resolved target span

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -307,6 +307,47 @@ func selfhostFilterCrossFileDuplicateUseDiagnostics(result *ResolveResult, file 
 	selfhostRefreshResolveDiagnosticSummary(result)
 }
 
+// selfhostUseAliasImportPaths walks every use-decl in file and returns a map
+// from the resolved alias (the binding name) to the full import path stored
+// on the use-decl AST node. Group/scoped imports are flattened — each leaf
+// child is visited. Used by adaptResolveResult to fill ResolvedSymbol.
+// ImportPath for kind == "package" entries. Tracked in
+// SPEC_GAPS.md::cross-pkg-module-resolution path #5.
+func selfhostUseAliasImportPaths(file *AstFile) map[string]string {
+	out := map[string]string{}
+	if file == nil || file.arena == nil {
+		return out
+	}
+	var walk func(int)
+	walk = func(idx int) {
+		if idx < 0 || idx >= len(file.arena.nodes) {
+			return
+		}
+		node := file.arena.nodes[idx]
+		if node == nil {
+			return
+		}
+		if _, ok := node.kind.(*AstNodeKind_AstNUseDecl); !ok {
+			return
+		}
+		if astUseDeclIsGroup(node) {
+			for _, childIdx := range node.children {
+				walk(childIdx)
+			}
+			return
+		}
+		alias := srAstUseAlias(file, node)
+		if alias == "" || node.text == "" {
+			return
+		}
+		out[alias] = node.text
+	}
+	for _, declIdx := range file.arena.decls {
+		walk(declIdx)
+	}
+	return out
+}
+
 func selfhostPackageUseAliasStarts(file *AstFile, layout *selfhostPackageTokenLayout) map[string][]int {
 	out := map[string][]int{}
 	if file == nil || file.arena == nil {
@@ -517,21 +558,31 @@ func adaptResolveResult(resolved *SelfResolveResult, file *AstFile, offsets func
 		TypeRefs:    make([]ResolvedTypeRef, 0, len(resolved.typeRefList)),
 		Diagnostics: make([]ResolveDiagnosticRecord, 0, len(resolved.diagnostics)),
 	}
+	// Build alias → use-decl import path map for the "package" kind post-
+	// processing pass below. SelfSymbol (generated.go frozen seed) does not
+	// carry import paths, so we rebuild them from the AST here. Tracked in
+	// SPEC_GAPS.md::cross-pkg-module-resolution path #5.
+	importPaths := selfhostUseAliasImportPaths(file)
 	for _, sym := range resolved.symbols {
 		if sym == nil {
 			continue
 		}
 		start, end := offsets(sym.start, sym.end)
+		var importPath string
+		if sym.kind == "package" {
+			importPath = importPaths[sym.name]
+		}
 		result.Symbols = append(result.Symbols, ResolvedSymbol{
-			Node:   sym.node,
-			Name:   sym.name,
-			Kind:   sym.kind,
-			Type:   apiTypeReprFromLegacyName(sym.typeName),
-			Arity:  sym.arity,
-			Depth:  sym.depth,
-			Start:  start,
-			End:    end,
-			Public: sym.public,
+			Node:       sym.node,
+			Name:       sym.name,
+			Kind:       sym.kind,
+			Type:       apiTypeReprFromLegacyName(sym.typeName),
+			Arity:      sym.arity,
+			Depth:      sym.depth,
+			Start:      start,
+			End:        end,
+			Public:     sym.public,
+			ImportPath: importPath,
 		})
 	}
 	for _, ref := range resolved.refList {


### PR DESCRIPTION
## Summary

PR3-C-impl-go 분석 ([#1841](https://github.com/choiceoh/osty/pull/1841)) 의 post-processing layer 구현. step 1+2 (data flow 마련). step 3 (checker dispatch 활용) 은 후속 PR.

## 변경

### Step 1 — `api/types.go::ResolvedSymbol.ImportPath`

```go
type ResolvedSymbol struct {
    ...
    File       string `json:"file,omitempty"`
    ImportPath string `json:"importPath,omitempty"`  // 신규
}
```

`kind == "package"` 일 때 use-decl 의 full path (예: `"toolchain.check"`) 보유. 다른 kind 는 빈 문자열. JSON `omitempty` 로 wire backward compat.

### Step 2 — `resolve_adapter.go` post-processing

```go
// selfhostUseAliasImportPaths(file) — AstFile 의 use-decl walk
// alias → node.text (full path) map 빌드. group import 평탄.
func selfhostUseAliasImportPaths(file *AstFile) map[string]string { ... }

// adaptResolveResult 의 symbol loop:
if sym.kind == "package" {
    importPath = importPaths[sym.name]
}
result.Symbols = append(result.Symbols, ResolvedSymbol{
    ...
    ImportPath: importPath,
})
```

`SelfSymbol` (generated.go frozen seed) 가 importPath 필드 부재라 AstFile 의 use-decl 별도 walk 로 재구축. **generated.go 안 건드림**.

## 검증

```sh
$ just prepush
fmt-check + vet + repair-check + ci ALL PASS
```

회귀 0건. `ImportPath == ""` 인 기존 consumer 는 영향 없음.

## 비-목표 (Step 3 후속 PR)

- `internal/check` 또는 `toolchain/elab.osty` 의 method-call dispatch 에 `ImportPath != ""` 인 package symbol 의 module-scoped lookup 분기 추가
- `cmd/osty-native-checker/main.osty` 가 `use toolchain.check as tc` 형태로 toolchain 함수 호출 가능 검증

## 누적 (이 세션, 19 PR 머지 예정)

| # | PR |
|---|---|
| 1–18 | (PR0 ~ PR3-C-impl-go 분석) |
| 19 | (this) **PR3-C-impl-go step 1+2** |

## Test plan

- [x] `just prepush` 통과
- [x] selfhostUseAliasImportPaths group-import 평탄 처리 확인
- [x] backward compat (ImportPath omitempty)
- [ ] CI 그린 확인 + step 3 후속 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)