### PR TITLE
feat: PR3-E/F activation — cross-pkg method-call (E0703 해소)

### DIFF
--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -12,6 +12,7 @@
 // PR3 의 진짜 checker 호출 + L2/L3 corpus 진행 시 std.json 으로 교체.
 use std.io
 use std.strings
+use toolchain as tc
 
 fn naiveExtractSource(text: String) -> String {
     let openMarker = "\"source\":\""
@@ -32,6 +33,10 @@ fn emptyCheckResultJson() -> String {
 fn main() {
     let input = io.readLine()
     let _source = naiveExtractSource(input)
-    // 진짜 checker 호출은 PR3 — 현재는 모든 source 입력에 empty CheckResult.
+    // PR3-E/F smoke: cross-pkg method-call dispatch (PR #1886 narrow
+    // exception + PR #1889 [lib] scaffold 의 결합). `use toolchain as tc`
+    // 의 fn 등록 path 활성 검증.
+    let _typeRepr = tc.frontInvalidTypeRepr()
+    // 진짜 checker 호출은 추가 brick 의 작업.
     println(emptyCheckResultJson())
 }

--- a/cmd/osty-native-checker/osty.toml
+++ b/cmd/osty-native-checker/osty.toml
@@ -12,3 +12,4 @@ path = "main.osty"
 runtime = true
 
 [dependencies]
+toolchain = { path = "../../toolchain" }


### PR DESCRIPTION
## Summary

opt R3 trajectory **PR3-E + PR3-F** 활성 검증. [PR #1886](https://github.com/choiceoh/osty/pull/1886) (cross-pkg dispatch arm) + [PR #1889](https://github.com/choiceoh/osty/pull/1889) ([lib] manifest scaffold) 의 chain 활성화 확인.

## 핵심 발견 — dotted path resolution

`internal/resolve/workspace.go:235::dirFor`:
- `use toolchain.check` → `toolchain/check/` sub-package expect → **unresolvable** (toolchain is single dir, check is a file in it)
- `use toolchain` (single segment) → `toolchain/` directory resolve **OK**

PR #1886 dispatch chain (이미 인프라 있음):
1. `selfhostInstallImportSurfaces` (`internal/selfhost/package_adapter.go:390`) — imports.Functions 를 `owner=""` free fn 으로 register (line 225-229)
2. PR #1886 dispatch arm — `checkLookupFn(cx.env, methodName, "")` 매칭
3. → **E0703 해소** ✓

## 변경

| 파일 | 변경 |
|---|---|
| `cmd/osty-native-checker/osty.toml` | `[dependencies] toolchain = { path = "../../toolchain" }` |
| `cmd/osty-native-checker/main.osty` | `use toolchain as tc` + `tc.frontInvalidTypeRepr()` smoke call |

## 검증

- ✓ `.bin/osty build cmd/osty-native-checker/`: **E0703 해소** (이전 발화)
- ✓ `just osty-tests` — 129 passed (45+51+33)
- ✓ `just prepush` 통과

## 남은 wall

build path 의 `set.toString` / `string.endsWith` coercion — osty-self 자체 build path 의 stage0 cover gap (cross-pkg method-call 활성 후에도 다른 site 의 wall). multi-session, PR #1858 cascade 패턴 추가 wave 필요.

## R3 trajectory 진척

| brick | PR | 상태 |
|---|---|---|
| 1-7 root cause | 머지됨 | ✓ |
| (외부) PR3-C step 3 | [#1886](https://github.com/choiceoh/osty/pull/1886) | 머지 ✓ |
| PR3-D scaffold | [#1889](https://github.com/choiceoh/osty/pull/1889) | 머지 ✓ |
| **PR3-E/F activation** | **this PR** | open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)