### PR TITLE
docs: backend audit-out 함수 수 측정 — 4048 함수 (audit ~50%)

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -267,6 +267,21 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    **2026-05-17 stage0 audit scope 한계 측정**: `mirJsonObjectGetNamed` 가 stage0 decline 인데 audit 100% 인 이유 = `internal/selfhost/bundle/bundle.go::ToolchainCheckerFiles()` 가 mir_json.osty / mir_lower.osty / llvmgen.osty / lir_proto.osty / mir_generator.osty 등 toolchain backend 부분을 **audit 에 포함하지 않음**. 즉 audit 100% 는 **checker bundle (resolve/elab/check/ty/hir_lower/ast/lexer/parser) scope 만 cover**. install-self / build 시 monomorph 가 audit scope 외부 함수 reach 시 stage0 decline.
 
+   **2026-05-17 backend audit-out 함수 수 측정**:
+
+   | 파일 | 함수 수 |
+   |---|---|
+   | toolchain/mir_json.osty | 126 |
+   | toolchain/mir_lower.osty | 306 |
+   | toolchain/mir_optimize.osty | 39 |
+   | toolchain/mir_generator.osty | **2659** |
+   | toolchain/llvmgen.osty | 500 |
+   | toolchain/lir_proto.osty | 418 |
+   | **합 (backend, audit 외부)** | **4048** |
+   | (참고) toolchainCheckerFiles 25 파일 audit cover | 8240 |
+
+   audit cover (8240) 의 거의 절반에 해당하는 backend 영역 (4048) 이 audit 외부. PR #1858 의 3-commit cascade 도 checker bundle 의 16 decline 만 해소. **진짜 cross-cutting trajectory 의 다음 phase = backend 4048 함수의 stage0 cover wave**.
+
    plan §10.1 R2 (stage0 cover) 의 "종결" 도 **scope 제한적** — checker bundle 만. backend (mir_*, llvmgen) 의 stage0 cover 는 별도 audit / trajectory 필요. PR #1858 의 3-commit cascade 도 checker bundle 의 16 decline 만 해소.
 
    **🎉 2026-05-17 source bootstrap UNLOCK**: `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 OSTY_STDLIB_BODY_LOWER=1 .bin/osty install-self` **통과**! `osty-self` binary 가 `.osty/cache/self-host/<hash>-darwin-arm64/osty-self` 에 install. 조합:


### PR DESCRIPTION
## Summary

옵션 α (bundle scope 확장) 시도 시 측정. backend (mir_*, llvmgen, lir_proto) 의 함수 수 grep — **4048 함수** (audit cover 의 ~50%).

## 측정

| 파일 | 함수 수 |
|---|---|
| toolchain/mir_json.osty | 126 |
| toolchain/mir_lower.osty | 306 |
| toolchain/mir_optimize.osty | 39 |
| **toolchain/mir_generator.osty** | **2659** |
| toolchain/llvmgen.osty | 500 |
| toolchain/lir_proto.osty | 418 |
| **합 backend audit 외부** | **4048** |
| (참고) checker bundle audit cover | 8240 |

audit cover (8240) 의 거의 절반에 해당하는 backend 영역 (4048) 이 audit 외부.

## 의미

PR [#1858](https://github.com/choiceoh/osty/pull/1858) 의 16 decline → 0 cascade 도 checker bundle 만. **backend 4048 함수의 stage0 cover wave 가 진짜 cross-cutting trajectory 의 다음 phase**.

본 plan §10.1 R2 (stage0 cover) "종결" 은 scope 제한적. backend stage0 cover 는 별도 trajectory.

## 진짜 진척 path

| # | 접근 |
|---|---|
| α' | bundle.go 의 toolchainCheckerFiles 에 backend 추가 → 새 audit (4048 함수 + 새 decline 수 측정) |
| β | PR #1858 author 의 후속 wave (backend stage0 cover, 외부 trajectory) |
| γ | osty-self 의 LIR Proto pipeline (Phase 1+) 직접 활성 — stage0 우회 |

## 변경

| 파일 | 변경 |
|---|---|
| `SPEC_GAPS.md::cross-pkg-module-resolution` | backend audit-out 함수 수 표 + R2 scope 한계 |

## 누적 (이 세션, 37 PR 머지 예정)

| # | PR |
|---|---|
| 1–36 | (이전) |
| 37 | (this) **backend audit-out 4048 함수 측정** |

## Test plan

- [x] `just prepush` 통과
- [x] 6 backend file 함수 수 grep
- [x] audit cover 대비 비율 확인
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)