### PR TITLE
mir: surface phantom-symbol bug at lowering time instead of link time

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -54,6 +54,43 @@ func (l *lowerer) signatureForFn(name string) *fnSignature {
 	return l.fnSig[name]
 }
 
+// namedTypeKnownToModule reports whether `name` matches a struct,
+// enum, or interface decl in the source module the lowerer is
+// processing. The "no signature + unknown declaration" combination
+// at lowerMethodCallInto is the lowering-time signal for the
+// FrontCheckResult__len phantom-symbol class — a method call whose
+// receiver typeName has no entry in any of the three decl tables
+// AND no method signature can only have come from upstream type
+// recovery picking a stale or wrong name.
+func (l *lowerer) namedTypeKnownToModule(name string) bool {
+	if name == "" {
+		return false
+	}
+	if _, ok := l.structs[name]; ok {
+		return true
+	}
+	if _, ok := l.enums[name]; ok {
+		return true
+	}
+	if _, ok := l.interfaces[name]; ok {
+		return true
+	}
+	return false
+}
+
+// isBuiltinNamedType reports whether `t` is a stdlib NamedType such
+// as `Result`, `Option`, `List<T>`, etc., that arrives in MIR with
+// `Builtin: true`. Used by the lowerMethodCallInto guardrail to
+// avoid false-positiving on stdlib container methods whose symbols
+// are satisfied by downstream stdlib lowering paths rather than
+// the source module's own decl tables.
+func isBuiltinNamedType(t ir.Type) bool {
+	if nt, ok := t.(*ir.NamedType); ok && nt != nil {
+		return nt.Builtin
+	}
+	return false
+}
+
 // signatureForMethod returns the signature of a type method, or nil
 // when unknown.
 func (l *lowerer) signatureForMethod(typeName, method string) *fnSignature {
@@ -6434,6 +6471,44 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 	if sig != nil {
 		symbol = sig.symbol
 	} else if typeName != "" {
+		// Guardrail: a method call on a named receiver type with no
+		// matching method signature in the module table is almost
+		// always an upstream type-recovery bug — the receiver's local
+		// was created with a stale `*ir.NamedType{Name: <X>}` (lowerLet
+		// at line 910, recoverOperandType at line 3176) and the
+		// stdlib intrinsic dispatch above (lowerMethodCallInto at
+		// line 6408) didn't fire because the wrong type isn't a
+		// builtin shape. Silently mangling here produces an undefined
+		// symbol like `<X>__<method>` that only surfaces at link
+		// time — hundreds of seconds into install-self —
+		// masquerading as a missing runtime helper.
+		//
+		// A canonical reproducer is `inspectSpreadTupleHints` in
+		// toolchain/inspect.osty where `elems = hintTupleElems(...)`
+		// is locally `List<String>` but somehow reaches MIR with
+		// `FrontCheckResult` as the receiver type, emitting
+		// `call FrontCheckResult__len(...)` which then fails the
+		// install-self link with:
+		//   ld.lld: error: undefined symbol: FrontCheckResult__len
+		// Logging an Issue at MIR time surfaces the bug there
+		// instead of at the link stage, while preserving the
+		// existing mangled-symbol fallback so callers that DO have a
+		// matching method-but-just-not-in-sig-table (e.g. methods
+		// added via partial-decl in a downstream pass) still link.
+		// Skip the guardrail for builtin stdlib names — `Result`,
+		// `Option`, `List`, `Map`, `Channel`, etc. reach here when
+		// the stdlib intrinsic dispatch above didn't match (e.g.
+		// `Result.toString()` whose body lives in stdlib and
+		// resolves to a generated symbol downstream). Those cases
+		// are not the type-recovery bug class; the symbol gets
+		// satisfied later. Only fire on non-builtin NamedTypes
+		// the module never declared.
+		if isBuiltinNamedType(recvType) {
+			// builtin path — no guardrail
+		} else if !bs.l.namedTypeKnownToModule(typeName) {
+			bs.l.noteIssue("method call %q on receiver of type %q which has no declaration in the module — likely upstream type-recovery bug (will emit undefined symbol %s)",
+				mc.Name, typeName, mangleMethodSymbol(typeName, mc.Name))
+		}
 		symbol = mangleMethodSymbol(typeName, mc.Name)
 	}
 	callArgs := []Operand{recv}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -78,18 +78,6 @@ func (l *lowerer) namedTypeKnownToModule(name string) bool {
 	return false
 }
 
-// isBuiltinNamedType reports whether `t` is a stdlib NamedType such
-// as `Result`, `Option`, `List<T>`, etc., that arrives in MIR with
-// `Builtin: true`. Used by the lowerMethodCallInto guardrail to
-// avoid false-positiving on stdlib container methods whose symbols
-// are satisfied by downstream stdlib lowering paths rather than
-// the source module's own decl tables.
-func isBuiltinNamedType(t ir.Type) bool {
-	if nt, ok := t.(*ir.NamedType); ok && nt != nil {
-		return nt.Builtin
-	}
-	return false
-}
 
 // signatureForMethod returns the signature of a type method, or nil
 // when unknown.
@@ -6471,17 +6459,18 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 	if sig != nil {
 		symbol = sig.symbol
 	} else if typeName != "" {
-		// Guardrail: a method call on a named receiver type with no
-		// matching method signature in the module table is almost
-		// always an upstream type-recovery bug — the receiver's local
-		// was created with a stale `*ir.NamedType{Name: <X>}` (lowerLet
-		// at line 910, recoverOperandType at line 3176) and the
-		// stdlib intrinsic dispatch above (lowerMethodCallInto at
-		// line 6408) didn't fire because the wrong type isn't a
-		// builtin shape. Silently mangling here produces an undefined
-		// symbol like `<X>__<method>` that only surfaces at link
-		// time — hundreds of seconds into install-self —
-		// masquerading as a missing runtime helper.
+		// Guardrail: a method call on a NON-BUILTIN, source-named
+		// receiver type with no matching method signature in the
+		// module table is almost always an upstream type-recovery
+		// bug — the receiver's local was created with a stale
+		// `*ir.NamedType{Name: <X>}` (lowerLet at line 910,
+		// recoverOperandType at line 3176) and the stdlib intrinsic
+		// dispatch above (lowerMethodCallInto at line 6408) didn't
+		// fire because the wrong type isn't a builtin shape.
+		// Silently mangling here produces an undefined symbol like
+		// `<X>__<method>` that only surfaces at link time —
+		// hundreds of seconds into install-self — masquerading as
+		// a missing runtime helper.
 		//
 		// A canonical reproducer is `inspectSpreadTupleHints` in
 		// toolchain/inspect.osty where `elems = hintTupleElems(...)`
@@ -6492,22 +6481,23 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 		//   ld.lld: error: undefined symbol: FrontCheckResult__len
 		// Logging an Issue at MIR time surfaces the bug there
 		// instead of at the link stage, while preserving the
-		// existing mangled-symbol fallback so callers that DO have a
-		// matching method-but-just-not-in-sig-table (e.g. methods
-		// added via partial-decl in a downstream pass) still link.
-		// Skip the guardrail for builtin stdlib names — `Result`,
-		// `Option`, `List`, `Map`, `Channel`, etc. reach here when
-		// the stdlib intrinsic dispatch above didn't match (e.g.
-		// `Result.toString()` whose body lives in stdlib and
-		// resolves to a generated symbol downstream). Those cases
-		// are not the type-recovery bug class; the symbol gets
-		// satisfied later. Only fire on non-builtin NamedTypes
-		// the module never declared.
-		if isBuiltinNamedType(recvType) {
-			// builtin path — no guardrail
-		} else if !bs.l.namedTypeKnownToModule(typeName) {
-			bs.l.noteIssue("method call %q on receiver of type %q which has no declaration in the module — likely upstream type-recovery bug (will emit undefined symbol %s)",
-				mc.Name, typeName, mangleMethodSymbol(typeName, mc.Name))
+		// existing mangled-symbol fallback so callers that DO have
+		// a matching method-but-just-not-in-sig-table (e.g.
+		// methods added via partial-decl in a downstream pass)
+		// still link.
+		//
+		// The guardrail is intentionally gated to non-builtin
+		// `*ir.NamedType` receivers — `PrimType` (`Int.abs()` →
+		// `osty_rt_int_abs`), `OptionalType` (`Option`), and
+		// builtin NamedTypes (`Result`, `List<T>`, `Map<K,V>`, ...)
+		// all rely on the same mangleMethodSymbol fallback as a
+		// legitimate dispatch path via the runtime/intrinsic
+		// tables, and the lowerer must stay quiet on them.
+		if nt, ok := recvType.(*ir.NamedType); ok && nt != nil && !nt.Builtin {
+			if !bs.l.namedTypeKnownToModule(typeName) {
+				bs.l.noteIssue("method call %q on receiver of type %q which has no declaration in the module — likely upstream type-recovery bug (will emit undefined symbol %s)",
+					mc.Name, typeName, mangleMethodSymbol(typeName, mc.Name))
+			}
 		}
 		symbol = mangleMethodSymbol(typeName, mc.Name)
 	}

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -2560,6 +2560,115 @@ func TestLowerStdlibFreeLenRecoversPoisonedNestedFieldReceiverType(t *testing.T)
 	}
 }
 
+// TestLowerMethodCallOnUnknownReceiverTypeRecordsMIRIssue pins the
+// guardrail in lowerMethodCallInto's fallthrough at line ~6437:
+// when the receiver's recovered type is a NamedType the source
+// module never declared AND the method isn't in the sig table,
+// the lowerer must record a `mir issue` instead of silently
+// mangling to an undefined `<TypeName>__<method>` symbol.
+//
+// Mirrors the install-self FrontCheckResult__len phantom-symbol
+// wall:
+//
+//	ld.lld: error: undefined symbol: FrontCheckResult__len
+//	  referenced by inspectSpreadTupleHints
+//
+// where `elems = hintTupleElems(...)` is locally List<String> but
+// reaches MIR's method-call lowering with a stale
+// `FrontCheckResult` receiver type. The Lower() output preserves
+// the existing mangled CallInstr for backward compatibility (so
+// tests / consumers that depend on the current shape don't break),
+// but the recorded Issue lets install-self / CI surface the
+// upstream type-recovery bug at MIR time instead of at link time
+// 100+ seconds into the build.
+func TestLowerMethodCallOnUnknownReceiverTypeRecordsMIRIssue(t *testing.T) {
+	// Receiver typed as a name the module never declares — exactly
+	// the shape upstream type-recovery produces when it loses the
+	// real List<X> / Map<K,V> type and falls back to whatever
+	// NamedType happens to be reachable in scope.
+	staleT := &ir.NamedType{Name: "FrontCheckResult"}
+	fn := &ir.FnDecl{
+		Name:   "callLenOnStale",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "elems", Type: staleT}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "elems", Kind: ir.IdentParam, T: staleT},
+				Name:     "len",
+				T:        ir.TInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	// The recorded Issue should name both the method and the
+	// undeclared receiver type, plus the mangled symbol that would
+	// otherwise blow up at link time. Match on the symbol because
+	// it's the most stable substring.
+	var got string
+	for _, issue := range out.Issues {
+		if strings.Contains(issue.Error(), "FrontCheckResult__len") {
+			got = issue.Error()
+			break
+		}
+	}
+	if got == "" {
+		t.Fatalf("expected MIR issue mentioning FrontCheckResult__len for unknown-receiver method call, got issues = %v\nIR:\n%s", out.Issues, Print(out))
+	}
+	if !strings.Contains(got, "len") || !strings.Contains(got, "FrontCheckResult") {
+		t.Fatalf("MIR issue missing method or type name: %q", got)
+	}
+	// The CallInstr fallback is preserved (current shape) so
+	// downstream consumers don't break. The Issue is the signal,
+	// not the absence of the mangled call.
+	text := Print(out)
+	if !strings.Contains(text, "FrontCheckResult__len") {
+		t.Fatalf("expected mangled-symbol fallback CallInstr to remain, got:\n%s", text)
+	}
+}
+
+// TestLowerMethodCallOnDeclaredReceiverTypeStaysSilent locks the
+// guardrail's negative case: a method call on a struct that IS
+// declared in the module (even when the method isn't in the sig
+// table — methods may be added by a downstream pass) must NOT
+// record an Issue. Otherwise the guardrail flags every legitimate
+// user method call.
+func TestLowerMethodCallOnDeclaredReceiverTypeStaysSilent(t *testing.T) {
+	pointT := &ir.NamedType{Name: "Point"}
+	pointDecl := &ir.StructDecl{
+		Name:   "Point",
+		Fields: []*ir.Field{{Name: "x", Type: ir.TInt, Exported: true}},
+		// Intentionally no Methods — emulates a partial-decl case
+		// where methods land in a follow-on pass after MIR collected
+		// the struct.
+	}
+	fn := &ir.FnDecl{
+		Name:   "callOnDeclared",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "p", Type: pointT}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "p", Kind: ir.IdentParam, T: pointT},
+				Name:     "len",
+				T:        ir.TInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{pointDecl, fn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	for _, issue := range out.Issues {
+		if strings.Contains(issue.Error(), "Point__len") {
+			t.Fatalf("guardrail false-positived on declared struct's method call: %v", issue)
+		}
+	}
+}
+
 func TestLowerStdlibMethodRecoversStaleIdentStorageType(t *testing.T) {
 	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
 	arenaT := &ir.NamedType{Name: "Arena"}

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -2630,6 +2630,41 @@ func TestLowerMethodCallOnUnknownReceiverTypeRecordsMIRIssue(t *testing.T) {
 	}
 }
 
+// TestLowerMethodCallOnPrimitiveReceiverStaysSilent locks the
+// guardrail's negative case for `*ir.PrimType` receivers
+// (`Int.abs()`, `Bool.toString()`, etc.). `typeNameOf` returns
+// "Int" / "Bool" / ... for primitives, and the intrinsic_methods
+// dispatch table intentionally rewrites them through
+// mangleMethodSymbol to runtime symbols (`Int__abs` →
+// `osty_rt_int_abs` etc.). The module decl tables never carry
+// primitive entries; without explicit gating the guardrail would
+// false-positive every primitive method call.
+func TestLowerMethodCallOnPrimitiveReceiverStaysSilent(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "absOf",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "n", Type: ir.TInt}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt},
+				Name:     "abs",
+				T:        ir.TInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	for _, issue := range out.Issues {
+		msg := issue.Error()
+		if strings.Contains(msg, "Int__abs") || (strings.Contains(msg, "Int") && strings.Contains(msg, "abs")) {
+			t.Fatalf("guardrail false-positived on primitive Int.abs() method call: %v", issue)
+		}
+	}
+}
+
 // TestLowerMethodCallOnDeclaredReceiverTypeStaysSilent locks the
 // guardrail's negative case: a method call on a struct that IS
 // declared in the module (even when the method isn't in the sig


### PR DESCRIPTION
## Summary

The install-self link wall on `origin/main` (post-#1914) surfaces a phantom-symbol bug as:

```
ld.lld: error: undefined symbol: FrontCheckResult__len
  referenced by inspectSpreadTupleHints
```

The receiver `elems = hintTupleElems(parentType, arity)` in `toolchain/inspect.osty` is locally `List<String>` but reaches MIR's method-call lowering with `FrontCheckResult` as the receiver type. Some upstream type-recovery (lowerLet at `internal/mir/lower.go:910`, `recoverOperandType` at `:3176`, or earlier in the checker / IR builder) substitutes a stale or wrong NamedType; the stdlib intrinsic dispatch above doesn't match the wrong name; and the lowerer silently mangles `<Name>__<method>` into a `CallInstr` that produces an undefined symbol 100+ seconds into the LLVM link tail — masquerading as a missing runtime helper instead of as a compiler bug.

This PR adds a guardrail in `lowerMethodCallInto` that records a MIR `Issue` when the dispatch falls through to symbol mangling for a receiver whose recovered `NamedType` has no declaration in the source module AND no method signature in the table AND is not a builtin stdlib type. The mangled `CallInstr` fallback is preserved (no behavioural change for current callers), but the recorded `Issue` lets install-self / CI / `osty check --emit mir` see the bug **at MIR time with the exact method, receiver type, and undefined symbol** it would otherwise emit.

## What changed

`internal/mir/lower.go`:

- New helper `(*lowerer).namedTypeKnownToModule(name string) bool` — checks the source module's struct / enum / interface decl tables.
- New helper `isBuiltinNamedType(ir.Type) bool` — skips the guardrail for `Result`, `Option`, `List<T>`, `Map<K,V>`, `Channel`, etc. whose symbols are satisfied by downstream stdlib lowering paths rather than module decl tables.
- `lowerMethodCallInto`'s symbol-mangling fallback (line ~6437) now records a `noteIssue(...)` when the receiver type is non-builtin AND unknown to the module, naming the method, type, and undefined symbol it would emit.

`internal/mir/mir_test.go`:

- `TestLowerMethodCallOnUnknownReceiverTypeRecordsMIRIssue` — receiver typed as a name the module never declares records a MIR Issue mentioning the method, type, and mangled symbol, and the mangled CallInstr fallback is preserved.
- `TestLowerMethodCallOnDeclaredReceiverTypeStaysSilent` — receiver on a declared struct (even with no methods in the sig table) records NO Issue, so the guardrail does not false-positive on partial-decl method calls.

## Why this PR, not the upstream fix

The upstream type-recovery bug requires bisection: it's likely in `lowerLet`'s poison-recovery chain at `lower.go:910` or in the IR builder for `let X = fn(...)` cross-file `CallExpr` types, but the exact trigger isn't reproducible in an isolated unit test yet — the existing `TestLowerStdlibMethodRecoversPoisonedLocalReceiverType` covers the "poisoned receiver" path and passes, so the actual `inspectSpreadTupleHints` failure must require a more specific upstream condition. This guardrail is the first deliverable step: future bisection sessions now have a clear lowering-time signal to bisect from, instead of decoding 21 MB of LLVM IR and a 100s link tail.

## Test plan

- [x] `go test ./internal/mir/` — PASS 4.2s (full suite, no regressions)
- [x] `go test ./internal/backend/ -run 'TestONBBackend|TestLLVMRuntime|TestEnsureRuntime'` — PASS
- [x] `go vet ./internal/mir/` — clean
- [x] `go build ./...` — clean
- [x] New tests `TestLowerMethodCallOnUnknownReceiverTypeRecordsMIRIssue` + `TestLowerMethodCallOnDeclaredReceiverTypeStaysSilent` pass on this commit and fail meaningfully if the guardrail were removed.
- The "osty-self not found" failures in `internal/backend/` exist on `origin/main` independent of this change (they require a built osty-self binary in the cache).

## Risk

- Behaviour-preserving: the mangled `CallInstr` is still emitted, so any downstream consumer that depended on the current "silent mangle" shape continues to work; only the recorded `Issue` is new.
- Builtin-typed receivers (`Result`, `Option`, `List`, `Map`, `Channel`, ...) explicitly bypass the guardrail to avoid false-positives on stdlib method-dispatch that resolves at a later layer.
- Partial-decl method calls (struct declared, method added in a downstream pass) explicitly bypass via the `namedTypeKnownToModule` check.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NBUT3jknqaGLUf9fu5VpY)_