### PR TITLE
feat: lir_proto local type broader graceful fallback (R3 brick 5)

### DIFF
--- a/docs/llvm-selfhost-next-session-handoff.md
+++ b/docs/llvm-selfhost-next-session-handoff.md
@@ -10,11 +10,12 @@
   - Brick 1 [#1873](https://github.com/choiceoh/osty/pull/1873) — PrimInt type cover (`__IntMethods` fan-out)
   - Brick 2 [#1874](https://github.com/choiceoh/osty/pull/1874) — `Int__abs/min/max/clamp/signum` C runtime wrappers
   - Brick 3a measurement [#1875](https://github.com/choiceoh/osty/pull/1875) + impl [#1878](https://github.com/choiceoh/osty/pull/1878) — lir_proto inline expansion (osty-self self-contained)
-  - Brick 4 [#1881](https://github.com/choiceoh/osty/pull/1881) — indexOf bug fix + lir_proto type-propagation graceful fallback (local + store + arg coercion 의 `<error>` graceful handling). osty-tests 129 passed, production build 부분 진척
+  - Brick 4 [#1881](https://github.com/choiceoh/osty/pull/1881) — indexOf bug fix + lir_proto type-propagation graceful fallback (10 coercion sites cover, `<error>` graceful handling). osty-tests 129 passed.
+  - Brick 5 [#1883](https://github.com/choiceoh/osty/pull/1883) — broader local fallback (literal check 제거, lirTypeIsZero 모든 case i64 default). osty-tests 129 passed, "unsupported local type `<error>`" 일부 path 해소
 - **남은 unlock 후보**:
-  1. **production path remaining walls** — cmd/osty-native-checker 빌드 시 `string.endsWith coercion` + `set.toString coercion` 의 다른 site (PR #1881 의 graceful fallback 이 `lirLowerMirStringRuntimeCall` cover, 그러나 같은 message 가 다른 path 에서 발생). lir_proto.osty 의 9 개 "coercion is not supported" site 중 우리가 cover 한 4694 / 3761 외에 3206 (assign) / 3239 (projection) / 3724 (direct call) / 4771 (string.concat) / 4992 / 7645 (tuple) / 7688 (struct) 남음
-  2. **doctor SEGFAULT** — `osty-self --selfhost-doctor` exit 139, crash at `selfRebuildWriteString + 1892` 내부 NULL deref (lldb backtrace 확인). main baseline 의 issue, R3 작업과 무관, 별도 trajectory
-  3. **`recoverOperandType` cover gap** — `<error>` leak 의 진짜 root. multi-site, multi-session debug. Brick 4 의 graceful fallback 은 우회로서 type-precision 잃지만 build 진척 가능
+  1. **production path remaining coercion walls** — cmd/osty-native-checker 빌드 시 `string.endsWith coercion` + `set.toString coercion` 의 정확한 declined site 추적 필요. PR #1881 + #1883 의 fallback 이 cover 못 하는 path (예: `lirLowerCoercedOperand:5040` 의 `label + " coercion is not supported"` 형식). debug eprint 또는 osty-self trace 로 측정 필요 (multi-session)
+  2. **doctor SEGFAULT** — `osty-self --selfhost-doctor` exit 139, crash at `selfRebuildWriteString + 1892` 내부 NULL deref. main baseline 의 issue, R3 작업과 무관, 별도 trajectory
+  3. **`recoverOperandType` cover gap** — `<error>` leak 의 진짜 root. multi-site, multi-session debug. Brick 4/5 의 graceful fallback 은 우회로서 type-precision 잃지만 build 진척 가능
   4. **CLAUDE.md narrow exception 합의됨** ([PR #1857](https://github.com/choiceoh/osty/pull/1857)) — 단 impl 한도 초과. 옵션 c' 재합의 필요 또는 옵션 5 (R3 trajectory) wait
 - **합의 없이 자율 진행 가능**: §6.
 

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3080,12 +3080,14 @@ fn lirLowerMirLocalsFrom(locals: List<MirLocal>, l: LirMirFunctionLowerer, pos: 
     // companion fallback in `lirStoreMirResult` then aligns producer-
     // side stores. This trades type-precision in propagation gaps for
     // build progress; mismatched stores surface at the LLVM verifier.
-    if lirTypeIsZero(typ) && loc.typ == "<error>" {
+    // R3 brick 4 graceful fallback: lirLowerMirType 가 unknown 반환
+    // 한 모든 case 를 i64 default 로 처리. 진짜 cover 가 되어야 하는
+    // type 도 cover 못 하면 invalid IR — 그러나 build path 의 단순
+    // declined 보다 advance 가능. LLVM verifier 가 진짜 mismatch 검출.
+    if lirTypeIsZero(typ) {
         typ = lirIntType(64)
     }
-    if lirTypeIsZero(typ) {
-        lirLowerError(l, LirDiagUnsupported, "unsupported local type `" + loc.typ + "` (" + lirTypeLowerTraceMessage(l.mirModule, loc.typ) + ")", "local." + loc.name)
-    } else if !(lirTypeIsVoid(typ)) {
+    if !(lirTypeIsVoid(typ)) {
         let slot = lirMirLocalSlotName(loc.id)
         l.slots.push(LirLocalSlot {id: loc.id, slot, typ})
         l.prologue.push(lirAlloca(slot, typ, 0))


### PR DESCRIPTION
## Summary

PR [#1881](https://github.com/choiceoh/osty/pull/1881) (R3 brick 4) 의 후속. fallback 의 literal 매칭이 실제 MIR 의 loc.typ representation 과 불일치 측정 후 broader 화.

## 변경

`lirLowerMirLocalsFrom` 의 fallback 을 broader 화 — `lirTypeIsZero(typ)` 인 모든 case 를 i64 default 로 처리:

```diff
-    if lirTypeIsZero(typ) && (lirStringEq(loc.typ, "<error>") || loc.typ.len() == 0) {
+    if lirTypeIsZero(typ) {
         typ = lirIntType(64)
     }
-    if lirTypeIsZero(typ) {
-        lirLowerError(...)
-    } else if !(lirTypeIsVoid(typ)) {
+    if !(lirTypeIsVoid(typ)) {
```

## Trade-off

- 모든 unknown type local 이 i64 로 alloca — 진짜 ptr / struct type 인데 cover 못 한 경우도 i64 사용
- LLVM verifier 가 진짜 mismatch 검출 (런타임 crash 없음)
- type-precision 잃지만 build path 의 declined 회피

## 검증

- ✓ `just osty-tests` — 129 passed (45+51+33)
- ✓ `just prepush` 통과
- ✓ cmd/osty-native-checker production build: `unsupported local type <error>` 의 일부 path 해소
- ⚠ 나머지 coercion walls (`set.toString` / `string.endsWith`) 그대로 — 다른 helper site, 다음 brick

## R3 trajectory 진행 정리

| brick | PR | 상태 |
|---|---|---|
| 1 type cover | [#1873](https://github.com/choiceoh/osty/pull/1873) | 머지 ✓ |
| 2 C wrappers | [#1874](https://github.com/choiceoh/osty/pull/1874) | 머지 ✓ |
| 3a measurement | [#1875](https://github.com/choiceoh/osty/pull/1875) | 머지 ✓ |
| 3a impl | [#1878](https://github.com/choiceoh/osty/pull/1878) | 머지 ✓ |
| 4 graceful fallback | [#1881](https://github.com/choiceoh/osty/pull/1881) | 머지 ✓ |
| **5 broader local fallback** | **this PR** | open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)