### PR TITLE
docs: 옵션 α' 측정 정정 — audit scope = toolchain/ 전체, build path 별개

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -284,6 +284,12 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    plan §10.1 R2 (stage0 cover) 의 "종결" 도 **scope 제한적** — checker bundle 만. backend (mir_*, llvmgen) 의 stage0 cover 는 별도 audit / trajectory 필요. PR #1858 의 3-commit cascade 도 checker bundle 의 16 decline 만 해소.
 
+   **2026-05-17 옵션 α' 측정 정정**: `internal/backend/stage0_toolchain_audit_test.go::TestStage0ToolchainAudit` 는 `resolve.PackageSourcePaths(pkgDir, false)` 사용 — toolchain/ **전체 .osty 파일** walk. bundle.ToolchainCheckerFiles() 무관. 즉 audit 의 8240/8241 (100.0%) 가 이미 mir_json / mir_lower / llvmgen / lir_proto 등 **backend 포함 전체 toolchain/ scope**. bundle.go 의 25 파일 list 는 별도 (checker bundle 구성용).
+
+   `mirJsonObjectGetNamed` 가 build path 에서 stage0 decline 인 이유 = audit "covered" 의 의미가 "stage0 가 MIR shape lower 가능" — 그러나 install-self/build 시 monomorph + LLVM IR emit 단계의 **다른 specialization** 가 stage0 decline. **audit-pass ≠ build-pass**.
+
+   본 plan 의 진짜 wall = `osty-self` 의 LLVM IR emit 단계 (LIR Proto Phase 1+ vs stage0 fallback) 활성화. PR #1858 도 audit-pass 만 해소; build/install-self pass 는 별개 wave (옵션 γ 또는 backend 별 monomorph cover).
+
    **🎉 2026-05-17 source bootstrap UNLOCK**: `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 OSTY_STDLIB_BODY_LOWER=1 .bin/osty install-self` **통과**! `osty-self` binary 가 `.osty/cache/self-host/<hash>-darwin-arm64/osty-self` 에 install. 조합:
    - stage0 100% (PR #1858)
    - execWith / execInputWith C wrappers (PR #1861)


### PR DESCRIPTION
## Summary

옵션 α' (bundle scope 확장) 시도 시 **PR #1865/#1868 의 측정 정정** 발견.

## 측정

- bundle.go 의 `toolchainCheckerFiles` 에 `mir_json.osty` 추가 시도
- audit 결과 변동 없음 (8240/8241 100.0% 그대로)
- 원인: `internal/backend/stage0_toolchain_audit_test.go::TestStage0ToolchainAudit` 가 `resolve.PackageSourcePaths(pkgDir, false)` 사용 — toolchain/ **전체 .osty walk**. `bundle.ToolchainCheckerFiles()` 와 무관

## 측정 정정

| 이전 (PR #1865/#1868) | 정정 |
|---|---|
| audit 100% = checker bundle 만 cover | **audit 100% = toolchain/ 전체 cover** |
| backend 4048 함수 audit 외부 | **backend 4048 함수도 audit 안에 포함** |
| backend stage0 cover wave 가 다음 phase | **wave 의 진짜 단계 = build path 의 LLVM IR emit** |

## 진짜 wall 의미 재정리

- `mirJsonObjectGetNamed` audit "covered" = stage0 가 MIR shape **lower 가능**
- 그러나 build/install-self 시 monomorph + LLVM IR emit 의 **다른 specialization** 가 stage0 decline
- **audit-pass ≠ build-pass**

본 plan 의 진짜 wall = `osty-self` 의 **LLVM IR emit 단계** (LIR Proto Phase 1+ vs stage0 fallback) 활성화. PR #1858 도 audit-pass 만 해소; build pass 는 별개 wave (옵션 γ).

## 변경

| 파일 | 변경 |
|---|---|
| `SPEC_GAPS.md::cross-pkg-module-resolution` | 옵션 α' 정정 + audit scope 명확화 + build path 별개 wall 명시 |
| `internal/selfhost/bundle/bundle.go` | mir_json.osty 추가 revert (의미 없음) |

## 누적 (이 세션, 39 PR 머지 예정)

| # | PR |
|---|---|
| 1–38 | (이전) |
| 39 | (this) **옵션 α' 측정 정정** |

## Test plan

- [x] `just prepush` 통과
- [x] audit test 의 source loader 위치 확인 (`resolve.PackageSourcePaths`)
- [x] bundle.go revert
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)