### PR TITLE
fix: brick 12 projection bug (brick 14) + assign coercion case-by-case (brick 15)

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3269,12 +3269,45 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
         } else {
             let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, destType, lirPrimitiveTypeIsUnsigned(instr.src.typ))
             if castOp == "" {
-                lirLowerError(l, LirDiagUnsupported, "assign coercion is not supported", "assign")
-                return
+                // R3 brick 15: cross-family coercion case-by-case fix.
+                // Each branch emits *correct* LLVM IR (SSA-valid)
+                // instead of the brick-8 broadest "skip" path (which
+                // broke SSA invariants by treating mismatched value as
+                // dest type without any actual conversion).
+                if value.typ.className == LirTypeInt && destType.className == LirTypeAggregate {
+                    // i64 → Option<T> / Result<T,E>: wrap as Some/Ok
+                    // (disc=0). Payload slot stays i64 since
+                    // `lirEmitAlgebraicI64` builds the canonical 2-i64
+                    // shape. Same path the production sentinel-wrap
+                    // helpers use for `xs.first()` / Option<Int>.
+                    let merged = lirEmitAlgebraicI64(l, destType, 0, value.value, "assign.wrap")
+                    if merged == "undef" {
+                        lirLowerError(l, LirDiagUnsupported, "assign coercion is not supported (aggregate wrap failed)", "assign")
+                        return
+                    }
+                    value = LirOperand {typ: destType, value: merged}
+                } else if value.typ.className == LirTypeAggregate && destType.className == LirTypeInt {
+                    // Aggregate → i64: extract first field (disc).
+                    let discReg = lirFresh(l)
+                    l.instrs.push(lirExtractValue(discReg, value.typ, value.value, [0]))
+                    value = LirOperand {typ: destType, value: discReg}
+                } else if value.typ.className == LirTypePtr && destType.className == LirTypeInt {
+                    let castName = lirFresh(l)
+                    l.instrs.push(lirCast(castName, "ptrtoint", value, destType))
+                    value = LirOperand {typ: destType, value: castName}
+                } else if value.typ.className == LirTypeInt && destType.className == LirTypePtr {
+                    let castName = lirFresh(l)
+                    l.instrs.push(lirCast(castName, "inttoptr", value, destType))
+                    value = LirOperand {typ: destType, value: castName}
+                } else {
+                    lirLowerError(l, LirDiagUnsupported, "assign coercion is not supported", "assign")
+                    return
+                }
+            } else {
+                let castName = lirFresh(l)
+                l.instrs.push(lirCast(castName, castOp, value, destType))
+                value = LirOperand {typ: destType, value: castName}
             }
-            let castName = lirFresh(l)
-            l.instrs.push(lirCast(castName, castOp, value, destType))
-            value = LirOperand {typ: destType, value: castName}
         }
     }
     let mut slot = lirMirLocalSlot(l, destLoc.id)

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3232,17 +3232,26 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let mut destType = lirLowerMirType(l, destLoc.typ)
     let hasProj = mirPlaceHasProjections(instr.dest)
-    if lirTypeIsZero(destType) && !hasProj {
+    if lirTypeIsZero(destType) {
         // R3 brick 12: dest local type 이 `<error>` literal (또는
         // unknown) 인 경우 i64 default 로 graceful fallback. brick 5
         // (lirLowerMirLocalsFrom) 가 같은 패턴으로 local alloca 단계
         // cover — assign 단계도 일관성 유지. Companion fallback chain:
         // local alloca → i64 (brick 5), assign dest → i64 (this brick).
         //
-        // R3 brick 14 (post `--emit=llvm-ir` measurement): projection
-        // path 에서 i64 fallback 시 `projection on non-aggregate type
-        // i64` wall trigger (51건). projection 은 aggregate 가 필요
-        // 하므로 unknown root type 일 때 fallback 적용 안 함.
+        // R3 brick 14: projection path 에서 i64 fallback 시
+        // `projection on non-aggregate type i64` wall trigger.
+        // projection 은 aggregate 가 필요하므로 별도 reject.
+        //
+        // R3 brick 16 (PR #1906 Copilot review feedback): brick 14 의
+        // silent fall-through 가 `lirStoreProjectedMirValue` 의 root
+        // aggregate check 에서 별도 declined message 발화 — confused
+        // diagnostic. 명시적 reject 로 caller 가 root cause 한 번에
+        // 식별. brick 5 의 i64 alloca 와의 mismatch 도 명시.
+        if hasProj {
+            lirLowerError(l, LirDiagUnsupported, "unsupported projected assign destination type `" + destLoc.typ + "` — projection requires concrete aggregate root (brick 5 alloca'd i64; recoverOperandType cover gap upstream)", "assign.dest.projected")
+            return
+        }
         destType = lirIntType(64)
     }
     if hasProj {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3231,15 +3231,21 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     let mut destType = lirLowerMirType(l, destLoc.typ)
-    if lirTypeIsZero(destType) {
+    let hasProj = mirPlaceHasProjections(instr.dest)
+    if lirTypeIsZero(destType) && !hasProj {
         // R3 brick 12: dest local type 이 `<error>` literal (또는
         // unknown) 인 경우 i64 default 로 graceful fallback. brick 5
         // (lirLowerMirLocalsFrom) 가 같은 패턴으로 local alloca 단계
         // cover — assign 단계도 일관성 유지. Companion fallback chain:
         // local alloca → i64 (brick 5), assign dest → i64 (this brick).
+        //
+        // R3 brick 14 (post `--emit=llvm-ir` measurement): projection
+        // path 에서 i64 fallback 시 `projection on non-aggregate type
+        // i64` wall trigger (51건). projection 은 aggregate 가 필요
+        // 하므로 unknown root type 일 때 fallback 적용 안 함.
         destType = lirIntType(64)
     }
-    if mirPlaceHasProjections(instr.dest) {
+    if hasProj {
         let leafTypeName = lirMirProjectionLeafType(instr.dest.projections)
         let leafType = lirLowerMirType(l, leafTypeName)
         let value = lirLowerMirRValue(l, instr.src, leafTypeName, leafType)


### PR DESCRIPTION
## Summary

R3 trajectory **brick 14 + 15** — graceful fallback chain 의 정확성 확장.

## Brick 14 — brick 12 projection bug fix

`brick 12` (`<error>` → i64 fallback) 가 projection path 의 51건 `projection.variant: non-aggregate i64` 트리거. `hasProj` guard 추가:

```osty
-    if lirTypeIsZero(destType) {
+    let hasProj = mirPlaceHasProjections(instr.dest)
+    if lirTypeIsZero(destType) && !hasProj {
         destType = lirIntType(64)
     }
```

## Brick 15 — assign coercion case-by-case cross-family fix

`brick 8` 시도 (broadest "skip" fallback) 가 SSA invariant 깼던 (`%t28 referenced before definition`) 위험. case-by-case correct LLVM IR emit:

```osty
} else {
    let castOp = lirPlanSameFamilyCoercionOpcode(...)
    if castOp == "" {
        if value.typ.className == LirTypeInt && destType.className == LirTypeAggregate {
            // i64 → Option/Result: Some/Ok wrap (disc=0, i64 payload)
            let merged = lirEmitAlgebraicI64(l, destType, 0, value.value, "assign.wrap")
            value = LirOperand {typ: destType, value: merged}
        } else if value.typ.className == LirTypeAggregate && destType.className == LirTypeInt {
            // Aggregate → i64: extractvalue [0] (disc)
            ...
        } else if value.typ.className == LirTypePtr && destType.className == LirTypeInt {
            // ptr → int: ptrtoint
            ...
        } else if value.typ.className == LirTypeInt && destType.className == LirTypePtr {
            // int → ptr: inttoptr
            ...
        } else {
            lirLowerError(...)
        }
    } else {
        ... 기존 cast path ...
    }
}
```

4 cross-family case (i64↔aggregate, i64↔ptr) cover. 각 branch 가 *correct* LLVM IR emit (SSA-valid).

## 검증

- ✓ `just osty-tests` — 129 passed (회귀 zero)
- ✓ `just prepush` 통과
- ⚠ toolchain build declined count 동일 (osty-self stage0 cover gap, brick 8-14 패턴)

## Chicken-and-egg note

brick 8-15 모두 osty-self runtime 미반영. graceful fallback infra 누적 — 외부 fix wave (PR #1898 패턴) 머지 후 활성화 기대.

R3 trajectory 의 multi-session brick wave 중 두 brick 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)