### PR TITLE
spec: CLAUDE.md narrow exception 합의 (옵션 c) — frozen seed surgical hand-edit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,12 @@ winget install --id LLVM.LLVM                              # clang/lld/llc (머�
 
 - Osty로 작성 가능한 로직을 Go로 새로 작성
 - 제거된 부트스트랩 Osty→Go 트랜스파일러 재도입 (`internal/selfhost/generated.go` 는 동결된 시드; 재생성 경로 없음)
+  - **예외 (LLVM self-host critical path)**: cross-package method-call dispatch site 같은 **surgical hand-edit** 은 허용. 단:
+    1. 단일 PR 에서 `toolchain/*.osty` 의 동등 변경 의무 (drift 방지)
+    2. 영향 범위 한 함수 내 또는 한 dispatch arm (~50 LOC) 만
+    3. PR description 에 진단 코드 + LLVM self-host plan 의 단계 명시 (예: "PR3-C step 3, E0703 dispatch, cross-pkg method lookup")
+    4. 새 dispatch arm 추가만 — 기존 path 변경 금지 (regression 회피)
+    5. `SPEC_GAPS.md::cross-pkg-module-resolution` trajectory 완성 시 narrow exception 자체 retire — full regen 모델 재고. 합의 근거: [docs/llvm-selfhost-plan-pr3-c-step3-c-spec-draft.md](docs/llvm-selfhost-plan-pr3-c-step3-c-spec-draft.md)
 - `panic`으로 유저 입력 에러 처리
 - `ERROR_CODES.md`, `payload-types.ts` 같은 생성 파일 수동 편집
 - 외부 Go 의존성 추가 (`go.mod` 최소 상태 유지)

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -259,6 +259,8 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    각 옵션은 단일 세션 무리 + spec/team 합의 동반. PR3-C-step3-design.md (별도 doc) 가 다음 단계.
 
+   **2026-05-17 합의 (옵션 c 채택)**: 사용자/팀이 `docs/llvm-selfhost-plan-pr3-c-step3-c-spec-draft.md` §3 의 narrow exception 표현 합의. CLAUDE.md "하지 말 것" 의 frozen seed line 에 narrow exception 추가 (단일 PR 에서 5 자기-제한 메커니즘 의무). 다음 sub-PR: `PR3-C-step3-c-impl` (`generated.go:41950` method-call dispatch 분기 추가 + `toolchain/elab.osty:19712` 동등 변경) → `PR3-C-step3-c-test` (use toolchain.check 통과 검증). 본 gap 의 trajectory 완성 시 narrow exception 자체 retire 예정.
+
    **2026-05-17 옵션 d 검토 (HIR/MIR method dispatch)**: HIR / IR / MIR lowering 의 method-call 처리 (`hirLowerMethodCallExprFromCore`, `lowerMethodCall`, etc.) 는 모두 elab 이 끝난 후 typed core 만 소비. 즉 elab 의 method-call sig lookup (poison 또는 valid) 결과를 그대로 받음. **옵션 d 도 같은 wall** — elab 의 dispatch 가 진짜 root.
 
    **2026-05-17 우회 use form 검토**:


### PR DESCRIPTION
## Summary

옵션 c 합의 — PR3-C-step3-c-spec-merge ([#1848 spec draft §3](https://github.com/choiceoh/osty/pull/1848)). CLAUDE.md "하지 말 것" 의 frozen seed line 에 narrow exception 추가.

## 변경

```diff
 - 제거된 부트스트랩 Osty→Go 트랜스파일러 재도입 (...)
+  - **예외 (LLVM self-host critical path)**: cross-package method-call
+    dispatch site 같은 surgical hand-edit 은 허용. 단:
+    1. 단일 PR 에서 toolchain/*.osty 의 동등 변경 의무 (drift 방지)
+    2. 영향 범위 한 함수 / dispatch arm (~50 LOC)
+    3. PR description 에 진단 코드 + 단계 명시
+    4. 새 dispatch arm 추가만 (기존 path 변경 금지)
+    5. SPEC_GAPS::cross-pkg-module-resolution trajectory 완성 시 narrow
+       exception 자체 retire
```

## 다음 sub-PR sequencing

```
PR3-C-step3-c-spec-merge (this PR, ~10 LOC)
  ↓
PR3-C-step3-c-impl       (~50 LOC, generated.go:41950 + elab.osty:19712 동등)
  ↓
PR3-C-step3-c-test       (use toolchain.check 통과)
  ↓
PR3-D / PR3-E / PR3-F    (cmd/osty lib build + 진짜 checker + L1/L2/L3 corpus)
```

## 합의 근거

- 옵션 a (generated.go 전체 수정): spec 위반
- 옵션 b (post-processing): **불가능** (elabPoisonResult 가 caller 로 전파)
- **옵션 c (narrow exception)**: 5 자기-제한 메커니즘으로 slippery slope 방지
- 옵션 d (HIR/MIR method lookup): 같은 wall

자세한 분석: [docs/llvm-selfhost-plan-pr3-c-step3-c-spec-draft.md](docs/llvm-selfhost-plan-pr3-c-step3-c-spec-draft.md), [docs/llvm-selfhost-plan-pr3-c-step3-design.md](docs/llvm-selfhost-plan-pr3-c-step3-design.md).

## 변경 파일

| 파일 | 변경 |
|---|---|
| `CLAUDE.md` | "하지 말 것" frozen seed line 에 narrow exception 추가 (5 자기-제한 의무) |
| `SPEC_GAPS.md::cross-pkg-module-resolution` | path #5 갱신 — 2026-05-17 합의 (옵션 c 채택) 명시 |

## Test plan

- [x] `just prepush` 통과
- [x] CLAUDE.md narrow exception 표현이 spec-draft §3 와 일치 확인
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)