### PR TITLE
feat: backend.Request.ExtraObjects link plumbing (PR-G1 scaffold)

### DIFF
--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -522,7 +522,17 @@ func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyqu
 	linkLibraries := resolvedLinkLibraries(resolved)
 
 	if backendID == backend.NameLLVM {
-		if emitResult, usedExternal, err := tryExternalPackageLLVMArtifacts(context.Background(), emitMode, layout, binName, features, linkLibraries, entryAbs, pkg); usedExternal {
+		// Cross-package dependency objects: built once per dep,
+		// passed as ExtraObjects to the link step. Empty for
+		// packages with no resolved deps — the common case. The
+		// builder is wired but currently returns nil (PR-G1 ships
+		// the link plumbing; PR-G2 fills in actual dep `.o`
+		// compilation through the LIR Proto subprocess).
+		var extraObjects []string
+		if emitMode == backend.EmitBinary {
+			extraObjects = buildCrossPkgDepObjects(context.Background(), root, m, eng, lower, resolved, feats, layout)
+		}
+		if emitResult, usedExternal, err := tryExternalPackageLLVMArtifacts(context.Background(), emitMode, layout, binName, features, linkLibraries, extraObjects, entryAbs, pkg); usedExternal {
 			if err != nil {
 				exitBackendEmitError(command, emitResult, err)
 			}

--- a/cmd/osty/cross_pkg_deps.go
+++ b/cmd/osty/cross_pkg_deps.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/profile"
+	ostyquery "github.com/osty/osty/internal/query/osty"
+)
+
+// buildCrossPkgDepObjects compiles each cross-package dependency the
+// main entry directly or transitively reaches into a standalone `.o`
+// artifact and returns the absolute paths so the link step can
+// resolve `declare`d symbols. Returns nil when there are no deps to
+// compile.
+//
+// PR-G1 ships only the wiring scaffold — this function returns nil
+// while PR-G2 fills in actual dep compilation. Until then, packages
+// with cross-pkg `use` declarations still build IR successfully (the
+// declares land in `main.ll`) but fail at link time as before. That
+// failure mode is unchanged by this commit; the field plumbing just
+// lets PR-G2 land without touching every caller again.
+func buildCrossPkgDepObjects(_ context.Context, _ string, _ *manifest.Manifest, _ *ostyquery.Engine, _ ostyquery.LowerKey, _ *profile.Resolved, _ map[string]bool, _ backend.Layout) []string {
+	return nil
+}

--- a/cmd/osty/llvm_external_emit.go
+++ b/cmd/osty/llvm_external_emit.go
@@ -17,7 +17,7 @@ var tryExternalPackageLLVMIR = func(entryPath string, pkg *resolve.Package) ([]b
 
 var emitPrebuiltLLVMIR = backend.EmitPrebuiltLLVMIR
 
-func tryExternalPackageLLVMArtifacts(ctx context.Context, emitMode backend.EmitMode, layout backend.Layout, binaryName string, features []string, linkLibraries []string, entryPath string, pkg *resolve.Package) (*backend.Result, bool, error) {
+func tryExternalPackageLLVMArtifacts(ctx context.Context, emitMode backend.EmitMode, layout backend.Layout, binaryName string, features []string, linkLibraries []string, extraObjects []string, entryPath string, pkg *resolve.Package) (*backend.Result, bool, error) {
 	if pkg == nil || !backend.UseNativeOwnedLLVMIR(features, emitMode) {
 		return nil, false, nil
 	}
@@ -31,6 +31,7 @@ func tryExternalPackageLLVMArtifacts(ctx context.Context, emitMode backend.EmitM
 		BinaryName:    binaryName,
 		Features:      features,
 		LinkLibraries: linkLibraries,
+		ExtraObjects:  extraObjects,
 	}, out, warnings)
 	return result, true, err
 }

--- a/cmd/osty/llvm_external_emit_test.go
+++ b/cmd/osty/llvm_external_emit_test.go
@@ -64,7 +64,7 @@ func TestTryExternalPackageLLVMArtifactsUsesCoveredExternalIR(t *testing.T) {
 	result, used, err := tryExternalPackageLLVMArtifacts(context.Background(), backend.EmitObject, backend.Layout{
 		Root:    pkg.Dir,
 		Profile: "debug",
-	}, "app", nil, []string{"osty_qt", "WebView2Loader"}, "/tmp/main.osty", pkg)
+	}, "app", nil, []string{"osty_qt", "WebView2Loader"}, nil, "/tmp/main.osty", pkg)
 	if err != nil {
 		t.Fatalf("tryExternalPackageLLVMArtifacts() error = %v", err)
 	}
@@ -91,7 +91,7 @@ func TestTryExternalPackageLLVMArtifactsSkipsWhenFeatureOverridesNativePath(t *t
 	result, used, err := tryExternalPackageLLVMArtifacts(context.Background(), backend.EmitBinary, backend.Layout{
 		Root:    pkg.Dir,
 		Profile: "debug",
-	}, "app", []string{"mir-backend"}, nil, "/tmp/main.osty", pkg)
+	}, "app", []string{"mir-backend"}, nil, nil, "/tmp/main.osty", pkg)
 	if err != nil {
 		t.Fatalf("tryExternalPackageLLVMArtifacts() error = %v", err)
 	}

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -699,7 +699,7 @@ func compileNativeTestBundle(ctx context.Context, b backend.Backend, tmpRoot str
 	if result, usedExternal, err := tryExternalPackageLLVMArtifacts(ctx, backend.EmitObject, backend.Layout{
 		Root:    layoutRoot,
 		Profile: "test",
-	}, "", nil, nil, sourcePath, pkg); usedExternal {
+	}, "", nil, nil, nil, sourcePath, pkg); usedExternal {
 		if err != nil {
 			return nativeTestBundleAssets{}, err
 		}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -153,6 +153,17 @@ type Request struct {
 	BinaryName    string
 	Features      []string
 	LinkLibraries []string
+	// ExtraObjects is a list of absolute paths to additional object
+	// files that should be linked alongside the main package's
+	// object when `Emit == EmitBinary`. Used by cmd/osty's cross-
+	// package build path to bring in dependency packages compiled
+	// as standalone `.o` artifacts (see PR3-G: cross-pkg link).
+	// Backends that don't link (`EmitLLVMIR`, `EmitObject`) ignore
+	// this field. Entries are appended after the main object and
+	// before the runtime object — order matters when symbol
+	// resolution depends on link order, but cross-pkg deps should
+	// be self-contained so order is rarely material.
+	ExtraObjects []string
 }
 
 // Artifacts returns the conventional artifact paths for backend n.

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -141,6 +141,11 @@ func (b LLVMBackend) emitPrebuiltIR(ctx context.Context, req Request, irOut []by
 		return out, err
 	}
 	linkObjects := []string{out.Artifacts.Object}
+	// Cross-package dependency objects (see backend.Request.ExtraObjects
+	// docs) are linked after the main package object but before the
+	// runtime, so that dep `define`s satisfy main's `declare`s while
+	// the runtime still gets the last shot at any unresolved symbol.
+	linkObjects = append(linkObjects, req.ExtraObjects...)
 	if runtimeObject != "" {
 		linkObjects = append(linkObjects, runtimeObject)
 	}

--- a/internal/backend/llvm_extra_objects_test.go
+++ b/internal/backend/llvm_extra_objects_test.go
@@ -1,0 +1,88 @@
+package backend
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestLLVMBackendEmitPrebuiltIncludesExtraObjectsInLink verifies that
+// `Request.ExtraObjects` paths flow into the `LinkBinary` call between
+// the main package object and the runtime object — the slot the
+// cross-package dependency link path needs to satisfy main's
+// `declare`d symbols (PR-G1 wiring scaffold).
+//
+// The check is order-sensitive: deps after main so dep `define`s
+// resolve main `declare`s, runtime last so it gets the last shot at
+// unresolved symbols. Anyone reordering the slice without auditing
+// the existing OS-specific link library ordering (e.g. macOS
+// `-framework Security`) will trip here.
+func TestLLVMBackendEmitPrebuiltIncludesExtraObjectsInLink(t *testing.T) {
+	tc := &fakeLLVMToolchain{}
+	b := LLVMBackend{toolchain: tc}
+
+	root := t.TempDir()
+	extraA := filepath.Join(root, "dep_a.o")
+	extraB := filepath.Join(root, "dep_b.o")
+
+	req := Request{
+		Layout: Layout{
+			Root:    root,
+			Profile: "debug",
+		},
+		Emit:         EmitBinary,
+		BinaryName:   "test_extra_objects",
+		ExtraObjects: []string{extraA, extraB},
+	}
+
+	_, err := b.emitPrebuiltIR(context.Background(), req, []byte("; minimal placeholder IR\n"), nil)
+	if err != nil {
+		t.Fatalf("emitPrebuiltIR returned error: %v", err)
+	}
+	if len(tc.links) != 1 {
+		t.Fatalf("link calls = %d, want 1", len(tc.links))
+	}
+	got := tc.links[0].objectPaths
+	if len(got) < 3 {
+		t.Fatalf("linkObjects = %#v, want at least [main, dep_a.o, dep_b.o] (3 entries)", got)
+	}
+	// Main object first, then deps in order, then runtime.
+	if got[1] != extraA {
+		t.Errorf("linkObjects[1] = %q, want %q (first ExtraObject)", got[1], extraA)
+	}
+	if got[2] != extraB {
+		t.Errorf("linkObjects[2] = %q, want %q (second ExtraObject)", got[2], extraB)
+	}
+}
+
+// TestLLVMBackendEmitPrebuiltSkipsEmptyExtraObjects verifies the
+// baseline shape (main + runtime only) is unchanged when
+// ExtraObjects is nil — the common case for packages without
+// cross-pkg deps. Without this, the PR-G1 plumbing could silently
+// introduce a stray empty-string entry that breaks the link command.
+func TestLLVMBackendEmitPrebuiltSkipsEmptyExtraObjects(t *testing.T) {
+	tc := &fakeLLVMToolchain{}
+	b := LLVMBackend{toolchain: tc}
+
+	req := Request{
+		Layout: Layout{
+			Root:    t.TempDir(),
+			Profile: "debug",
+		},
+		Emit:       EmitBinary,
+		BinaryName: "test_no_extras",
+	}
+
+	_, err := b.emitPrebuiltIR(context.Background(), req, []byte("; minimal placeholder IR\n"), nil)
+	if err != nil {
+		t.Fatalf("emitPrebuiltIR returned error: %v", err)
+	}
+	if len(tc.links) != 1 {
+		t.Fatalf("link calls = %d, want 1", len(tc.links))
+	}
+	for i, p := range tc.links[0].objectPaths {
+		if p == "" {
+			t.Errorf("linkObjects[%d] = empty string, want non-empty path", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Cross-package dependency linking wall (cmd/osty-native-checker 등이 \`use toolchain as tc; tc.fn()\` 호출 시 linker 가 \`_toolchain.fn\` symbol 못 찾아 fail) 의 첫 번째 단계: link 단계 multi-object 지원 인프라.

## 변경

- [internal/backend/backend.go](internal/backend/backend.go) `Request`: `ExtraObjects []string` 필드 추가
- [internal/backend/llvm.go](internal/backend/llvm.go) `emitPrebuiltIR`: linkObjects 에 ExtraObjects 포함 — main 뒤, runtime 앞
- [cmd/osty/llvm_external_emit.go](cmd/osty/llvm_external_emit.go) signature 확장 + Request 전달
- [cmd/osty/build.go](cmd/osty/build.go) `emitViaQuery`: ExtraObjects 빌더 호출 (현재 stub)
- [cmd/osty/cross_pkg_deps.go](cmd/osty/cross_pkg_deps.go) (신규): `buildCrossPkgDepObjects` stub (PR-G2 가 채울 자리)
- [cmd/osty/test_native.go](cmd/osty/test_native.go) + [cmd/osty/llvm_external_emit_test.go](cmd/osty/llvm_external_emit_test.go): caller signature 업데이트
- [internal/backend/llvm_extra_objects_test.go](internal/backend/llvm_extra_objects_test.go) (신규):
  - `TestLLVMBackendEmitPrebuiltIncludesExtraObjectsInLink`: ExtraObjects 가 main 와 runtime 사이 순서 보존되어 포함됨
  - `TestLLVMBackendEmitPrebuiltSkipsEmptyExtraObjects`: nil ExtraObjects 시 empty entry 안 생김

## 영향

- PR-G1 은 인프라만 — `buildCrossPkgDepObjects` 가 nil 반환하므로 현재 빌드 동작 무변경. cmd/osty-native-checker cross-pkg link wall 도 아직 그대로 (PR-G2 에서 dep 컴파일 채우면 해소 예정).
- 기존 builds (cross-pkg dep 없는 패키지) 에 무영향 — linkObjects shape 동일.

## Test plan
- [x] 신규 2 테스트 통과 (`TestLLVMBackendEmitPrebuilt{Includes,Skips}*`)
- [x] `just prepush` 통과
- [x] `go test ./cmd/osty/ -run TestTryExternalPackageLLVMArtifacts` 통과 (signature 업데이트 후)
- [ ] CI 그린 확인

## 후속 (PR-G2)

`buildCrossPkgDepObjects` 채우기:
1. workspace 의 dep package 들 iterate
2. 각 dep 의 [lib] entry 를 EmitObject mode 로 컴파일
3. 결과 `.o` path 수집해 ExtraObjects 로 전달

dep `.o` 컴파일은 dep 의 main entry 제외 + 모든 pub 심볼 export 의 library mode 가 필요 — 현재 build path 의 `[lib]-without-[bin]` decline branch (build.go:471) 수정이 동반됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)