### PR TITLE
feat: std.os.execOutput shim — install-self link gap closeout

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -31001,6 +31001,42 @@ void osty_rt_audit_os_exit(int64_t code) __asm__(
     OSTY_RT_AUDIT_SYMBOL("std.os.exit")) OSTY_RT_AUDIT_USED;
 void osty_rt_audit_os_exit(int64_t code) { exit((int)code); }
 
+/* std.os.execOutput(exitCode, stdout, stderr, timedOut) — pure struct
+ * constructor for the Osty `ExecOutput` value used by self-rebuild
+ * error paths (toolchain/main.osty: `os.execOutput(1, "", "", false)`).
+ * The stdlib defines a body but install-self's bootstrap compile keeps
+ * the stdlib symbol unresolved; stage0 then emits an external call to
+ * `std.os.execOutput` that the linker can't satisfy without this stub.
+ *
+ * Layout matches the stage0 stdlib fallback for ExecOutput
+ * (internal/backend/stage0/stdlib_struct_fallback.go): `{ i64 exitCode,
+ * ptr stdout, ptr stderr, i1 timedOut }`, GC-managed so downstream
+ * field reads see live memory. Pre-PR #1858 the install-self path
+ * declined the callers entirely (decline-stub unreachable trap) so
+ * this symbol was never referenced; now they emit real call sites and
+ * need a definition. */
+typedef struct osty_rt_audit_exec_output {
+  int64_t exit_code;
+  const char *stdout_text;
+  const char *stderr_text;
+  bool timed_out;
+} osty_rt_audit_exec_output;
+
+void *osty_rt_audit_os_exec_output(int64_t exit_code, const char *stdout_text,
+                                   const char *stderr_text,
+                                   bool timed_out) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("std.os.execOutput")) OSTY_RT_AUDIT_USED;
+void *osty_rt_audit_os_exec_output(int64_t exit_code, const char *stdout_text,
+                                   const char *stderr_text, bool timed_out) {
+  osty_rt_audit_exec_output *out = (osty_rt_audit_exec_output *)
+      osty_rt_stage0_alloc((int64_t)sizeof(osty_rt_audit_exec_output));
+  out->exit_code = exit_code;
+  out->stdout_text = stdout_text;
+  out->stderr_text = stderr_text;
+  out->timed_out = timed_out;
+  return out;
+}
+
 /* std.process.abort(msg) — emit `msg` to stderr and abort. Declared
  * `Never` on the Osty side. */
 void osty_rt_audit_process_abort(const char *msg) __asm__(


### PR DESCRIPTION
## Summary
- 마지막 남은 install-self link wall (`_std.os.execOutput`) 해소.
- PR #1858 (stage0 audit 100%) → #1861 (execWith/execInputWith wrappers) 시리즈의 마무리.
- 이제 `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 .bin/osty install-self` 가 19M osty-self 바이너리를 끝까지 빌드+설치.

## Context
- 호출자: `toolchain/main.osty:456` 의 self-rebuild 에러 분기 (`os.execOutput(1, "", "", false)`).
- 본래 stdlib body 로 정의되나 install-self bootstrap 은 stdlib 본체를 모듈에 포함하지 않음.
- PR #1858 이전엔 호출자가 declined → unreachable stub 이라 IR 에 호출이 없었음. audit 100% 이후 실제 emit 되면서 linker 가 정의를 요구.

## Approach
- 기존 L3-audit 패턴 (`osty_rt_audit_os_exit` 와 동일) 채택: `__asm__(OSTY_RT_AUDIT_SYMBOL("std.os.execOutput"))` 로 dotted symbol 직접 export.
- 본문: `osty_rt_stage0_alloc` 로 GC 관리 메모리에 ExecOutput layout `{i64 exitCode, ptr stdout, ptr stderr, i1 timedOut}` 할당 + field 저장.
- Layout 은 PR #1858 의 `stage0KnownStdlibStructLayout("ExecOutput")` 과 일치.

## Test plan
- [x] `just prepush` 통과 (fmt-check + vet + repair-check + ci)
- [x] `rm -rf .osty/cache/self-host/ toolchain/.osty/out/ && OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 .bin/osty install-self` 성공 (19M osty-self 생성/설치)
- [x] `osty-self --help` 정상 응답
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)