### PR TITLE
feat: term.branch aggregate cond → disc extract + icmp eq 0 (R3 brick 11)

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2914,10 +2914,24 @@ fn lirLowerMirBlockTerm(l: LirMirFunctionLowerer, bb: MirBasicBlock, ret: LirTyp
             // i64 instead of i1. The icmp coercion preserves Osty's
             // C-style "non-zero is true" semantics and lets the
             // function lower instead of declining the whole module.
+            //
+            // R3 brick 11 (post PR #1898): aggregate cond (e.g.
+            // %Option.Int reaching here from an upstream type leak in
+            // `if let Some(i) = strings.indexOf(...)`) → extract the
+            // discriminant field (index 0, i64) and treat
+            // `disc == 0` as "Some/Ok" (present). The Option/Result
+            // ABI guarantees disc=0 for the truthy variant
+            // (mirSomeAggregateLines / mirOkAggregateLines).
             if cond.typ.className == LirTypeInt {
                 let coerced = lirFresh(l)
                 l.instrs.push(lirBinary(coerced, "icmp ne", cond.typ, cond.value, "0"))
                 cond = LirOperand {typ: lirIntType(1), value: coerced}
+            } else if cond.typ.className == LirTypeAggregate {
+                let discReg = lirFresh(l)
+                l.instrs.push(lirExtractValue(discReg, cond.typ, cond.value, [0]))
+                let presentReg = lirFresh(l)
+                l.instrs.push(lirBinary(presentReg, "icmp eq", lirIntType(64), discReg, "0"))
+                cond = LirOperand {typ: lirIntType(1), value: presentReg}
             } else {
                 lirLowerError(l, LirDiagUnsupported, "branch condition requires i1, got `" + cond.typ.llvm + "`", "term.branch")
                 return lirUnreachable()
@@ -7218,11 +7232,18 @@ fn lirLowerMirTerm(l: LirMirFunctionLowerer, term: MirTerm, ret: LirType) -> Lir
             // Same coerce-via-icmp-ne-0 path as the sibling block-term
             // branch (search "branch condition requires i1" above for
             // the rationale). Keeps the two terminator-emit sites in
-            // sync.
+            // sync. R3 brick 11: aggregate cond → disc extract +
+            // `icmp eq disc, 0` for Some/Ok (present) detection.
             if cond.typ.className == LirTypeInt {
                 let coerced = lirFresh(l)
                 l.instrs.push(lirBinary(coerced, "icmp ne", cond.typ, cond.value, "0"))
                 cond = LirOperand {typ: lirIntType(1), value: coerced}
+            } else if cond.typ.className == LirTypeAggregate {
+                let discReg = lirFresh(l)
+                l.instrs.push(lirExtractValue(discReg, cond.typ, cond.value, [0]))
+                let presentReg = lirFresh(l)
+                l.instrs.push(lirBinary(presentReg, "icmp eq", lirIntType(64), discReg, "0"))
+                cond = LirOperand {typ: lirIntType(1), value: presentReg}
             } else {
                 lirLowerError(l, LirDiagUnsupported, "branch condition requires i1, got `" + cond.typ.llvm + "`", "term.branch")
                 return lirUnreachable()


### PR DESCRIPTION
## Summary

[PR #1898](https://github.com/choiceoh/osty/pull/1898) (i64 cond → i1 via icmp ne 0) 의 후속. aggregate cond 도 i1 으로 narrow.

## 변경

| site | line | scope |
|---|---|---|
| `lirLowerMirBlockTerminator` | 2906 | LirTypeAggregate else-if 추가 |
| `lirLowerMirTerminator` | 7229 | 동일 (sibling site) |

```osty
// PR #1898 의 i64 chain 후에 추가:
} else if cond.typ.className == LirTypeAggregate {
    let discReg = lirFresh(l)
    l.instrs.push(lirExtractValue(discReg, cond.typ, cond.value, [0]))
    let presentReg = lirFresh(l)
    l.instrs.push(lirBinary(presentReg, "icmp eq", lirIntType(64), discReg, "0"))
    cond = LirOperand {typ: lirIntType(1), value: presentReg}
}
```

## 배경

main.osty 의 `if let Some(i) = strings.indexOf(...)` 의 desugar 가 switch_int term 으로 lower (input MIR 깨끗, [PR #1899](https://github.com/choiceoh/osty/pull/1899) 측정 확인). 그러나 osty-self runtime 의 BranchTerm 처리 path 가 wrong-code 로 cond aggregate 호출 → declined.

이 fix 는 aggregate cond 도 graceful 처리. Option/Result ABI 의 disc=0 (truthy variant) 보장.

## 검증

- ✓ `just osty-tests` 통과 (회귀 zero)
- ✓ `just prepush` 통과
- ⚠ cmd/osty-native-checker build: declined message 그대로 — osty-self stage0 cover gap 으로 runtime 미반영 가능성

## Chicken-and-egg note

brick 8/9/10 같은 stage0 cover gap. 단 본 PR 의 변경 = PR #1898 의 else-if 확장 (같은 shape), stage0 cover 가능성 있음. 측정 결과 별도 confirm.

## R3 trajectory 진척

| brick | PR | scope |
|---|---|---|
| 1-7 root cause | 머지 | basic + recoverOperandType MatchExpr/BlockExpr |
| PR3-D scaffold | [#1889](https://github.com/choiceoh/osty/pull/1889) 머지 | toolchain [lib] |
| PR3-E/F activation | [#1890](https://github.com/choiceoh/osty/pull/1890) 머지 | cross-pkg method-call |
| measurement v1-3 | [#1892](https://github.com/choiceoh/osty/pull/1892)/[#1893](https://github.com/choiceoh/osty/pull/1893)/[#1896](https://github.com/choiceoh/osty/pull/1896)/[#1899](https://github.com/choiceoh/osty/pull/1899) 머지 | wall measurement |
| brick 10 (i64 cond) | [#1898](https://github.com/choiceoh/osty/pull/1898) 머지 | i64 → i1 coerce |
| **brick 11 (aggregate cond)** | **this PR** | aggregate → i1 narrow |

🤖 Generated with [Claude Code](https://claude.com/claude-code)