### PR TITLE
fix: branch terminator coerces i64 cond → i1 via icmp ne 0

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2904,10 +2904,24 @@ fn lirLowerMirBlockTerm(l: LirMirFunctionLowerer, bb: MirBasicBlock, ret: LirTyp
         return t
     }
     if termKind == MirTermBranch {
-        let cond = lirLowerMirOperand(l, l.instrs, bb.termCond, "Bool", lirIntType(1))
+        let mut cond = lirLowerMirOperand(l, l.instrs, bb.termCond, "Bool", lirIntType(1))
         if cond.typ.llvm != "i1" {
-            lirLowerError(l, LirDiagUnsupported, "branch condition requires i1, got `" + cond.typ.llvm + "`", "term.branch")
-            return lirUnreachable()
+            // Coerce integer cond → i1 via `icmp ne %v, 0`. Upstream
+            // type leaks (typically a `<error>` slot read as i64) can
+            // surface a non-i1 cond at this terminator even though the
+            // source is a Bool — `if x.endsWith(s) { ... }` after a
+            // type-leak in a sibling expression typed `_iflet.slot` as
+            // i64 instead of i1. The icmp coercion preserves Osty's
+            // C-style "non-zero is true" semantics and lets the
+            // function lower instead of declining the whole module.
+            if cond.typ.className == LirTypeInt {
+                let coerced = lirFresh(l)
+                l.instrs.push(lirBinary(coerced, "icmp ne", cond.typ, cond.value, "0"))
+                cond = LirOperand {typ: lirIntType(1), value: coerced}
+            } else {
+                lirLowerError(l, LirDiagUnsupported, "branch condition requires i1, got `" + cond.typ.llvm + "`", "term.branch")
+                return lirUnreachable()
+            }
         }
         let mut t = lirCondBr(cond.value, lirLabelForMirBlock(l, bb.termThenBlock), lirLabelForMirBlock(l, bb.termElseBlock))
         if bb.termLoopBackEdge && lirFnHasLoopHints(l.fn_) {
@@ -7199,10 +7213,20 @@ fn lirLowerMirTerm(l: LirMirFunctionLowerer, term: MirTerm, ret: LirType) -> Lir
         return t
     }
     if term.kind == MirTermBranch {
-        let cond = lirLowerMirOperand(l, l.instrs, term.cond, "Bool", lirIntType(1))
+        let mut cond = lirLowerMirOperand(l, l.instrs, term.cond, "Bool", lirIntType(1))
         if cond.typ.llvm != "i1" {
-            lirLowerError(l, LirDiagUnsupported, "branch condition requires i1, got `" + cond.typ.llvm + "`", "term.branch")
-            return lirUnreachable()
+            // Same coerce-via-icmp-ne-0 path as the sibling block-term
+            // branch (search "branch condition requires i1" above for
+            // the rationale). Keeps the two terminator-emit sites in
+            // sync.
+            if cond.typ.className == LirTypeInt {
+                let coerced = lirFresh(l)
+                l.instrs.push(lirBinary(coerced, "icmp ne", cond.typ, cond.value, "0"))
+                cond = LirOperand {typ: lirIntType(1), value: coerced}
+            } else {
+                lirLowerError(l, LirDiagUnsupported, "branch condition requires i1, got `" + cond.typ.llvm + "`", "term.branch")
+                return lirUnreachable()
+            }
         }
         let mut t = lirCondBr(cond.value, lirLabelForMirBlock(l, term.thenBlock), lirLabelForMirBlock(l, term.elseBlock))
         if term.loopBackEdge && lirFnHasLoopHints(l.fn_) {


### PR DESCRIPTION
## Summary

LIR Proto subprocess 의 두 branch-terminator emit site (`lirLowerMirBlockTerminator` + `lirLowerMirTerminator`) 가 cond 의 llvm type 이 `i1` 이 아니면 `term.branch unsupported` 로 decline. 업스트림 type 누수 (예: \`_iflet.slot\` 이 i64 로 잘못 typed 되어 sibling expression 에서 cond 가 i64 로 도착) 가 발생하면 함수 전체 build 가 실패.

## 변경

- [toolchain/lir_proto.osty:2906](toolchain/lir_proto.osty:2906) `lirLowerMirBlockTerminator` + [:7201](toolchain/lir_proto.osty:7201) `lirLowerMirTerminator`: cond 이 integer 일 때 `icmp ne <cond>, 0` 으로 coerce 해 i1 으로 만들어 build 진행. Osty 의 C-style "non-zero is true" semantic 보존. cond 의 className 이 non-Int 이면 (예: ptr) 기존 decline path 유지.

## 영향

- cmd/osty-native-checker build 의 `term.branch: requires i1, got i64` wall 2 건 해소 (PR3-E/F 의 cross-pkg call 후속 type-leak path)
- 기존 i1 cond path 무영향 (분기 들어가지 않음)

## Test plan
- [x] `osty build /tmp/branch_test` (\`if xs.len() > 0 { ... }\`) end-to-end 성공, 출력 \`[10, 20, 30]\`
- [x] `osty install-self` 클린 빌드 통과
- [x] `just osty-tests` 33 tests passed (회귀 없음)
- [x] `go test ./internal/mir/ -run TestLirProto` 통과
- [x] `just prepush` 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)