### PR TITLE
feat: projection i64 materialize cast (R3 brick 22, infra)

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -8076,6 +8076,39 @@ fn lirLowerMirOperand(l: LirMirFunctionLowerer, instrs: List<LirInstr>, op: MirO
                     current = LirOperand {typ: step.typ, value: current.value}
                     continue
                 }
+                // R3 brick 22 (PR #1909 review feedback follow-up):
+                // materialize cast path. current.typ.llvm == "i64" 인데
+                // step.typ != i64 인 경우 type-specific cast emit:
+                //   - LirTypePtr  → inttoptr (i64 → ptr)
+                //   - LirTypeInt (다른 width) → trunc (i64 → smaller)
+                //   - LirTypeAggregate → 별도 (lirEmitAlgebraicI64
+                //     이 path 에서 부적합; declined 유지)
+                // brick 21 의 restrict 가 type-compatible 만 cover 했고
+                // 본 brick 이 cast 가능한 추가 case 활성화.
+                if lirStringEq(current.typ.llvm, "i64") {
+                    if step.typ.className == LirTypePtr {
+                        let castName = lirFresh(l)
+                        instrs.push(lirCast(castName, "inttoptr", current, step.typ))
+                        current = LirOperand {typ: step.typ, value: castName}
+                        continue
+                    }
+                    if step.typ.className == LirTypeInt {
+                        let castName = lirFresh(l)
+                        instrs.push(lirCast(castName, "trunc", current, step.typ))
+                        current = LirOperand {typ: step.typ, value: castName}
+                        continue
+                    }
+                    if step.typ.className == LirTypeAggregate {
+                        // i64 → Option/Result aggregate: Some/Ok wrap
+                        // (disc=0 + i64 payload). lirEmitAlgebraicI64
+                        // 의 same path — assign coercion brick 15 cover.
+                        let merged = lirEmitAlgebraicI64(l, step.typ, 0, current.value, "projection.i64.wrap")
+                        if !lirStringEq(merged, "undef") {
+                            current = LirOperand {typ: step.typ, value: merged}
+                            continue
+                        }
+                    }
+                }
                 lirLowerError(l, LirDiagUnsupported, "projection on non-aggregate type `" + current.typ.llvm + "`", "projection." + mirProjectionKindName(proj.kind))
                 return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
             }


### PR DESCRIPTION
## Summary

R3 brick 22 — [PR #1909](https://github.com/choiceoh/osty/pull/1909) Copilot review feedback 의 두 번째 권장 path 구현. review 가 제안한 두 선택지 (restrict | materialize) 중 후자:

> Please either restrict this path to type-compatible `i64` projections [done in #1909] **or materialize a value with the projected LLVM type** [this PR].

## 추가된 cast cases

```osty
if lirStringEq(current.typ.llvm, "i64") {
    if step.typ.className == LirTypePtr {
        // i64 → ptr: inttoptr
        ...
    }
    if step.typ.className == LirTypeInt {
        // i64 → smaller int: trunc
        ...
    }
    if step.typ.className == LirTypeAggregate {
        // i64 → Option/Result: Some/Ok wrap (disc=0, i64 payload)
        // brick 15 의 lirEmitAlgebraicI64 path 와 일치
        ...
    }
}
```

각 cast 가 정확한 LLVM IR emit (type-specific).

## 검증

- ✓ `just osty-tests` — 129 passed (회귀 zero)
- ✓ `just prepush` 통과
- ✓ install-self 통과
- ⚠ toolchain --emit=llvm-ir declined: 50건 그대로 (brick 22 효과 0)

## Effect 0 의 의미

brick 22 의 새 cases 가 osty-self runtime 미반영 — stage0 cover gap (brick 8-15 동일 패턴). 단:
- osty-tests 회귀 zero
- graceful fallback infra 누적
- 외부 fix wave 또는 PR #1908 같은 cascade 머지 후 활성화 기대

## R3 multi-session brick wave 진척

| brick | effect |
|---|---|
| 17 (intrinsic.print) | -12 |
| 18 (projection empty) | -21 |
| (외부 PR #1908: assign coercion) | -263 |
| 20 (projection i64, restrict 후 21) | type-compatible 만 |
| 21 (review restrict) | safety |
| **22 (materialize cast)** | **infra (effect 0)** |

graceful fallback infra 가 누적 — 다음 외부 stage0 cover wave 머지 시 활성화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)