### PR TITLE
ir: env-gated CallExpr return-type trace for FrontCheckResult&lt;String&gt; bisection

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -3024,10 +3024,13 @@ func callReturnTypeTraceEnabled() bool {
 
 // traceCallReturnType records the type decision IR `lowerCall`
 // made for a CallExpr. `calleeText` is a short label for the call
-// site — `<ident:name>` for direct calls, `<field:lhs.name>` for
-// method calls, `<other:%T>` for anything else. `source` names
-// which fallback layer supplied the recovered type. `t` is the IR
-// type the call site ended up tagged with.
+// site — `<ident:name>` for direct calls, `<other:%T>` for the
+// non-Ident exotic shapes. Method-call and module-qualified-call
+// shapes (`*ast.FieldExpr` callees) dispatch through
+// `lowerMethodCall` / `lowerQualifiedCall` and don't reach this
+// trace; instrumenting those separately is follow-on work.
+// `source` names which fallback layer supplied the recovered
+// type. `t` is the IR type the call site ended up tagged with.
 func traceCallReturnType(calleeText, source string, t Type) {
 	if !callReturnTypeTraceEnabled() {
 		return
@@ -3048,20 +3051,17 @@ func formatCallTraceType(t Type) string {
 	return t.String()
 }
 
+// calleeTraceText renders a short label for the trace's `callee=…`
+// field. `lowerCall` returns early for `*ast.FieldExpr` callees
+// (method-call and module-qualified-call shapes dispatch through
+// `lowerMethodCall` / `lowerQualifiedCall` before the trace site
+// is reached), so this function never sees a FieldExpr today —
+// only `*ast.Ident` direct-call callees and the `<other:%T>`
+// catch-all for non-Ident exotic shapes (e.g. `(f())()` indirect
+// calls through a CallExpr callee).
 func calleeTraceText(fn ast.Expr) string {
-	switch f := fn.(type) {
-	case *ast.Ident:
-		if f != nil {
-			return "<ident:" + f.Name + ">"
-		}
-	case *ast.FieldExpr:
-		if f != nil {
-			lhs := "?"
-			if id, ok := f.X.(*ast.Ident); ok && id != nil {
-				lhs = id.Name
-			}
-			return "<field:" + lhs + "." + f.Name + ">"
-		}
+	if id, ok := fn.(*ast.Ident); ok && id != nil {
+		return "<ident:" + id.Name + ">"
 	}
 	return fmt.Sprintf("<other:%T>", fn)
 }

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -2,6 +2,8 @@ package ir
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 	"strings"
 	"unicode"
@@ -2991,6 +2993,79 @@ func binaryOp(k token.Kind) (BinOp, bool) {
 	return 0, false
 }
 
+// ==== call-return-type trace (env-gated diagnostic) ====
+//
+// `OSTY_IR_TRACE_CALL_RETURN_TYPES=1` enables a per-`CallExpr` dump
+// at `lowerCall` that prints the callee name, the type the IR
+// builder settled on for the call's result, and which fallback path
+// supplied that type (`checker-typed-node` / `callee-fn-type` /
+// `fn-decl-return-type` / `ast-binding-type` / `unrecovered`).
+//
+// Used as the second-stage bisection tool for the FrontCheckResult__len
+// phantom-symbol class. The first-stage MIR trace (PR #1916) showed
+// the receiver of `elems.len()` typed as `FrontCheckResult<String>`
+// in `inspectSpreadTupleHints`. The let-binding's type comes from
+// `out.Value.Type()` — i.e. the CallExpr `hintTupleElems(...)`'s
+// result type, which this IR-layer trace exposes directly.
+//
+// Output goes to `callReturnTypeTraceWriter`, defaulting to `os.Stderr`
+// and overridable from package tests.
+
+var callReturnTypeTraceWriter io.Writer = os.Stderr
+
+func callReturnTypeTraceEnabled() bool {
+	switch os.Getenv("OSTY_IR_TRACE_CALL_RETURN_TYPES") {
+	case "", "0", "false", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// traceCallReturnType records the type decision IR `lowerCall`
+// made for a CallExpr. `calleeText` is a short label for the call
+// site — `<ident:name>` for direct calls, `<field:lhs.name>` for
+// method calls, `<other:%T>` for anything else. `source` names
+// which fallback layer supplied the recovered type. `t` is the IR
+// type the call site ended up tagged with.
+func traceCallReturnType(calleeText, source string, t Type) {
+	if !callReturnTypeTraceEnabled() {
+		return
+	}
+	fmt.Fprintf(callReturnTypeTraceWriter,
+		"ir call: callee=%s source=%s resultType=%s\n",
+		calleeText, source, formatCallTraceType(t),
+	)
+}
+
+func formatCallTraceType(t Type) string {
+	if t == nil {
+		return "<nil>"
+	}
+	if t == ErrTypeVal {
+		return "<error>"
+	}
+	return t.String()
+}
+
+func calleeTraceText(fn ast.Expr) string {
+	switch f := fn.(type) {
+	case *ast.Ident:
+		if f != nil {
+			return "<ident:" + f.Name + ">"
+		}
+	case *ast.FieldExpr:
+		if f != nil {
+			lhs := "?"
+			if id, ok := f.X.(*ast.Ident); ok && id != nil {
+				lhs = id.Name
+			}
+			return "<field:" + lhs + "." + f.Name + ">"
+		}
+	}
+	return fmt.Sprintf("<other:%T>", fn)
+}
+
 func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 	// Detect a print-family intrinsic on a bare identifier.
 	if id, ok := e.Fn.(*ast.Ident); ok {
@@ -3082,6 +3157,7 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 	}
 	callee := l.lowerExpr(fn)
 	t := l.exprType(e)
+	source := "checker-typed-node"
 	if t == ErrTypeVal || t == nil || hasPoisonedTypeArg(t) {
 		// Prefer the callee's FnType.Return when the call's own
 		// type is missing or carries a poisoned type-arg (the
@@ -3093,6 +3169,7 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 		// carry a fully-resolved return shape.
 		if recovered := recoverCallReturnType(callee); recovered != nil && recovered != ErrTypeVal && !hasPoisonedTypeArg(recovered) {
 			t = recovered
+			source = "callee-fn-type"
 		}
 		// Final fallback for bare-Ident callees whose FnType is
 		// also poisoned: re-lower the resolved fn declaration's AST
@@ -3105,15 +3182,26 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 			if id, ok := fn.(*ast.Ident); ok {
 				if rec := l.recoverFnDeclReturnType(id); rec != nil && rec != ErrTypeVal && !hasPoisonedTypeArg(rec) {
 					t = rec
+					source = "fn-decl-return-type"
 				}
 			}
 		}
 		if t == nil || t == ErrTypeVal || hasPoisonedTypeArg(t) {
 			if rec := l.bindingTypeFromAST(e); usableRecoveredType(rec) {
 				t = rec
+				source = "ast-binding-type"
 			}
 		}
+		if t == nil || t == ErrTypeVal || hasPoisonedTypeArg(t) {
+			source = "unrecovered"
+		}
 	}
+	// Trace dispatch site: this is where the FrontCheckResult<String>
+	// type for `let elems = hintTupleElems(...)` enters IR. The MIR
+	// receiver-type trace (PR #1916) shows the wrong type at the
+	// method-call site; this trace exposes which IR-builder fallback
+	// supplied it.
+	traceCallReturnType(calleeTraceText(fn), source, t)
 	out := &CallExpr{
 		Callee:   callee,
 		TypeArgs: typeArgs,

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -1,6 +1,8 @@
 package ir
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/osty/osty/internal/ast"
@@ -98,6 +100,89 @@ func TestLowerPreludeVariantCallBecomesVariantLit(t *testing.T) {
 	}
 	if got := len(lit.Args); got != 1 {
 		t.Fatalf("variant args = %d, want 1", got)
+	}
+}
+
+// TestLowerCallReturnTypeTraceDefaultSilent locks the off-by-default
+// behaviour of the OSTY_IR_TRACE_CALL_RETURN_TYPES env-gated trace:
+// without the env var set the trace writes nothing.
+func TestLowerCallReturnTypeTraceDefaultSilent(t *testing.T) {
+	prev := callReturnTypeTraceWriter
+	defer func() { callReturnTypeTraceWriter = prev }()
+	var buf bytes.Buffer
+	callReturnTypeTraceWriter = &buf
+
+	t.Setenv("OSTY_IR_TRACE_CALL_RETURN_TYPES", "")
+
+	call := &ast.CallExpr{
+		ID: 7,
+		Fn: &ast.Ident{Name: "make_string"},
+	}
+	file := &ast.File{
+		Stmts: []ast.Stmt{&ast.LetStmt{
+			Pattern: &ast.IdentPat{Name: "s"},
+			Value:   call,
+		}},
+	}
+	chk := &check.Result{
+		NativeCheckResult: &api.CheckResult{
+			TypedNodes: []api.CheckedNode{{
+				NodeID: int(call.ID),
+				Kind:   "Call",
+				Type:   &api.TypeRepr{Kind: "primitive", Name: "String"},
+			}},
+		},
+	}
+	Lower("main", file, nil, chk)
+	if buf.Len() != 0 {
+		t.Fatalf("trace writer received output despite env var off: %q", buf.String())
+	}
+}
+
+// TestLowerCallReturnTypeTraceEnabledRecordsSource exercises the
+// trace's happy path: with OSTY_IR_TRACE_CALL_RETURN_TYPES=1 each
+// `CallExpr` lowering emits one line carrying the callee text,
+// the recovery source label, and the resulting type. The minimal
+// scenario uses a `make_string()` CallExpr whose checker-typed
+// node returns String, so the trace must report
+// `source=checker-typed-node` and `resultType=String`.
+func TestLowerCallReturnTypeTraceEnabledRecordsSource(t *testing.T) {
+	prev := callReturnTypeTraceWriter
+	defer func() { callReturnTypeTraceWriter = prev }()
+	var buf bytes.Buffer
+	callReturnTypeTraceWriter = &buf
+
+	t.Setenv("OSTY_IR_TRACE_CALL_RETURN_TYPES", "1")
+
+	call := &ast.CallExpr{
+		ID: 7,
+		Fn: &ast.Ident{Name: "make_string"},
+	}
+	file := &ast.File{
+		Stmts: []ast.Stmt{&ast.LetStmt{
+			Pattern: &ast.IdentPat{Name: "s"},
+			Value:   call,
+		}},
+	}
+	chk := &check.Result{
+		NativeCheckResult: &api.CheckResult{
+			TypedNodes: []api.CheckedNode{{
+				NodeID: int(call.ID),
+				Kind:   "Call",
+				Type:   &api.TypeRepr{Kind: "primitive", Name: "String"},
+			}},
+		},
+	}
+	Lower("main", file, nil, chk)
+	got := buf.String()
+	for _, want := range []string{
+		`callee=<ident:make_string>`,
+		`source=checker-typed-node`,
+		`resultType=String`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("trace missing field %q\nfull output:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds an env-gated diagnostic trace in `lowerCall` (`internal/ir/lower.go`) for bisecting which IR-builder fallback supplied the wrong `FrontCheckResult<String>` type for `elems = hintTupleElems(...)`'s let-binding in `inspectSpreadTupleHints`. Companion to #1916's MIR-side method-call trace.

## What the trace prints

With `OSTY_IR_TRACE_CALL_RETURN_TYPES=1`:

```
ir call: callee=<ident:hintTupleElems> source=checker-typed-node resultType=FrontCheckResult<String>
```

Fields:
- `callee` — `<ident:name>` for direct calls, `<field:lhs.name>` for method-call shape, `<other:%T>` otherwise
- `source` — which fallback supplied the type, one of:
  - `checker-typed-node` — `chk.Types[e]` / `nativeCheckedType(e)`
  - `callee-fn-type` — `callee.Type().Return`
  - `fn-decl-return-type` — re-lowering `ast.FnDecl.ReturnType` via resolver
  - `ast-binding-type` — `bindingTypeFromAST` walk
  - `unrecovered` — every layer came back poisoned
- `resultType` — the IR type tagged on the resulting `*CallExpr.T` (`ir.Type.String()`, with explicit `<nil>` / `<error>` placeholders)

## Why

The MIR method-call trace from #1916 showed `recvType=FrontCheckResult<String>` for `elems.len()`, even though `hintTupleElems` declares return type `List<String>`. The let-binding's type comes from `out.Value.Type()` in `lowerLetStmt` — i.e. the CallExpr's tagged type after `lowerCall`. **This trace exposes which IR-builder fallback supplied that wrong type**, so the next fix PR can target the actual checker / resolver / `exprType` / `recoverFnDeclReturnType` layer that's regressing.

The first IR trace I'd run on a current install-self looks like:
```
OSTY_IR_TRACE_CALL_RETURN_TYPES=1 \
OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 \
OSTY_STAGE0_FALLBACK=1 \
.bin/osty install-self 2> /tmp/ir_call_trace.log
grep "hintTupleElems" /tmp/ir_call_trace.log
```

If `source=checker-typed-node` and `resultType=FrontCheckResult<String>` show up together → the checker's `TypedNodes` index is mismapped at the call's NodeID. If `source=fn-decl-return-type` and the result is wrong → `recoverFnDeclReturnType`'s resolver lookup is returning the wrong `*ast.FnDecl`. Either way the bisection narrows to a precise file + lookup.

## Test plan

- [x] `go test ./internal/ir/` — PASS 5.9s (full suite, no regressions)
- [x] `go test ./internal/mir/` — PASS 4.4s
- [x] New tests pass:
  - `TestLowerCallReturnTypeTraceDefaultSilent` — env empty → trace writer receives zero output despite a real CallExpr lowering.
  - `TestLowerCallReturnTypeTraceEnabledRecordsSource` — env set → output contains `callee=<ident:make_string>`, `source=checker-typed-node`, `resultType=String` for the checker-typed-node happy path.
- [x] `go build ./...` clean

## Risk

- Behaviour-preserving: every `Lower()` output node still carries identical types and shapes. The trace fires unconditionally inside `lowerCall` but exits in two compares when the env var is unset, so production `osty build` / `osty check` runs pay no measurable cost.
- Mirrors the pattern from #1916 (`OSTY_MIR_TRACE_METHOD_CALLS`) — same env-var precedence (`""`/`"0"`/`"false"`/`"off"` → off), same `Writer` override hook for tests, same `<nil>` / `<error>` placeholders.
- The trace surface is intentionally narrow (free-function and method-shape direct calls). Variant constructors (`Some(x)` / `Ok(x)`) and `IntrinsicCall` rewrites short-circuit before reaching the trace site, by design — those paths don't enter the `recoverCallReturnType` fallback chain this PR instruments.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NBUT3jknqaGLUf9fu5VpY)_