### PR TITLE
feat: std.os.execWith / execInputWith — C wrappers + MIR rewrite (옵션 5 progress)

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -29828,6 +29828,30 @@ osty_rt_os_exec_result *osty_rt_os_exec_input(const char *cmd, void *args,
                                        stdin_text);
 }
 
+/* std.os.execWith(cmd, args, cwd, env, timeoutMillis) — `shell=false`
+ * variant of osty_rt_os_exec_options. Wired through MIR symbol rewrite for
+ * the LLVM self-host source-bootstrap path (cf. SPEC_GAPS::cross-pkg-module-
+ * resolution path #5; PR3-C trajectory). */
+osty_rt_os_exec_result *osty_rt_os_exec_with(const char *cmd, void *args,
+                                             const char *cwd,
+                                             void *env_overrides,
+                                             int64_t timeout_ms) {
+  return osty_rt_os_exec_options(cmd, args, /*shell=*/false, cwd,
+                                 env_overrides, timeout_ms);
+}
+
+/* std.os.execInputWith(cmd, args, stdin, cwd, env, timeoutMillis) —
+ * `shell=false` variant with stdin pipe. */
+osty_rt_os_exec_result *osty_rt_os_exec_input_with(const char *cmd,
+                                                   void *args,
+                                                   const char *stdin_text,
+                                                   const char *cwd,
+                                                   void *env_overrides,
+                                                   int64_t timeout_ms) {
+  return osty_rt_os_exec_input_options(cmd, args, /*shell=*/false, cwd,
+                                       env_overrides, timeout_ms, stdin_text);
+}
+
 osty_rt_os_string_result *osty_rt_os_hostname(void) {
 #if defined(_WIN32)
   char buf[MAX_COMPUTERNAME_LENGTH + 1];

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -5826,6 +5826,10 @@ func rewriteStdlibSymbolToRuntime(sym string) string {
 	switch sym {
 	case "std.io.readLine":
 		return "osty_rt_io_read_line"
+	case "std.os.execWith":
+		return "osty_rt_os_exec_with"
+	case "std.os.execInputWith":
+		return "osty_rt_os_exec_input_with"
 	}
 	return sym
 }


### PR DESCRIPTION
## Summary

PR [#1858](https://github.com/choiceoh/osty/pull/1858) (stage0 100%) 머지 후 옵션 5 source bootstrap 의 next layer wall (#1860 측정) 의 **2 symbol 해소**.

## 변경

### C runtime (2 thin wrapper)

```c
osty_rt_os_exec_result *osty_rt_os_exec_with(const char *cmd, void *args,
                                              const char *cwd, void *env_overrides,
                                              int64_t timeout_ms) {
  return osty_rt_os_exec_options(cmd, args, /*shell=*/false, cwd, env_overrides, timeout_ms);
}

osty_rt_os_exec_result *osty_rt_os_exec_input_with(const char *cmd, void *args,
                                                    const char *stdin_text,
                                                    const char *cwd, void *env_overrides,
                                                    int64_t timeout_ms) {
  return osty_rt_os_exec_input_options(cmd, args, /*shell=*/false, cwd, env_overrides,
                                       timeout_ms, stdin_text);
}
```

### MIR rewrite (`internal/mir/lower.go::rewriteStdlibSymbolToRuntime`)

```go
case "std.os.execWith":      return "osty_rt_os_exec_with"
case "std.os.execInputWith": return "osty_rt_os_exec_input_with"
```

PR1c 옵션 1 패턴 그대로 — narrow exception 안 거침.

## 검증

```sh
$ OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 .bin/osty install-self
# 이전: _std.os.execWith / _std.os.execInputWith / _std.os.execOutput undefined
# 이후: execWith / execInputWith 해소
#       다음 wall = execOutput (constructor, stdlib body lowering 필요)
#                + tyToRepr (monomorph 격차)
```

## 다음 wall (별도 PR)

| symbol | 종류 |
|---|---|
| `_std.os.execOutput` | struct constructor — stdlib body lowering 또는 별도 C wrapper |
| `tyToRepr` | toolchain 함수, monomorph 후 stage0 decline (audit 100% 와의 격차) |

## LOC

- C runtime: +24
- Go MIR: +4
- 합 ~28 LOC

## 누적 (이 세션, 32 PR 머지 예정)

| # | PR |
|---|---|
| 1–31 | (이전) |
| 32 | (this) **🎯 std.os.exec wrappers — source bootstrap progress** |

## Test plan

- [x] `just prepush` 통과
- [x] `execWith` + `execInputWith` undefined 해소 확인
- [x] 다음 wall (`execOutput` + `tyToRepr`) 측정
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)