### PR TITLE
docs: 옵션 5 source bootstrap 시도 — stage0 100% 후 next layer wall (std.os.exec*)

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -261,6 +261,17 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    **2026-05-17 합의 (옵션 c 채택)**: 사용자/팀이 `docs/llvm-selfhost-plan-pr3-c-step3-c-spec-draft.md` §3 의 narrow exception 표현 합의. CLAUDE.md "하지 말 것" 의 frozen seed line 에 narrow exception 추가 (단일 PR 에서 5 자기-제한 메커니즘 의무). 다음 sub-PR: `PR3-C-step3-c-impl` (`generated.go:41950` method-call dispatch 분기 추가 + `toolchain/elab.osty:19712` 동등 변경) → `PR3-C-step3-c-test` (use toolchain.check 통과 검증). 본 gap 의 trajectory 완성 시 narrow exception 자체 retire 예정.
 
+   **2026-05-17 PR #1858 머지 — stage0 100% 달성**: 다른 작업자 (choiceoh) 가 3-commit cascade ([70717f66](https://github.com/choiceoh/osty/commit/70717f66) classifier + map_new + stdlib struct fallback / [5ab677ff](https://github.com/choiceoh/osty/commit/5ab677ff) Cat B FnConst-in-arith / [61eec8f1](https://github.com/choiceoh/osty/commit/61eec8f1) Result/Option payload coercion + __toString) 으로 audit 8221/8237 → **8240/8241 (100.0%)**. 본 plan §10.1 R2 (stage0 cover) **종결**.
+
+   **2026-05-17 옵션 5 (source bootstrap) 시도 — next layer wall**: stage0 100% 통과 후 `OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 osty install-self` 시도 시 link 단계에서:
+   ```
+   Undefined symbols for architecture arm64:
+     "_std.os.execInputWith", referenced from: _selfRebuildWriteString
+     "_std.os.execOutput",    referenced from: _main
+     "_std.os.execWith",      referenced from: _selfRebuildBundleSource, _selfRebuildClangLinkArgs, _selfRebuildRunClang, _runSelfRebuild, _main
+   ```
+   C runtime (`osty_runtime.c:28567`) 에 `osty_rt_os_exec(cmd, args, shell)` 만 정의 — `execWith` / `execInputWith` / `execOutput` 등 8 exec 변종 부재. Osty `std.os.exec*` 9 함수 중 1 만 C runtime cover. 즉 옵션 5 도 **추가 backend wave** 동반 (C runtime 확장 + rewriteStdlibSymbolToRuntime 매핑 8+ symbol).
+
    **2026-05-17 PR3-C-step3-c-impl 시도 결과 — narrow exception 의 한도 초과**: dispatch 분기 분석 시 std.* 의 cross-package method 가 작동하는 mechanism 측정:
    - `generated.go:48427` 부근의 use-decl 처리에 `registerStdStringsAliasFns(env, alias)` / `registerStdTestingAliasFns` / `registerStdFsAliasFns` 등 **hardcoded prelude-path chain**
    - 각 `registerStdXxxAliasFns` 는 그 module 의 모든 함수를 `env.global.fns` 에 등록 → 그 후 `xxx.fn(...)` 호출이 method dispatch 안 거치고 일반 function call 로 resolve


### PR DESCRIPTION
## Summary

**🎉 PR [#1858](https://github.com/choiceoh/osty/pull/1858) (다른 작업자) 가 stage0 audit 99.8% → 100.0% 달성**. plan §10.1 R2 (stage0 cover) 종결. 본 PR 은 즉시 옵션 5 (source bootstrap) 시도 + next layer wall 측정.

## stage0 100% 머지 (PR #1858)

3-commit cascade by choiceoh:
- [70717f66](https://github.com/choiceoh/osty/commit/70717f66) — classifier + map_new + stdlib struct fallback (16→10)
- [5ab677ff](https://github.com/choiceoh/osty/commit/5ab677ff) — Cat B FnConst-in-arith + struct name inference (10→5)
- [61eec8f1](https://github.com/choiceoh/osty/commit/61eec8f1) — Result/Option payload coercion + primitive `__toString` + unwrap synth-return (5→0)

현재 audit: **8240 / 8241 (100.0%)**.

## 옵션 5 시도 — next layer wall

```sh
$ OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 .bin/osty install-self
osty build: llvm backend: clang link binary failed
Undefined symbols for architecture arm64:
  "_std.os.execInputWith", referenced from: _selfRebuildWriteString
  "_std.os.execOutput",    referenced from: _main
  "_std.os.execWith",      referenced from: _selfRebuildBundleSource, ...
```

`osty_runtime.c:28567` 에 `osty_rt_os_exec(cmd, args, shell)` 만 정의. **Osty `std.os.exec*` 9 함수 중 1 만 C runtime cover**.

## 부재 C runtime 함수

| Osty 함수 | C runtime |
|---|---|
| `exec` | `osty_rt_os_exec` ✓ |
| `execShell` | (mapped to `osty_rt_os_exec` with `shell=true`) |
| `execWith` | **부재** |
| `execShellWith` | **부재** |
| `execInput` | **부재** |
| `execShellInput` | **부재** |
| `execInputWith` | **부재** |
| `execShellInputWith` | **부재** |
| `execOutput` | **부재** (constructor) |

## 다음 작업

옵션 5 도 추가 backend wave 동반:
1. `osty_runtime.c` 에 8 exec 변종 C 함수 추가 (또는 통합 `osty_rt_os_exec_full` + mode flag)
2. `internal/mir/lower.go::rewriteStdlibSymbolToRuntime` 에 8+ symbol 매핑 (PR1c 옵션 1 패턴 그대로)
3. `OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 osty install-self` 재시도

단일 세션 무리 가능성 크나 narrow exception 안 거치고 추가 가능 — PR1c 옵션 1 의 안전 패턴 재사용.

## 변경

| 파일 | 변경 |
|---|---|
| `SPEC_GAPS.md::cross-pkg-module-resolution` | PR #1858 머지 (R2 종결) + 옵션 5 next layer wall (std.os.exec* 8 변종) |

## 누적 (이 세션, 31 PR 머지 예정)

| # | PR |
|---|---|
| 1–30 | (이전) |
| 31 | (this) **옵션 5 source bootstrap next layer wall** |

## Test plan

- [x] `just prepush` 통과
- [x] `OSTY_STAGE0_AUDIT=1 ...` 100.0% 재확인 (8240/8241)
- [x] source bootstrap 시도 → next wall (std.os.exec*) 측정
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)