### PR TITLE
fix: lirLowerMirAssign cross-pkg void → aggregate zero-init cascade

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3275,6 +3275,33 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
             // Graceful fallback (R3 brick 4): unknown value type from
             // `<error>` propagation leak — treat as already typed by dest.
             value = LirOperand {typ: destType, value: value.value}
+        } else if lirTypeIsVoid(value.typ) {
+            // Cross-pkg call with unresolved signature: PR3-C/F's
+            // dispatch arm emits `declare void @<pkg>.<fn>()` when the
+            // consumer's checker env doesn't know the dep's signature.
+            // The call result reaches here as void; the dest local was
+            // resolved to a concrete consumer-side type (often aggregate
+            // because the source binding annotated it). No coercion
+            // exists for void → anything.
+            //
+            // Allocate + zero-init the slot rather than skipping
+            // outright: a reader of the slot gets a well-defined zero
+            // value (LLVM `store zeroinitializer`) instead of
+            // uninitialized garbage. Cross-pkg paths typically bind to
+            // a leading-`_` "unused" local (smoke-test convention), so
+            // the zero value isn't read; if a real consumer does read,
+            // the LLVM verifier accepts the store and the runtime
+            // observes a deterministic zero instead of undefined
+            // behavior. Real semantic correctness requires proper
+            // cross-pkg signature resolution (PR-G3+ trajectory).
+            let mut slot = lirMirLocalSlot(l, destLoc.id)
+            if slot.slot == "" {
+                slot = LirLocalSlot {id: destLoc.id, slot: lirMirLocalSlotName(destLoc.id), typ: destType}
+                l.slots.push(slot)
+                l.instrs.push(lirAlloca(slot.slot, slot.typ, 0))
+            }
+            l.instrs.push(lirStore(lirOperand(destType, "zeroinitializer"), slot.slot, 0))
+            return
         } else {
             let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, destType, lirPrimitiveTypeIsUnsigned(instr.src.typ))
             if castOp == "" {
@@ -3308,8 +3335,33 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
                     let castName = lirFresh(l)
                     l.instrs.push(lirCast(castName, "inttoptr", value, destType))
                     value = LirOperand {typ: destType, value: castName}
+                } else if lirTypeIsVoid(value.typ) {
+                    // Cross-pkg call with unresolved signature: PR3-C/F
+                    // dispatch arm emits `declare void @<pkg>.<fn>()`
+                    // when the consumer's checker env doesn't know the
+                    // dep's signature. Call result arrives as void;
+                    // dest local was resolved to a concrete consumer-
+                    // side type (often aggregate because the source
+                    // binding annotated it). No coercion exists for
+                    // void → anything. Allocate + zero-init the slot
+                    // rather than declining the whole function: a
+                    // reader gets a deterministic zero value (LLVM
+                    // `store zeroinitializer`) instead of an SSA-
+                    // invalid skip. Cross-pkg paths typically bind to
+                    // a leading-`_` "unused" smoke-test local so the
+                    // zero is unread. Real semantic correctness
+                    // requires proper cross-pkg signature resolution
+                    // (PR-G3+ trajectory).
+                    let mut voidSlot = lirMirLocalSlot(l, destLoc.id)
+                    if voidSlot.slot == "" {
+                        voidSlot = LirLocalSlot {id: destLoc.id, slot: lirMirLocalSlotName(destLoc.id), typ: destType}
+                        l.slots.push(voidSlot)
+                        l.instrs.push(lirAlloca(voidSlot.slot, voidSlot.typ, 0))
+                    }
+                    l.instrs.push(lirStore(lirOperand(destType, "zeroinitializer"), voidSlot.slot, 0))
+                    return
                 } else {
-                    lirLowerError(l, LirDiagUnsupported, "assign coercion is not supported", "assign")
+                    lirLowerError(l, LirDiagUnsupported, "assign coercion `" + value.typ.llvm + "` → `" + destType.llvm + "` is not supported", "assign")
                     return
                 }
             } else {


### PR DESCRIPTION
## Summary

PR3-C/F 의 narrow cross-package dispatch arm 이 method-call 을 resolve 하지만 consumer 의 checker env 가 dep signature 를 알지 못해 결과 type 이 \`<error>\` 로 leak. lir_proto subprocess 가 그 호출 결과를 \`void\` 로 받는 반면 dest local 은 consumer 의 source binding 이 annotate 한 concrete type (대개 aggregate) 으로 lowered. 기존 R3 brick 15 의 cross-family coercion ladder (Int↔Aggregate / Int↔Ptr) 는 void → anything 패턴은 cover 안 함 → 함수 전체 build 실패.

## 변경

[toolchain/lir_proto.osty](toolchain/lir_proto.osty) \`lirLowerMirAssign\` 의 cross-family coercion ladder 에 새 분기 추가:

- **value.typ == void**: dest slot allocate + \`store zeroinitializer\` emit. 함수 lower 진행, dest 는 well-defined zero 값 (LLVM verifier 통과, UB 없음). cross-pkg path 는 보통 leading-\`_\` "unused" smoke-test local 에 binding 하므로 zero 가 unread. proper cross-pkg signature resolution 은 별도 trajectory (PR-G3+).
- **진단 메시지 개선**: 기존 \`"assign coercion is not supported"\` → \`"assign coercion \`<from>\` → \`<dest>\` is not supported"\`. 미래 cascade 분류 / wall 디버깅 시 type 정보 즉시 표시.

## 영향

- **cmd/osty-native-checker production-path build UNBLOCK**: [PR-G1 (#1902)](https://github.com/choiceoh/osty/pull/1902) + [PR-G2 (#1905)](https://github.com/choiceoh/osty/pull/1905) + 본 PR 의 결합으로 build → link → 실행 가능한 76k 바이너리 생성. (semantic 은 incomplete — \`<error>\` cascade 의 다른 layer walls 가 일부 MIR insts skip 시켜 program 동작은 degraded; 추가 cross-pkg signature work 가 필요)
- **기존 코드 무영향**: 본 분기는 value.typ 이 void 일 때만 fire. R3 brick 15 의 cross-family ladder branches (Int↔Agg, Int↔Ptr) 는 unchanged.

## Test plan
- [x] \`osty build cmd/osty-native-checker\` end-to-end 성공 — 76k 바이너리 생성
- [x] 바이너리 실행 가능 (exit 1, no output — \`<error>\` cascade 의 일부 MIR skip 되지만 crash 안 함)
- [x] \`osty install-self\` 클린 빌드 통과
- [x] \`just osty-tests\` 33 tests passed (회귀 없음)
- [x] \`go test ./internal/mir/... -run TestLirProto\` 통과
- [x] \`just prepush\` 통과
- [ ] CI 그린 확인

## 후속 (PR-G3+)

본 PR 은 wall 1 개 해소 (assign void→aggregate). cmd/osty-native-checker 의 program semantics 완전 복구는:
1. Upstream cross-pkg signature resolution — dep signature 가 consumer env 에 leak 되도록 (cross-env / module-meta 확장)
2. \`<error>\` cascade 의 다른 layer walls 의 cascade fixes
3. 위 후 zero-init fall-through path 도 가능한 한 narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)