### PR TITLE
chore: .gitignore cmd/*/osty.lock + graphify update 세션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ graphify-out/
 
 # `go build ./cmd/osty-vs-go` artifact when built outside .bin/.
 /osty-vs-go
+
+# osty.lock for cmd/*/ — these are dep-driven manifests; cmd subprojects
+# with [dependencies] empty regenerate a stale lock on each build.
+# examples/<name>/main.osty.lock is a different naming and stays tracked.
+cmd/*/osty.lock


### PR DESCRIPTION
## Summary

이 세션의 마지막 cleanup. `.gitignore` 에 `cmd/*/osty.lock` 패턴 추가 — `cmd/osty-native-checker/osty.lock` 같은 dep 0 cmd subproject 의 stale lock 이 매 빌드 재생성 + untracked 노이즈 ("Warning: 1 uncommitted change") 해소.

## Cleanup 묶음

| 항목 | 처리 |
|---|---|
| `cmd/*/osty.lock` ignore | 본 PR — pattern `cmd/*/osty.lock` 추가 |
| `graphify update .` 실행 | 본 세션 (CLAUDE.md global 권장) — 15155 nodes / 50848 edges / 67 communities 갱신. `graphify-out/` 는 `.gitignore` 이미 cover |
| `examples/<name>/main.osty.lock` | 영향 없음 (다른 naming, 이미 tracked) |

## graphify update 결과

```
$ graphify update .
[graphify watch] Rebuilt: 15155 nodes, 50848 edges, 67 communities
[graphify watch] graph.json and GRAPH_REPORT.md updated
```

이전 CLAUDE.md 기록 (13.6k nodes / 44.9k edges / 159 communities) 대비 +1.5k nodes / +5.9k edges. PR3 / Phase 1c.5 cleanup / LLVM fn-attrs 등 다수 머지로 노드/엣지 증가, community 수는 축소 (67) — 다른 작업자의 cleanup 진척으로 코드 더 응집.

## 누적 (이 세션, 27 PR 머지 예정)

| # | PR |
|---|---|
| 1–26 | (이전) |
| 27 | (this) **cleanup + graphify** |

## Test plan

- [x] `just prepush` 통과
- [x] `.gitignore` 추가 패턴 검증 (`git status` 후 osty.lock 사라짐)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)