### PR TITLE
feat: PrimInt method cover (opt R3 brick 1) + docs: α' framing 결함

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -284,11 +284,19 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    plan §10.1 R2 (stage0 cover) 의 "종결" 도 **scope 제한적** — checker bundle 만. backend (mir_*, llvmgen) 의 stage0 cover 는 별도 audit / trajectory 필요. PR #1858 의 3-commit cascade 도 checker bundle 의 16 decline 만 해소.
 
-   **2026-05-17 옵션 α' 측정 정정**: `internal/backend/stage0_toolchain_audit_test.go::TestStage0ToolchainAudit` 는 `resolve.PackageSourcePaths(pkgDir, false)` 사용 — toolchain/ **전체 .osty 파일** walk. bundle.ToolchainCheckerFiles() 무관. 즉 audit 의 8240/8241 (100.0%) 가 이미 mir_json / mir_lower / llvmgen / lir_proto 등 **backend 포함 전체 toolchain/ scope**. bundle.go 의 25 파일 list 는 별도 (checker bundle 구성용).
+   **2026-05-17 옵션 α' 측정 정정** (외부 PR + 이 PR 동시 발견, 같은 결론 다른 angle):
+
+   *Angle 1 — audit scope*: `internal/backend/stage0_toolchain_audit_test.go::TestStage0ToolchainAudit` 는 `resolve.PackageSourcePaths(pkgDir, false)` 사용 — toolchain/ **전체 .osty 파일** walk. bundle.ToolchainCheckerFiles() 무관. 즉 audit 의 8240/8241 (100.0%) 가 이미 mir_json / mir_lower / llvmgen / lir_proto 등 **backend 포함 전체 toolchain/ scope**. handoff §10 의 "audit 외부 4048" framing 자체가 잘못 (외부 PR 발견).
+
+   *Angle 2 — bundle probe-only* (이 PR): `toolchainCheckerFiles` 에 backend 6 파일 추가 시도 → bundle 가 **probe-only**. `bundle.ToolchainCheckerFiles()` / `bundle.MergeToolchainChecker(root)` 의 production consumer 0건 (`bundle_test.go` + `toolchain_checker_probe_test.go` test only). `cmd/osty-native-checker/main.go` 가 `selfhost.CheckSourceStructured` 호출 → `internal/selfhost/generated.go` (frozen seed) 가 진짜 production checker. bundle scope 확장은 production capability 영향 **zero**.
+
+   두 angle 결론 동일: handoff §10 의 "α' = production capability 확장" framing 이 실제 mechanism 과 mismatch.
 
    `mirJsonObjectGetNamed` 가 build path 에서 stage0 decline 인 이유 = audit "covered" 의 의미가 "stage0 가 MIR shape lower 가능" — 그러나 install-self/build 시 monomorph + LLVM IR emit 단계의 **다른 specialization** 가 stage0 decline. **audit-pass ≠ build-pass**.
 
    본 plan 의 진짜 wall = `osty-self` 의 LLVM IR emit 단계 (LIR Proto Phase 1+ vs stage0 fallback) 활성화. PR #1858 도 audit-pass 만 해소; build/install-self pass 는 별개 wave (옵션 γ 또는 backend 별 monomorph cover).
+
+   진짜 production capability 확장 path: generated.go 직접 수정 — 옵션 c' (narrow exception 한도 확대) / γ (deep type-propagation fix) / frozen seed regen 모델 재고 셋 중 선택.
 
    **🎉 2026-05-17 source bootstrap UNLOCK**: `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 OSTY_STDLIB_BODY_LOWER=1 .bin/osty install-self` **통과**! `osty-self` binary 가 `.osty/cache/self-host/<hash>-darwin-arm64/osty-self` 에 install. 조합:
    - stage0 100% (PR #1858)

--- a/docs/llvm-selfhost-next-session-handoff.md
+++ b/docs/llvm-selfhost-next-session-handoff.md
@@ -271,6 +271,23 @@ audit 100% 는 checker bundle 만. backend 4048 함수의 stage0 cover 는 별�
 
 위 선택지 중 하나가 명확해지면 본 doc 의 §2 cheat sheet 만으로 즉시 PR 시작 가능.
 
+### 10.1 옵션 α' framing 결함 (2026-05-17 측정)
+
+`toolchainCheckerFiles` 에 backend 6 파일 (mir_json/mir_lower/mir_optimize/mir_generator/llvmgen/lir_proto) 추가 시도. 측정 결과 **framing 결함 발견**:
+
+- `bundle.ToolchainCheckerFiles()` / `bundle.MergeToolchainChecker(root)` 의 **production consumer 0건**. `grep` 결과 `bundle_test.go` + `toolchain_checker_probe_test.go` (test only) 만 호출
+- `cmd/osty-native-checker/main.go` 가 `selfhost.CheckSourceStructured / CheckPackageStructured` 호출 → `internal/selfhost/generated.go` (frozen seed) 가 진짜 production checker. **bundle merge 와 무관**
+- `internal/toolchain/native_checker.go::buildNativeChecker` 가 `go build ./cmd/osty-native-checker` 로 native checker 빌드 — bundle scope 미참조
+
+**즉 옵션 α' 은 probe-only 작업**. bundle 확장은 production checker capability 에 영향 zero. handoff §10 의 "α' = production capability 확장" framing 이 실제 mechanism 과 mismatch.
+
+진짜 production capability 확장 path = `internal/selfhost/generated.go` 의 backend logic 추가:
+1. **옵션 c' (재합의)**: narrow exception 한도 확대 + `registerToolchainAliasFns` 같은 단일 mechanism. spec 재합의 필요
+2. **옵션 γ (deep)**: type-propagation gap fix (`<error>` leak 의 IR→MIR seam, `internal/mir/lower.go:3012` 코멘트 명시). multi-PR, 측정 spike 부터 시작 필요
+3. **frozen seed 정책 재고**: generated.go regen 모델 재도입 — `internal/selfhost/generated.go` 자체를 다시 자동 생성 가능하게. CLAUDE.md 의 frozen seed 결정 (PR #854) 자체 revisit
+
+α' 자체는 dropped path (probe-only). 다음 trajectory 는 위 3 path 중 선택.
+
 ## 10. 본 doc 의 갱신 트리거
 
 - 새 PR 머지 시 §7 카탈로그 갱신

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3461,6 +3461,29 @@ func builtinMethodReturnType(recvT ir.Type, method string) ir.Type {
 		}
 	}
 	if pt, ok := recvT.(*ir.PrimType); ok {
+		// `__IntMethods` (internal/stdlib/primitives/int.osty) fan-out:
+		// abs / min / max / clamp / signum / pow + the wrapping / saturating
+		// arithmetic families all return `Self` and apply to every integer
+		// kind. `checked*` returns `Self?`. Recovering the return type via
+		// the receiver primitive un-poisons MIR temps that would otherwise
+		// reach lir_proto as `<error>`.
+		switch pt.Kind {
+		case ir.PrimInt, ir.PrimByte:
+			switch method {
+			case "abs", "min", "max", "clamp", "signum", "pow",
+				"wrappingAdd", "wrappingSub", "wrappingMul", "wrappingDiv",
+				"wrappingMod", "wrappingShl", "wrappingShr",
+				"wrappingAbs", "wrappingNeg",
+				"saturatingAdd", "saturatingSub", "saturatingMul", "saturatingDiv":
+				return recvT
+			case "checkedAdd", "checkedSub", "checkedMul", "checkedDiv",
+				"checkedMod", "checkedShl", "checkedShr",
+				"checkedAbs", "checkedNeg":
+				return &ir.OptionalType{Inner: recvT}
+			case "toString":
+				return ir.TString
+			}
+		}
 		switch pt.Kind {
 		case ir.PrimInt:
 			switch method {


### PR DESCRIPTION
## Summary

opt R3 trajectory (LLVM path 완성) 의 시작:

1. **feat: builtinMethodReturnType PrimInt/PrimByte __IntMethods cover** (43d2ca21..d6f470d1)
   - Spike 1 측정 결과 = osty-self lir-proto-lower-mir-json 의 \"<error>\" decline 의 root cause 는 MIR generator 의 type-propagation gap
   - `recoverOperandType` 의 MethodCall 경로가 `recoveredMethodReturnType → builtinMethodReturnType` 에 도달하나 PrimInt case 가 abs/min/max/clamp/signum/pow + wrapping*/saturating*/checked*/toString 미cover

2. **docs: handoff §10 α' framing 결함** (43d2ca21)
   - α' (bundle scope 확장) framing 이 실제 mechanism 과 mismatch
   - 두 angle (audit scope + bundle probe-only) 측정 통합

## 변경 1: builtinMethodReturnType cover

`internal/stdlib/primitives/int.osty` 의 `#[intrinsic_methods(Int, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Byte)]` 정의에 맞춰:

| return | method |
|---|---|
| Self → recvT | abs/min/max/clamp/signum/pow + wrapping{Add/Sub/Mul/Div/Mod/Shl/Shr/Abs/Neg} + saturating{Add/Sub/Mul/Div} |
| Self? → Optional{recvT} | checked{Add/Sub/Mul/Div/Mod/Shl/Shr/Abs/Neg} |
| ir.TString | toString |

PrimInt + PrimByte 같은 fan-out.

### 효과

- testClampAcrossArithmeticExpressions / testMinAcrossArithmeticExpressions 등 osty-tests 의 \"declined <error>\" 단계 해소
- 다음 wall expose: `Int__clamp` 등 method body LLVM symbol 부재 (link 단계). multi-PR R3 trajectory 의 다음 brick

## 변경 2: handoff §10 α' framing 결함

- bundle.ToolchainCheckerFiles / MergeToolchainChecker 의 production consumer 0건
- cmd/osty-native-checker/main.go → selfhost.CheckSourceStructured → internal/selfhost/generated.go (frozen seed) 가 진짜 production checker
- bundle scope 확장 production capability 영향 zero

두 angle (외부 PR audit scope + 이 PR bundle probe-only) 통합 → 진짜 path = generated.go 수정 (c'/γ/regen). 우리는 R3 (γ trajectory) 진행.

## Test plan

- [x] `just front` — 회귀 0건 (osty-tests cache 없을 때 skip)
- [x] `just prepush` — fmt-check + vet + repair-check + ci 통과
- [x] osty-self 재빌드 + osty-tests 시도 → \"<error>\" 단계는 해소, link symbol 부재의 다른 wall 노출 (예상한 다음 brick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)