### PR TITLE
docs: handoff §10 — backend audit-out 4048 측정 + next-phase trajectory

### DIFF
--- a/docs/llvm-selfhost-next-session-handoff.md
+++ b/docs/llvm-selfhost-next-session-handoff.md
@@ -210,6 +210,30 @@ D)  PR3 자체 보류 — M2 partial 로 만족. source bootstrap UNLOCK 이 핵
 
 **권장 (옵션 A')**: production path next wall (mirJsonObjectGetNamed) 의 stage0 cover wave 가 가장 직접적 진척. PR #1858 의 3-commit cascade 패턴 재사용 가능. unblock 시 production path 전체 활성 → cmd/osty-native-checker 의 M3 (L2 corpus) 자동 가능성.
 
+## 10. 2026-05-17 최종 측정 (PR #1865/#1868)
+
+**audit scope 의 한계 발견** + **backend audit-out 함수 수**:
+
+| file | 함수 수 | scope |
+|---|---|---|
+| toolchain/mir_json.osty | 126 | audit 외부 |
+| toolchain/mir_lower.osty | 306 | audit 외부 |
+| toolchain/mir_optimize.osty | 39 | audit 외부 |
+| toolchain/mir_generator.osty | **2659** | audit 외부 |
+| toolchain/llvmgen.osty | 500 | audit 외부 |
+| toolchain/lir_proto.osty | 418 | audit 외부 |
+| **backend 합 (audit 외부)** | **4048** | — |
+| (참고) toolchainCheckerFiles audit cover | 8240 | audit 내부 |
+
+audit 100% 는 checker bundle 만. backend 4048 함수의 stage0 cover 는 별도 trajectory. PR #1858 의 16 decline → 0 cascade 도 checker bundle 만 적용.
+
+**진짜 next-phase trajectory**: backend 4048 함수의 stage0 cover wave. PR #1858 의 classifier mechanism + 3-commit cascade 패턴 재사용 가능. 단일 fresh session 으로 가능한지 미지수 (4048 vs 16 비율 100배 이상).
+
+대안:
+- **bundle scope 확장** (옵션 α'): toolchainCheckerFiles 에 backend 파일 추가 → 새 audit 측정 → cascade unblock
+- **osty-self LIR Proto pipeline (Phase 1+) 직접 활성** (옵션 γ): stage0 우회, osty-self 의 별도 구조 변경
+- **PR #1858 author 후속 wave wait** (옵션 β): 외부 trajectory 의존
+
 위 선택지 중 하나가 명확해지면 본 doc 의 §2 cheat sheet 만으로 즉시 PR 시작 가능.
 
 ## 10. 본 doc 의 갱신 트리거


### PR DESCRIPTION
## Summary

PR [#1865](https://github.com/choiceoh/osty/pull/1865) (audit scope 한계) + [#1868](https://github.com/choiceoh/osty/pull/1868) (backend 4048 함수 측정) 의 결과를 handoff doc 의 §10 에 반영.

## §10 추가 내용

- audit 100% 의 scope = checker bundle (8240 함수) 만
- backend audit 외부 함수 수 표 (mir_json 126 + mir_lower 306 + mir_optimize 39 + mir_generator 2659 + llvmgen 500 + lir_proto 418 = **4048**)
- audit cover (8240) 의 거의 절반에 해당하는 backend 영역이 audit 외부
- PR #1858 의 16 decline cascade 도 checker bundle 만 적용
- next-phase trajectory 3 옵션 (α' bundle scope 확장 / γ LIR Proto Phase 1+ / β PR #1858 author 후속)

## 다음 세션 시작점

§9 의 4 옵션 (A'/B/C/D) + §10 의 3 옵션 (α'/γ/β) 비교 후 선택. **권장 = A'** (osty-self monomorph cover wave) 단 4048 vs 16 비율 100배 이상이라 단일 fresh session 으로 가능한지 미지수.

## 누적 (이 세션, 38 PR 머지 예정)

| # | PR |
|---|---|
| 1–37 | (이전) |
| 38 | (this) **handoff §10 — backend audit-out 4048** |

## Test plan

- [x] `just prepush` 통과
- [x] 4048 측정값 + scope 표 정합 확인
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)