### PR TITLE
feat: Int__{abs,min,max,clamp,signum} C runtime wrappers (R3 brick 2)

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -29878,6 +29878,41 @@ osty_rt_os_exec_output(int64_t exit_code, void *stdout_text, void *stderr_text,
   return out;
 }
 
+/* `__IntMethods` fan-out (internal/stdlib/primitives/int.osty) wired to
+ * the MIR symbol rewrite (`rewriteStdlibSymbolToRuntime` in
+ * `internal/mir/lower.go`). stage0 emits these calls inline via
+ * `renderKnownIntMethodCall`; the source-bootstrap LIR Proto path lacks
+ * an equivalent and was reaching link with `Int__{abs,min,max,clamp,
+ * signum}` undefined. Routing the symbol to a small C wrapper closes
+ * the link gap without porting the inline shape into
+ * `toolchain/lir_proto.osty`. */
+int64_t osty_rt_int_abs(int64_t self) {
+  return self < 0 ? -self : self;
+}
+
+int64_t osty_rt_int_min(int64_t self, int64_t other) {
+  return self < other ? self : other;
+}
+
+int64_t osty_rt_int_max(int64_t self, int64_t other) {
+  return self > other ? self : other;
+}
+
+int64_t osty_rt_int_clamp(int64_t self, int64_t lo, int64_t hi) {
+  int64_t lower = self < lo ? lo : self;
+  return lower > hi ? hi : lower;
+}
+
+int64_t osty_rt_int_signum(int64_t self) {
+  if (self < 0) {
+    return -1;
+  }
+  if (self > 0) {
+    return 1;
+  }
+  return 0;
+}
+
 osty_rt_os_string_result *osty_rt_os_hostname(void) {
 #if defined(_WIN32)
   char buf[MAX_COMPUTERNAME_LENGTH + 1];

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -5846,6 +5846,10 @@ func qualifiedSymbol(use *ir.UseDecl, name string) string {
 //   - std.os.execWith     → osty_rt_os_exec_with
 //   - std.os.execInputWith → osty_rt_os_exec_input_with
 //   - std.os.execOutput   → osty_rt_os_exec_output
+//   - Int__abs/min/max/clamp/signum → osty_rt_int_abs/min/max/clamp/signum
+//     (__IntMethods fan-out; source-bootstrap LIR Proto path needs a
+//     real callable target where stage0 would have inlined via
+//     `renderKnownIntMethodCall`.)
 //
 // Production path (lir_proto) sees the same rewritten symbol; if it had
 // a separate mapping for the original symbol that arm is now bypassed
@@ -5860,6 +5864,16 @@ func rewriteStdlibSymbolToRuntime(sym string) string {
 		return "osty_rt_os_exec_input_with"
 	case "std.os.execOutput":
 		return "osty_rt_os_exec_output"
+	case "Int__abs":
+		return "osty_rt_int_abs"
+	case "Int__min":
+		return "osty_rt_int_min"
+	case "Int__max":
+		return "osty_rt_int_max"
+	case "Int__clamp":
+		return "osty_rt_int_clamp"
+	case "Int__signum":
+		return "osty_rt_int_signum"
 	}
 	return sym
 }
@@ -8582,9 +8596,13 @@ func optionInnerType(t ir.Type) Type {
 }
 
 // mangleMethodSymbol returns the method symbol name shared with the
-// llvmgen convention (Type__method).
+// llvmgen convention (Type__method). The result passes through
+// `rewriteStdlibSymbolToRuntime` so primitive intrinsic fan-outs (e.g.
+// `Int__abs`) get routed to a real C-runtime callable on the
+// source-bootstrap LIR Proto path. stage0 loses its inline expansion
+// for these names in exchange for a single, definable link target.
 func mangleMethodSymbol(owner, method string) string {
-	return owner + "__" + method
+	return rewriteStdlibSymbolToRuntime(owner + "__" + method)
 }
 
 // methodCallSig returns a copy of sig without its leading receiver


### PR DESCRIPTION
## Summary
- opt R3 trajectory 의 두 번째 brick. [PR #1873](https://github.com/choiceoh/osty/pull/1873) 후 expose 된 link wall (`_Int__{abs,min,max,clamp,signum}` undefined) 해소
- C runtime wrapper 5개 + `rewriteStdlibSymbolToRuntime` 매핑 + `mangleMethodSymbol` filter

## 배경

- stage0 의 `renderKnownIntMethodCall` 가 inline LLVM IR expansion — primitive method 의 host-side cover
- source-bootstrap LIR Proto path (osty-self) 는 equivalent 부재 → link 시 undefined symbol
- [PR #854](https://github.com/choiceoh/osty/pull/854) 가 Osty→Go transpiler retire 후 LLVM-built osty-self 가 method body 의 wire-up 부재

## 변경

| 파일 | 변경 |
|---|---|
| `internal/backend/runtime/osty_runtime.c` | `osty_rt_int_abs/min/max/clamp/signum` 5 함수 추가 |
| `internal/mir/lower.go::rewriteStdlibSymbolToRuntime` | `Int__{abs,min,max,clamp,signum}` 매핑 추가 |
| `internal/mir/lower.go::mangleMethodSymbol` | filter through `rewriteStdlibSymbolToRuntime` |

## Trade-off

stage0 의 inline expansion 잃음 (rewritten symbol 매칭 안 되어 external call). 단 5 essential method 모두 small constant-time helper 라 function call overhead 무시 가능.

## 검증

- ✓ `just osty-tests` — 모든 그룹 통과 (45 + 51 + 33 = **129 tests passed**)
  - 이전 (PR #1873 만 머지): 51/51 fail (`<error>` declined) 또는 link miss
- ✓ `just front` — 회귀 0건
- ✓ `just prepush` — fmt-check + vet + repair-check + ci 통과

## 다음 brick

- wrapping\*/saturating\*/checked\* method 도 필요 시 같은 mechanism 으로 cover
- 또는 `toolchain/lir_proto.osty` 에 inline expansion 포팅 (정확성 한 단계 위)

🤖 Generated with [Claude Code](https://claude.com/claude-code)