### PR TITLE
mir: env-gated method-call dispatch trace for FrontCheckResult__len bisection

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -86,12 +86,14 @@ func methodCallTraceEnabled() bool {
 
 // traceMethodCallDispatch records the arm a `lowerMethodCallInto`
 // call took. `recvType` is the type the lowerer recovered for the
-// receiver (post `recoveredTypeOf`), printed via `ir.PrintType` so
-// even poisoned / `*ir.NamedType` / `*ir.PrimType` shapes are
-// legible. `arm` is a short label naming which dispatch branch
-// fired; `symbol` is the symbol the emitted CallInstr or
-// IntrinsicInstr targets — for the mangled fallback that's the
-// `<TypeName>__<method>` form the bisection cares about most.
+// receiver (post `recoveredTypeOf`), printed via `formatTraceType`
+// (which delegates to `ir.Type.String()` plus explicit `<nil>` /
+// `<error>` placeholders) so even poisoned / `*ir.NamedType` /
+// `*ir.PrimType` shapes are legible. `arm` is a short label
+// naming which dispatch branch fired; `symbol` is the symbol the
+// emitted CallInstr or IntrinsicInstr targets — for the mangled
+// fallback that's the `<TypeName>__<method>` form the bisection
+// cares about most.
 func traceMethodCallDispatch(method, arm, symbol string, recvType ir.Type) {
 	if !methodCallTraceEnabled() {
 		return

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2,6 +2,8 @@ package mir
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 	"strings"
 
@@ -52,6 +54,66 @@ type fnSignature struct {
 // name, or nil if not known.
 func (l *lowerer) signatureForFn(name string) *fnSignature {
 	return l.fnSig[name]
+}
+
+// ==== method-call trace (env-gated diagnostic) ====
+//
+// `OSTY_MIR_TRACE_METHOD_CALLS=1` enables a per-`MethodCall`
+// dump that prints which dispatch arm `lowerMethodCallInto` took
+// (intrinsic / qualified-use / mangled fallback / …) along with
+// the receiver type the lowerer recovered. Used as the bisection
+// tool for the FrontCheckResult__len phantom-symbol class — when
+// the install-self link surfaces `<TypeName>__<method>` as an
+// undefined symbol, this trace makes it possible to see which
+// `recvType` the lowerer believed the receiver had at that
+// dispatch site.
+//
+// Output goes to `methodCallTraceWriter`, which defaults to
+// `os.Stderr` and is overridable from package tests so the
+// negative case (env unset → no output) and the field shape can
+// be asserted without parsing real stderr.
+
+var methodCallTraceWriter io.Writer = os.Stderr
+
+func methodCallTraceEnabled() bool {
+	switch os.Getenv("OSTY_MIR_TRACE_METHOD_CALLS") {
+	case "", "0", "false", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// traceMethodCallDispatch records the arm a `lowerMethodCallInto`
+// call took. `recvType` is the type the lowerer recovered for the
+// receiver (post `recoveredTypeOf`), printed via `ir.PrintType` so
+// even poisoned / `*ir.NamedType` / `*ir.PrimType` shapes are
+// legible. `arm` is a short label naming which dispatch branch
+// fired; `symbol` is the symbol the emitted CallInstr or
+// IntrinsicInstr targets — for the mangled fallback that's the
+// `<TypeName>__<method>` form the bisection cares about most.
+func traceMethodCallDispatch(method, arm, symbol string, recvType ir.Type) {
+	if !methodCallTraceEnabled() {
+		return
+	}
+	fmt.Fprintf(methodCallTraceWriter,
+		"mir method-call: method=%q arm=%s symbol=%q recvType=%s\n",
+		method, arm, symbol, formatTraceType(recvType),
+	)
+}
+
+// formatTraceType renders a type for the method-call trace dump.
+// `<nil>` and `<error>` get explicit placeholders so the bisection
+// can spot upstream type-recovery gaps; every other shape
+// delegates to the `ir.Type.String()` method.
+func formatTraceType(t ir.Type) string {
+	if t == nil {
+		return "<nil>"
+	}
+	if isPoisonType(t) {
+		return "<error>"
+	}
+	return t.String()
 }
 
 // signatureForMethod returns the signature of a type method, or nil
@@ -6431,11 +6493,23 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 	typeName := typeNameOf(recvType)
 	sig := bs.l.signatureForMethod(typeName, mc.Name)
 	symbol := mc.Name
+	arm := "method-bare-name"
 	if sig != nil {
 		symbol = sig.symbol
+		arm = "method-sig-found"
 	} else if typeName != "" {
 		symbol = mangleMethodSymbol(typeName, mc.Name)
+		arm = "method-mangled-fallback"
 	}
+	// Trace point: this dispatch site is where the
+	// FrontCheckResult__len phantom-symbol class surfaces — when
+	// `recvType` is a wrong/stale `*ir.NamedType` planted by upstream
+	// type-recovery, the lowerer correctly mangles to `<Name>__<method>`
+	// based on what it was told, and the undefined symbol only shows
+	// up at link time. The env-gated trace prints what `recvType`,
+	// `typeName`, and `symbol` were so bisection can compare against
+	// the source's expected receiver type.
+	traceMethodCallDispatch(mc.Name, arm, symbol, recvType)
 	callArgs := []Operand{recv}
 	var rest []Operand
 	if sig != nil {

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -1,6 +1,7 @@
 package mir
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -694,6 +695,89 @@ func TestLowerMethodCall(t *testing.T) {
 	// Ensure no MethodCall sugar survives.
 	if strings.Contains(text, "MethodCall") {
 		t.Fatalf("HIR MethodCall leaked:\n%s", text)
+	}
+}
+
+// TestLowerMethodCallTraceDefaultSilent locks the off-by-default
+// behaviour of the OSTY_MIR_TRACE_METHOD_CALLS env-gated diagnostic:
+// without the env var set the trace writes nothing, so production
+// `osty build` / `osty check` runs do not get extra stderr noise.
+func TestLowerMethodCallTraceDefaultSilent(t *testing.T) {
+	prev := methodCallTraceWriter
+	defer func() { methodCallTraceWriter = prev }()
+	var buf bytes.Buffer
+	methodCallTraceWriter = &buf
+
+	t.Setenv("OSTY_MIR_TRACE_METHOD_CALLS", "")
+
+	pointT := &ir.NamedType{Name: "Point"}
+	pointDecl := &ir.StructDecl{
+		Name:    "Point",
+		Fields:  []*ir.Field{{Name: "x", Type: ir.TInt, Exported: true}},
+		Methods: []*ir.FnDecl{{Name: "get", Return: ir.TInt, Params: []*ir.Param{{Name: "self", Type: pointT}}, Body: &ir.Block{Result: &ir.Ident{Name: "self", T: pointT}}}},
+	}
+	fn := &ir.FnDecl{
+		Name:   "callGet",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "p", Type: pointT}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "p", Kind: ir.IdentParam, T: pointT},
+				Name:     "get",
+				T:        ir.TInt,
+			},
+		},
+	}
+	Lower(&ir.Module{Package: "main", Decls: []ir.Decl{pointDecl, fn}})
+	if buf.Len() != 0 {
+		t.Fatalf("trace writer received output despite env var off: %q", buf.String())
+	}
+}
+
+// TestLowerMethodCallTraceEnabledEmitsFields exercises the trace's
+// happy path: when OSTY_MIR_TRACE_METHOD_CALLS is set the lowerer
+// emits one line per `MethodCall` dispatch carrying the method name,
+// the dispatch arm, the output symbol, and the recovered receiver
+// type. Used as the bisection tool for the FrontCheckResult__len
+// phantom-symbol class — the receiver-type field is what makes the
+// upstream type-recovery gap visible without parsing the resulting
+// LLVM IR.
+func TestLowerMethodCallTraceEnabledEmitsFields(t *testing.T) {
+	prev := methodCallTraceWriter
+	defer func() { methodCallTraceWriter = prev }()
+	var buf bytes.Buffer
+	methodCallTraceWriter = &buf
+
+	t.Setenv("OSTY_MIR_TRACE_METHOD_CALLS", "1")
+
+	// Receiver typed as a name the module never declares — mirrors
+	// the FrontCheckResult__len shape upstream type-recovery
+	// produces when a List<X> receiver gets a stale `*ir.NamedType`.
+	staleT := &ir.NamedType{Name: "Stale"}
+	fn := &ir.FnDecl{
+		Name:   "callLenOnStale",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "xs", Type: staleT}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: staleT},
+				Name:     "len",
+				T:        ir.TInt,
+			},
+		},
+	}
+	Lower(&ir.Module{Package: "main", Decls: []ir.Decl{fn}})
+
+	got := buf.String()
+	for _, want := range []string{
+		`method="len"`,
+		`arm=method-mangled-fallback`,
+		`symbol="Stale__len"`,
+		`recvType=Stale`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("trace missing field %q\nfull output:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds an env-gated diagnostic trace in `lowerMethodCallInto` (`internal/mir/lower.go`) for bisecting the `FrontCheckResult__len` phantom-symbol class without changing lowering behaviour. Replaces the rejected guardrail attempt from #1915 (closed without merging).

## What the trace prints

When `OSTY_MIR_TRACE_METHOD_CALLS=1` is set, one line per `MethodCall` dispatch lands on stderr (or a configurable writer):

```
mir method-call: method="len" arm=method-mangled-fallback symbol="FrontCheckResult__len" recvType=FrontCheckResult
```

Fields:
- `method` — `mc.Name`
- `arm` — which dispatch branch fired: `method-sig-found` (real signature in the table), `method-mangled-fallback` (the bug-prone path), or `method-bare-name`
- `symbol` — the symbol the emitted `CallInstr` targets — for the mangled fallback that's the `<TypeName>__<method>` form
- `recvType` — the receiver type the lowerer recovered post-`recoveredTypeOf`, rendered via `ir.Type.String()` with explicit `<nil>` / `<error>` placeholders so upstream type-recovery gaps stay visible

## Motivation

The install-self link wall on `origin/main` surfaces the bug as:

```
ld.lld: error: undefined symbol: FrontCheckResult__len
  referenced by inspectSpreadTupleHints
```

The receiver `elems = hintTupleElems(...)` in `toolchain/inspect.osty` is locally `List<String>` but reaches MIR's method-call lowering with `FrontCheckResult` as the receiver type. The lowerer correctly mangles `<TypeName>__<method>` based on what it was told, so the bug is **upstream** — in IR builder / checker / `lowerLet`'s poison-recovery chain at `lower.go:910` or `recoverOperandType` at `:3176`.

Without per-call visibility into what `recvType` the lowerer believed the receiver had, the bisection requires decoding 21+ MB of LLVM IR and a 100+ second link tail. With this trace, one `OSTY_MIR_TRACE_METHOD_CALLS=1 osty build toolchain/` run lists every dispatch site's recovered type — the receiver-type field is the bisection's leverage.

## Why not #1915's guardrail

#1915 tried to surface the bug at MIR time via a `noteIssue` guardrail when the receiver type wasn't declared in the module decl tables. Analysis after Codex's P1 review showed:

1. **Doesn't catch the actual bug** — at the package-aware lowering install-self uses (`PreparePackage` → merged module), `FrontCheckResult` IS declared in the merged toolchain/ module (`toolchain/check.osty:195`); the guardrail would not have fired.
2. **False-positive risk** — at the single-file `PrepareEntry` path, the guardrail can't distinguish phantom symbols from legitimate cross-file method calls (`let p: Point = ...; p.foo()` where `Point` lives in a sibling file of the same package).

This PR replaces that approach with a pure-diagnostic tool that never changes lowering behaviour or adds production stderr noise.

## Test plan

- [x] `go test ./internal/mir/` — PASS 4.2s (full suite, no regressions)
- [x] New tests pass:
  - `TestLowerMethodCallTraceDefaultSilent` — env var empty, trace writer receives zero output despite real method-call lowering
  - `TestLowerMethodCallTraceEnabledEmitsFields` — env var set, output contains `method="len"`, `arm=method-mangled-fallback`, `symbol="Stale__len"`, `recvType=Stale` for the mangled fallback shape
- [x] `go build ./...` clean

## Risk

- Behaviour-preserving: the trace only writes when `OSTY_MIR_TRACE_METHOD_CALLS` is non-empty / non-`0`/`false`/`off`. Empty env → zero output, zero allocation overhead (the `os.Getenv` check is `bs.l`-free and runs first).
- The `methodCallTraceWriter` package-level variable defaults to `os.Stderr` and is intended for test override only. Production never touches it.
- Trace pattern mirrors `llvmBackendTraceEnabled` in `internal/backend/llvm.go` (same env-var precedence, same "off when empty" default) so the diagnostic surface stays consistent.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NBUT3jknqaGLUf9fu5VpY)_