### PR TITLE
[codex] make stage0 bootstrap explicit

### DIFF
--- a/.github/workflows/bootstrap-smoke-test.yml
+++ b/.github/workflows/bootstrap-smoke-test.yml
@@ -90,7 +90,6 @@ jobs:
           # state.
           OSTY_SELF_BIN: ""
           OSTY_SELF_TRUSTED_KEY: ""
-          OSTY_STAGE0_FALLBACK: ""
         run: |
           set -euo pipefail
           cd "$RUNNER_TEMP/scratch/osty"

--- a/.github/workflows/build-osty-self.yml
+++ b/.github/workflows/build-osty-self.yml
@@ -172,15 +172,14 @@ jobs:
           else
             # Missing seed is a recoverable condition (first round, or
             # a deliberately-cleared release). Surface it but let the
-            # build try `OSTY_STAGE0_FALLBACK=1` so the matrix can
+            # build try its internal source bootstrap so the matrix can
             # still produce *something* for the maintainer to inspect.
-            echo "Seed not available at $seed_url — falling through to stage0 fallback for this run." >&2
-            echo "OSTY_STAGE0_FALLBACK=1" >> "$GITHUB_ENV"
+            echo "Seed not available at $seed_url — falling through to source bootstrap for this run." >&2
           fi
 
       - name: Install self-host artifact into cache
         # Drives toolchain → osty-self build using the seed we just
-        # placed (or stage0 fallback if no seed). The cache layout is
+        # placed (or source bootstrap if no seed). The cache layout is
         # the local `.osty/cache/self-host/<sha>-<triple>/` tree.
         env:
           OSTY_BUILD_FLAGS: ${{ env.OSTY_BUILD_FLAGS }}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ native-only through the LLVM backend.
 | Package manager (`osty add` / `osty update`, path + git + registry sources, SemVer resolver, deterministic lockfile) | wired — `add` mutates `osty.toml` and re-vendors; `update` re-resolves selectively or in full |
 | `osty run` (build + exec through backend) | wired — resolves manifest, vendors deps, emits the native entry artifact, runs the backend binary with profile/feature flags, and rejects cross-target execution |
 | `osty publish` (pack + upload tarball to a registry) | wired — deterministic gzipped tar, sha256 checksum, bearer-auth POST; `--dry-run` stops before upload |
-| `osty-native-checker` LLVM self-build (`cmd/osty-native-checker/main.osty`) | walking skeleton (2026-05-17) — `OSTY_STAGE0_FALLBACK=1 osty build --backend llvm cmd/osty-native-checker/` 가 binary 산출 + 실행, empty-source fixture 에서 Go-built `osty-native-checker` 와 byte-identical `CheckResult` JSON 출력 (M2 partial). 진짜 checker 호출 (`elabFile` 등) 은 cross-package method-call wall ([`SPEC_GAPS::cross-pkg-module-resolution`](./SPEC_GAPS.md), [docs/llvm-selfhost-plan.md](./docs/llvm-selfhost-plan.md) PR3-C step 3) 으로 차단. multi-fixture / L2 spec corpus / L3 toolchain self-input parity 는 step 3 unlock 후 — 자세한 trajectory 는 [`cmd/osty-native-checker/README.md`](./cmd/osty-native-checker/README.md) |
+| `osty-native-checker` LLVM self-build (`cmd/osty-native-checker/main.osty`) | walking skeleton (2026-05-17) — `osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/` 가 binary 산출 + 실행, empty-source fixture 에서 Go-built `osty-native-checker` 와 byte-identical `CheckResult` JSON 출력 (M2 partial). 진짜 checker 호출 (`elabFile` 등) 은 cross-package method-call wall ([`SPEC_GAPS::cross-pkg-module-resolution`](./SPEC_GAPS.md), [docs/llvm-selfhost-plan.md](./docs/llvm-selfhost-plan.md) PR3-C step 3) 으로 차단. multi-fixture / L2 spec corpus / L3 toolchain self-input parity 는 step 3 unlock 후 — 자세한 trajectory 는 [`cmd/osty-native-checker/README.md`](./cmd/osty-native-checker/README.md) |
 
 Status note (revalidated 2026-04-28): the universal
 LLVM CLI wedge called out in older status docs is closed. A hello-world
@@ -305,7 +305,6 @@ Consumer-side env vars:
 | `OSTY_SELF_REGISTRY_OFFLINE` | When truthy, hard-disables the fetcher even with a registry URL set. CI / air-gapped environments. |
 | `OSTY_SELF_TRUSTED_KEY` | 64-char hex ed25519 public key. When set, manifests must be signed under the matching private key or the fetcher rejects them. Unset ⇒ falls back to `selfhostcache.DefaultTrustedKeyHex`; if both are empty, unsigned manifests are accepted (warn-only mode). |
 | `OSTY_SELF_BIN` | Bypass everything and use this binary path. |
-| `OSTY_STAGE0_FALLBACK` | Last-resort emergency-only Go MIR→LLVM emitter. See `docs/osty_self_bootstrap_design.md`. |
 
 The fetcher verifies the binary's SHA-256 against the manifest
 unconditionally. The signature check is opt-in via

--- a/cmd/osty-native-checker/README.md
+++ b/cmd/osty-native-checker/README.md
@@ -9,7 +9,7 @@ matching responsibilities, built from disjoint sources.
 | target | command | source | status |
 |---|---|---|---|
 | Go-built | `go build -o /tmp/go-checker ./cmd/osty-native-checker` | `main.go` (~38 LOC) + `internal/selfhost/generated.go` (frozen seed) | production |
-| LLVM-built | `OSTY_STAGE0_FALLBACK=1 .bin/osty build --backend llvm cmd/osty-native-checker/` | `main.osty` + manual naive parser | **walking skeleton** (stub CheckResult) |
+| LLVM-built | `.bin/osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/` | `main.osty` + manual naive parser | **walking skeleton** (stub CheckResult) |
 
 ## Why two targets
 
@@ -20,7 +20,7 @@ reaches behavior parity (plan §12 M3/M4).
 
 ## Current state (2026-05-17)
 
-- ✓ **M1** — LLVM-built binary builds + runs (`OSTY_STAGE0_FALLBACK=1`)
+- ✓ **M1** — LLVM-built binary builds + runs (`--bootstrap-stage0`)
 - ✓ **M2 (partial)** — empty-source fixture byte-parity:
   ```
   $ echo '{"source":""}' | /tmp/go-checker
@@ -36,19 +36,19 @@ reaches behavior parity (plan §12 M3/M4).
 ```sh
 # from repo root
 go build -o .bin/osty ./cmd/osty
-OSTY_STAGE0_FALLBACK=1 .bin/osty build --backend llvm cmd/osty-native-checker/
+.bin/osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/
 
 # run
 echo '{"source":""}' | ./cmd/osty-native-checker/.osty/out/debug/llvm/osty-native-checker-llvm
 ```
 
-`OSTY_STAGE0_FALLBACK=1` is still the practical default for this LLVM build
+`--bootstrap-stage0` is still the practical default for this LLVM build
 because **normal MIR→LLVM emission goes through `osty-self lir-proto-lower`**
 (`internal/backend/llvm.go` `emitLLVMFallback`). On a checkout without a
 working `osty-self` cache (or when that subprocess declines the MIR payload),
 the dispatcher only proceeds if you opt into the in-process **stage0**
-bootstrap emitter (`internal/backend/stage0/`, gated by this env var;
-see `internal/backend/bootstrap.go`).
+bootstrap emitter (`internal/backend/stage0/`; see
+`internal/backend/bootstrap.go`).
 
 Stage0 **audit coverage** of `toolchain/*.osty` reached **100%** after PR
 [#1858](https://github.com/choiceoh/osty/pull/1858) (2026-05-17,

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -52,6 +52,8 @@ func runBuild(args []string, flags cliFlags) {
 	fs.BoolVar(&locked, "locked", false, "fail if osty.lock would change")
 	fs.BoolVar(&frozen, "frozen", false, "imply --locked --offline; require an existing osty.lock")
 	fs.BoolVar(&force, "force", false, "ignore the build cache; rebuild every input")
+	var bootstrapStage0 bool
+	fs.BoolVar(&bootstrapStage0, "bootstrap-stage0", false, "internal: allow the install-self bootstrap stage0 emitter when osty-self is missing")
 	var aiRepairModeName string
 	registerAIRepairCommandFlags(fs, &flags.aiRepair, &aiRepairModeName)
 	var backendName string
@@ -157,9 +159,9 @@ func runBuild(args []string, flags cliFlags) {
 	featSet := featureSet(resolved)
 	var emitResult *backend.Result
 	if m.Workspace != nil {
-		emitResult = buildWorkspace(root, m, flags, deps, resolved, featSet, backendID, emitMode)
+		emitResult = buildWorkspace(root, m, flags, deps, resolved, featSet, backendID, emitMode, bootstrapStage0)
 	} else {
-		emitResult = buildPackage(root, m, flags, deps, resolved, featSet, backendID, emitMode)
+		emitResult = buildPackage(root, m, flags, deps, resolved, featSet, backendID, emitMode, bootstrapStage0)
 	}
 
 	// Step 6: record the build fingerprint under .osty/cache/ so the
@@ -305,7 +307,7 @@ func cachedArtifactsExist(root string, artifacts map[string]string) bool {
 // targets to vendored packages resolve. When the root manifest declares
 // a binary entry point, it is additionally emitted through the selected
 // backend.
-func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode) *backend.Result {
+func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode, bootstrapStage0 bool) *backend.Result {
 	ws, err := resolve.NewWorkspace(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
@@ -336,7 +338,7 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 			return emitAndBuildViaQuery(dir, m, eng, ostyquery.LowerKey{
 				WorkspaceRoot: seeded.Root,
 				Dir:           rootDir,
-			}, resolved, feats, backendID, emitMode)
+			}, resolved, feats, backendID, emitMode, bootstrapStage0)
 		}
 	}
 	return nil
@@ -348,7 +350,7 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 // so `use` references to vendored external deps resolve through the
 // DepProvider. The zero-dep path uses the same native package loader without
 // workspace state.
-func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode) *backend.Result {
+func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode, bootstrapStage0 bool) *backend.Result {
 	if deps != nil {
 		ws, err := resolve.NewWorkspace(dir)
 		if err != nil {
@@ -370,7 +372,7 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 			return emitAndBuildViaQuery(dir, m, eng, ostyquery.LowerKey{
 				WorkspaceRoot: seeded.Root,
 				Dir:           rootDir,
-			}, resolved, feats, backendID, emitMode)
+			}, resolved, feats, backendID, emitMode, bootstrapStage0)
 		}
 		return nil
 	}
@@ -398,7 +400,7 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 	}
 	return emitAndBuildViaQuery(dir, m, eng, ostyquery.LowerKey{
 		Dir: seeded.Dir,
-	}, resolved, feats, backendID, emitMode)
+	}, resolved, feats, backendID, emitMode, bootstrapStage0)
 }
 
 func seedBuildWorkspaceEngine(ws *resolve.Workspace) (*ostyquery.Engine, ostyquery.SeededWorkspace) {
@@ -449,17 +451,17 @@ func resDiags(res *resolve.PackageResult) []*diag.Diagnostic {
 	return res.Diags
 }
 
-func emitAndBuildViaQuery(root string, m *manifest.Manifest, eng *ostyquery.Engine, lower ostyquery.LowerKey, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode) *backend.Result {
+func emitAndBuildViaQuery(root string, m *manifest.Manifest, eng *ostyquery.Engine, lower ostyquery.LowerKey, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode, bootstrapStage0 bool) *backend.Result {
 	profileName, triple := resolvedKey(resolved)
 	binName := buildBinaryNameForEmit(m, resolved, triple, emitMode)
-	emitResult := emitViaQuery("build", root, m, eng, lower, resolved, feats, backendID, emitMode, binName)
+	emitResult := emitViaQuery("build", root, m, eng, lower, resolved, feats, backendID, emitMode, binName, bootstrapStage0)
 	if emitResult == nil {
 		return nil
 	}
 	return finishBuildEmitResult(backendID, emitMode, emitResult, profileName)
 }
 
-func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyquery.Engine, lower ostyquery.LowerKey, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode, binName string) *backend.Result {
+func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyquery.Engine, lower ostyquery.LowerKey, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode, binName string, bootstrapStage0 bool) *backend.Result {
 	commandName := "osty " + command
 	// Library-only manifest (`[lib]` without `[bin]`): currently the cmd/osty
 	// build pipeline only knows how to emit binaries, so a library crate's
@@ -542,7 +544,8 @@ func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyqu
 	lower.SourcePath = entryAbs
 	lower.EntryPath = entryAbs
 	target := ostyquery.NewEmitTarget(lower, backendID, emitMode, layout, binName, features).
-		WithLinkLibraries(linkLibraries)
+		WithLinkLibraries(linkLibraries).
+		WithBootstrapStage0(bootstrapStage0)
 	emitted := eng.Queries.Emit.Get(eng.DB, target)
 	if emitted.Err != nil {
 		exitBackendEmitError(command, emitted.Result, emitted.Err)

--- a/cmd/osty/cache_self_test.go
+++ b/cmd/osty/cache_self_test.go
@@ -55,7 +55,7 @@ func TestCacheSelfPathPrintsCanonicalLocation(t *testing.T) {
 		t.Fatalf("cache-self: %v\n%s", err, out)
 	}
 	got := strings.TrimSpace(string(out))
-	if !strings.Contains(got, ".osty/cache/self-host/") {
+	if !strings.Contains(filepath.ToSlash(got), ".osty/cache/self-host/") {
 		t.Errorf("path missing canonical prefix: %s", got)
 	}
 	if !strings.HasSuffix(got, selfhostcache.BinaryName()) {

--- a/cmd/osty/install_self.go
+++ b/cmd/osty/install_self.go
@@ -10,10 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/osty/osty/internal/backend/stage0"
 	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
-
-const installSelfAllowSourceBootstrapEnv = "OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP"
 
 // runInstallSelf orchestrates the bootstrap "build osty-self →
 // promote into cache" sequence. It:
@@ -106,34 +105,14 @@ func runInstallSelf(args []string, _ cliFlags) {
 			fmt.Printf("up-to-date:  %s\n", cachedPath)
 			return
 		}
-	} else if !installSelfSourceBootstrapAllowed() {
-		fmt.Fprintf(os.Stderr, "osty install-self: no osty-self bootstrap source available: %v\n", resolveErr)
-		if os.Getenv("OSTY_STAGE0_FALLBACK") == "" {
-			printInstallSelfBootstrapHint()
-		} else {
-			fmt.Fprintln(os.Stderr, "")
-			fmt.Fprintln(os.Stderr, "stage0 fallback is enabled, but a full source bootstrap currently requires opt-in because it can exceed memory/time limits before the emergency emitter is reached.")
-		}
-		fmt.Fprintf(os.Stderr, "to attempt the heavy source bootstrap anyway, set %s=1.\n", installSelfAllowSourceBootstrapEnv)
-		os.Exit(1)
+	} else {
+		fmt.Fprintf(os.Stderr, "osty install-self: no prebuilt osty-self available; attempting source bootstrap: %v\n", resolveErr)
 	}
 
 	builtBin, err := buildOstySelf(context.Background(), hostOsty, root, tcAbs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty install-self: build: %v\n", err)
-		// The chicken-egg: a fresh clone has no osty-self in cache,
-		// no in-tree build, and (by default) no registry URL. The
-		// host osty's LLVM backend forks `osty-self lir-proto-lower`
-		// for emit, which declines without an osty-self to fork.
-		// `OSTY_STAGE0_FALLBACK=1` activates the bootstrap-only
-		// emitter (`docs/osty_self_bootstrap_design.md`) which can
-		// emit a small subset of MIR patterns — enough for the
-		// emergency path but not yet for the full toolchain. Surface
-		// the workflow options so the user does not have to hunt
-		// through the resolver chain in the dark.
-		if os.Getenv("OSTY_STAGE0_FALLBACK") == "" {
-			printInstallSelfBootstrapHint()
-		}
+		printInstallSelfBootstrapHint()
 
 		os.Exit(1)
 	}
@@ -144,41 +123,31 @@ func runInstallSelf(args []string, _ cliFlags) {
 	fmt.Printf("installed:   %s\n", cachedPath)
 }
 
+// printInstallSelfBootstrapHint points users at prebuilt recovery options
+// after the internal source bootstrap path has already failed.
+func printInstallSelfBootstrapHint() {
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "hint: install-self tried the internal source bootstrap path.")
+	fmt.Fprintln(os.Stderr, "      To avoid source bootstrap, provide a prebuilt osty-self:")
+	fmt.Fprintln(os.Stderr, "  - point OSTY_SELF_REGISTRY_URL at a registry serving a pre-built osty-self,")
+	fmt.Fprintln(os.Stderr, "  - or point OSTY_SELF_BIN at an existing osty-self binary.")
+}
+
 // buildOstySelf invokes the host `osty` binary with the standard
 // build flags used by the self-rebuild ratchet. Returns the absolute
 // path to the produced osty-self binary.
-func installSelfSourceBootstrapAllowed() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(installSelfAllowSourceBootstrapEnv))) {
-	case "1", "true", "yes", "on":
-		return true
-	default:
-		return false
-	}
-}
-
-func printInstallSelfBootstrapHint() {
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "hint: bootstrap from a fresh clone needs an osty-self source. Pick one:")
-	fmt.Fprintln(os.Stderr, "  - point OSTY_SELF_REGISTRY_URL at a registry serving a pre-built osty-self,")
-	fmt.Fprintln(os.Stderr, "  - point OSTY_SELF_BIN at an existing osty-self binary, or")
-	fmt.Fprintln(os.Stderr, "  - retry with OSTY_STAGE0_FALLBACK=1 to use the emergency bootstrap emitter")
-	fmt.Fprintln(os.Stderr, "    (subset coverage; see docs/osty_self_bootstrap_design.md).")
-}
-
 func buildOstySelf(ctx context.Context, hostOsty, root, toolchainDir string) (string, error) {
-	cmd := exec.CommandContext(ctx, hostOsty, "build", "--backend=llvm", "--emit", "binary", "--force", toolchainDir)
-	// Forward env vars set by the user (OSTY_STAGE0_FALLBACK,
-	// OSTY_STDLIB_BODY_LOWER, etc.) and additionally enable
-	// LIST_ALL_DECLINES when stage0 fallback is active. The cascade
+	cmd := exec.CommandContext(ctx, hostOsty, "build", "--bootstrap-stage0", "--backend=llvm", "--emit", "binary", "--force", toolchainDir)
+	// Forward user env vars and enable LIST_ALL_DECLINES for the
+	// install-self bootstrap build. The cascade
 	// of stdlib-generic-method monomorph functions (Result.unwrapOr,
 	// List.pop, ...) that stage0 can't fully match are diagnostic-only
 	// in the install-self critical path — emitting them as `unreachable`
 	// decline stubs lets the binary link without changing the runtime
-	// behaviour of the covered code paths. Users wanting strict mode
-	// can still override by setting OSTY_STAGE0_LIST_ALL_DECLINES=0.
+	// behaviour of the covered code paths.
 	cmd.Env = os.Environ()
-	if os.Getenv("OSTY_STAGE0_FALLBACK") != "" && os.Getenv("OSTY_STAGE0_LIST_ALL_DECLINES") == "" {
-		cmd.Env = append(cmd.Env, "OSTY_STAGE0_LIST_ALL_DECLINES=1")
+	if os.Getenv(stage0.ListAllDeclinesEnv) == "" {
+		cmd.Env = append(cmd.Env, stage0.ListAllDeclinesEnv+"=1")
 	}
 	cmd.Dir = root
 	cmd.Stdout = os.Stdout

--- a/cmd/osty/install_self_test.go
+++ b/cmd/osty/install_self_test.go
@@ -73,6 +73,13 @@ func main() {
 	return bin
 }
 
+func fakeExePath(dir, base string) string {
+	if runtime.GOOS == "windows" {
+		base += ".exe"
+	}
+	return filepath.Join(dir, base)
+}
+
 // TestBuildOstySelfRunsHostBinary covers the lower-level helper
 // directly without going through the CLI flag parser. Confirms the
 // helper invokes the host binary in the right directory and finds the
@@ -114,7 +121,7 @@ func main() { os.Exit(7) }
 `), 0o644); err != nil {
 		t.Fatalf("write fake osty: %v", err)
 	}
-	bin := filepath.Join(dir, "fake-osty-fail")
+	bin := fakeExePath(dir, "fake-osty-fail")
 	out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput()
 	if err != nil {
 		t.Fatalf("build: %v\n%s", err, out)
@@ -126,11 +133,9 @@ func main() { os.Exit(7) }
 }
 
 // TestRunInstallSelfPrintsBootstrapHintOnFailure exercises the
-// fresh-clone diagnostic added in B1: when `install-self` fails
-// without `OSTY_STAGE0_FALLBACK` already set, the user gets
-// pointed at the three workflow options (registry / OSTY_SELF_BIN /
-// stage0) instead of having to read the resolver source to figure
-// out what's wrong.
+// fresh-clone diagnostic: when the internal source bootstrap fails, the
+// user is pointed at the prebuilt osty-self options instead of env-var
+// bootstrap toggles.
 func TestRunInstallSelfPrintsBootstrapHintOnFailure(t *testing.T) {
 	ostyBin := buildOstyBinaryForTest(t)
 
@@ -147,8 +152,9 @@ func TestRunInstallSelfPrintsBootstrapHintOnFailure(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
 		t.Fatalf("main.osty: %v", err)
 	}
-	stub := filepath.Join(t.TempDir(), "stub-osty")
-	src := stub + ".go"
+	stubDir := t.TempDir()
+	stub := fakeExePath(stubDir, "stub-osty")
+	src := filepath.Join(stubDir, "stub-osty.go")
 	if err := os.WriteFile(src, []byte(`package main
 import "os"
 func main() { os.Exit(1) }
@@ -161,61 +167,22 @@ func main() { os.Exit(1) }
 
 	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", stub)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(), "OSTY_STAGE0_FALLBACK=") // explicitly unset
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected install-self to fail\n%s", out)
 	}
 	got := string(out)
 	for _, want := range []string{
-		"hint: bootstrap from a fresh clone",
+		"hint: install-self tried the internal source bootstrap path",
 		"OSTY_SELF_REGISTRY_URL",
 		"OSTY_SELF_BIN",
-		"OSTY_STAGE0_FALLBACK=1",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q:\n%s", want, got)
 		}
 	}
-}
-
-// TestRunInstallSelfSuppressesHintWhenStage0Set confirms the new
-// diagnostic does not double-up on users who have already opted
-// into the stage0 path.
-func TestRunInstallSelfSuppressesHintWhenStage0Set(t *testing.T) {
-	ostyBin := buildOstyBinaryForTest(t)
-
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
-		t.Fatalf("osty.toml: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
-		t.Fatalf("toolchain mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
-		t.Fatalf("main.osty: %v", err)
-	}
-	stub := filepath.Join(t.TempDir(), "stub-osty")
-	src := stub + ".go"
-	if err := os.WriteFile(src, []byte(`package main
-import "os"
-func main() { os.Exit(1) }
-`), 0o644); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-	if out, err := exec.Command("go", "build", "-o", stub, src).CombinedOutput(); err != nil {
-		t.Fatalf("build stub: %v\n%s", err, out)
-	}
-
-	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", stub)
-	cmd.Dir = root
-	cmd.Env = append(os.Environ(), "OSTY_STAGE0_FALLBACK=1")
-	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected install-self to fail\n%s", out)
-	}
-	if strings.Contains(string(out), "hint: bootstrap from a fresh clone") {
-		t.Errorf("hint should be suppressed when stage0 already set:\n%s", out)
+	if strings.Contains(got, "OSTY_STAGE0_FALLBACK") || strings.Contains(got, "OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP") {
+		t.Errorf("output should not mention removed bootstrap env vars:\n%s", got)
 	}
 }
 
@@ -231,7 +198,7 @@ func main() {}
 `), 0o644); err != nil {
 		t.Fatalf("write fake osty: %v", err)
 	}
-	bin := filepath.Join(dir, "fake-osty-noop")
+	bin := fakeExePath(dir, "fake-osty-noop")
 	out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput()
 	if err != nil {
 		t.Fatalf("build: %v\n%s", err, out)

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -173,7 +173,7 @@ func runRun(args []string, cliF cliFlags) {
 	emitResult := emitViaQuery("run", root, m, eng, ostyquery.LowerKey{
 		WorkspaceRoot: seeded.Root,
 		Dir:           rootDir,
-	}, resolved, featureSet(resolved), backendID, emitMode, binName)
+	}, resolved, featureSet(resolved), backendID, emitMode, binName, false)
 	if emitResult == nil {
 		fmt.Fprintf(os.Stderr, "osty run: backend did not produce a runnable artifact\n")
 		os.Exit(1)

--- a/cmd/osty/sign_self_test.go
+++ b/cmd/osty/sign_self_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -72,7 +73,7 @@ func TestSignSelfGenKeyProducesValidPair(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Errorf("key file perm = %v, want 0600", info.Mode().Perm())
 	}
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -153,6 +153,10 @@ type Request struct {
 	BinaryName    string
 	Features      []string
 	LinkLibraries []string
+	// BootstrapStage0 allows the emergency Go-side stage0 emitter to
+	// participate when bootstrapping osty-self from source. Normal
+	// production builds leave this false and stay on the self-hosted path.
+	BootstrapStage0 bool
 	// ExtraObjects is a list of absolute paths to additional object
 	// files that should be linked alongside the main package's
 	// object when `Emit == EmitBinary`. Used by cmd/osty's cross-

--- a/internal/backend/bootstrap.go
+++ b/internal/backend/bootstrap.go
@@ -1,30 +1,11 @@
 package backend
 
 import (
-	"os"
 	"strings"
 
 	"github.com/osty/osty/internal/backend/stage0"
 	"github.com/osty/osty/internal/llvmabi"
 )
-
-// Stage0FallbackEnv is the env-var name that opts a build into the
-// stage0 bootstrap fallback emitter. The dispatcher consults it when the
-// native LIR Proto subprocess declined because `osty-self` is missing, or
-// because the only available `osty-self` is itself a stage0 partial binary
-// that trapped in a declined function.
-const Stage0FallbackEnv = "OSTY_STAGE0_FALLBACK"
-
-// Stage0FallbackEnabled reports whether the stage0 fallback emitter
-// should be considered when the LIR Proto subprocess declines due to
-// `osty-self` not being built yet.
-func Stage0FallbackEnabled() bool {
-	switch strings.TrimSpace(os.Getenv(Stage0FallbackEnv)) {
-	case "1", "true", "TRUE", "True", "on", "ON", "On", "yes", "YES", "Yes":
-		return true
-	}
-	return false
-}
 
 // tryStage0Fallback invokes the stage0 emitter with the entry's MIR.
 // Indirection so tests can stub it without touching the live emitter.

--- a/internal/backend/lir_proto_gate_test.go
+++ b/internal/backend/lir_proto_gate_test.go
@@ -28,7 +28,7 @@ const lirProtoGateSrc = `fn main() {
 func TestLLVMDispatchAppendsLIRProtoFallbackWarning(t *testing.T) {
 	req := newBackendRequest(t, EmitLLVMIR, lirProtoGateSrc)
 	t.Setenv(llvmabi.LIRProtoEnvVar, "1")
-	_, warnings, _ := generateLLVMIR(req.Entry, "arm64-apple-macosx", req.Features, req.Emit)
+	_, warnings, _ := generateLLVMIR(req.Entry, "arm64-apple-macosx", req.Features, req.Emit, false)
 	found := false
 	for _, w := range warnings {
 		if errors.Is(w, llvmabi.ErrLIRProtoNotWired) {
@@ -48,7 +48,7 @@ func TestLLVMDispatchAppendsLIRProtoFallbackWarning(t *testing.T) {
 func TestLLVMDispatchSkipsLIRProtoWarningWhenGateOff(t *testing.T) {
 	req := newBackendRequest(t, EmitLLVMIR, lirProtoGateSrc)
 	t.Setenv(llvmabi.LIRProtoEnvVar, "")
-	_, warnings, _ := generateLLVMIR(req.Entry, req.Layout.Target, req.Features, req.Emit)
+	_, warnings, _ := generateLLVMIR(req.Entry, req.Layout.Target, req.Features, req.Emit, false)
 	for _, w := range warnings {
 		if errors.Is(w, llvmabi.ErrLIRProtoNotWired) {
 			t.Fatalf("warnings unexpectedly include ErrLIRProtoNotWired with gate off: %s", joinLirProtoWarnings(warnings))

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -51,7 +51,7 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	if err := ValidateEmit(NameLLVM, req.Emit); err != nil {
 		return nil, err
 	}
-	irOut, warnings, genErr := generateLLVMIR(req.Entry, req.Layout.Target, req.Features, req.Emit)
+	irOut, warnings, genErr := generateLLVMIR(req.Entry, req.Layout.Target, req.Features, req.Emit, req.BootstrapStage0)
 	if genErr == nil {
 		return b.emitPrebuiltIR(ctx, req, irOut, warnings)
 	}
@@ -65,7 +65,7 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 // EmitLLVMIRText runs the LLVM lowering pipeline for one prepared entry and
 // returns the textual IR bytes directly, without creating artifact paths.
 func EmitLLVMIRText(entry Entry, target string, features []string) ([]byte, []error, error) {
-	return generateLLVMIR(entry, target, features, EmitLLVMIR)
+	return generateLLVMIR(entry, target, features, EmitLLVMIR, false)
 }
 
 // TryEmitNativeOwnedLLVMIRText is retained as a compatibility probe while the
@@ -182,7 +182,7 @@ func (b LLVMBackend) preparePrebuiltIRResult(req Request, irOut []byte, warnings
 	}, nil
 }
 
-func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode) ([]byte, []error, error) {
+func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode, bootstrapStage0 bool) ([]byte, []error, error) {
 	if entry.IR == nil {
 		return nil, nil, fmt.Errorf("llvm backend: missing lowered IR entry")
 	}
@@ -227,10 +227,10 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 		return renderUnsupportedLLVMIR(entry, target, emit, warnings, diag, llvmDispatchUnsupportedPreflight)
 	}
 	if capabilities.CanRoute(llvmDispatchNativeOwned) {
-		if Stage0FallbackEnabled() {
+		if bootstrapStage0 {
 			if nativeWarnings, missing := probeStage0BootstrapMissingOstySelf(); missing {
 				traceLLVMDispatch("stage0 fallback shortcut: osty-self missing before native MIR payload marshal package=%s source=%s", entry.PackageName, entry.SourcePath)
-				if out, stage0Warnings, handled := emitStage0FallbackForMissingOstySelf(entry, opts, nativeWarnings); handled {
+				if out, stage0Warnings, handled := emitStage0FallbackForMissingOstySelf(entry, opts, nativeWarnings, bootstrapStage0); handled {
 					return out, append(warnings, stage0Warnings...), nil
 				} else {
 					return renderStage0FallbackUnsupportedLLVMIR(entry, target, emit, append(warnings, stage0Warnings...), llvmDispatchNativeOwned)
@@ -270,7 +270,7 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 		traceLLVMDispatch("%s unsupported: %s %s (%s)", route, diag.Code, diag.Kind, row.Subject)
 		return renderUnsupportedLLVMIR(entry, target, emit, warnings, diag, route)
 	}
-	irOut, fallbackWarnings, genErr := emitLLVMFallback(route, entry, opts)
+	irOut, fallbackWarnings, genErr := emitLLVMFallback(route, entry, opts, bootstrapStage0)
 	warnings = append(warnings, fallbackWarnings...)
 	if genErr == nil {
 		traceLLVMDispatch("%s succeeded package=%s source=%s", route, entry.PackageName, entry.SourcePath)
@@ -289,12 +289,12 @@ func llvmFallbackDispatchRoute(opts llvmabi.Options, entry Entry) llvmDispatchRo
 // subprocess. The Go MIR emitter is gone, so MIR-direct emission rides the
 // same `tryNativeOwnedMIRPayloadLLVMIRText` boundary the native-owned route
 // uses. When the subprocess declines because `osty-self` is not built yet
-// (the canonical bootstrap symptom), an opt-in stage0 fallback can step in
-// and emit a small bootstrap-only subset; see
-// `docs/osty_self_bootstrap_design.md`. Without the env-var opt-in the
-// dispatcher still declines so production builds never silently route
-// through the bootstrap emitter.
-func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options) ([]byte, []error, error) {
+// (the canonical bootstrap symptom), the install-self bootstrap path can step
+// in and emit a small bootstrap-only subset; see
+// `docs/osty_self_bootstrap_design.md`. Normal production builds pass
+// bootstrapStage0=false, so the dispatcher still declines instead of silently
+// routing through the bootstrap emitter.
+func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options, bootstrapStage0 bool) ([]byte, []error, error) {
 	if entry.MIR == nil {
 		return nil, nil, llvmabi.Unsupported("source-layout", "nil MIR module")
 	}
@@ -305,7 +305,7 @@ func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options
 	if ok {
 		return out, nativeWarnings, nil
 	}
-	if out, stage0Warnings, handled := emitStage0FallbackForMissingOstySelf(entry, opts, nativeWarnings); handled {
+	if out, stage0Warnings, handled := emitStage0FallbackForMissingOstySelf(entry, opts, nativeWarnings, bootstrapStage0); handled {
 		return out, stage0Warnings, nil
 	} else {
 		nativeWarnings = stage0Warnings
@@ -317,8 +317,8 @@ func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options
 	return nil, nativeWarnings, llvmabi.Unsupported("mir-emit", detail)
 }
 
-func emitStage0FallbackForMissingOstySelf(entry Entry, opts llvmabi.Options, nativeWarnings []error) ([]byte, []error, bool) {
-	if !Stage0FallbackEnabled() || !ShouldUseStage0BootstrapFallback(nativeWarnings) {
+func emitStage0FallbackForMissingOstySelf(entry Entry, opts llvmabi.Options, nativeWarnings []error, bootstrapStage0 bool) ([]byte, []error, bool) {
+	if !bootstrapStage0 || !ShouldUseStage0BootstrapFallback(nativeWarnings) {
 		return nil, nativeWarnings, false
 	}
 	s0Out, s0Err := tryStage0Fallback(entry, opts)
@@ -326,8 +326,8 @@ func emitStage0FallbackForMissingOstySelf(entry Entry, opts llvmabi.Options, nat
 		nativeWarnings = append(nativeWarnings, errors.New("stage0 fallback: emitted MIR through bootstrap-only path"))
 		return s0Out, nativeWarnings, true
 	}
-	// Bootstrap path: when both `OSTY_STAGE0_FALLBACK=1` and
-	// `OSTY_STAGE0_LIST_ALL_DECLINES=1` are set, stage0 emits
+	// Bootstrap path: when install-self enables stage0 bootstrap and
+	// `OSTY_STAGE0_LIST_ALL_DECLINES=1` is set, stage0 emits
 	// partial IR + an aggregated declines error. Accept that
 	// partial IR so the chicken-and-egg `osty install-self` can
 	// produce an osty-self binary whose body covers the
@@ -336,10 +336,10 @@ func emitStage0FallbackForMissingOstySelf(entry Entry, opts llvmabi.Options, nat
 	// Without this branch, the very first build on a fresh
 	// clone fails hard the moment any toolchain function falls
 	// outside stage0's pattern set — even though the produced
-	// binary is good enough to run the smoke tests that
-	// exercise only the covered subset. Only fires when the
-	// caller has explicitly opted into both env vars, so
-	// production builds remain unaffected.
+	// binary is good enough to run the smoke tests that exercise
+	// only the covered subset. Only fires when the caller has
+	// explicitly opted into bootstrap mode, so production builds
+	// remain unaffected.
 	if len(s0Out) > 0 && stage0.IsListAllDeclines() {
 		nativeWarnings = append(nativeWarnings,
 			errors.New("stage0 fallback: partial IR with aggregated declines (OSTY_STAGE0_LIST_ALL_DECLINES=1)"),

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -159,12 +159,13 @@ int main(void) {
 }
 
 func TestBundledRuntimeListReserveBacktraceIsOptional(t *testing.T) {
+	runtimeSource := strings.ReplaceAll(bundledRuntimeSource, "\r\n", "\n")
 	for _, want := range []string{
 		"#ifndef OSTY_RT_HAS_BACKTRACE\n#define OSTY_RT_HAS_BACKTRACE 0\n#endif",
-		"#if OSTY_RT_HAS_BACKTRACE\n        void *bt[32];",
-		"#endif\n        osty_rt_abort(\"list allocation request exceeds 1G elements\");",
+		"#if OSTY_RT_HAS_BACKTRACE\n    void *bt[32];",
+		"#endif\n    osty_rt_abort(\"list allocation request exceeds 1G elements\");",
 	} {
-		if !strings.Contains(bundledRuntimeSource, want) {
+		if !strings.Contains(runtimeSource, want) {
 			t.Fatalf("bundled runtime source missing %q", want)
 		}
 	}

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -353,6 +353,9 @@ func TestEmitLLVMIRTextMatchesBackendArtifactOutput(t *testing.T) {
 }
 `)
 	req.Features = []string{"mir-backend"}
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return []byte("declare i32 @printf(ptr, ...)\ndefine i32 @main() { ret i32 0 }\n"), true, nil, nil
+	})
 
 	got, _, directErr := EmitLLVMIRText(req.Entry, "", req.Features)
 	if directErr != nil {
@@ -786,6 +789,9 @@ func TestLLVMBackendDispatchTraceReportsSelectedRoute(t *testing.T) {
 }
 `)
 	req.Features = []string{"mir-backend"}
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return []byte("; mir-direct covered by test stub\n"), true, nil, nil
+	})
 
 	result, emitErr, trace := captureLLVMBackendTrace(t, backend, req)
 	if emitErr != nil {

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -97,8 +97,8 @@ func fnTargetFeaturesAttr(features []string) string {
 // instead of serializing them.
 //
 // The env var is read once per EmitMIR call. No effect on production
-// builds (stage0 is only consulted under OSTY_STAGE0_FALLBACK=1 in the
-// first place — see internal/backend/bootstrap.go).
+// builds (stage0 is only consulted by the explicit install-self bootstrap path;
+// see internal/backend/bootstrap.go).
 const ListAllDeclinesEnv = "OSTY_STAGE0_LIST_ALL_DECLINES"
 
 // IsListAllDeclines reports whether `OSTY_STAGE0_LIST_ALL_DECLINES=1`

--- a/internal/backend/stage0_dispatch_test.go
+++ b/internal/backend/stage0_dispatch_test.go
@@ -26,40 +26,11 @@ func withStage0MissingOstySelfProbe(t *testing.T, fn func() ([]error, bool)) {
 	t.Cleanup(func() { probeStage0BootstrapMissingOstySelf = old })
 }
 
-func TestStage0FallbackDisabledByDefault(t *testing.T) {
-	if Stage0FallbackEnabled() {
-		t.Fatalf("OSTY_STAGE0_FALLBACK must default to off; saw enabled")
-	}
-}
-
-func TestStage0FallbackEnabledRespectsEnvVar(t *testing.T) {
-	cases := []struct {
-		value string
-		want  bool
-	}{
-		{"", false},
-		{"0", false},
-		{"false", false},
-		{"off", false},
-		{"1", true},
-		{"true", true},
-		{"TRUE", true},
-		{"On", true},
-		{"yes", true},
-	}
-	for _, c := range cases {
-		c := c
-		t.Run(c.value, func(t *testing.T) {
-			t.Setenv(Stage0FallbackEnv, c.value)
-			if got := Stage0FallbackEnabled(); got != c.want {
-				t.Fatalf("Stage0FallbackEnabled with %q = %v, want %v", c.value, got, c.want)
-			}
-		})
-	}
+func emitLLVMIRTextWithStage0Bootstrap(entry Entry, target string, features []string) ([]byte, []error, error) {
+	return generateLLVMIR(entry, target, features, EmitLLVMIR, true)
 }
 
 func TestGenerateLLVMIRShortCircuitsNativeMIRMarshalWhenStage0FreshClone(t *testing.T) {
-	t.Setenv(Stage0FallbackEnv, "1")
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
     println(1)
 }
@@ -79,7 +50,7 @@ func TestGenerateLLVMIRShortCircuitsNativeMIRMarshalWhenStage0FreshClone(t *test
 		return []byte("; stage0 shortcut IR for test\n"), nil
 	})
 
-	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	got, warnings, err := emitLLVMIRTextWithStage0Bootstrap(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
 	}
@@ -92,7 +63,6 @@ func TestGenerateLLVMIRShortCircuitsNativeMIRMarshalWhenStage0FreshClone(t *test
 }
 
 func TestEmitLLVMFallbackUsesStage0WhenOstySelfMissing(t *testing.T) {
-	t.Setenv(Stage0FallbackEnv, "1")
 	withStage0MissingOstySelfProbe(t, func() ([]error, bool) { return nil, false })
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
     println(1)
@@ -111,7 +81,7 @@ func TestEmitLLVMFallbackUsesStage0WhenOstySelfMissing(t *testing.T) {
 		return []byte("; stage0 fallback IR for test\n"), nil
 	})
 
-	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	got, warnings, err := emitLLVMIRTextWithStage0Bootstrap(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
 	}
@@ -127,7 +97,6 @@ func TestEmitLLVMFallbackUsesStage0WhenOstySelfMissing(t *testing.T) {
 }
 
 func TestEmitLLVMFallbackUsesStage0WhenPartialOstySelfDeclines(t *testing.T) {
-	t.Setenv(Stage0FallbackEnv, "1")
 	withStage0MissingOstySelfProbe(t, func() ([]error, bool) { return nil, false })
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
     println(1)
@@ -146,7 +115,7 @@ func TestEmitLLVMFallbackUsesStage0WhenPartialOstySelfDeclines(t *testing.T) {
 		return []byte("; stage0 fallback after partial osty-self\n"), nil
 	})
 
-	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	got, warnings, err := emitLLVMIRTextWithStage0Bootstrap(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
 	}
@@ -161,12 +130,9 @@ func TestEmitLLVMFallbackUsesStage0WhenPartialOstySelfDeclines(t *testing.T) {
 	}
 }
 
-func TestEmitLLVMFallbackSkipsStage0WhenEnvNotSet(t *testing.T) {
-	// No env var set — stage0 must not be reached even when the
+func TestEmitLLVMFallbackSkipsStage0ByDefault(t *testing.T) {
+	// Strict default mode must not reach stage0 even when the
 	// native subprocess declined with the osty-self signal.
-	if v := Stage0FallbackEnabled(); v {
-		t.Fatalf("env should be unset before this test")
-	}
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
     println(1)
 }
@@ -175,7 +141,7 @@ func TestEmitLLVMFallbackSkipsStage0WhenEnvNotSet(t *testing.T) {
 		return nil, false, []error{errors.New("osty-self not found")}, nil
 	})
 	withStage0FallbackOverride(t, func(Entry, llvmabi.Options) ([]byte, error) {
-		t.Fatal("stage0 fallback must not run without OSTY_STAGE0_FALLBACK")
+		t.Fatal("stage0 fallback must not run without bootstrap mode")
 		return nil, nil
 	})
 
@@ -186,9 +152,8 @@ func TestEmitLLVMFallbackSkipsStage0WhenEnvNotSet(t *testing.T) {
 }
 
 func TestEmitLLVMFallbackSkipsStage0WhenDeclineNotOstySelf(t *testing.T) {
-	// Env var set, but the decline reason is unrelated — stage0
+	// Bootstrap mode is set, but the decline reason is unrelated — stage0
 	// should NOT run; the dispatcher should pass the decline up.
-	t.Setenv(Stage0FallbackEnv, "1")
 	withStage0MissingOstySelfProbe(t, func() ([]error, bool) { return nil, false })
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
     println(1)
@@ -202,15 +167,14 @@ func TestEmitLLVMFallbackSkipsStage0WhenDeclineNotOstySelf(t *testing.T) {
 		return nil, nil
 	})
 
-	_, _, err := EmitLLVMIRText(req.Entry, "", nil)
+	_, _, err := emitLLVMIRTextWithStage0Bootstrap(req.Entry, "", nil)
 	if err == nil {
 		t.Fatal("expected ErrLLVMNotImplemented when stage0 is not eligible")
 	}
 }
 
 func TestEmitLLVMFallbackBubblesUpStage0Decline(t *testing.T) {
-	// Env on, native declined with osty-self-missing, stage0 declines too.
-	t.Setenv(Stage0FallbackEnv, "1")
+	// Bootstrap mode on, native declined with osty-self-missing, stage0 declines too.
 	withStage0MissingOstySelfProbe(t, func() ([]error, bool) { return nil, false })
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
     println(1)
@@ -224,7 +188,7 @@ func TestEmitLLVMFallbackBubblesUpStage0Decline(t *testing.T) {
 		return nil, stage0Reason
 	})
 
-	_, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	_, warnings, err := emitLLVMIRTextWithStage0Bootstrap(req.Entry, "", nil)
 	if err == nil {
 		t.Fatal("expected ErrLLVMNotImplemented when stage0 also declines")
 	}
@@ -234,8 +198,7 @@ func TestEmitLLVMFallbackBubblesUpStage0Decline(t *testing.T) {
 }
 
 func TestEmitLLVMFallbackPrefersNativeWhenItCovers(t *testing.T) {
-	// Env on but native subprocess succeeds — stage0 must not run.
-	t.Setenv(Stage0FallbackEnv, "1")
+	// Bootstrap mode on but native subprocess succeeds — stage0 must not run.
 	withStage0MissingOstySelfProbe(t, func() ([]error, bool) { return nil, false })
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
     println(1)
@@ -249,7 +212,7 @@ func TestEmitLLVMFallbackPrefersNativeWhenItCovers(t *testing.T) {
 		return nil, nil
 	})
 
-	got, _, err := EmitLLVMIRText(req.Entry, "", nil)
+	got, _, err := emitLLVMIRTextWithStage0Bootstrap(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
 	}
@@ -280,11 +243,11 @@ func findWarning(warnings []error, sub string) bool {
 // just EmitLLVMIRText) to catch regressions in the binary / object
 // branches.
 func TestStage0FallbackSurvivesBinaryEmitPath(t *testing.T) {
-	t.Setenv(Stage0FallbackEnv, "1")
 	withStage0MissingOstySelfProbe(t, func() ([]error, bool) { return nil, false })
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
 	req := newBackendRequest(t, EmitBinary, `fn main() {}`)
+	req.BootstrapStage0 = true
 
 	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
 		return nil, false, []error{errors.New("osty-self not found")}, nil

--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -1278,7 +1278,6 @@ func runStage0AuditFixedPointVerify(t *testing.T, module *mir.Module, clangPath 
 	if stage0AuditFixedPointFullEnabled() {
 		t.Logf("fp-verify (full): launching produced binary as `install-self` — this can take >10 min")
 		runCmd := exec.Command(binPath, "install-self")
-		runCmd.Env = append(os.Environ(), "OSTY_STAGE0_FALLBACK=1")
 		runOut, runErr := runCmd.CombinedOutput()
 		if runErr != nil {
 			t.Logf("fp-verify (full): produced binary install-self FAILED: %v", runErr)

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -318,6 +318,7 @@ type EmitTarget struct {
 	BinaryName       string
 	FeaturesKey      string
 	LinkLibrariesKey string
+	BootstrapStage0  bool
 }
 
 // NewEmitTarget builds a normalized key for the Emit query.
@@ -338,6 +339,14 @@ func NewEmitTarget(lower LowerKey, name backend.Name, mode backend.EmitMode, lay
 // names that should be forwarded to the backend link step.
 func (t EmitTarget) WithLinkLibraries(libraries []string) EmitTarget {
 	t.LinkLibrariesKey = LinkLibrariesKey(libraries)
+	return t.normalized()
+}
+
+// WithBootstrapStage0 returns a copy of t that allows the backend's
+// bootstrap-only stage0 recovery path. Normal production query targets leave
+// this false.
+func (t EmitTarget) WithBootstrapStage0(enabled bool) EmitTarget {
+	t.BootstrapStage0 = enabled
 	return t.normalized()
 }
 
@@ -845,11 +854,12 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 					Profile: target.Profile,
 					Target:  target.Target,
 				},
-				Emit:          target.Emit,
-				Entry:         lowered.Entry,
-				BinaryName:    target.BinaryName,
-				Features:      target.Features(),
-				LinkLibraries: target.LinkLibraries(),
+				Emit:            target.Emit,
+				Entry:           lowered.Entry,
+				BinaryName:      target.BinaryName,
+				Features:        target.Features(),
+				LinkLibraries:   target.LinkLibraries(),
+				BootstrapStage0: target.BootstrapStage0,
 			})
 			return EmitResult{Result: result, Err: err}
 		},

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -568,7 +568,7 @@ func TestEmitQueryWritesLLVMIRArtifact(t *testing.T) {
 		backend.Layout{Root: root, Profile: "debug"},
 		"",
 		nil,
-	)
+	).WithBootstrapStage0(true)
 
 	emitted := eng.Queries.Emit.Get(eng.DB, target)
 	if emitted.Err != nil {

--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -401,9 +401,9 @@ build_self_binary() {
 	snapshot_binaries "$before"
 	log "$label: build toolchain package with $driver"
 	local forward_args
-	printf -v forward_args 'build\n--backend=llvm\n--emit\nbinary\n--force\n%s' "$toolchain_dir"
+	printf -v forward_args 'build\n--bootstrap-stage0\n--backend=llvm\n--emit\nbinary\n--force\n%s' "$toolchain_dir"
 	if [[ "$label" == "stage1" && -z "$host_guard" ]]; then
-		OSTY_STAGE0_FALLBACK=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
+		OSTY_STAGE0_LIST_ALL_DECLINES=1 OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --bootstrap-stage0 --backend=llvm --emit binary --force "$toolchain_dir"
 	elif [[ -n "$host_guard" ]]; then
 		OSTY_SELF_REBUILD_HOST_BIN="$host_guard" OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
 	else


### PR DESCRIPTION
## Summary

- Remove the production-facing `OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP` and `OSTY_STAGE0_FALLBACK` gates from the active bootstrap path.
- Add an explicit `--bootstrap-stage0` build path and carry it through backend requests/query targets so normal builds remain strict by default.
- Update install-self, self-rebuild, CI bootstrap wiring, docs, and tests to use the explicit bootstrap path instead of env toggles.
- Stub strict-mode backend tests where they previously depended on a local `osty-self`, and fix two Windows-only CLI test assumptions surfaced by the wider run.

## Why

The env-var bootstrap gates made production strict mode fragile: tests and bootstrap flows could silently rely on stage0 fallback. This moves stage0 use behind an explicit internal build option while keeping the default backend path strict.

## Validation

- `go test -count=1 -vet=off ./internal/ir ./internal/mir ./internal/backend ./internal/nativellvmgen ./internal/llvmabi ./internal/toolchain ./internal/query/osty ./cmd/osty-native-llvmgen ./cmd/osty`
- `git diff --check`

Note: `shfmt` and `shellcheck` were unavailable in the local Windows environment.