### PR TITLE
feat: std.os.execOutput — C runtime wrapper + MIR rewrite (PR1c pattern)

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -276,6 +276,8 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    plan §10.1 R2 (stage0 cover) **완전 종결**.
 
+   **2026-05-17 execOutput C wrapper (이 PR)**: `osty_rt_os_exec_output(int64_t exit_code, void *stdout, void *stderr, bool timed_out)` C wrapper + `rewriteStdlibSymbolToRuntime` 매핑 `std.os.execOutput → osty_rt_os_exec_output` 추가. ExecOutput struct ABI = `{i64, ptr, ptr, i1}` (stage0KnownStdlibStructLayout 와 일치). 효과: source bootstrap 명령에서 `OSTY_STDLIB_BODY_LOWER=1` flag **의존성 제거** — `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 .bin/osty install-self` 만으로 통과. minimum-flag combination 으로 source bootstrap path 안정화. PR #1861 의 PR1c 옵션 1 패턴 확장 — 위 §"옵션 5 next wall" 의 첫 path ("C wrapper") 채택.
+
    **2026-05-17 cmd/osty-native-checker production path next wall**: `osty-self` cached 후 `.bin/osty build --backend llvm cmd/osty-native-checker/` (stage0 fallback OFF) 시도 → `osty-self: stage0 declined function: mirJsonObjectGetNamed`. 즉 osty-self 자체가 cmd/osty-native-checker 의 main.osty (PR2 의 naive parser) 빌드 시 monomorph 후 `mirJsonObjectGetNamed` 함수가 stage0 decline. PR #1858 classifier trajectory 의 후속 작업 영역.
 
    **2026-05-17 옵션 5 next wall — execOutput constructor + cross-package struct literal**: PR #1861 후 남은 부재 symbol = `_std.os.execOutput` (single use site at `toolchain/main.osty:456`). 두 path 시도:

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -29852,6 +29852,32 @@ osty_rt_os_exec_result *osty_rt_os_exec_input_with(const char *cmd,
                                        env_overrides, timeout_ms, stdin_text);
 }
 
+/* std.os.execOutput(exitCode, stdout, stderr, timedOut) constructs an
+ * `ExecOutput` value. The stage0 stdlib body lowering doesn't reach this
+ * symbol on the source-bootstrap path, so the MIR pipeline rewrites the
+ * call to this C wrapper. The struct layout mirrors `ExecOutput` in the
+ * stage0 known-layout table (`stage0KnownStdlibStructLayout`):
+ *   { i64 exitCode; ptr stdout; ptr stderr; i1 timedOut }
+ */
+typedef struct osty_rt_exec_output_value {
+  int64_t exit_code;
+  void *stdout_text;
+  void *stderr_text;
+  bool timed_out;
+} osty_rt_exec_output_value;
+
+osty_rt_exec_output_value *
+osty_rt_os_exec_output(int64_t exit_code, void *stdout_text, void *stderr_text,
+                       bool timed_out) {
+  osty_rt_exec_output_value *out = (osty_rt_exec_output_value *)osty_rt_xmalloc(
+      sizeof(*out), "runtime.os.execOutput.result");
+  out->exit_code = exit_code;
+  out->stdout_text = stdout_text;
+  out->stderr_text = stderr_text;
+  out->timed_out = timed_out;
+  return out;
+}
+
 osty_rt_os_string_result *osty_rt_os_hostname(void) {
 #if defined(_WIN32)
   char buf[MAX_COMPUTERNAME_LENGTH + 1];

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -5818,10 +5818,15 @@ func qualifiedSymbol(use *ir.UseDecl, name string) string {
 // This lets stage0 fallback emit calls to runtime symbols without needing
 // per-symbol mir.IntrinsicKind cases or stage0/emit.go dispatch arms.
 //
-// Currently covered: std.io.readLine → osty_rt_io_read_line. Production
-// path (lir_proto) sees the same rewritten symbol; if it had a separate
-// mapping for the original symbol that arm is now bypassed (rewrites are
-// monotonic so no double-rewrite issue).
+// Coverage:
+//   - std.io.readLine     → osty_rt_io_read_line
+//   - std.os.execWith     → osty_rt_os_exec_with
+//   - std.os.execInputWith → osty_rt_os_exec_input_with
+//   - std.os.execOutput   → osty_rt_os_exec_output
+//
+// Production path (lir_proto) sees the same rewritten symbol; if it had
+// a separate mapping for the original symbol that arm is now bypassed
+// (rewrites are monotonic so no double-rewrite issue).
 func rewriteStdlibSymbolToRuntime(sym string) string {
 	switch sym {
 	case "std.io.readLine":
@@ -5830,6 +5835,8 @@ func rewriteStdlibSymbolToRuntime(sym string) string {
 		return "osty_rt_os_exec_with"
 	case "std.os.execInputWith":
 		return "osty_rt_os_exec_input_with"
+	case "std.os.execOutput":
+		return "osty_rt_os_exec_output"
 	}
 	return sym
 }


### PR DESCRIPTION
## Summary
- PR #1861 (execWith / execInputWith) 패턴 확장 — `execOutput` constructor 도 같은 C wrapper + MIR symbol rewrite
- SPEC_GAPS::cross-pkg-module-resolution path #5 의 §\"옵션 5 next wall\" 첫 path (\"C wrapper\") 채택
- source bootstrap 명령의 `OSTY_STDLIB_BODY_LOWER=1` flag 의존성 제거 — minimum-flag combination 안정화

## 변경

| 파일 | 변경 |
|---|---|
| `internal/backend/runtime/osty_runtime.c` | `osty_rt_os_exec_output(exit_code, stdout, stderr, timed_out)` C wrapper. ExecOutput struct ABI = `{i64, ptr, ptr, i1}` (stage0KnownStdlibStructLayout 와 일치) |
| `internal/mir/lower.go` | `rewriteStdlibSymbolToRuntime` 매핑 `std.os.execOutput → osty_rt_os_exec_output` |
| `SPEC_GAPS.md` | cross-pkg-module-resolution 의 \"execOutput C wrapper (이 PR)\" 진척 기록 |

## 효과

| | 이전 (PR #1861 후) | 현재 (이 PR 후) |
|---|---|---|
| install-self flag 조합 | `STAGE0_FALLBACK=1` + `INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1` + `STDLIB_BODY_LOWER=1` | `STAGE0_FALLBACK=1` + `INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1` |
| stdlib body lowering 의존 | yes (monomorph 후 tyToRepr decline 위험 path) | **no** |

## Test plan

- [x] `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 .bin/osty install-self` → osty-self 빌드+install 성공 (without OSTY_STDLIB_BODY_LOWER)
- [x] `just front` — 회귀 0건
- [x] `just prepush` — fmt-check + vet + repair-check + ci 모두 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)