### PR TITLE
fix: guard lowerNamedType against resolver TypeRefsByID mismappings — unblocks install-self end-to-end

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -833,8 +833,21 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 	}
 
 	// Consult the resolver for the head symbol so we can classify
-	// builtins vs user declarations vs generic parameters.
-	if sym := l.typeRef(nt); sym != nil && resolverSymbolMatchesSourceName(sym, pkg, name, nt.Path) {
+	// builtins vs user declarations vs generic parameters. The
+	// `resolverSymbolMatchesSourceName` guard rejects answers whose
+	// `Name` doesn't match the source's bare ident (a `TypeRefsByID`
+	// mismapping that has been observed in multi-file packages —
+	// see the helper's doc and PR #1919); rejected lookups fall
+	// through to source-name-based classification at the bottom of
+	// the function. Each rejection is also logged through the
+	// `OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD` env-gated trace so the
+	// underlying resolver bug stays observable.
+	sym := l.typeRef(nt)
+	if sym != nil && !resolverSymbolMatchesSourceName(sym, pkg, name, nt.Path) {
+		traceLowerNamedTypeGuardReject(name, sym.Name, pkg)
+		sym = nil
+	}
+	if sym != nil {
 		symName := sym.Name
 		if pkg != "" && len(nt.Path) > 0 && symName == nt.Path[0] {
 			symName = name
@@ -886,38 +899,78 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 //
 // The guard accepts the resolver-returned symbol when either:
 //
-//   - the source is package-qualified (`pkg != ""`) — package
-//     paths legitimately route through arbitrarily-named symbols
-//     (e.g. `use std.foo as bar` + `bar.Baz`), so the head-ident
-//     match below is sufficient
-//   - the source is bare AND the symbol's name matches the
-//     source last-path component
-//   - the symbol's name matches the source's first-path component
-//     (the existing fallback for qualified paths where the head
-//     is the alias and the resolver records the package symbol)
+//   - the source is **bare** (no package qualifier) AND the
+//     symbol's `Name` matches the source path's last component.
+//     Bare paths must round-trip through the resolver under their
+//     source name; anything else is a TypeRefsByID mismapping.
+//   - the source is **package-qualified** (`pkg != ""`).
+//     Cross-package type references legitimately route through
+//     arbitrarily-named symbols (e.g. `use foo as bar` +
+//     `bar.Baz` resolves through package alias machinery), so
+//     trust the resolver in that path.
 //
-// Otherwise the resolver path is skipped and `lowerNamedType`
-// falls through to the source-name-based builtin / generic-name
-// resolution at the bottom of the function, which correctly
-// classifies `List`/`Map`/`Set`/`Option`/`Result` as builtin
-// containers and everything else as a user-named type.
+// When the guard rejects, `lowerNamedType` skips the resolver
+// path and falls through to the source-name-based builtin /
+// generic-name resolution at the bottom of the function, which
+// correctly classifies `List` / `Map` / `Set` / `Option` /
+// `Result` as builtin containers and everything else as a user-
+// named type. Each rejection is also logged through
+// `traceLowerNamedTypeGuardReject` (env-gated) so the underlying
+// resolver `TypeRefsByID` bug remains observable for follow-up
+// investigation rather than silently masked.
 func resolverSymbolMatchesSourceName(sym *resolve.Symbol, pkg, name string, path []string) bool {
 	if sym == nil {
 		return false
 	}
-	if sym.Name == name {
+	if pkg == "" {
+		return sym.Name == name
+	}
+	// Package-qualified path: trust the resolver. Cross-package
+	// type references legitimately route through arbitrarily-named
+	// symbols, so accepting the resolver answer avoids false-
+	// positives on legitimate aliases. The `path` parameter is
+	// retained on the signature for parity with the qualified-path
+	// caller — future tightening of this branch can use it to
+	// require `sym.Name == path[0]` instead of the unconditional
+	// trust, but doing so today would regress on the
+	// `pub use std.X as Y` rename machinery.
+	_ = path
+	return true
+}
+
+// ==== lowerNamedType guard-reject trace (env-gated diagnostic) ====
+//
+// `OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD=1` enables a stderr line
+// each time `resolverSymbolMatchesSourceName` rejects a resolver-
+// returned symbol. Used so the underlying resolver `TypeRefsByID`
+// bug (`List` AST node → `FrontCheckResult` symbol etc.) remains
+// observable when the IR-layer guard masks its downstream
+// FrontCheckResult__len failure mode.
+
+var lowerNamedTypeGuardTraceWriter io.Writer = os.Stderr
+
+func lowerNamedTypeGuardTraceEnabled() bool {
+	switch os.Getenv("OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD") {
+	case "", "0", "false", "off":
+		return false
+	default:
 		return true
 	}
-	if pkg != "" {
-		if len(path) > 0 && sym.Name == path[0] {
-			return true
-		}
-		// Package-qualified paths can resolve through arbitrarily-named
-		// symbols. Accept the resolver answer rather than risking
-		// false-positives on legitimate cross-package type references.
-		return true
+}
+
+// traceLowerNamedTypeGuardReject records each guard rejection
+// (source name vs resolver-returned symbol name mismatch).
+// `sourceName` is the source path's last component, `symName` is
+// the rejected resolver answer, `pkg` is the source path's
+// package prefix (empty for bare).
+func traceLowerNamedTypeGuardReject(sourceName, symName, pkg string) {
+	if !lowerNamedTypeGuardTraceEnabled() {
+		return
 	}
-	return false
+	fmt.Fprintf(lowerNamedTypeGuardTraceWriter,
+		"ir lowerNamedType guard reject: sourceName=%q symName=%q pkg=%q\n",
+		sourceName, symName, pkg,
+	)
 }
 
 // joinDottedPath joins a non-empty string slice with '.'.

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -834,7 +834,7 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 
 	// Consult the resolver for the head symbol so we can classify
 	// builtins vs user declarations vs generic parameters.
-	if sym := l.typeRef(nt); sym != nil {
+	if sym := l.typeRef(nt); sym != nil && resolverSymbolMatchesSourceName(sym, pkg, name, nt.Path) {
 		symName := sym.Name
 		if pkg != "" && len(nt.Path) > 0 && symName == nt.Path[0] {
 			symName = name
@@ -872,6 +872,52 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 		}
 	}
 	return &NamedType{Package: pkg, Name: name, Args: args}
+}
+
+// resolverSymbolMatchesSourceName guards `lowerNamedType`'s
+// resolver-driven path against `TypeRefsByID` mismappings that
+// have been observed in multi-file packages — for example, the
+// `List` head ident in `hintTupleElems`'s return type signature
+// (toolchain/inspect_hint.osty) resolves to the `FrontCheckResult`
+// symbol (toolchain/check.osty) instead of `List`, producing a
+// downstream `FrontCheckResult__len` undefined symbol at
+// install-self link. See PR #1916 / #1917 / #1918 for the three
+// stages of the bisection that pinpointed this site.
+//
+// The guard accepts the resolver-returned symbol when either:
+//
+//   - the source is package-qualified (`pkg != ""`) — package
+//     paths legitimately route through arbitrarily-named symbols
+//     (e.g. `use std.foo as bar` + `bar.Baz`), so the head-ident
+//     match below is sufficient
+//   - the source is bare AND the symbol's name matches the
+//     source last-path component
+//   - the symbol's name matches the source's first-path component
+//     (the existing fallback for qualified paths where the head
+//     is the alias and the resolver records the package symbol)
+//
+// Otherwise the resolver path is skipped and `lowerNamedType`
+// falls through to the source-name-based builtin / generic-name
+// resolution at the bottom of the function, which correctly
+// classifies `List`/`Map`/`Set`/`Option`/`Result` as builtin
+// containers and everything else as a user-named type.
+func resolverSymbolMatchesSourceName(sym *resolve.Symbol, pkg, name string, path []string) bool {
+	if sym == nil {
+		return false
+	}
+	if sym.Name == name {
+		return true
+	}
+	if pkg != "" {
+		if len(path) > 0 && sym.Name == path[0] {
+			return true
+		}
+		// Package-qualified paths can resolve through arbitrarily-named
+		// symbols. Accept the resolver answer rather than risking
+		// false-positives on legitimate cross-package type references.
+		return true
+	}
+	return false
 }
 
 // joinDottedPath joins a non-empty string slice with '.'.

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -167,6 +167,87 @@ func TestLowerNamedTypeRejectsResolverNameMismatch(t *testing.T) {
 	}
 }
 
+// TestLowerNamedTypeGuardRejectionEmitsTrace locks the
+// observability guarantee Copilot review #1919 asked for: when the
+// IR-layer guard rejects a resolver-returned symbol, the env-gated
+// `OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD` trace must fire so the
+// underlying resolver `TypeRefsByID` mismapping stays observable
+// rather than being silently masked.
+func TestLowerNamedTypeGuardRejectionEmitsTrace(t *testing.T) {
+	prev := lowerNamedTypeGuardTraceWriter
+	defer func() { lowerNamedTypeGuardTraceWriter = prev }()
+	var buf bytes.Buffer
+	lowerNamedTypeGuardTraceWriter = &buf
+
+	t.Setenv("OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD", "1")
+
+	listAST := &ast.NamedType{
+		ID:   ast.NodeID(44),
+		Path: []string{"List"},
+		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
+	}
+	wrongSym := &resolve.Symbol{
+		Name: "FrontCheckResult",
+		Kind: resolve.SymStruct,
+		Decl: &ast.StructDecl{Name: "FrontCheckResult"},
+	}
+	l := &lowerer{
+		res: &resolve.Result{
+			TypeRefsByID: map[ast.NodeID]*resolve.Symbol{
+				listAST.ID: wrongSym,
+			},
+		},
+	}
+	_ = l.lowerNamedType(listAST)
+
+	got := buf.String()
+	for _, want := range []string{
+		`sourceName="List"`,
+		`symName="FrontCheckResult"`,
+		`pkg=""`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("guard-reject trace missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+// TestLowerNamedTypeGuardTraceDefaultSilent locks the
+// off-by-default behaviour of the guard trace: without
+// OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD set, even a rejection
+// emits no stderr noise (production `osty build` runs see nothing).
+func TestLowerNamedTypeGuardTraceDefaultSilent(t *testing.T) {
+	prev := lowerNamedTypeGuardTraceWriter
+	defer func() { lowerNamedTypeGuardTraceWriter = prev }()
+	var buf bytes.Buffer
+	lowerNamedTypeGuardTraceWriter = &buf
+
+	t.Setenv("OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD", "")
+
+	listAST := &ast.NamedType{
+		ID:   ast.NodeID(45),
+		Path: []string{"List"},
+		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
+	}
+	wrongSym := &resolve.Symbol{
+		Name: "FrontCheckResult",
+		Kind: resolve.SymStruct,
+		Decl: &ast.StructDecl{Name: "FrontCheckResult"},
+	}
+	l := &lowerer{
+		res: &resolve.Result{
+			TypeRefsByID: map[ast.NodeID]*resolve.Symbol{
+				listAST.ID: wrongSym,
+			},
+		},
+	}
+	_ = l.lowerNamedType(listAST)
+
+	if buf.Len() != 0 {
+		t.Fatalf("guard trace writer received output despite env off: %q", buf.String())
+	}
+}
+
 // TestLowerNamedTypeAcceptsResolverNameMatch locks the
 // positive-case half of the guard: when the resolver-returned
 // symbol's name DOES match the source path's last component, the

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -103,6 +103,102 @@ func TestLowerPreludeVariantCallBecomesVariantLit(t *testing.T) {
 	}
 }
 
+// TestLowerNamedTypeRejectsResolverNameMismatch locks the
+// defensive guard added to `lowerNamedType` for the
+// FrontCheckResult<String> class of resolver TypeRefsByID
+// mismappings. The bug: in multi-file packages the resolver
+// occasionally records the wrong `*resolve.Symbol` against an
+// `*ast.NamedType` node's ID — e.g. the `List` head ident in
+// `hintTupleElems`'s return type signature
+// (toolchain/inspect_hint.osty) resolves to the
+// `FrontCheckResult` struct symbol (toolchain/check.osty) instead
+// of `List`, producing a downstream `FrontCheckResult__len`
+// undefined symbol at install-self link.
+//
+// The fix: when the resolver returns a symbol whose name doesn't
+// match the source path's last component AND the source is bare
+// (no package qualifier), `lowerNamedType` skips the resolver
+// path and falls back to source-name-based resolution, which
+// correctly classifies `List<X>`, `Map<K,V>`, etc. as builtin
+// containers via the name table at the bottom of the function.
+//
+// This test simulates the exact bug shape by hand-building a
+// `resolve.Result` whose `TypeRefsByID` maps the `List` AST
+// node's ID to a `FrontCheckResult` struct symbol. With the
+// guard in place, `lowerNamedType` returns
+// `&NamedType{Name: "List", Args: [String], Builtin: true}`
+// instead of `&NamedType{Name: "FrontCheckResult", ...}`.
+func TestLowerNamedTypeRejectsResolverNameMismatch(t *testing.T) {
+	// Simulate the resolver's TypeRefsByID returning a wrong
+	// `FrontCheckResult` symbol for a `List` AST node.
+	listAST := &ast.NamedType{
+		ID:   ast.NodeID(42),
+		Path: []string{"List"},
+		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
+	}
+	wrongSym := &resolve.Symbol{
+		Name: "FrontCheckResult",
+		Kind: resolve.SymStruct,
+		Decl: &ast.StructDecl{Name: "FrontCheckResult"},
+	}
+	l := &lowerer{
+		res: &resolve.Result{
+			TypeRefsByID: map[ast.NodeID]*resolve.Symbol{
+				listAST.ID: wrongSym,
+			},
+		},
+	}
+	got := l.lowerNamedType(listAST)
+	nt, ok := got.(*NamedType)
+	if !ok {
+		t.Fatalf("lowerNamedType returned %T, want *NamedType", got)
+	}
+	if nt.Name != "List" {
+		t.Errorf("guard failed: NamedType.Name = %q, want %q (resolver returned wrong symbol but bare source name is List)", nt.Name, "List")
+	}
+	if !nt.Builtin {
+		t.Errorf("List<String> should be marked Builtin: true; got %+v", nt)
+	}
+	if len(nt.Args) != 1 {
+		t.Fatalf("List<String> should have 1 arg; got %d", len(nt.Args))
+	}
+	if nt.Args[0] != TString {
+		t.Errorf("List<String> arg[0] = %v, want TString", nt.Args[0])
+	}
+}
+
+// TestLowerNamedTypeAcceptsResolverNameMatch locks the
+// positive-case half of the guard: when the resolver-returned
+// symbol's name DOES match the source path's last component, the
+// resolver-driven classification (Builtin / Generic / TypeAlias)
+// continues to work as before.
+func TestLowerNamedTypeAcceptsResolverNameMatch(t *testing.T) {
+	listAST := &ast.NamedType{
+		ID:   ast.NodeID(43),
+		Path: []string{"List"},
+		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
+	}
+	rightSym := &resolve.Symbol{
+		Name: "List",
+		Kind: resolve.SymBuiltin,
+	}
+	l := &lowerer{
+		res: &resolve.Result{
+			TypeRefsByID: map[ast.NodeID]*resolve.Symbol{
+				listAST.ID: rightSym,
+			},
+		},
+	}
+	got := l.lowerNamedType(listAST)
+	nt, ok := got.(*NamedType)
+	if !ok {
+		t.Fatalf("lowerNamedType returned %T, want *NamedType", got)
+	}
+	if nt.Name != "List" || !nt.Builtin {
+		t.Errorf("resolver-name-match path failed: got %+v, want List builtin", nt)
+	}
+}
+
 // TestLowerCallReturnTypeTraceDefaultSilent locks the off-by-default
 // behaviour of the OSTY_IR_TRACE_CALL_RETURN_TYPES env-gated trace:
 // without the env var set the trace writes nothing.


### PR DESCRIPTION
## Summary

Unblocks install-self end-to-end by guarding `lowerNamedType` against `TypeRefsByID` mismappings that have been blocking the source bootstrap with an `undefined symbol: FrontCheckResult__len` link error since at least #1742.

Three-PR bisection chain leading here:
- **#1916** (merged) — MIR receiver-type trace showed `recvType=FrontCheckResult<String>` for `elems.len()` in `inspectSpreadTupleHints`.
- **#1917** (merged) — IR `CallExpr` return-type trace pinpointed `source=fn-decl-return-type` for the wrong type.
- **#1918** (open) — Deep `recoverFnDeclReturnType` trace nailed the bug to `lowerType` specifically.

The decisive trace line:

```
ir fn-decl-recovery: ident="hintTupleElems" symName="hintTupleElems"
  fnName="hintTupleElems" astReturnType=Named(List)<Named(String)>
  recovered=FrontCheckResult<String> status=ok
```

Every step up to `lowerType` is correct (resolver Symbol, `*ast.FnDecl`, AST `ReturnType` all carry `List<String>`), but `lowerNamedType`'s `l.res.TypeRefsByID[nt.ID]` returns the **`FrontCheckResult` struct symbol** for the `List` head ident in `hintTupleElems`'s return type signature (toolchain/inspect_hint.osty). The resolver's `TypeRefsByID` has a mismapping for this specific multi-file site, and the IR builder trusted it unconditionally.

## What changed

Introduces `resolverSymbolMatchesSourceName` in `internal/ir/lower.go`. The IR builder accepts the resolver-returned symbol only when one of:

- the symbol's `Name` matches the source path's last component (the common case: bare `List` → `Symbol{Name:"List"}`)
- the source is package-qualified AND the symbol's name matches the source's first path component (existing fallback for `use foo as bar` + `bar.Baz`)
- the source is package-qualified — package paths legitimately route through arbitrarily-named symbols, so trust the resolver

Otherwise — i.e. the source is **bare** AND the resolver's symbol name doesn't match the source ident — the resolver path is skipped and `lowerNamedType` falls through to the source-name-based builtin table at the bottom of the function. `List`, `Map`, `Set`, `Option`, `Result` then correctly classify as builtin containers; anything else lands as a user-named `NamedType` with the source name.

## End-to-end verification

```
$ OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 \
  OSTY_STAGE0_FALLBACK=1 \
  .bin/osty install-self
Profile: debug  Target: host  Features: none
Built /home/user/osty/toolchain/.osty/out/debug/llvm/osty-self (debug)
installed:   /home/user/osty/.osty/cache/self-host/.../osty-self
```

**🎉 First end-to-end install-self success from source bootstrap.** osty-self binary builds, installs into the content-addressed cache, and `--selfhost-doctor` returns 0.

## Test plan

- [x] `go test ./internal/ir/ ./internal/mir/ ./internal/check/ ./internal/resolve/` — PASS (no regressions across all four packages)
- [x] `go build ./...` clean
- [x] End-to-end install-self runs to completion (vs. timing out / failing at link before this fix)
- [x] New tests pin both directions:
  - `TestLowerNamedTypeRejectsResolverNameMismatch` — hand-builds a `resolve.Result` whose `TypeRefsByID` maps the `List` AST node's ID to a `FrontCheckResult` struct symbol (the exact bug shape), asserts `lowerNamedType` returns `&NamedType{Name:"List", Builtin:true, Args:[String]}` instead of `&NamedType{Name:"FrontCheckResult", ...}`.
  - `TestLowerNamedTypeAcceptsResolverNameMatch` — same shape but with the resolver returning a Symbol whose name matches the source ident, asserts the resolver-driven classification path continues to fire as before.

## Risk

- **Defensive at the IR layer**: the root resolver bug (`TypeRefsByID` mismapping for the `List` head ident in `hintTupleElems`'s return type signature) remains; chasing it requires resolver-layer instrumentation beyond the current bisection chain. This patch is intentionally narrow — only skips the resolver path when the symbol's name doesn't match the source, otherwise behaviour is unchanged.
- **Preserves existing resolver-driven behaviour**: the four canonical paths (`SymBuiltin` / `SymGeneric` / `SymTypeAlias` / user struct/enum) all continue to work when the resolver returns a name-matching symbol. The guard only redirects mismatched bare-name lookups.
- **No public API change**: `resolverSymbolMatchesSourceName` is package-private. The only externally-observable change is that legitimate source-named bare types no longer silently become a different type name from the resolver.

## Follow-up

The root resolver bug should still be hunted in a separate PR. Suspected location: `internal/resolve` `TypeRefsByID` population for cross-file type reference paths. Adding an env-gated trace at the resolver layer (analogous to #1916/#1917/#1918) would be the natural first step.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NBUT3jknqaGLUf9fu5VpY)_