### PR TITLE
fix: 4 intrinsic dest checks recognize `T?` sugar form

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -5734,7 +5734,7 @@ fn lirLowerMirMapGet(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "map.get destination local out of range", "map.get")
         return
     }
-    if !(lirIsOptionTypeName(loc.typ)) {
+    if !(lirIsOptionTypeName(loc.typ) || lirStringHasQuestionSuffix(loc.typ)) {
         lirLowerError(l, LirDiagUnsupported, "map.get destination must be Option<V>, got `" + loc.typ + "`", "map.get")
         return
     }
@@ -5816,7 +5816,7 @@ fn lirLowerMirListFirstOrLast(l: LirMirFunctionLowerer, instr: MirInstr, isLast:
         lirLowerError(l, LirDiagInvalidInput, label + " destination local out of range", label)
         return
     }
-    if !(lirIsOptionTypeName(loc.typ)) {
+    if !(lirIsOptionTypeName(loc.typ) || lirStringHasQuestionSuffix(loc.typ)) {
         lirLowerError(l, LirDiagUnsupported, label + " destination must be Option<T>, got `" + loc.typ + "`", label)
         return
     }
@@ -5922,7 +5922,7 @@ fn lirLowerMirListPop(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "list.pop destination local out of range", "list.pop")
         return
     }
-    if !(lirIsOptionTypeName(loc.typ)) {
+    if !(lirIsOptionTypeName(loc.typ) || lirStringHasQuestionSuffix(loc.typ)) {
         lirLowerError(l, LirDiagUnsupported, "list.pop destination must be Option<T>, got `" + loc.typ + "`", "list.pop")
         return
     }
@@ -6010,7 +6010,7 @@ fn lirLowerMirBytesGet(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "bytes.get destination local out of range", "bytes.get")
         return
     }
-    if !(lirIsOptionTypeName(loc.typ)) {
+    if !(lirIsOptionTypeName(loc.typ) || lirStringHasQuestionSuffix(loc.typ)) {
         lirLowerError(l, LirDiagUnsupported, "bytes.get destination must be Option<Byte>, got `" + loc.typ + "`", "bytes.get")
         return
     }


### PR DESCRIPTION
## Summary

\`lirLowerMirMapGet\` / \`lirLowerMirListFirstOrLast\` / \`lirLowerMirListPop\` / \`lirLowerMirBytesGet\` 의 dest local 타입 체크가 \`lirIsOptionTypeName(loc.typ)\` 만 사용 — explicit \`Option<T>\` 형태만 인식하고 \`T?\` sugar 는 wall 로 거부. [PR #1898](https://github.com/choiceoh/osty/pull/1898) 의 indexOf-sugar 픽스와 같은 패턴.

## 변경

4 sites 각각:
- [toolchain/lir_proto.osty:5737](toolchain/lir_proto.osty:5737) — map.get
- [toolchain/lir_proto.osty:5819](toolchain/lir_proto.osty:5819) — list.first / list.last (label-based)
- [toolchain/lir_proto.osty:5925](toolchain/lir_proto.osty:5925) — list.pop
- [toolchain/lir_proto.osty:6013](toolchain/lir_proto.osty:6013) — bytes.get

각 사이트의 체크 한 줄 변경:
```diff
- if !(lirIsOptionTypeName(loc.typ)) {
+ if !(lirIsOptionTypeName(loc.typ) || lirStringHasQuestionSuffix(loc.typ)) {
```

## 영향

- \`T?\` sugar 로 typed dest 에 위 4 intrinsic 호출 시 발생하던 wall 4종 해소
- 기존 explicit \`Option<T>\` 호출은 무영향 (첫 arm 매치)
- 다운스트림 lowering 은 기존 \`lirCanonicalizeOptionalSugar\` 가 \`T?\` → \`Option<T>\` 정규화해 줘서 변경 불필요

## Test plan
- [x] \`osty install-self --force\` 클린 빌드 통과
- [x] \`just osty-tests\` 33 tests passed (회귀 없음)
- [x] \`go test ./internal/mir/... -run TestLirProto\` 통과
- [x] \`just prepush\` 통과
- [ ] CI 그린 확인

## 후속

이 PR 은 build-time wall 4종을 좁힘. 일부 다운스트림 코드 (예: \`list.first()\` 의 Option 결과를 i64 로 collapse 하는 케이스) 는 별 layer 의 이슈 (upstream type-leak + brick 17/18 graceful fallback + [PR #1908](https://github.com/choiceoh/osty/pull/1908) void cascade 누적) — 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)