### PR TITLE
feat(lir_proto): trace-enriched diagnostics batch 2 — INSTR/RECV (10 sites)

### DIFF
--- a/LLVM_BACKEND_GAP_PLAN.md
+++ b/LLVM_BACKEND_GAP_PLAN.md
@@ -79,8 +79,8 @@ Go MIR emitter 미러는 PR #1405에서 제거됐다 (`internal/llvmgen` 112K LO
 |---|---|---|---|
 | GAP-INSTR-001 | 2070 | `unsupported MIR instruction kind` | 새 MirInstr* 추가 시 catch-all |
 | GAP-INSTR-002 | 2186 | `unsupported MIR callee kind` | 미정의 callee variant |
-| GAP-INSTR-003 | 2245 | `cross-module call arg type \`T\` is not implemented` | scalar/string 외 인자 |
-| GAP-INSTR-004 | 2300 | `indirect call arg type \`T\` is not implemented` | 위와 동일 indirect |
+| GAP-INSTR-003 | lir_proto.osty:3340 | ✅ 2026-05-17 trace 추가 (`lirTypeLowerTraceMessage`) | `cross-module call arg type \`T\` is not implemented` + root-cause hint |
+| GAP-INSTR-004 | lir_proto.osty:3526 | ✅ 2026-05-17 trace 추가 | `indirect call arg type \`T\` is not implemented` + 동일 trace |
 | GAP-INSTR-005 | 2110 | `<context> requires aggregate root` | projection이 비-aggregate 대상 |
 | GAP-INSTR-006 | 2134, 2139 | `projection on non-aggregate type` / `unsupported projection` | nested struct binding pattern 등 |
 

--- a/LLVM_BACKEND_GAP_PLAN.md
+++ b/LLVM_BACKEND_GAP_PLAN.md
@@ -88,9 +88,9 @@ Go MIR emitter 미러는 PR #1405에서 제거됐다 (`internal/llvmgen` 112K LO
 
 | ID | 코드 위치 | 메시지 | 시나리오 |
 |---|---|---|---|
-| GAP-RECV-001 | 3105 | `<label> could not extract element type from receiver \`T\`` | List/Map/Set 타입 이름 파싱 실패 |
+| GAP-RECV-001 | lir_proto.osty:4775,4869,4986,5040,5818,6782,6843 | ✅ 2026-05-17 trace 추가 (`lirReceiverParseTraceMessage`) | List/Map/Set/Channel 타입 이름 파싱 실패 + container prefix 매치 trace |
 | GAP-RECV-002 | lir_proto.osty:4781,4786 | ✅ 2026-05-17 trace 추가 (`lirTypeLowerTraceMessage`) | `<label> element type \`T\` has no LIR runtime lane (or MIR layout)` + root-cause hint |
-| GAP-RECV-003 | 3117 | `<label> could not extract value type from receiver \`T\`` | Map<K, V>의 V 추출 실패 |
+| GAP-RECV-003 | lir_proto.osty:4802 | ✅ 2026-05-17 trace 추가 (`lirReceiverParseTraceMessage`) | Map<K, V>의 V 추출 실패 + container prefix 매치 trace |
 | GAP-RECV-004 | lir_proto.osty:4809 | ✅ 2026-05-17 trace 추가 | `<label> value type \`T\` has no LIR runtime lane or MIR layout` + 동일 trace |
 | GAP-RECV-005 | 3204 | `list.push composite element type \`T\` has no MIR layout` | bytes-v1 fallback도 layout 없으면 실패 |
 

--- a/LLVM_BACKEND_GAP_PLAN.md
+++ b/LLVM_BACKEND_GAP_PLAN.md
@@ -77,12 +77,12 @@ Go MIR emitter 미러는 PR #1405에서 제거됐다 (`internal/llvmgen` 112K LO
 
 | ID | 코드 위치 | 메시지 | 시나리오 |
 |---|---|---|---|
-| GAP-INSTR-001 | 2070 | `unsupported MIR instruction kind` | 새 MirInstr* 추가 시 catch-all |
-| GAP-INSTR-002 | 2186 | `unsupported MIR callee kind` | 미정의 callee variant |
+| GAP-INSTR-001 | lir_proto.osty:3151 | `unsupported MIR instruction kind \`mirInstrKindName(instr.kind)\`` — kind 이름 이미 surface 됨 (trace 불필요) | 새 MirInstr* 추가 시 catch-all |
+| GAP-INSTR-002 | lir_proto.osty:3297 | `unsupported MIR callee kind \`mirCalleeKindName(...)\`` — 동일 (kind 이름 이미 surface) | 미정의 callee variant |
 | GAP-INSTR-003 | lir_proto.osty:3340 | ✅ 2026-05-17 trace 추가 (`lirTypeLowerTraceMessage`) | `cross-module call arg type \`T\` is not implemented` + root-cause hint |
 | GAP-INSTR-004 | lir_proto.osty:3526 | ✅ 2026-05-17 trace 추가 | `indirect call arg type \`T\` is not implemented` + 동일 trace |
-| GAP-INSTR-005 | 2110 | `<context> requires aggregate root` | projection이 비-aggregate 대상 |
-| GAP-INSTR-006 | 2134, 2139 | `projection on non-aggregate type` / `unsupported projection` | nested struct binding pattern 등 |
+| GAP-INSTR-005 | lir_proto.osty:3203 | ✅ 2026-05-17 rootType.llvm 포함 | `<context> requires aggregate root, got \`<llvm-type>\`` |
+| GAP-INSTR-006 | lir_proto.osty:3238,3243 | ✅ 2026-05-17 current type + projection kind 포함 | `projection on non-aggregate type \`<llvm>\` (projection kind: ...)` / `unsupported projection kind \`<kind>\` on type \`<llvm>\`` |
 
 #### 2.2.4 Container receiver type extraction
 

--- a/LLVM_BACKEND_GAP_PLAN.md
+++ b/LLVM_BACKEND_GAP_PLAN.md
@@ -89,9 +89,9 @@ Go MIR emitter 미러는 PR #1405에서 제거됐다 (`internal/llvmgen` 112K LO
 | ID | 코드 위치 | 메시지 | 시나리오 |
 |---|---|---|---|
 | GAP-RECV-001 | 3105 | `<label> could not extract element type from receiver \`T\`` | List/Map/Set 타입 이름 파싱 실패 |
-| GAP-RECV-002 | 3110 | `<label> element type \`T\` has no LIR runtime lane` | 복합 element (struct in List 등) — `bytes-v1` fallback 필요 |
+| GAP-RECV-002 | lir_proto.osty:4781,4786 | ✅ 2026-05-17 trace 추가 (`lirTypeLowerTraceMessage`) | `<label> element type \`T\` has no LIR runtime lane (or MIR layout)` + root-cause hint |
 | GAP-RECV-003 | 3117 | `<label> could not extract value type from receiver \`T\`` | Map<K, V>의 V 추출 실패 |
-| GAP-RECV-004 | 3122 | `<label> value type \`T\` has no LIR runtime lane` | 복합 V (struct/enum in Map<K, V>) |
+| GAP-RECV-004 | lir_proto.osty:4809 | ✅ 2026-05-17 trace 추가 | `<label> value type \`T\` has no LIR runtime lane or MIR layout` + 동일 trace |
 | GAP-RECV-005 | 3204 | `list.push composite element type \`T\` has no MIR layout` | bytes-v1 fallback도 layout 없으면 실패 |
 
 #### 2.2.5 Print intrinsic

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3200,7 +3200,7 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
 }
 fn lirStoreProjectedMirValue(l: LirMirFunctionLowerer, place: MirPlace, root: MirLocal, rootType: LirType, value: LirOperand, valueMirType: String, context: String) {
     if rootType.className != LirTypeAggregate {
-        lirLowerError(l, LirDiagUnsupported, context + " requires aggregate root", context)
+        lirLowerError(l, LirDiagUnsupported, context + " requires aggregate root, got `" + rootType.llvm + "`", context)
         return
     }
     let leafTypeName = lirMirProjectionLeafType(place.projections)
@@ -3235,12 +3235,12 @@ fn lirStoreProjectedMirValue(l: LirMirFunctionLowerer, place: MirPlace, root: Mi
     let mut idx = 0
     for proj in place.projections {
         if current.typ.className != LirTypeAggregate {
-            lirLowerError(l, LirDiagUnsupported, context + " projection on non-aggregate type", context)
+            lirLowerError(l, LirDiagUnsupported, context + " projection on non-aggregate type `" + current.typ.llvm + "` (projection kind: " + mirProjectionKindName(proj.kind) + ")", context)
             return
         }
         let step = lirProjectionStepFromMir(l, proj)
         if step.kind == LirProjInvalid {
-            lirLowerError(l, LirDiagUnsupported, context + " unsupported projection", context)
+            lirLowerError(l, LirDiagUnsupported, context + " unsupported projection kind `" + mirProjectionKindName(proj.kind) + "` on type `" + current.typ.llvm + "`", context)
             return
         }
         frames.push(lirProjectionFrame(current, step.index))

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3337,7 +3337,7 @@ fn lirLowerMirCrossModuleCall(l: LirMirFunctionLowerer, instr: MirInstr) {
     for arg in instr.args {
         let paramType = lirLowerMirType(l, arg.typ)
         if lirTypeIsZero(paramType) {
-            lirLowerError(l, LirDiagUnsupported, "cross-module call arg type `" + arg.typ + "` is not implemented", "call.cross")
+            lirLowerError(l, LirDiagUnsupported, "cross-module call arg type `" + arg.typ + "` is not implemented (" + lirTypeLowerTraceMessage(l.mirModule, arg.typ) + ")", "call.cross")
             return
         }
         let value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, paramType)
@@ -3523,7 +3523,7 @@ fn lirLowerMirIndirectCall(l: LirMirFunctionLowerer, instr: MirInstr) {
     for arg in instr.args {
         let paramType = lirLowerMirType(l, arg.typ)
         if lirTypeIsZero(paramType) {
-            lirLowerError(l, LirDiagUnsupported, "indirect call arg type `" + arg.typ + "` is not implemented", "call.indirect")
+            lirLowerError(l, LirDiagUnsupported, "indirect call arg type `" + arg.typ + "` is not implemented (" + lirTypeLowerTraceMessage(l.mirModule, arg.typ) + ")", "call.indirect")
             return
         }
         let value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, paramType)

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2246,6 +2246,37 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path:
     LirType {llvm: "", className: LirTypeUnknown}
 }
 
+/// lirReceiverParseTraceMessage builds the "List<...> prefix miss;
+/// Set<...> prefix miss; Map<K, V> prefix miss; Channel<...> prefix miss"
+/// trace that surfaces in `could not extract element/value type from
+/// receiver \`T\`` errors. Reports which container prefix patterns were
+/// recognized — `match` means the prefix matched but inner arg extraction
+/// failed (malformed); `miss` means the receiver type didn't look like
+/// that container at all.
+fn lirReceiverParseTraceMessage(typeName: String) -> String {
+    let listMatch = if strings.startsWith(typeName, "List<") {
+        "match"
+    } else {
+        "miss"
+    }
+    let setMatch = if strings.startsWith(typeName, "Set<") {
+        "match"
+    } else {
+        "miss"
+    }
+    let mapMatch = if strings.startsWith(typeName, "Map<") {
+        "match"
+    } else {
+        "miss"
+    }
+    let channelMatch = if strings.startsWith(typeName, "Channel<") {
+        "match"
+    } else {
+        "miss"
+    }
+    "List<...> prefix " + listMatch + "; Set<...> prefix " + setMatch + "; Map<K, V> prefix " + mapMatch + "; Channel<...> prefix " + channelMatch
+}
+
 /// lirTypeLowerTraceMessage builds the "primitive miss; ref-builtin miss;
 /// option/result miss; N interface layout(s); ..." trace string that
 /// surfaces in `unsupported {module/param/local/assign-dest} type` errors.
@@ -4772,7 +4803,7 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
         lirListElemTypeName(instr.args[0].typ)
     }
     if elemName == "" {
-        lirLowerError(l, LirDiagUnsupported, label + " could not extract element type from receiver `" + instr.args[0].typ + "`", label)
+        lirLowerError(l, LirDiagUnsupported, label + " could not extract element type from receiver `" + instr.args[0].typ + "` (" + lirReceiverParseTraceMessage(instr.args[0].typ) + ")", label)
         return lirContainerReceiverInvalid()
     }
     let mut elemLir = lirContainerElemLaneType(elemName)
@@ -4799,7 +4830,7 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
     if kind == "map.kv" {
         let valueName = lirMapValueTypeName(instr.args[0].typ)
         if valueName == "" {
-            lirLowerError(l, LirDiagUnsupported, label + " could not extract value type from receiver `" + instr.args[0].typ + "`", label)
+            lirLowerError(l, LirDiagUnsupported, label + " could not extract value type from receiver `" + instr.args[0].typ + "` (" + lirReceiverParseTraceMessage(instr.args[0].typ) + ")", label)
             return lirContainerReceiverInvalid()
         }
         let mut valueLir = lirContainerElemLaneType(valueName)
@@ -4866,7 +4897,7 @@ fn lirLowerMirListPush(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let elemName = lirListElemTypeName(instr.args[0].typ)
     if elemName == "" {
-        lirLowerError(l, LirDiagUnsupported, "list.push could not extract element type from receiver `" + instr.args[0].typ + "`", "list.push")
+        lirLowerError(l, LirDiagUnsupported, "list.push could not extract element type from receiver `" + instr.args[0].typ + "` (" + lirReceiverParseTraceMessage(instr.args[0].typ) + ")", "list.push")
         return
     }
     let elemLane = lirContainerElemLaneType(elemName)
@@ -4983,7 +5014,7 @@ fn lirLowerMirListGet(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let elemName = lirListElemTypeName(instr.args[0].typ)
     if elemName == "" {
-        lirLowerError(l, LirDiagUnsupported, "list.get could not extract element type from receiver `" + instr.args[0].typ + "`", "list.get")
+        lirLowerError(l, LirDiagUnsupported, "list.get could not extract element type from receiver `" + instr.args[0].typ + "` (" + lirReceiverParseTraceMessage(instr.args[0].typ) + ")", "list.get")
         return
     }
     if lirTypeIsZero(lirContainerElemLaneType(elemName)) {
@@ -5037,7 +5068,7 @@ fn lirLowerMirListInsert(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let elemName = lirListElemTypeName(instr.args[0].typ)
     if elemName == "" {
-        lirLowerError(l, LirDiagUnsupported, "list.insert could not extract element type from receiver `" + instr.args[0].typ + "`", "list.insert")
+        lirLowerError(l, LirDiagUnsupported, "list.insert could not extract element type from receiver `" + instr.args[0].typ + "` (" + lirReceiverParseTraceMessage(instr.args[0].typ) + ")", "list.insert")
         return
     }
     if lirTypeIsZero(lirContainerElemLaneType(elemName)) {
@@ -5815,7 +5846,7 @@ fn lirLowerMirSelectSend(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let elemName = lirChannelElementTypeName(instr.args[1].typ)
     if elemName == "" {
-        lirLowerError(l, LirDiagUnsupported, "select.send could not extract element type from channel `" + instr.args[1].typ + "`", "select.send")
+        lirLowerError(l, LirDiagUnsupported, "select.send could not extract element type from channel `" + instr.args[1].typ + "` (" + lirReceiverParseTraceMessage(instr.args[1].typ) + ")", "select.send")
         return
     }
     let elemLir = lirContainerElemLaneType(elemName)
@@ -6779,7 +6810,7 @@ fn lirLowerMirChanSend(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let elemName = lirChannelElementTypeName(instr.args[0].typ)
     if elemName == "" {
-        lirLowerError(l, LirDiagUnsupported, "chan.send could not extract element type from `" + instr.args[0].typ + "`", "chan.send")
+        lirLowerError(l, LirDiagUnsupported, "chan.send could not extract element type from `" + instr.args[0].typ + "` (" + lirReceiverParseTraceMessage(instr.args[0].typ) + ")", "chan.send")
         return
     }
     let elemLir = lirContainerElemLaneType(elemName)
@@ -6840,7 +6871,7 @@ fn lirLowerMirChanRecv(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let elemName = lirChannelElementTypeName(instr.args[0].typ)
     if elemName == "" {
-        lirLowerError(l, LirDiagUnsupported, "chan.recv could not extract element type from `" + instr.args[0].typ + "`", "chan.recv")
+        lirLowerError(l, LirDiagUnsupported, "chan.recv could not extract element type from `" + instr.args[0].typ + "` (" + lirReceiverParseTraceMessage(instr.args[0].typ) + ")", "chan.recv")
         return
     }
     let elemLir = lirContainerElemLaneType(elemName)

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -4778,12 +4778,12 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
     let mut elemLir = lirContainerElemLaneType(elemName)
     if lirTypeIsZero(elemLir) {
         if kind != "list.elem" {
-            lirLowerError(l, LirDiagUnsupported, label + " element type `" + elemName + "` has no LIR runtime lane", label)
+            lirLowerError(l, LirDiagUnsupported, label + " element type `" + elemName + "` has no LIR runtime lane (" + lirTypeLowerTraceMessage(l.mirModule, elemName) + ")", label)
             return lirContainerReceiverInvalid()
         }
         let compositeElem = lirLowerMirType(l, elemName)
         if lirTypeIsZero(compositeElem) || lirTypeIsVoid(compositeElem) {
-            lirLowerError(l, LirDiagUnsupported, label + " element type `" + elemName + "` has no LIR runtime lane or MIR layout", label)
+            lirLowerError(l, LirDiagUnsupported, label + " element type `" + elemName + "` has no LIR runtime lane or MIR layout (" + lirTypeLowerTraceMessage(l.mirModule, elemName) + ")", label)
             return lirContainerReceiverInvalid()
         }
         elemLir = compositeElem
@@ -4806,7 +4806,7 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
         if lirTypeIsZero(valueLir) {
             let compositeValue = lirLowerMirType(l, valueName)
             if lirTypeIsZero(compositeValue) || lirTypeIsVoid(compositeValue) {
-                lirLowerError(l, LirDiagUnsupported, label + " value type `" + valueName + "` has no LIR runtime lane or MIR layout", label)
+                lirLowerError(l, LirDiagUnsupported, label + " value type `" + valueName + "` has no LIR runtime lane or MIR layout (" + lirTypeLowerTraceMessage(l.mirModule, valueName) + ")", label)
                 return lirContainerReceiverInvalid()
             }
             valueLir = compositeValue


### PR DESCRIPTION
## Summary

PR #1846 의 follow-up. 같은 trace 패턴을 module-context fallthrough 외 10 사이트에 확장.

### 적용 사이트

**Instr-level (GAP-INSTR-003/004)** — `lirTypeLowerTraceMessage`:
- `lirLowerMirCrossModuleCall:3340` (cross-module arg type)
- `lirLowerMirIndirectCall:3526` (indirect arg type)

**Receiver lane/layout (GAP-RECV-002/004)** — `lirTypeLowerTraceMessage`:
- `lirContainerReceiver:4781,4786` (element lane / lane+layout)
- `lirContainerReceiver:4809` (value lane+layout)

**Receiver parse (GAP-RECV-001/003)** — 새 helper `lirReceiverParseTraceMessage`:
- `lirContainerReceiver:4775,4802`
- `lirLowerMirListPush/Get/Insert:4869,4986,5040`
- `lirLowerMirSelectSend:5818`
- `lirLowerMirChanSend/Recv:6782,6843`

**Projection (GAP-INSTR-005/006)** — type+kind inline:
- `lirStoreProjectedMirValue:3203` — `rootType.llvm` 포함
- `lirStoreProjectedMirValue:3238,3243` — `current.typ.llvm` + `mirProjectionKindName(proj.kind)` (line 7609/7721 와 일관)

### Scope 외

- **GAP-INSTR-001/002** — kind name 이미 메시지에 surface (`mirInstrKindName(kind)` / `mirCalleeKindName(kind)`), trace 의미 없음
- **GAP-IFACE-001..005** — silent (no diag at all) — 실제 feature 구현 (boxing site / vtable / dispatch / shim) 필요. Phase E 작업, Phase 0 bootstrap 차단

### 효과 (예시)

Before: `list.push could not extract element type from receiver \`Map<String, Int>\``
After: `list.push could not extract element type from receiver \`Map<String, Int>\` (List<...> prefix miss; Set<...> prefix miss; Map<K, V> prefix match; Channel<...> prefix miss)` — \`Map\` prefix 매치 = list.push 가 잘못된 receiver 타입 받음

Before: `projection on non-aggregate type`
After: `projection on non-aggregate type \`i64\` (projection kind: Field)` — 어떤 타입이 어떤 projection 으로 깨졌는지 즉시 가시화

### Dormancy

\`toolchain/lir_proto.osty\` 라 generated.go frozen seed 와 분리 — LLVM 셀프호스팅 flip 까지 production 영향 없음. Stage0 P24+ unblock 디버깅 productivity multiplier.

## Test plan

- [ ] \`.bin/osty check toolchain/lir_proto.osty\` clean
- [ ] \`just front\` 통과
- [ ] \`LLVM_BACKEND_GAP_PLAN.md\` GAP-INSTR-003/004/005/006 + GAP-RECV-001/002/003/004 ✅ 표기

🤖 Generated with [Claude Code](https://claude.com/claude-code)