### PR TITLE
fix: address PR #1882 + #1886 Copilot review feedback (12 items)

### DIFF
--- a/internal/backend/stage0/coerce_scalar_for_store_test.go
+++ b/internal/backend/stage0/coerce_scalar_for_store_test.go
@@ -1,0 +1,89 @@
+package stage0
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCoerceScalarForStoreBoolUsesIcmpNeNull is the regression test for
+// the PR #1882 review bug fix: opaque-pointer → bool coercion used to
+// `ptrtoint ptr ... to i64` then `trunc i64 ... to i1`, which only
+// reads the low bit of the pointer and was always 0 for aligned heap
+// pointers (effectively "result := false" regardless of the pointer
+// value). The fix emits `icmp ne ptr %v, null` so the result reflects
+// the actual null-ness of the operand. Locking down here so the
+// regression can't silently come back.
+func TestCoerceScalarForStoreBoolUsesIcmpNeNull(t *testing.T) {
+	nextSSA := 0
+	ctx := &whileLoopEmitCtx{nextSSA: &nextSSA}
+	var out strings.Builder
+	got, ok := coerceScalarForStore(ctx, &out, "%v", scalarOpaquePtr, scalarBool)
+	if !ok {
+		t.Fatalf("coerceScalarForStore opaque→bool returned ok=false (want true)")
+	}
+	emitted := out.String()
+	if !strings.Contains(emitted, "icmp ne ptr %v, null") {
+		t.Fatalf("opaque→bool should emit `icmp ne ptr %%v, null`, got:\n%s", emitted)
+	}
+	if strings.Contains(emitted, "ptrtoint") || strings.Contains(emitted, "trunc") {
+		t.Fatalf("opaque→bool must not use the old ptrtoint+trunc pair, got:\n%s", emitted)
+	}
+	if got == "" || got == "%v" {
+		t.Fatalf("returned register should be a fresh SSA name, got %q", got)
+	}
+}
+
+// TestCoerceScalarForStorePtrToIntPair covers the sibling opaque-ptr
+// → int coercion that the review noted was already correct (ptrtoint
+// to i64). Locks the ladder shape so a future refactor can't drop the
+// case without an explicit test signal.
+func TestCoerceScalarForStorePtrToIntPair(t *testing.T) {
+	nextSSA := 0
+	ctx := &whileLoopEmitCtx{nextSSA: &nextSSA}
+	var out strings.Builder
+	got, ok := coerceScalarForStore(ctx, &out, "%v", scalarOpaquePtr, scalarInt)
+	if !ok {
+		t.Fatalf("coerceScalarForStore opaque→int returned ok=false (want true)")
+	}
+	if !strings.Contains(out.String(), "ptrtoint ptr %v to i64") {
+		t.Fatalf("opaque→int should emit `ptrtoint ptr %%v to i64`, got:\n%s", out.String())
+	}
+	if got == "" || got == "%v" {
+		t.Fatalf("returned register should be a fresh SSA name, got %q", got)
+	}
+}
+
+// TestCoerceScalarForStorePtrShape verifies the trivial cases — both
+// pointer-shaped scalars (String/OpaquePtr) and strict match — emit no
+// cast and return the original expression. These short-circuit paths
+// were the PR #1877 starting point and are easy to break by accident
+// when adding new ladder rungs.
+func TestCoerceScalarForStorePtrShape(t *testing.T) {
+	cases := []struct {
+		name string
+		from scalarType
+		to   scalarType
+	}{
+		{"strict match int", scalarInt, scalarInt},
+		{"strict match ptr", scalarOpaquePtr, scalarOpaquePtr},
+		{"string ↔ opaque", scalarString, scalarOpaquePtr},
+		{"opaque ↔ string", scalarOpaquePtr, scalarString},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			nextSSA := 0
+			ctx := &whileLoopEmitCtx{nextSSA: &nextSSA}
+			var out strings.Builder
+			got, ok := coerceScalarForStore(ctx, &out, "%v", c.from, c.to)
+			if !ok {
+				t.Fatalf("expected ok=true")
+			}
+			if got != "%v" {
+				t.Fatalf("expected no-op (returns %%v), got %q", got)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("expected no IR emitted, got:\n%s", out.String())
+			}
+		})
+	}
+}

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -1440,8 +1440,9 @@ func scalarFromTypeInternal(t mir.Type, allowUserNamed bool) scalarType {
 // opaqueBuiltinTemplateNames is the canonical list of stdlib generic
 // templates whose box layouts are opaque-ptr-shaped at runtime. Used
 // by isOpaqueNamedType for both canonical names (set lookup) and
-// monomorph mangled names (per-template substring check). Hoisted out
-// of the per-call slice allocation called out in the PR #1877 review.
+// monomorph mangled names (per-template anchored-prefix check via
+// isMangledBuiltinTemplate). Hoisted out of the per-call slice
+// allocation called out in the PR #1877 review.
 var opaqueBuiltinTemplateNames = []string{
 	"List", "Map", "Set", "Option", "Maybe", "Result", "Channel", "Handle", "TaskGroup",
 }
@@ -9831,12 +9832,14 @@ func recoverMapNewArgScalarsFromCalleeParam(fn *mir.Function, mapID mir.LocalID,
 //
 // Soundness: the function emits an opaque-pointer Map handle defaulted
 // to `(String, String)` runtime kind tags. Only safe when the map is
-// purely opaque — no in-function MapGet/MapSet/MapContains/MapKeysSorted
-// operations would observe the synthesised tags. The check below
-// rejects the moment any of those intrinsics references `mapID`, so a
-// real conflict stops the recovery cold rather than emitting incorrect
-// runtime layout. Functions that survive this gate either pass the map
-// straight to a callee or hold it unused (rare).
+// purely opaque to the K/V layout — no in-function MapGet /
+// MapContains / MapKeysSorted / MapIncr touches `mapID` (these all
+// observe the K layout), and the only MapSet that touches `mapID` does
+// so as the **value being inserted** (Args[2]) where the local is
+// passed opaque. MapSet's map-arg (Args[0]) and key-arg (Args[1])
+// rejections still apply (PR #1882 review tightened the distinction).
+// Functions that survive this gate either pass the map straight to a
+// callee or appear only as a MapSet value payload (rare).
 func recoverMapNewArgScalarsAsOpaquePassThrough(fn *mir.Function, mapID mir.LocalID) (scalarType, scalarType, bool) {
 	if fn == nil {
 		return scalarUnknown, scalarUnknown, false
@@ -11148,18 +11151,22 @@ func optionPayloadScalar(t mir.Type, mctx *moduleCtx) (scalarType, bool) {
 // concrete instances of stdlib generic boxes whose canonical name
 // ("Option", "Result") survives only as a length-prefixed substring.
 // isMangledBuiltinTemplate reports whether `name` is the Itanium-style
-// `_ZTSN4main<len><template>...` mangling for a builtin generic
-// template ("Option", "Result", "List", "Map", "Set", ...). The check
-// anchors on the `N4main` namespace prefix and verifies the
-// length-prefixed identifier that follows is exactly `template` — a
-// looser substring scan could false-positive on inner template
-// arguments (PR #1877 review).
+// `_ZTSN<nslen><namespace><tlen><template>...` mangling for a builtin
+// generic template ("Option", "Result", "List", "Map", "Set", ...).
+// Accepts any namespace identifier (the monomorphiser emits both
+// `main` for toolchain-owned mangles and `osty` for stdlib/builtin
+// boxes; PR #1882 review flagged the prior `main`-only hard-code).
+// Length-prefixed exact match on the template head avoids inner
+// template-argument false positives (PR #1877 review).
 func isMangledBuiltinTemplate(name, template string) bool {
-	const prefix = "_ZTSN4main"
+	const prefix = "_ZTSN"
 	if !strings.HasPrefix(name, prefix) {
 		return false
 	}
-	rest := name[len(prefix):]
+	rest, ok := skipMangledNamespace(name[len(prefix):])
+	if !ok {
+		return false
+	}
 	digitEnd := 0
 	for digitEnd < len(rest) && rest[digitEnd] >= '0' && rest[digitEnd] <= '9' {
 		digitEnd++
@@ -11172,6 +11179,26 @@ func isMangledBuiltinTemplate(name, template string) bool {
 		return false
 	}
 	return rest[digitEnd:digitEnd+n] == template
+}
+
+// skipMangledNamespace consumes the first length-prefixed identifier
+// (the namespace) at the start of `rest`, returning the remainder.
+// Both `4main` and `4osty` appear in production manglings; treating
+// the namespace as opaque means new namespaces (e.g. `<pkg>`) work
+// without per-name updates.
+func skipMangledNamespace(rest string) (string, bool) {
+	digitEnd := 0
+	for digitEnd < len(rest) && rest[digitEnd] >= '0' && rest[digitEnd] <= '9' {
+		digitEnd++
+	}
+	if digitEnd == 0 {
+		return "", false
+	}
+	n, err := strconv.Atoi(rest[:digitEnd])
+	if err != nil || n <= 0 || digitEnd+n > len(rest) {
+		return "", false
+	}
+	return rest[digitEnd+n:], true
 }
 
 // isMangledOstyMonomorphFn reports whether `name` is an Itanium-style
@@ -11189,16 +11216,20 @@ func isMangledOstyMonomorphFn(name string) bool {
 // demangleMonomorphTemplateArg extracts the first template argument
 // from an Itanium-style mangling. For `_ZTSN4main4ListIN4main14MirFieldLayoutEEE`
 // (canonical `List<MirFieldLayout>`) returns `MirFieldLayout`. The
-// parser walks past the template head, requires `I` (template-args
-// start), then `N4main<len><name>E` for the single argument, then `EE`
-// for `E` (close-template) + `E` (close-nested). Returns "" when the
-// form doesn't match the single-arg main-namespace shape.
+// parser walks past the namespace + template head, requires `I`
+// (template-args start), then `N<ns><len><name>E` for the single
+// argument, then `EE` for `E` (close-template) + `E` (close-nested).
+// Returns "" when the form doesn't match. Accepts mangled instances
+// where the inner namespace differs from the outer (PR #1882 review).
 func demangleMonomorphTemplateArg(name string) string {
-	const prefix = "_ZTSN4main"
+	const prefix = "_ZTSN"
 	if !strings.HasPrefix(name, prefix) {
 		return ""
 	}
-	rest := name[len(prefix):]
+	rest, ok := skipMangledNamespace(name[len(prefix):])
+	if !ok {
+		return ""
+	}
 	// Skip the outer template head (length-prefixed name).
 	digitEnd := 0
 	for digitEnd < len(rest) && rest[digitEnd] >= '0' && rest[digitEnd] <= '9' {
@@ -11212,16 +11243,15 @@ func demangleMonomorphTemplateArg(name string) string {
 		return ""
 	}
 	rest = rest[digitEnd+n:]
-	if !strings.HasPrefix(rest, "I") {
+	if !strings.HasPrefix(rest, "IN") {
 		return ""
 	}
-	rest = rest[1:]
-	// Parse one nested name `N4main<len><name>E`.
-	const innerPrefix = "N4main"
-	if !strings.HasPrefix(rest, innerPrefix) {
+	rest = rest[2:] // skip "IN"
+	// Skip inner namespace (length-prefixed).
+	rest, ok = skipMangledNamespace(rest)
+	if !ok {
 		return ""
 	}
-	rest = rest[len(innerPrefix):]
 	digitEnd = 0
 	for digitEnd < len(rest) && rest[digitEnd] >= '0' && rest[digitEnd] <= '9' {
 		digitEnd++
@@ -11246,14 +11276,15 @@ func demangleMonomorphTemplateArg(name string) string {
 // (no template args) returns `MirStructLayout`. For templated forms
 // (`_ZTSN4main6OptionIN4main13FrontTypeReprEEE`) returns "" — those
 // are handled by isMangledBuiltinTemplate / isOpaqueNamedType.
-// Returns "" when the format doesn't match.
+// Returns "" when the format doesn't match. Accepts any namespace
+// (`main`, `osty`, package-qualified) per PR #1882 review.
 func demangleMonomorphStructName(name string) string {
-	const prefix = "_ZTSN4main"
+	const prefix = "_ZTSN"
 	if !strings.HasPrefix(name, prefix) {
 		return ""
 	}
-	rest := name[len(prefix):]
-	if rest == "" {
+	rest, ok := skipMangledNamespace(name[len(prefix):])
+	if !ok || rest == "" {
 		return ""
 	}
 	// Parse one length-prefixed component: <digits><name>.
@@ -11998,39 +12029,32 @@ func resolveWhileIndexedOperand(ctx *whileLoopEmitCtx, out *strings.Builder, pla
 	//     is a NamedType (user struct / opaque builtin).
 	// Final fallback: IndexProj.ElemType erased to `<error>`, list
 	// local lowers to opaque ptr — default the element scalar to
-	// opaque ptr. **Brittle assumption** (PR #1877 review): every
-	// monomorph List in install-self today is `List<NamedType>`,
-	// whose elements are pointer-shaped at runtime. A `List<Int>` /
-	// `List<Bool>` reaching this fallback would silently read the
-	// element as a pointer (wrong runtime semantics, valid IR). The
-	// upstream loss has only been observed for the named-element case
-	// so far — the list local itself usually carries the Args. Three
-	// safe shapes accepted:
-	//   - listType is mangled List monomorph (`_ZTSN4main4ListI…EE`)
-	//   - listType is canonical `List<NamedType>` with Args[0] named
-	//   - listType is itself erased to ErrType but listScalarTy is
-	//     opaque ptr AND the call-site dest is also opaque (the
-	//     mirLowerMultiAssign shape — list type info lost upstream
-	//     but the indexed read feeds a NamedType local)
+	// opaque ptr. Two safe shapes (PR #1882 review tightened the
+	// primitive-List case):
+	//   - Mangled List monomorph `_ZTSN<ns>4ListIN<ns>…EEE` where
+	//     `demangleMonomorphTemplateArg` parses out a named-struct
+	//     template argument. Mangled `List<Primitive>` (`…ListIlEE`,
+	//     `…ListIhEE`, etc.) skips this branch because the parser
+	//     rejects the `I<primitive-code>E` shape — primitives are
+	//     read at their actual scalar width upstream.
+	//   - Canonical `List<NamedType>` where Args[0] is a NamedType.
+	// The ErrType-list shape from PR #1877 is removed — without dest
+	// context (resolveWhileIndexedOperand has none) the fallback was
+	// unsound for `List<Int>`-like reads that flow into a primitive
+	// destination. Caller has to surface the right elem type via
+	// inferIndexedElementScalarFromPlace.
 	if elemTy == scalarUnknown && listScalarTy == scalarOpaquePtr {
 		listType := placeResultType(ctx.fn, listPlace)
-		accept := false
 		if named, ok := listType.(*ir.NamedType); ok && named != nil {
 			if isMangledBuiltinTemplate(named.Name, "List") {
-				accept = true
+				if demangleMonomorphTemplateArg(named.Name) != "" {
+					elemTy = scalarOpaquePtr
+				}
 			} else if named.Name == "List" && len(named.Args) > 0 {
 				if _, isNamed := named.Args[0].(*ir.NamedType); isNamed {
-					accept = true
+					elemTy = scalarOpaquePtr
 				}
 			}
-		} else if isErrType(listType) {
-			// listType fully erased upstream — surface the opaque
-			// default so the install-self build can complete. See
-			// brittle-assumption note above.
-			accept = true
-		}
-		if accept {
-			elemTy = scalarOpaquePtr
 		}
 	}
 	if elemTy == scalarUnknown {

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -35758,6 +35758,14 @@ func checkRecordSymbol(env *CheckEnv, nodeIdx int, kind string, name string, own
 // toolchain/check_env.osty::checkOwnerIsUseAlias. Used by the
 // cross-package method-call dispatch arm in elab.
 //
+// Shadowing (PR #1886 review): the caller derives `name` from the
+// receiver TYPE (`elabOwnerNameForReceiver`), so a local shadowing
+// the use-alias surfaces a different ownerName and never queries
+// this helper with the shadowed name.
+//
+// Cost (PR #1886 review): O(N) over `symbolRecords` on the cold path
+// (only invoked after method lookup intentionally fails).
+//
 // CLAUDE.md narrow exception (PR3-C step 3 surgical hand-edit of the
 // frozen seed). See SPEC_GAPS.md::cross-pkg-module-resolution.
 func checkOwnerIsUseAlias(env *CheckEnv, name string) bool {

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -893,6 +893,20 @@ pub fn checkRecordSymbol(env: CheckEnv, nodeIdx: Int, kind: String, name: String
 /// lookup of `fn` instead of failing as E0703. See
 /// SPEC_GAPS.md::cross-pkg-module-resolution (PR3-C step 3 narrow
 /// exception in CLAUDE.md).
+///
+/// Shadowing (PR #1886 review): the caller derives `name` from the
+/// receiver TYPE (`elabOwnerNameForReceiver`), not from the bare
+/// ident. A local `let tc = SomeInt` shadows the use-alias's tyNamed
+/// binding, so the receiver's resolved type is `SomeInt` and
+/// `elabOwnerNameForReceiver` returns "SomeInt" rather than "tc" —
+/// this helper is never queried with the shadowed name. The
+/// kind=="use" check below remains the right gate for the
+/// non-shadowed case.
+///
+/// Cost (PR #1886 review): O(N) over `symbolRecords` on the cold
+/// path (only invoked after method lookup intentionally fails).
+/// `symbolRecords` typically stays bounded per file; the hottest
+/// expected call rate is once per `tc.fn()` site, not per call edge.
 pub fn checkOwnerIsUseAlias(env: CheckEnv, name: String) -> Bool {
     if name == "" {
         return false

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -1924,16 +1924,22 @@ pub fn lirPlanScalarCastOpcode(from: LirType, to: LirType, unsigned: Bool) -> St
     }
     ""
 }
-/// lirPlanSameFamilyCoercionOpcode plans a store-site coercion: integer
-/// resize, float resize, and the int↔ptr reinterpret cast pair. The
-/// name predates the int↔ptr addition (PR #1877); those cases are
-/// **cross-family** reinterprets that lose/synthesize pointer
-/// provenance, unlike the intra-int/intra-float widening/narrowing.
-/// Callers must not assume a pure same-family widening — the planner
-/// is a "what cast opcode lets this store typecheck" oracle, not a
-/// provenance-preserving one. Cross-family conversion that does
-/// preserve provenance must still come from MIR as an explicit cast
-/// node.
+/// lirPlanSameFamilyCoercionOpcode plans a coercion that lets one LIR
+/// value flow into a slot / call argument / aggregate field typed
+/// `to`. Despite the legacy name, the planner is used at every
+/// coercion site in lir_proto: `lirStoreMirResult`,
+/// `lirLowerCoercedOperand`, `lirLowerMirStringRuntimeCall` args,
+/// `lirStoreProjectedMirValue`, etc. It is the single "what cast
+/// opcode lets this store typecheck" oracle.
+///
+/// Covered cast pairs:
+///   - integer ↔ integer (zext / sext / trunc) — pure widening/narrowing
+///   - float ↔ float (fpext / fptrunc)
+///   - int ↔ ptr (inttoptr / ptrtoint) — **cross-family reinterpret**
+///     added in PR #1877. Loses/synthesises pointer provenance; not
+///     a provenance-preserving conversion. Cross-family conversion
+///     that needs to preserve provenance must come from MIR as an
+///     explicit cast node, not this helper.
 pub fn lirPlanSameFamilyCoercionOpcode(from: LirType, to: LirType, unsigned: Bool) -> String {
     if from.llvm == to.llvm {
         return ""


### PR DESCRIPTION
## Summary
PR #1882 + #1886 머지 후 Copilot 리뷰 12개 (정확성 4 + 코드 품질 8) 전부 해소. 추가로 PR #1882 bool coercion bug 재발 방지 회귀 테스트 (4 케이스) 신규.

### 정확성 (4)
1. `isMangledBuiltinTemplate` 의 `main` hard-code → `skipMangledNamespace` 헬퍼로 임의 네임스페이스 (`main`, `osty`, `<pkg>`) 수용
2. `demangleMonomorphTemplateArg` 의 outer/inner namespace 불일치 mangled instance 정상 파싱
3. `resolveWhileIndexedOperand` List 원소 opaque fallback 강화 — primitive List 인스턴스 (`List<Int>` mangled) 차단 + ErrType-list shape 제거
4. **icmp ne ptr 회귀 테스트** (`coerce_scalar_for_store_test.go`, 4 케이스) — bool coercion bug 재발 방지

### 코드 품질 (8)
- stale comments refresh (3 사이트)
- `lirPlanSameFamilyCoercionOpcode` docstring 정확화
- `checkOwnerIsUseAlias` shadowing/cost 설명 추가 (Osty + Go seed 동기)

## Test plan
- [x] TestStage0ToolchainAudit: 8243/8243 (100.0%) 유지
- [x] TestCoerceScalarForStoreBoolUsesIcmpNeNull + PtrToIntPair + PtrShape: 4 케이스 PASS
- [x] `go test ./internal/backend/stage0/` 통과
- [x] just prepush 통과
- [x] install-self cold rebuild: 19M osty-self 생성 — regression 없음
- [ ] CI 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)