### PR TITLE
fix: address PR #1894 Copilot review feedback (4 items)

### DIFF
--- a/internal/mirjson/intrinsic_wire_test.go
+++ b/internal/mirjson/intrinsic_wire_test.go
@@ -17,6 +17,13 @@ import (
 // `string.endsWith` for months because `IntrinsicBytesConcat` sat at
 // Go position 86 while the toolchain enum had it at position 7.
 //
+// The list covers all 138 wire positions (0..=137) that both sides
+// share. Positions 138+ are Go-only (`IntrinsicLikely`,
+// `IntrinsicUnlikely`) — appended *after* the shared range so the
+// completeness assertion below catches anyone who inserts a new
+// shared intrinsic in the middle (which would shift `SetClear`'s
+// position and break the wire format).
+//
 // Add a case here whenever a new intrinsic is appended on either
 // side; the test forces the two enums to stay aligned at the wire
 // boundary.
@@ -94,11 +101,98 @@ func TestIntrinsicKindWireValuesMatchToolchain(t *testing.T) {
 		{mir.IntrinsicStringStartsWith, 65, "MirIntrinsicStringStartsWith"},
 		{mir.IntrinsicStringEndsWith, 66, "MirIntrinsicStringEndsWith"},
 		{mir.IntrinsicStringIndexOf, 67, "MirIntrinsicStringIndexOf"},
+		{mir.IntrinsicStringSplit, 68, "MirIntrinsicStringSplit"},
+		{mir.IntrinsicStringTrim, 69, "MirIntrinsicStringTrim"},
+		{mir.IntrinsicStringToUpper, 70, "MirIntrinsicStringToUpper"},
+		{mir.IntrinsicStringToLower, 71, "MirIntrinsicStringToLower"},
+		{mir.IntrinsicStringToInt, 72, "MirIntrinsicStringToInt"},
+		{mir.IntrinsicStringToFloat, 73, "MirIntrinsicStringToFloat"},
+		{mir.IntrinsicStringReplace, 74, "MirIntrinsicStringReplace"},
+		{mir.IntrinsicStringChars, 75, "MirIntrinsicStringChars"},
+		{mir.IntrinsicStringBytes, 76, "MirIntrinsicStringBytes"},
+		{mir.IntrinsicBytesLen, 77, "MirIntrinsicBytesLen"},
+		{mir.IntrinsicBytesIsEmpty, 78, "MirIntrinsicBytesIsEmpty"},
+		{mir.IntrinsicBytesGet, 79, "MirIntrinsicBytesGet"},
+		{mir.IntrinsicBytesContains, 80, "MirIntrinsicBytesContains"},
+		{mir.IntrinsicBytesStartsWith, 81, "MirIntrinsicBytesStartsWith"},
+		{mir.IntrinsicBytesEndsWith, 82, "MirIntrinsicBytesEndsWith"},
+		{mir.IntrinsicBytesIndexOf, 83, "MirIntrinsicBytesIndexOf"},
+		{mir.IntrinsicBytesLastIndexOf, 84, "MirIntrinsicBytesLastIndexOf"},
+		{mir.IntrinsicBytesSplit, 85, "MirIntrinsicBytesSplit"},
+		{mir.IntrinsicBytesJoin, 86, "MirIntrinsicBytesJoin"},
+		{mir.IntrinsicBytesRepeat, 87, "MirIntrinsicBytesRepeat"},
+		{mir.IntrinsicBytesReplace, 88, "MirIntrinsicBytesReplace"},
+		{mir.IntrinsicBytesReplaceAll, 89, "MirIntrinsicBytesReplaceAll"},
+		{mir.IntrinsicBytesTrimLeft, 90, "MirIntrinsicBytesTrimLeft"},
+		{mir.IntrinsicBytesTrimRight, 91, "MirIntrinsicBytesTrimRight"},
+		{mir.IntrinsicBytesTrim, 92, "MirIntrinsicBytesTrim"},
+		{mir.IntrinsicBytesTrimSpace, 93, "MirIntrinsicBytesTrimSpace"},
+		{mir.IntrinsicBytesToUpper, 94, "MirIntrinsicBytesToUpper"},
+		{mir.IntrinsicBytesToLower, 95, "MirIntrinsicBytesToLower"},
+		{mir.IntrinsicBytesToHex, 96, "MirIntrinsicBytesToHex"},
+		{mir.IntrinsicBytesSlice, 97, "MirIntrinsicBytesSlice"},
+		{mir.IntrinsicOptionIsSome, 98, "MirIntrinsicOptionIsSome"},
+		{mir.IntrinsicOptionIsNone, 99, "MirIntrinsicOptionIsNone"},
+		{mir.IntrinsicOptionUnwrap, 100, "MirIntrinsicOptionUnwrap"},
+		{mir.IntrinsicOptionUnwrapOr, 101, "MirIntrinsicOptionUnwrapOr"},
+		{mir.IntrinsicResultIsOk, 102, "MirIntrinsicResultIsOk"},
+		{mir.IntrinsicResultIsErr, 103, "MirIntrinsicResultIsErr"},
+		{mir.IntrinsicResultUnwrap, 104, "MirIntrinsicResultUnwrap"},
+		{mir.IntrinsicResultUnwrapOr, 105, "MirIntrinsicResultUnwrapOr"},
+		{mir.IntrinsicRawNull, 106, "MirIntrinsicRawNull"},
+		{mir.IntrinsicStringJoin, 107, "MirIntrinsicStringJoin"},
+		{mir.IntrinsicListPop, 108, "MirIntrinsicListPop"},
+		{mir.IntrinsicStringSubstring, 109, "MirIntrinsicStringSubstring"},
+		{mir.IntrinsicByteToInt, 110, "MirIntrinsicByteToInt"},
+		{mir.IntrinsicCharToInt, 111, "MirIntrinsicCharToInt"},
+		{mir.IntrinsicListSlice, 112, "MirIntrinsicListSlice"},
+		{mir.IntrinsicMapGetOr, 113, "MirIntrinsicMapGetOr"},
+		{mir.IntrinsicStringSplitInto, 114, "MirIntrinsicStringSplitInto"},
+		{mir.IntrinsicStringNthSegment, 115, "MirIntrinsicStringNthSegment"},
+		{mir.IntrinsicMapIncr, 116, "MirIntrinsicMapIncr"},
+		{mir.IntrinsicStringRepeat, 117, "MirIntrinsicStringRepeat"},
+		{mir.IntrinsicStringTrimPrefix, 118, "MirIntrinsicStringTrimPrefix"},
+		{mir.IntrinsicStringTrimSuffix, 119, "MirIntrinsicStringTrimSuffix"},
+		{mir.IntrinsicStringTrimStart, 120, "MirIntrinsicStringTrimStart"},
+		{mir.IntrinsicStringTrimEnd, 121, "MirIntrinsicStringTrimEnd"},
+		{mir.IntrinsicStringReplaceAll, 122, "MirIntrinsicStringReplaceAll"},
+		{mir.IntrinsicStringSplitN, 123, "MirIntrinsicStringSplitN"},
+		{mir.IntrinsicStringFields, 124, "MirIntrinsicStringFields"},
+		{mir.IntrinsicStringLastIndexOf, 125, "MirIntrinsicStringLastIndexOf"},
+		{mir.IntrinsicBytesFromList, 126, "MirIntrinsicBytesFromList"},
+		{mir.IntrinsicBytesFromString, 127, "MirIntrinsicBytesFromString"},
+		{mir.IntrinsicBytesToString, 128, "MirIntrinsicBytesToString"},
+		{mir.IntrinsicBytesFromHex, 129, "MirIntrinsicBytesFromHex"},
+		{mir.IntrinsicIntToByte, 130, "MirIntrinsicIntToByte"},
+		{mir.IntrinsicIntToChar, 131, "MirIntrinsicIntToChar"},
+		{mir.IntrinsicByteToChar, 132, "MirIntrinsicByteToChar"},
+		{mir.IntrinsicCharToByte, 133, "MirIntrinsicCharToByte"},
+		{mir.IntrinsicListInsert, 134, "MirIntrinsicListInsert"},
+		{mir.IntrinsicListClear, 135, "MirIntrinsicListClear"},
+		{mir.IntrinsicMapClear, 136, "MirIntrinsicMapClear"},
+		{mir.IntrinsicSetClear, 137, "MirIntrinsicSetClear"},
 	}
 	for _, c := range cases {
 		if int(c.kind) != c.wire {
 			t.Errorf("Go IntrinsicKind for %s = %d, want %d (toolchain wire value). Adding a new intrinsic at the wrong position shifts every subsequent intrinsic's wire value and silently miscompiles all source that uses them; see internal/mir/mir.go and toolchain/mir_json.osty for the authoritative alignment.",
 				c.name, int(c.kind), c.wire)
 		}
+	}
+	// Completeness sentinel: `IntrinsicSetClear` is the last
+	// intrinsic the toolchain table claims (toolchain/mir_json.osty:1739).
+	// If anyone inserts a new shared intrinsic in the middle of
+	// `internal/mir/mir.go` without re-anchoring this table, the
+	// sentinel's wire position drifts and this assertion fires.
+	// Likewise, appending a new shared intrinsic between `SetClear`
+	// and `Likely` (currently 138/139, Go-only) shifts `SetClear`'s
+	// position downward and would also trip here.
+	const expectedSharedCount = 138
+	if got := len(cases); got != expectedSharedCount {
+		t.Fatalf("wire-format case list length = %d, expected %d (one entry per shared toolchain enum slot 0..=137). Update both the case list and `expectedSharedCount` when adding a new shared intrinsic.",
+			got, expectedSharedCount)
+	}
+	if got, want := int(mir.IntrinsicSetClear), expectedSharedCount-1; got != want {
+		t.Fatalf("int(IntrinsicSetClear) = %d, want %d. Either a new shared intrinsic was inserted before SetClear (re-anchor the toolchain table + this test), or SetClear was moved (don't — toolchain's mir_json.osty pins its position at 137).",
+			got, want)
 	}
 }

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -6344,11 +6344,12 @@ fn lirLowerMirIndexOf(l: LirMirFunctionLowerer, instr: MirInstr, symbol: String,
         // Sentinel-aware wrap: `osty_rt_strings_IndexOf` returns -1
         // for "not found", any non-negative i for the byte offset.
         // We compare against -1 and merge `Some(i)` / `None` through
-        // an alloca slot. Without the `Question` sugar guard below,
-        // a dest typed `Int?` falls through to `lirStoreMirResult`
-        // which would auto-wrap *unconditionally* as `Some(-1)` —
-        // semantically wrong: the caller would see `Some(-1)` for
-        // "not found" instead of `None`.
+        // an alloca slot. Without the `lirStringHasQuestionSuffix`
+        // arm in this branch's condition, a dest typed `Int?` falls
+        // through to `lirStoreMirResult` which would auto-wrap
+        // *unconditionally* as `Some(-1)` — semantically wrong: the
+        // caller would see `Some(-1)` for "not found" instead of
+        // `None`.
         let merged = lirWrapOptionFromI64Sentinel(l, indexReg, destType, label)
         lirStoreMirResult(l, instr.dest, lirOperand(destType, merged), loc.typ, label + " result")
         return


### PR DESCRIPTION
## Summary

PR #1894 (MIR JSON wire-format alignment) 머지 후 Copilot review 4 건. 정확성 우려 없음 — 테스트 커버리지 + 코멘트 명확성 개선.

### Items addressed

1. **Test count 67 → 138**: 정렬 검증을 critical prefix (0..=67) 만이 아니라 toolchain 과 공유하는 모든 138 wire position (0..=137) 으로 확장. `MirIntrinsicSetClear` 까지. 138+ 는 Go-only (`IntrinsicLikely`/`IntrinsicUnlikely`) 라 제외.
2. **Completeness sentinel**: `len(cases) == 138` AND `int(IntrinsicSetClear) == 137` assertion. 누가 중간에 새 shared intrinsic 끼워 넣으면 `SetClear` position drift → 즉시 fail. List 끝에 append 만 하고 sentinel 갱신 안 해도 fail.
3. **PR description count 정정**: 이전 PR 가 "67" 이라고 했는데 실제론 `Invalid=0` 포함 68 cases 였음 (Copilot #1). 이제 138 이라 본 불일치 자체가 무효.
4. **lir_proto.osty 코멘트 명확화**: "Without the \`Question\` sugar guard below" → "Without the \`lirStringHasQuestionSuffix\` arm in this branch's condition". 가드가 별도 `if` 가 아니라 `if (lirIsOptionTypeName || lirStringHasQuestionSuffix)` 의 second arm 임을 명시.

## Test plan
- [x] `go test ./internal/mirjson/...` — 138 case 모두 통과 + sentinel assertion 통과
- [x] `osty check toolchain/lir_proto.osty` 통과
- [x] `just prepush` 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)