### PR TITLE
docs: README status — osty-native-checker LLVM self-build entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ native-only through the LLVM backend.
 | Package manager (`osty add` / `osty update`, path + git + registry sources, SemVer resolver, deterministic lockfile) | wired — `add` mutates `osty.toml` and re-vendors; `update` re-resolves selectively or in full |
 | `osty run` (build + exec through backend) | wired — resolves manifest, vendors deps, emits the native entry artifact, runs the backend binary with profile/feature flags, and rejects cross-target execution |
 | `osty publish` (pack + upload tarball to a registry) | wired — deterministic gzipped tar, sha256 checksum, bearer-auth POST; `--dry-run` stops before upload |
+| `osty-native-checker` LLVM self-build (`cmd/osty-native-checker/main.osty`) | walking skeleton (2026-05-17) — `OSTY_STAGE0_FALLBACK=1 osty build --backend llvm cmd/osty-native-checker/` 가 binary 산출 + 실행, empty-source fixture 에서 Go-built `osty-native-checker` 와 byte-identical `CheckResult` JSON 출력 (M2 partial). 진짜 checker 호출 (`elabFile` 등) 은 cross-package method-call wall ([`SPEC_GAPS::cross-pkg-module-resolution`](./SPEC_GAPS.md), [docs/llvm-selfhost-plan.md](./docs/llvm-selfhost-plan.md) PR3-C step 3) 으로 차단. multi-fixture / L2 spec corpus / L3 toolchain self-input parity 는 step 3 unlock 후 — 자세한 trajectory 는 [`cmd/osty-native-checker/README.md`](./cmd/osty-native-checker/README.md) |
 
 Status note (revalidated 2026-04-28): the universal
 LLVM CLI wedge called out in older status docs is closed. A hello-world


### PR DESCRIPTION
## Summary

2026-05-17 세션의 LLVM self-host trajectory (M1 ✓ + M2 partial) 를 README 의 status 표에 entry 추가. 사용자가 LLVM self-build target 의 현재 상태와 trajectory 빠르게 파악 가능.

## Entry

```
| `osty-native-checker` LLVM self-build | walking skeleton (2026-05-17) —
  `OSTY_STAGE0_FALLBACK=1 osty build --backend llvm cmd/osty-native-checker/`
  가 binary 산출 + 실행, empty-source fixture 에서 Go-built 와 byte-identical
  CheckResult JSON (M2 partial). 진짜 checker 호출은 cross-package wall
  (SPEC_GAPS::cross-pkg-module-resolution, PR3-C step 3) 차단. multi-fixture
  / L2 / L3 corpus parity 는 step 3 unlock 후. 자세한 trajectory:
  cmd/osty-native-checker/README.md |
```

## Cross-link

- [`SPEC_GAPS.md::cross-pkg-module-resolution`](SPEC_GAPS.md)
- [`docs/llvm-selfhost-plan.md`](docs/llvm-selfhost-plan.md)
- [`cmd/osty-native-checker/README.md`](cmd/osty-native-checker/README.md)

## 누적 (이 세션, 25 PR 머지 예정)

| # | PR |
|---|---|
| 1–24 | (PR0 ~ cmd/.../README.md) |
| 25 | (this) **README status entry** |

## Test plan

- [x] `just prepush` 통과
- [x] README cross-link 정합 (SPEC_GAPS / plan / cmd/.../README.md)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)