### PR TITLE
docs: stage0 audit scope 한계 — checker bundle 만 cover (backend 별도)

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -265,6 +265,10 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    **2026-05-17 옵션 5 진척 (PR #1861)**: `osty_rt_os_exec_with` + `osty_rt_os_exec_input_with` C wrapper (2 함수) + `rewriteStdlibSymbolToRuntime` 매핑 2 (`std.os.execWith`, `std.os.execInputWith`) 추가. source bootstrap 의 link 단계 wall 부분 해소.
 
+   **2026-05-17 stage0 audit scope 한계 측정**: `mirJsonObjectGetNamed` 가 stage0 decline 인데 audit 100% 인 이유 = `internal/selfhost/bundle/bundle.go::ToolchainCheckerFiles()` 가 mir_json.osty / mir_lower.osty / llvmgen.osty / lir_proto.osty / mir_generator.osty 등 toolchain backend 부분을 **audit 에 포함하지 않음**. 즉 audit 100% 는 **checker bundle (resolve/elab/check/ty/hir_lower/ast/lexer/parser) scope 만 cover**. install-self / build 시 monomorph 가 audit scope 외부 함수 reach 시 stage0 decline.
+
+   plan §10.1 R2 (stage0 cover) 의 "종결" 도 **scope 제한적** — checker bundle 만. backend (mir_*, llvmgen) 의 stage0 cover 는 별도 audit / trajectory 필요. PR #1858 의 3-commit cascade 도 checker bundle 의 16 decline 만 해소.
+
    **🎉 2026-05-17 source bootstrap UNLOCK**: `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 OSTY_STDLIB_BODY_LOWER=1 .bin/osty install-self` **통과**! `osty-self` binary 가 `.osty/cache/self-host/<hash>-darwin-arm64/osty-self` 에 install. 조합:
    - stage0 100% (PR #1858)
    - execWith / execInputWith C wrappers (PR #1861)


### PR DESCRIPTION
## Summary

옵션 A' (`mirJsonObjectGetNamed` unblock) 시도 시 핵심 발견. audit 100% 의 scope 가 **checker bundle 만** — backend (mir_*, llvmgen) 는 별도 trajectory.

## 측정

`internal/selfhost/bundle/bundle.go::ToolchainCheckerFiles()` 의 cover 목록:
- ✓ resolve / elab / check / ty / hir_lower / ast / lexer / parser
- ✗ mir_json / mir_lower / mir_generator / mir_optimize / llvmgen / lir_proto

`mirJsonObjectGetNamed` 가 mir_json.osty:43 에 정의. **audit 에 포함 안 됨**. 그래서:
- audit 100% (8240/8241) ✓
- 그러나 install-self / build 시 monomorph 가 mir_json reach → stage0 decline

## plan §10.1 R2 의 의미 재정정

R2 (stage0 cover) "종결" = checker bundle 만. PR #1858 의 3-commit cascade 도 checker bundle 의 16 decline 만 해소. **backend 부분의 stage0 cover 는 별도 wave**.

진짜 의미: source bootstrap UNLOCK ([PR #1863](https://github.com/choiceoh/osty/pull/1863)) 은 valid (osty-self install) 하나 production path 의 모든 빌드 (cmd/osty-native-checker 포함) 는 backend stage0 cover 의 추가 wave 필요. 본 plan 의 M3/M4 진척은 그 외부 trajectory 의존.

## 다음 작업 옵션

| # | 접근 | 위험 |
|---|---|---|
| α | `bundle.ToolchainCheckerFiles()` scope 확장 — mir_*, llvmgen 포함 후 새 audit 측정 | 새 stage0 decline 다수 발견 가능성 (16개보다 훨씬 많음) |
| β | PR #1858 trajectory 의 follow-up — mir_* / llvmgen 의 stage0 cover wave | 다른 작업자의 작업, 본 plan scope 외 |
| γ | LIR Proto pipeline (Phase 1+) 의 직접 활성화 — stage0 우회 | osty-self 의 별도 구조 변경 |

## 변경

| 파일 | 변경 |
|---|---|
| `SPEC_GAPS.md::cross-pkg-module-resolution` | stage0 audit scope 한계 측정 + R2 의미 재정정 + backend stage0 cover trajectory 분리 |

## 누적 (이 세션, 36 PR 머지 예정)

| # | PR |
|---|---|
| 1–35 | (이전) |
| 36 | (this) **stage0 audit scope 한계 측정** |

## Test plan

- [x] `just prepush` 통과
- [x] mir_json.osty 가 ToolchainCheckerFiles() 외부 확인
- [x] audit 100% 의 scope 명확화
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)