### PR TITLE
docs: handoff §10a — 옵션 γ Phase 1 인벤토리 (mir_generator.osty)

### DIFF
--- a/docs/llvm-selfhost-next-session-handoff.md
+++ b/docs/llvm-selfhost-next-session-handoff.md
@@ -210,6 +210,27 @@ D)  PR3 자체 보류 — M2 partial 로 만족. source bootstrap UNLOCK 이 핵
 
 **권장 (옵션 A')**: production path next wall (mirJsonObjectGetNamed) 의 stage0 cover wave 가 가장 직접적 진척. PR #1858 의 3-commit cascade 패턴 재사용 가능. unblock 시 production path 전체 활성 → cmd/osty-native-checker 의 M3 (L2 corpus) 자동 가능성.
 
+## 10a. 2026-05-17 옵션 γ Phase 1 인벤토리 측정
+
+`toolchain/mir_generator.osty` 의 Phase 1 단계 (grep `Phase 1[a-z]`):
+
+| Phase | 내용 | 상태 |
+|---|---|---|
+| **1a** | block label + operand-free terminator (return / goto / unreachable) | ✓ 착륙 |
+| **1b** | terminator operands wired (PR #1271) | ✓ 착륙 |
+| **1c** | per-instruction emission (MirInstrAssign + rvalue arms) | **진행 중** (line 17715+) |
+| **1d** | MirRVNullary 진짜 값 + MirInstrCall + Intrinsic | TODO |
+| **1p** | MirConstString string pool | ✓ 착륙 |
+
+`mirJsonObjectGetNamed` decline = Phase 1c/d 의 미구현 reach (for loop 의 list indexing + if + early Some return + None fallback = MirInstrAssign + multiple rvalue arms + MirInstrCall).
+
+**옵션 γ 의 진짜 sub-trajectory** = mir_generator.osty 의 **Phase 1c + Phase 1d 진척**. 추정 작업:
+- Phase 1c rvalue arms 확장 (~수십 LOC per arm × 10+ arms)
+- Phase 1d MirInstrCall / Intrinsic emit (수백 LOC, intrinsic family 별)
+- 검증: cmd/osty-native-checker build production path 통과
+
+본 plan scope 외 — mir_generator owner trajectory. PR #1858 의 stage0 cascade 패턴 (PR1/PR2/PR3 wave) 으로 cover 추가도 같은 layer 의 별개 작업.
+
 ## 10. 2026-05-17 최종 측정 (PR #1865/#1868)
 
 **audit scope 의 한계 발견** + **backend audit-out 함수 수**:


### PR DESCRIPTION
## Summary

옵션 γ (osty-self LIR Proto pipeline 활성) 의 진짜 sub-trajectory 측정. handoff doc 에 §10a 추가.

## Phase 1 단계 인벤토리

| Phase | 내용 | 상태 |
|---|---|---|
| **1a** | block label + operand-free terminator | ✓ 착륙 |
| **1b** | terminator operands ([PR #1271](https://github.com/choiceoh/osty/pull/1271)) | ✓ 착륙 |
| **1c** | per-instruction emission (MirInstrAssign + rvalue arms) | **진행 중** (line 17715+) |
| **1d** | MirRVNullary 진짜 값 + MirInstrCall + Intrinsic | TODO |
| **1p** | MirConstString string pool | ✓ 착륙 |

## 의미

`mirJsonObjectGetNamed` decline = Phase 1c/d 미구현 reach (for loop + list indexing + if + early Some return + None fallback = MirInstrAssign + multiple rvalue arms + MirInstrCall).

**옵션 γ 의 진짜 작업** = mir_generator.osty 의 Phase 1c+1d 진척:
- Phase 1c rvalue arms 확장 (~수십 LOC per arm × 10+ arms)
- Phase 1d MirInstrCall / Intrinsic emit (수백 LOC)
- 검증: cmd/osty-native-checker production path build pass

본 plan scope 외 — mir_generator owner trajectory. PR [#1858](https://github.com/choiceoh/osty/pull/1858) 의 stage0 cascade 패턴으로 cover 추가도 같은 layer 의 별개 작업.

## 변경

| 파일 | 변경 |
|---|---|
| `docs/llvm-selfhost-next-session-handoff.md` | §10a 신규 — Phase 1 인벤토리 표 + 옵션 γ sub-trajectory 명세 |

## 누적 (이 세션, 40 PR 머지 예정)

| # | PR |
|---|---|
| 1–39 | (이전) |
| 40 | (this) **옵션 γ Phase 1 인벤토리** |

## Test plan

- [x] `just prepush` 통과
- [x] mir_generator.osty 의 Phase 1[a-z] grep 정합
- [x] handoff §10a 표 작성
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)