### PR TITLE
docs: 🎉 source bootstrap UNLOCK — osty-self install + next wall 측정

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -265,6 +265,15 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    **2026-05-17 옵션 5 진척 (PR #1861)**: `osty_rt_os_exec_with` + `osty_rt_os_exec_input_with` C wrapper (2 함수) + `rewriteStdlibSymbolToRuntime` 매핑 2 (`std.os.execWith`, `std.os.execInputWith`) 추가. source bootstrap 의 link 단계 wall 부분 해소.
 
+   **🎉 2026-05-17 source bootstrap UNLOCK**: `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 OSTY_STDLIB_BODY_LOWER=1 .bin/osty install-self` **통과**! `osty-self` binary 가 `.osty/cache/self-host/<hash>-darwin-arm64/osty-self` 에 install. 조합:
+   - stage0 100% (PR #1858)
+   - execWith / execInputWith C wrappers (PR #1861)
+   - `OSTY_STDLIB_BODY_LOWER=1` 활성 → execOutput body lower + tyToRepr 의 monomorph cover
+
+   plan §10.1 R2 (stage0 cover) **완전 종결**.
+
+   **2026-05-17 cmd/osty-native-checker production path next wall**: `osty-self` cached 후 `.bin/osty build --backend llvm cmd/osty-native-checker/` (stage0 fallback OFF) 시도 → `osty-self: stage0 declined function: mirJsonObjectGetNamed`. 즉 osty-self 자체가 cmd/osty-native-checker 의 main.osty (PR2 의 naive parser) 빌드 시 monomorph 후 `mirJsonObjectGetNamed` 함수가 stage0 decline. PR #1858 classifier trajectory 의 후속 작업 영역.
+
    **2026-05-17 옵션 5 next wall — execOutput constructor + cross-package struct literal**: PR #1861 후 남은 부재 symbol = `_std.os.execOutput` (single use site at `toolchain/main.osty:456`). 두 path 시도:
    - **inline struct literal**: `os.ExecOutput {exitCode: 1, stdout: "", stderr: "", timedOut: false}` — `E0500 undefined name 'timedOut'` (field shorthand 인지 부족)
    - **qualifier 제거**: `ExecOutput {...}` — `E0745 cannot find 'ExecOutput' in this scope` (cross-package type 이 toolchain prelude 에 미포함)


### PR DESCRIPTION
## 🎉 SOURCE BOOTSTRAP UNLOCK

```sh
$ OSTY_STAGE0_FALLBACK=1 \
  OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 \
  OSTY_STDLIB_BODY_LOWER=1 \
  .bin/osty install-self
Built osty-self (debug)
installed: .osty/cache/self-host/<hash>-darwin-arm64/osty-self
```

`osty-self` binary 가 cache 에 install. plan §10.1 R2 (stage0 cover) **완전 종결**.

## 조합

| 요소 | PR | 가중치 |
|---|---|---|
| stage0 audit 100% | [#1858](https://github.com/choiceoh/osty/pull/1858) (외부) | 16 decline → 0 |
| `osty_rt_os_exec_with` / `_input_with` C wrappers | [#1861](https://github.com/choiceoh/osty/pull/1861) (이 세션) | 2 symbol 해소 |
| `OSTY_STDLIB_BODY_LOWER=1` env | (기존 flag) | execOutput body inline + tyToRepr monomorph cover |

세 요소 조합이 source bootstrap 의 link + stage0 + stdlib body 의 모든 layer 통과.

## 그러나 production path 의 next wall

`osty-self` cached 후 cmd/osty-native-checker 빌드 (`OSTY_STAGE0_FALLBACK=0` default):

```
osty-self: stage0 declined function: mirJsonObjectGetNamed
osty-self: this codepath requires the LIR Proto self-host pipeline (Phase 1+)
```

`osty-self` 자체가 cmd/osty-native-checker 빌드 시 monomorph 후 새 stage0 decline. PR #1858 classifier trajectory 의 후속 작업 영역.

## 의미

- `osty-self` install 자체는 unlock — plan 의 핵심 milestone
- 그러나 production path 의 LIR Proto pipeline (Phase 1+) 자체가 stage0 → LIR Proto 의 추가 layer 가 새 wall
- 본 plan 의 trajectory 와는 별개 (osty-self 자체의 LLVM 빌드 가능성 검증). cmd/osty-native-checker 의 byte parity 진척 (M2 → M3) 은 osty-self 의 monomorph cover 추가 wave 후

## 변경

| 파일 | 변경 |
|---|---|
| `SPEC_GAPS.md::cross-pkg-module-resolution` | source bootstrap unlock + production path next wall (`mirJsonObjectGetNamed`) 명시 |

## 누적 (이 세션, 34 PR 머지 예정)

| # | PR |
|---|---|
| 1–33 | (이전) |
| 34 | (this) **🎉 source bootstrap UNLOCK + production path next wall** |

## Test plan

- [x] `just prepush` 통과
- [x] source bootstrap 3-flag 조합 통과 확인
- [x] `osty-self` cache install 확인
- [x] production path next wall (`mirJsonObjectGetNamed`) 측정
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)