### PR TITLE
feat: cross-pkg dep library compile path (PR-G2, opt-in)

### DIFF
--- a/cmd/osty-native-llvmgen/library_mode_test.go
+++ b/cmd/osty-native-llvmgen/library_mode_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/mir"
+)
+
+// TestStripMainForLibraryModeRemovesMainAndKeepsOthers locks the
+// PR-G2 dep-as-library helper behavior: only the `main` function is
+// stripped, every other MIR function survives. Without this, a future
+// over-aggressive filter could silently drop pub helpers and break
+// the link step downstream.
+func TestStripMainForLibraryModeRemovesMainAndKeepsOthers(t *testing.T) {
+	mainFn := &mir.Function{Name: "main"}
+	helperFn := &mir.Function{Name: "frontInvalidTypeRepr"}
+	otherFn := &mir.Function{Name: "checkLookupFn"}
+
+	entry := &backend.Entry{
+		MIR: &mir.Module{
+			Functions: []*mir.Function{mainFn, helperFn, otherFn},
+		},
+	}
+	stripMainForLibraryMode(entry)
+
+	if len(entry.MIR.Functions) != 2 {
+		t.Fatalf("Functions length = %d, want 2 (after stripping main)", len(entry.MIR.Functions))
+	}
+	for _, fn := range entry.MIR.Functions {
+		if fn.Name == "main" {
+			t.Errorf("`main` survived strip: still in Functions list")
+		}
+	}
+	names := map[string]bool{}
+	for _, fn := range entry.MIR.Functions {
+		names[fn.Name] = true
+	}
+	if !names["frontInvalidTypeRepr"] {
+		t.Errorf("frontInvalidTypeRepr was stripped (should survive)")
+	}
+	if !names["checkLookupFn"] {
+		t.Errorf("checkLookupFn was stripped (should survive)")
+	}
+}
+
+// TestStripMainForLibraryModeHandlesNilSafely guards against nil
+// entry / nil MIR / nil function slice — preparePackageEntry can fail
+// in ways that produce partial entries, and the strip helper runs
+// unconditionally after a successful prepare call. Without this
+// test, a regression that crashes on nil could ship undetected
+// because the cross-pkg dep path is opt-in via env var (only fires
+// in dev / one-off CI runs).
+func TestStripMainForLibraryModeHandlesNilSafely(t *testing.T) {
+	stripMainForLibraryMode(nil)
+	stripMainForLibraryMode(&backend.Entry{})
+
+	entry := &backend.Entry{MIR: &mir.Module{}}
+	stripMainForLibraryMode(entry)
+	if len(entry.MIR.Functions) != 0 {
+		t.Fatalf("Functions length = %d, want 0 (no-op on empty)", len(entry.MIR.Functions))
+	}
+
+	entry2 := &backend.Entry{
+		MIR: &mir.Module{
+			Functions: []*mir.Function{nil, {Name: "main"}, nil, {Name: "helper"}},
+		},
+	}
+	stripMainForLibraryMode(entry2)
+	if len(entry2.MIR.Functions) != 1 {
+		t.Fatalf("Functions length = %d, want 1 (helper survived, nils + main stripped)", len(entry2.MIR.Functions))
+	}
+	if entry2.MIR.Functions[0].Name != "helper" {
+		t.Fatalf("survivor = %q, want \"helper\"", entry2.MIR.Functions[0].Name)
+	}
+}

--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -48,6 +48,9 @@ func run(stdin io.Reader, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if req.Package != nil && req.Package.LibraryMode {
+		stripMainForLibraryMode(&entry)
+	}
 	ir, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(entry, "")
 	if err != nil {
 		return fmt.Errorf("emit native llvm-ir: %w", err)
@@ -170,6 +173,32 @@ func preparePackageEntry(req llvmgenRequest) (backend.Entry, error) {
 		chk = &check.Result{}
 	}
 	return backend.PrepareGraphPackage("main", entryPath, graph, "", entryFile, chk)
+}
+
+// stripMainForLibraryMode removes any top-level `main` function from
+// the entry's MIR + IR before LLVM emission. Called when the cmd/osty
+// build path requests a dependency package built as a library .o so
+// the resulting object can link alongside a consumer's own `main`
+// without `_main` symbol collision (PR-G2 cross-pkg link). All other
+// pub bodies are preserved so the consumer's `declare`d symbols get
+// resolved at link time.
+func stripMainForLibraryMode(entry *backend.Entry) {
+	if entry == nil {
+		return
+	}
+	if entry.MIR != nil {
+		filtered := entry.MIR.Functions[:0]
+		for _, fn := range entry.MIR.Functions {
+			if fn == nil {
+				continue
+			}
+			if fn.Name == "main" {
+				continue
+			}
+			filtered = append(filtered, fn)
+		}
+		entry.MIR.Functions = filtered
+	}
 }
 
 func writePackageRequest(req llvmgenRequest) (string, string, error) {

--- a/cmd/osty/cross_pkg_deps.go
+++ b/cmd/osty/cross_pkg_deps.go
@@ -2,25 +2,143 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/nativellvmgen"
 	"github.com/osty/osty/internal/profile"
 	ostyquery "github.com/osty/osty/internal/query/osty"
+	"github.com/osty/osty/internal/resolve"
 )
 
-// buildCrossPkgDepObjects compiles each cross-package dependency the
-// main entry directly or transitively reaches into a standalone `.o`
-// artifact and returns the absolute paths so the link step can
+// buildCrossPkgDepObjects compiles every cross-package dependency the
+// main entry reaches through the workspace into a standalone library
+// `.o` artifact and returns the absolute paths so the link step can
 // resolve `declare`d symbols. Returns nil when there are no deps to
 // compile.
 //
-// PR-G1 ships only the wiring scaffold — this function returns nil
-// while PR-G2 fills in actual dep compilation. Until then, packages
-// with cross-pkg `use` declarations still build IR successfully (the
-// declares land in `main.ll`) but fail at link time as before. That
-// failure mode is unchanged by this commit; the field plumbing just
-// lets PR-G2 land without touching every caller again.
-func buildCrossPkgDepObjects(_ context.Context, _ string, _ *manifest.Manifest, _ *ostyquery.Engine, _ ostyquery.LowerKey, _ *profile.Resolved, _ map[string]bool, _ backend.Layout) []string {
-	return nil
+// Each dep is compiled with `nativellvmgen.TryPackageLibrary` which
+// tells the subprocess to skip emitting `main` — without that, the
+// dep's own `_main` would collide with the consumer's `_main` at link
+// time. Dep IR + object artifacts land under
+// `<dep_dir>/.osty/out/<profile>/llvm-lib/` so they're discoverable
+// for caching purposes in a future iteration.
+//
+// **Opt-in via `OSTY_CROSS_PKG_LINK=1`**. The dep-compile path is
+// gated because the LIR Proto subprocess currently hangs on
+// large-dep library compilation (toolchain ≈100k lines triggers an
+// observed >10-minute stall) and because the consumer build itself
+// fails earlier on upstream `<error>`-type leaks from PR3-C's
+// cross-pkg dispatch arm (separate trajectory). PR-G2 ships the
+// wiring; flipping the env var enables the path for small-dep
+// experimentation while the upstream gaps close.
+//
+// Errors compiling any single dep are surfaced as warnings to stderr
+// but don't abort the build — the consumer link will simply fail
+// with the original undefined-symbol error if a needed dep didn't
+// produce an object, which is no worse than the pre-PR-G1 status quo.
+func buildCrossPkgDepObjects(ctx context.Context, _ string, _ *manifest.Manifest, eng *ostyquery.Engine, lower ostyquery.LowerKey, resolved *profile.Resolved, _ map[string]bool, layout backend.Layout) []string {
+	if !crossPkgLinkEnabled() {
+		return nil
+	}
+	if eng == nil || !backend.UseNativeOwnedLLVMIR(resolvedFeatures(resolved), backend.EmitBinary) {
+		return nil
+	}
+	if lower.WorkspaceRoot == "" {
+		return nil
+	}
+	rw := eng.Queries.ResolveWorkspace.Get(eng.DB, lower.WorkspaceRoot)
+	if rw == nil {
+		return nil
+	}
+	mainDir := ostyquery.NormalizePath(lower.Dir)
+	var objects []string
+	for _, pkg := range rw.Packages() {
+		if pkg == nil {
+			continue
+		}
+		depDir := ostyquery.NormalizePath(pkg.Dir)
+		if depDir == "" || depDir == mainDir {
+			continue
+		}
+		objPath, err := compileDepLibraryObject(ctx, pkg, layout)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty build: warning: dep %q library compile failed: %v\n", pkg.Name, err)
+			continue
+		}
+		if objPath != "" {
+			objects = append(objects, objPath)
+		}
+	}
+	return objects
+}
+
+// crossPkgLinkEnabled reads `OSTY_CROSS_PKG_LINK` and returns true
+// when the value is one of the canonical truthy spellings. Default
+// false so production builds keep the pre-PR-G2 behavior (consumer
+// builds still emit `declare` for cross-pkg calls and fail at link
+// time with the same undefined-symbol error as before) until the
+// upstream `<error>`-type cascade closes.
+func crossPkgLinkEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("OSTY_CROSS_PKG_LINK"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// compileDepLibraryObject runs `nativellvmgen.TryPackageLibrary` for
+// `pkg`, materializes the IR + object under the dep's own
+// `<dep>/.osty/out/<profile>/llvm-lib/` directory via
+// `backend.EmitPrebuiltLLVMIR(EmitObject)`, and returns the object
+// path on success.
+func compileDepLibraryObject(ctx context.Context, pkg *resolve.Package, layout backend.Layout) (string, error) {
+	entryPath := depEntryPath(pkg)
+	if entryPath == "" {
+		return "", fmt.Errorf("no source files")
+	}
+	ir, covered, _, err := nativellvmgen.TryPackageLibrary(".", entryPath, pkg)
+	if err != nil {
+		return "", fmt.Errorf("native llvmgen: %w", err)
+	}
+	if !covered || len(ir) == 0 {
+		return "", fmt.Errorf("native llvmgen returned no IR (subprocess declined coverage)")
+	}
+	depLayout := backend.Layout{
+		Root:    pkg.Dir,
+		Profile: layout.Profile,
+		Target:  layout.Target,
+	}
+	req := backend.Request{
+		Layout:     depLayout,
+		Emit:       backend.EmitObject,
+		BinaryName: "lib",
+	}
+	res, err := backend.EmitPrebuiltLLVMIR(ctx, req, ir, nil)
+	if err != nil {
+		return "", fmt.Errorf("compile object: %w", err)
+	}
+	if res == nil || res.Artifacts.Object == "" {
+		return "", fmt.Errorf("EmitPrebuiltLLVMIR returned no object artifact")
+	}
+	return res.Artifacts.Object, nil
+}
+
+func depEntryPath(pkg *resolve.Package) string {
+	if pkg == nil {
+		return ""
+	}
+	// The subprocess loads every file in the package; the entry path
+	// is only used to anchor the temp workspace, so any file works.
+	// Prefer the first non-nil path for stable behavior.
+	for _, pf := range pkg.Files {
+		if pf != nil && pf.Path != "" {
+			return pf.Path
+		}
+	}
+	return ""
 }

--- a/internal/nativellvmgen/exec.go
+++ b/internal/nativellvmgen/exec.go
@@ -35,6 +35,14 @@ type MIRInput struct {
 type PackageInput struct {
 	Files             []PackageFile `json:"files,omitempty"`
 	RuntimeCapability bool          `json:"runtimeCapability,omitempty"`
+	// LibraryMode tells the subprocess to skip emitting a top-level
+	// `main` function in the resulting LLVM IR. Used by cmd/osty's
+	// cross-package dep compilation (PR-G2 / cross-pkg link) so the
+	// resulting `.o` can be linked alongside a consumer's `main`
+	// without `_main` symbol collision. The non-main bodies of the
+	// dep are still emitted so `declare`s in the consumer's IR get
+	// resolved.
+	LibraryMode bool `json:"libraryMode,omitempty"`
 }
 
 type PackageFile struct {
@@ -95,6 +103,26 @@ func TryPackage(start, entryPath string, pkg *resolve.Package) ([]byte, bool, []
 	req, err := RequestFromPackage(entryPath, pkg)
 	if err != nil {
 		return nil, false, nil, err
+	}
+	resp, err := Run(start, req)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	return []byte(resp.LLVMIR), resp.Covered, warningErrors(resp.Warnings), nil
+}
+
+// TryPackageLibrary compiles a package the same way TryPackage does
+// but with `PackageInput.LibraryMode = true`, telling the subprocess
+// to skip emitting `main` so the resulting IR can be linked into a
+// consumer binary without `_main` symbol collision. Used by the
+// cross-package dep `.o` compile path (PR-G2 cross-pkg link).
+func TryPackageLibrary(start, entryPath string, pkg *resolve.Package) ([]byte, bool, []error, error) {
+	req, err := RequestFromPackage(entryPath, pkg)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	if req.Package != nil {
+		req.Package.LibraryMode = true
 	}
 	resp, err := Run(start, req)
 	if err != nil {


### PR DESCRIPTION
## Summary

[PR-G1 (#1902)](https://github.com/choiceoh/osty/pull/1902) 가 \`backend.Request.ExtraObjects\` 인프라를 추가했고, 본 PR 은 실제 dep 컴파일 파이프라인을 채움.

## 변경

- [internal/nativellvmgen/exec.go](internal/nativellvmgen/exec.go): \`PackageInput.LibraryMode\` 필드 + \`TryPackageLibrary\` 신규
- [cmd/osty-native-llvmgen/main.go](cmd/osty-native-llvmgen/main.go): \`stripMainForLibraryMode\` 헬퍼 — preparePackageEntry 후 \`Name == "main"\` 함수 필터링 (nil-safe)
- [cmd/osty/cross_pkg_deps.go](cmd/osty/cross_pkg_deps.go) \`buildCrossPkgDepObjects\`: 워크스페이스 dep 패키지 iterate, 각각 \`TryPackageLibrary\` → \`backend.EmitPrebuiltLLVMIR(EmitObject)\` 로 \`.o\` 컴파일. 출력: \`<dep>/.osty/out/<profile>/llvm-lib/lib.o\`
- [cmd/osty-native-llvmgen/library_mode_test.go](cmd/osty-native-llvmgen/library_mode_test.go): nil-safe + main-only-stripped lock

## **opt-in via \`OSTY_CROSS_PKG_LINK=1\`**

dep-compile path 는 기본 OFF. 이유:

1. **대용량 dep 의 library 컴파일 stall**: toolchain (~100k 줄) 을 library 모드로 LIR Proto subprocess 에 보내면 10 분+ 진행 후에도 미완료 관측됨. 별도 trajectory (subprocess perf / streaming).
2. **Consumer build 의 upstream \`<error>\` cascade**: PR3-C 의 cross-pkg dispatch arm 이 method-call 을 resolve 하지만 결과 local 의 type 이 \`<error>\` 로 leak. main 패키지 자체의 MIR generation 이 먼저 실패하므로 dep \`.o\` 가 준비되어도 link 단계까지 도달 못 함.

PR-G2 는 wiring 을 채움 — 옵션 활성화 시 환경/실험적 빌드 시도 가능. 실전 unblock 은 위 2 갭 해소 후 default-on flip 될 예정.

## Test plan
- [x] 신규 2 unit tests 통과 (\`TestStripMainForLibraryMode*\`)
- [x] 기존 \`TestLLVMBackendEmitPrebuilt*\` 통과 (회귀 없음)
- [x] \`OSTY_CROSS_PKG_LINK=0\` (default) 빌드 동작 무변경
- [x] \`just prepush\` 통과
- [ ] CI 그린 확인

## 후속 (PR-G3+)

1. lir_proto subprocess 의 library-mode 대용량 컴파일 perf — toolchain 100k 줄이 10 분+ 안 끝나는 원인 찾기
2. \`<error>\` cascade 해소 — PR3-C cross-pkg dispatch arm 의 type-leak 패치 → consumer build 의 MIR generation 통과
3. 위 2 갭 해소 후 \`OSTY_CROSS_PKG_LINK\` default-on

🤖 Generated with [Claude Code](https://claude.com/claude-code)