### PR TITLE
fix: List/Map/Set toString receiver-return-type recovery

### DIFF
--- a/internal/backend/llvm_collection_tostring_test.go
+++ b/internal/backend/llvm_collection_tostring_test.go
@@ -1,0 +1,62 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestLLVMBackendBinaryRunsCollectionToString covers the
+// `List<T>.toString()` / `Set<T>.toString()` / `Map<K, V>.toString()`
+// method-call return-type recovery that was missing from
+// `builtinMethodReturnType` in `internal/mir/lower.go`.
+//
+// Before the fix, the receiver type recovery for these three builtins
+// only listed `len` / `isEmpty` / `contains` / `containsKey`; calling
+// `.toString()` fell through, the local was typed `<error>` /
+// fallback-Int, and the lir_proto path silently:
+//
+//   - emitted a `ptrtoint` on the ptr-returning `osty_rt_<x>_to_string`
+//     result,
+//   - stored the resulting i64 into a slot the println intrinsic
+//     dispatch then routed to `osty_rt_int_to_string`,
+//   - producing the pointer address as decimal text instead of the
+//     intended `{1, 2, 3}` / `[a, b]` shape.
+//
+// The bug was completely hidden by the MIR JSON wire-format
+// off-by-one (PR #1894): with the wrong intrinsic dispatch,
+// `IntrinsicSetToString` decoded as something else entirely and the
+// observed runtime crash was `runtime.set.to_string: unsupported
+// element kind` — the wrong symptom for the wrong root cause.
+//
+// This regression test invokes all three `.toString()` paths end-to-end
+// (build → link → execute) and asserts the exact stdout shape so any
+// future drop of the toString return-type registration trips
+// immediately rather than going months without anyone noticing the
+// pointer-as-integer output.
+func TestLLVMBackendBinaryRunsCollectionToString(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let xs: List<Int> = [1, 2, 3]
+    println(xs.toString())
+    let s = xs.toSet()
+    println(s.toString())
+    let m: Map<String, Int> = {:}
+    println(m.toString())
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "[1, 2, 3]\n{1, 2, 3}\n{}\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3609,6 +3609,8 @@ func (bs *bodyState) recoveredMethodReturnType(recvT ir.Type, method string) ir.
 			return ir.TInt
 		case "isEmpty", "contains", "containsKey":
 			return ir.TBool
+		case "toString":
+			return ir.TString
 		}
 	case "List":
 		elemT := bs.l.listElementType(recvT)
@@ -3623,6 +3625,8 @@ func (bs *bodyState) recoveredMethodReturnType(recvT ir.Type, method string) ir.
 			return ir.TInt
 		case "isEmpty", "contains":
 			return ir.TBool
+		case "toString":
+			return ir.TString
 		}
 	case "Set":
 		switch method {
@@ -3630,6 +3634,8 @@ func (bs *bodyState) recoveredMethodReturnType(recvT ir.Type, method string) ir.
 			return ir.TInt
 		case "isEmpty", "contains":
 			return ir.TBool
+		case "toString":
+			return ir.TString
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

`builtinMethodReturnType` (internal/mir/lower.go:3444) 의 List / Map / Set 분기가 `len` / `isEmpty` / `contains` 만 등록하고 `toString` 누락. 호출 시 fallback path 가 dest local 을 \`<error>\` / Int 로 잘못 추론 → lir_proto subprocess 가 `ptrtoint` + `osty_rt_int_to_string` 으로 잘못 lowering → `println(set.toString())` 이 String 내용 대신 포인터 주소를 정수로 출력 (`4415602960` 같은 garbage).

이 버그는 [MIR JSON wire-format off-by-one (PR #1894)](https://github.com/choiceoh/osty/pull/1894) 에 가려져 있었음. wire format 이 -1 shift 였을 때 `IntrinsicSetToString` 이 잘못된 intrinsic 으로 디코딩 → 관찰된 runtime crash 는 `runtime.set.to_string: unsupported element kind` 였는데 실제 source of crash 는 별 intrinsic 의 잘못된 lowering 이지 set.toString 자체가 아님 — wire fix 후 진짜 root cause 가 드러남.

## 변경

- [internal/mir/lower.go:3611](internal/mir/lower.go:3611) — Map 분기에 `case "toString": return ir.TString` 추가
- [internal/mir/lower.go:3625](internal/mir/lower.go:3625) — List 분기에 동일 추가
- [internal/mir/lower.go:3633](internal/mir/lower.go:3633) — Set 분기에 동일 추가

## Test plan
- [x] 신규 [internal/backend/llvm_collection_tostring_test.go](internal/backend/llvm_collection_tostring_test.go) — build → link → execute end-to-end, stdout 정확히 매치:
  ```
  [1, 2, 3]
  {1, 2, 3}
  {}
  ```
- [x] `go test ./internal/mir/... ./internal/check/...` 통과
- [x] `just osty-tests` 33 통과
- [x] `just prepush` 통과
- [ ] CI 그린 확인

## 영향

이전엔 `set.toString()` 호출 site 가 runtime 에서 깨지거나 garbage 출력. 본 fix 후 `[1, 2, 3]` / `{1, 2, 3}` / `{}` 등 정확한 String 표현 반환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)