### PR TITLE
feat: lir_proto Int__* inline expansion (R3 brick 3a, surgical path)

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -43,6 +43,7 @@ pub enum LirInstrKind {
     LirInstrExtractValue,
     LirInstrGep,
     LirInstrComment,
+    LirInstrSelect,
 }
 pub enum LirTermKind {
     LirTermInvalid,
@@ -279,6 +280,18 @@ pub fn lirBinary(dest: String, op: String, typ: LirType, left: String, right: St
     i.typ = typ
     i.left = left
     i.right = right
+    i
+}
+pub fn lirSelect(dest: String, typ: LirType, cond: String, trueVal: String, falseVal: String) -> LirInstr {
+    let mut i = lirInstrInvalid()
+    i.kind = LirInstrSelect
+    i.dest = dest
+    i.typ = typ
+    i.args = [
+        lirOperand(lirIntType(1), cond),
+        lirOperand(typ, trueVal),
+        lirOperand(typ, falseVal),
+    ]
     i
 }
 pub fn lirUnary(dest: String, op: String, typ: LirType, value: String) -> LirInstr {
@@ -1040,6 +1053,7 @@ pub fn lirRenderInstr(i: LirInstr) -> String {
         LirInstrExtractValue -> i.dest + " = extractvalue " + lirTypeString(i.typ) + " " + i.aggregate + ", " + lirRenderIndices(i.indices),
         LirInstrGep -> lirRenderGepInstr(i),
         LirInstrComment -> lirRenderComment(i.text),
+        LirInstrSelect -> i.dest + " = select i1 " + i.args[0].value + ", " + lirTypeString(i.typ) + " " + i.args[1].value + ", " + lirTypeString(i.typ) + " " + i.args[2].value,
         _ -> "",
     }
     if base.len() == 0 || i.metadata.len() == 0 {
@@ -3311,6 +3325,9 @@ fn lirLowerMirCall(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerMirStdFsReadToStringCall(l, instr)
         return
     }
+    if lirTryLowerMirIntMethodIntrinsic(l, instr) {
+        return
+    }
     let callee = lirLookupMirFunction(l.mirModule, instr.calleeSymbol)
     if callee.name == "" {
         // Interface method-call indirect dispatch (E4).
@@ -3358,6 +3375,101 @@ fn lirLowerMirCall(l: LirMirFunctionLowerer, instr: MirInstr) {
 // return type from `instr.dest` local (or void if no dest), param
 // types from each arg's declared type. Declares the symbol via
 // runtimeDecls so the renderer emits a top-level `declare` line.
+// `lirTryLowerMirIntMethodIntrinsic` inlines the `__IntMethods` fan-out
+// (`Int__abs/min/max/clamp/signum`) directly in LLVM IR, mirroring
+// stage0's `renderKnownIntMethodCall`. The MIR `qualifiedSymbol` /
+// `mangleMethodSymbol` path rewrites these to the C-runtime callable
+// names (`osty_rt_int_abs/...`) via `rewriteStdlibSymbolToRuntime`,
+// so this matcher keys on the rewritten symbols. Returns true after
+// emitting the inline sequence; false when the symbol falls outside
+// this fan-out.
+fn lirTryLowerMirIntMethodIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) -> Bool {
+    let sym = instr.calleeSymbol
+    if sym != "osty_rt_int_abs" && sym != "osty_rt_int_min" && sym != "osty_rt_int_max" && sym != "osty_rt_int_clamp" && sym != "osty_rt_int_signum" {
+        return false
+    }
+    if !instr.hasDest {
+        lirLowerError(l, LirDiagInvalidInput, "int method intrinsic `" + sym + "` requires a destination", "call.intMethod")
+        return true
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "int method intrinsic `" + sym + "` destination local out of range", "call.intMethod")
+        return true
+    }
+    let intType = lirIntType(64)
+    let mut args: List<String> = []
+    for arg in instr.args {
+        let operand = lirLowerMirOperand(l, l.instrs, arg, arg.typ, intType)
+        if operand.value == "" {
+            return true
+        }
+        args.push(operand.value)
+    }
+    let result = if sym == "osty_rt_int_abs" {
+        if args.len() != 1 {
+            lirLowerError(l, LirDiagInvalidInput, "osty_rt_int_abs expects 1 arg", "call.intMethod.abs")
+            return true
+        }
+        let neg = lirFresh(l)
+        let isNeg = lirFresh(l)
+        let res = lirFresh(l)
+        l.instrs.push(lirBinary(neg, "sub", intType, "0", args[0]))
+        l.instrs.push(lirBinary(isNeg, "icmp slt", intType, args[0], "0"))
+        l.instrs.push(lirSelect(res, intType, isNeg, neg, args[0]))
+        res
+    } else if sym == "osty_rt_int_min" {
+        if args.len() != 2 {
+            lirLowerError(l, LirDiagInvalidInput, "osty_rt_int_min expects 2 args", "call.intMethod.min")
+            return true
+        }
+        let cmp = lirFresh(l)
+        let res = lirFresh(l)
+        l.instrs.push(lirBinary(cmp, "icmp slt", intType, args[0], args[1]))
+        l.instrs.push(lirSelect(res, intType, cmp, args[0], args[1]))
+        res
+    } else if sym == "osty_rt_int_max" {
+        if args.len() != 2 {
+            lirLowerError(l, LirDiagInvalidInput, "osty_rt_int_max expects 2 args", "call.intMethod.max")
+            return true
+        }
+        let cmp = lirFresh(l)
+        let res = lirFresh(l)
+        l.instrs.push(lirBinary(cmp, "icmp sgt", intType, args[0], args[1]))
+        l.instrs.push(lirSelect(res, intType, cmp, args[0], args[1]))
+        res
+    } else if sym == "osty_rt_int_clamp" {
+        if args.len() != 3 {
+            lirLowerError(l, LirDiagInvalidInput, "osty_rt_int_clamp expects 3 args", "call.intMethod.clamp")
+            return true
+        }
+        let ltLo = lirFresh(l)
+        let lower = lirFresh(l)
+        let gtHi = lirFresh(l)
+        let res = lirFresh(l)
+        l.instrs.push(lirBinary(ltLo, "icmp slt", intType, args[0], args[1]))
+        l.instrs.push(lirSelect(lower, intType, ltLo, args[1], args[0]))
+        l.instrs.push(lirBinary(gtHi, "icmp sgt", intType, lower, args[2]))
+        l.instrs.push(lirSelect(res, intType, gtHi, args[2], lower))
+        res
+    } else {
+        if args.len() != 1 {
+            lirLowerError(l, LirDiagInvalidInput, "osty_rt_int_signum expects 1 arg", "call.intMethod.signum")
+            return true
+        }
+        let ltZero = lirFresh(l)
+        let gtZero = lirFresh(l)
+        let nonNeg = lirFresh(l)
+        let res = lirFresh(l)
+        l.instrs.push(lirBinary(ltZero, "icmp slt", intType, args[0], "0"))
+        l.instrs.push(lirBinary(gtZero, "icmp sgt", intType, args[0], "0"))
+        l.instrs.push(lirSelect(nonNeg, intType, gtZero, "1", "0"))
+        l.instrs.push(lirSelect(res, intType, ltZero, "-1", nonNeg))
+        res
+    }
+    lirStoreMirResult(l, instr.dest, lirOperand(intType, result), loc.typ, "int method result")
+    return true
+}
 fn lirLowerMirCrossModuleCall(l: LirMirFunctionLowerer, instr: MirInstr) {
     let retType = if instr.hasDest {
         let loc = mirFunctionLocal(l.fn_, instr.dest.local)


### PR DESCRIPTION
## Summary

opt R3 trajectory **brick 3a 완성**. [PR #1874](https://github.com/choiceoh/osty/pull/1874) (C runtime wrapper) 의 self-contained 대안 — `toolchain/lir_proto.osty` 가 osty-self 자체 path 로 `Int__{abs,min,max,clamp,signum}` 의 inline LLVM IR expansion 직접 emit.

## Surgical path

이전 [PR #1875](https://github.com/choiceoh/osty/pull/1875) measurement 의 결론대로 **filter keep + hook 매칭 rewritten symbol** path:

- `mangleMethodSymbol` 의 rewrite (`Int__abs → osty_rt_int_abs`) 그대로 유지 — PR #1874 mechanism 보존, 회귀 risk 낮음
- stage0: rewritten symbol → C wrapper external call (PR #1874 path)
- lir_proto: rewritten symbol → 우리 hook 매칭 + inline expand (self-contained)

## 이전 시도 (PR #1875) 와 차이

| | PR #1875 시도 | 이 PR |
|---|---|---|
| `mangleMethodSymbol` filter | revert (raw symbol) | **keep (rewritten)** |
| hook 매칭 symbol | `Int__abs/...` | **`osty_rt_int_abs/...`** |
| osty-tests | **51/51 fail** (filter revert isolated effect) | **129 passed (회귀 zero)** |

## 변경

| | 변경 |
|---|---|
| `LirInstrKind` enum | `LirInstrSelect` 추가 |
| `LirInstr` | `lirSelect` constructor (3 operands: cond + true + false) |
| `lirRenderInstr` | select case 추가 |
| 새 함수 | `lirTryLowerMirIntMethodIntrinsic` — 5 method inline expansion |
| `lirLowerMirCall` | hook 추가 (cross-module lookup 직전) |

## 검증

- ✓ osty-self 재빌드 성공
- ✓ `just osty-tests` 33 passed (full 45+51+33 = 129 모두 OK)
- ✓ `just front` 회귀 zero
- ✓ `just prepush` fmt-check + vet + repair-check + ci 통과

## Note: doctor SEGFAULT

`osty-self --selfhost-doctor` exit 139 (SEGFAULT) — **main baseline 자체 issue**, 우리 변경 무관. PR #1875 의 step 1A measurement 결론 (\"enum-only가 SEGFAULT 트리거\") 가 잘못된 추론이었음 (baseline 측정 누락). 별도 trajectory.

## 다음 brick 후보

- **3b** (wrapping/saturating/checked C wrapper + inline): osty-tests 가 미사용이라 unblock effect 0. 같은 mechanism 으로 확장 가능
- **doctor SEGFAULT 해소**: main baseline 의 SEGFAULT root cause 추적 (별도 trajectory)
- **production path next wall** (`mirJsonObjectGetNamed`): R3 의 또 다른 brick

🤖 Generated with [Claude Code](https://claude.com/claude-code)