### PR TITLE
feat: assign.dest <error> graceful fallback to i64 (R3 brick 12)

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3230,10 +3230,14 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "assign destination local out of range", "assign.dest")
         return
     }
-    let destType = lirLowerMirType(l, destLoc.typ)
+    let mut destType = lirLowerMirType(l, destLoc.typ)
     if lirTypeIsZero(destType) {
-        lirLowerError(l, LirDiagUnsupported, "unsupported assign destination type `" + destLoc.typ + "` (" + lirTypeLowerTraceMessage(l.mirModule, destLoc.typ) + ")", "assign.dest")
-        return
+        // R3 brick 12: dest local type 이 `<error>` literal (또는
+        // unknown) 인 경우 i64 default 로 graceful fallback. brick 5
+        // (lirLowerMirLocalsFrom) 가 같은 패턴으로 local alloca 단계
+        // cover — assign 단계도 일관성 유지. Companion fallback chain:
+        // local alloca → i64 (brick 5), assign dest → i64 (this brick).
+        destType = lirIntType(64)
     }
     if mirPlaceHasProjections(instr.dest) {
         let leafTypeName = lirMirProjectionLeafType(instr.dest.projections)


### PR DESCRIPTION
## Summary

R3 trajectory brick 12. `lirLowerMirAssign` 의 dest local type 이 `<error>` literal 또는 zero-typed 인 경우 i64 default 로 graceful fallback. [brick 5](https://github.com/choiceoh/osty/pull/1883) (`lirLowerMirLocalsFrom`) 의 같은 패턴 — local alloca + assign dest 두 단계 fallback chain 일관성.

## 배경

cmd/osty-native-checker build 시 declined `unsupported assign destination type <error>`:
- `destLoc.typ` = `<error>` literal 또는 `lirLowerMirType` 가 zero 반환
- brick 5 가 local alloca 단계 i64 fallback. assign dest 도 동일.

## 변경

```osty
-    let destType = lirLowerMirType(l, destLoc.typ)
+    let mut destType = lirLowerMirType(l, destLoc.typ)
     if lirTypeIsZero(destType) {
-        lirLowerError(l, LirDiagUnsupported, "unsupported assign destination type ...", "assign.dest")
-        return
+        // R3 brick 12: brick 5 와 같은 i64 default fallback.
+        destType = lirIntType(64)
     }
```

## 검증

- ✓ `just osty-tests` 통과 (회귀 zero)
- ✓ `just prepush` 통과
- ⚠ cmd/osty-native-checker build: declined `assign.dest <error>` 그대로 (osty-self stage0 cover gap, brick 8-11 동일 패턴)

## Chicken-and-egg note

PR #1900 (brick 11 머지 후) 와 같은 cover gap 상태. graceful fallback chain 확장 — osty-self stage0 cover 가 PR #1898 같은 외부 fix 머지 후 활성화 기대.

🤖 Generated with [Claude Code](https://claude.com/claude-code)