### PR TITLE
fix: cihost Mach-O `_` prefix + Char shims + void cascade narrow

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -30468,6 +30468,21 @@ void *osty_rt_keychain_delete(const char *service, const char *account) {
 
 #if defined(__GNUC__) || defined(__clang__)
 
+/* Mach-O (macOS) prepends `_` to C-ABI symbol names; ELF (Linux) does not.
+ * The `__asm__("foo")` directive emits the literal string as the symbol
+ * name with NO further mangling — so the raw string we pass must already
+ * include any platform-specific prefix that the matching `declare @foo`
+ * IR-side reference will resolve to. `OSTY_GC_SYMBOL(name)` (defined
+ * above) does exactly that — adds `_` on `__APPLE__`, leaves bare
+ * elsewhere — and is reused here so the cihost shims, GC roots, and
+ * audit-symbol shims all share one source of truth.
+ *
+ * Without this prefix the cihost shims silently linked on Linux but
+ * failed on macOS with `Undefined symbols: "_runtime.cihost.X",
+ * referenced from <main.o>` — particularly visible after PR #1914
+ * dropped LTO from debug builds (LTO sometimes optimized away the dead
+ * ci.osty paths before the linker noticed the missing symbols). */
+
 static void *runtime_cihost_empty_string(void) {
   return osty_rt_string_dup_site("", 0, "runtime.cihost.stub");
 }
@@ -30475,60 +30490,54 @@ static void *runtime_cihost_empty_string(void) {
 static void *runtime_cihost_empty_list(void) { return osty_rt_list_new(); }
 
 /* --- Bool returning --- */
-bool runtime_cihost_KeepAlive(void) __asm__("runtime.cihost.KeepAlive");
+bool runtime_cihost_KeepAlive(void) __asm__(OSTY_GC_SYMBOL("runtime.cihost.KeepAlive"));
 bool runtime_cihost_KeepAlive(void) { return false; }
 
-bool runtime_cihost_HasManifest(void *manifest) __asm__(
-    "runtime.cihost.HasManifest");
+bool runtime_cihost_HasManifest(void *manifest) __asm__(OSTY_GC_SYMBOL("runtime.cihost.HasManifest"));
 bool runtime_cihost_HasManifest(void *manifest) {
   (void)manifest;
   return false;
 }
 
-bool runtime_cihost_HasWorkspace(void *manifest) __asm__(
-    "runtime.cihost.HasWorkspace");
+bool runtime_cihost_HasWorkspace(void *manifest) __asm__(OSTY_GC_SYMBOL("runtime.cihost.HasWorkspace"));
 bool runtime_cihost_HasWorkspace(void *manifest) {
   (void)manifest;
   return false;
 }
 
-bool runtime_cihost_HasDependencies(void *manifest) __asm__(
-    "runtime.cihost.HasDependencies");
+bool runtime_cihost_HasDependencies(void *manifest) __asm__(OSTY_GC_SYMBOL("runtime.cihost.HasDependencies"));
 bool runtime_cihost_HasDependencies(void *manifest) {
   (void)manifest;
   return false;
 }
 
 /* --- ptr returning, no args --- */
-void *runtime_cihost_NowUTC(void) __asm__("runtime.cihost.NowUTC");
+void *runtime_cihost_NowUTC(void) __asm__(OSTY_GC_SYMBOL("runtime.cihost.NowUTC"));
 void *runtime_cihost_NowUTC(void) { return NULL; }
 
-void *runtime_cihost_EmptyDiagnostics(void) __asm__(
-    "runtime.cihost.EmptyDiagnostics");
+void *runtime_cihost_EmptyDiagnostics(void) __asm__(OSTY_GC_SYMBOL("runtime.cihost.EmptyDiagnostics"));
 void *runtime_cihost_EmptyDiagnostics(void) {
   return runtime_cihost_empty_list();
 }
 
 void *
-runtime_cihost_EmptyPackages(void) __asm__("runtime.cihost.EmptyPackages");
+runtime_cihost_EmptyPackages(void) __asm__(OSTY_GC_SYMBOL("runtime.cihost.EmptyPackages"));
 void *runtime_cihost_EmptyPackages(void) { return runtime_cihost_empty_list(); }
 
-void *runtime_cihost_EmptyPackageResults(void) __asm__(
-    "runtime.cihost.EmptyPackageResults");
+void *runtime_cihost_EmptyPackageResults(void) __asm__(OSTY_GC_SYMBOL("runtime.cihost.EmptyPackageResults"));
 void *runtime_cihost_EmptyPackageResults(void) {
   return runtime_cihost_empty_list();
 }
 
 /* --- ptr returning, ptr args --- */
-void *runtime_cihost_DiagnosticSeverity(void *d) __asm__(
-    "runtime.cihost.DiagnosticSeverity");
+void *runtime_cihost_DiagnosticSeverity(void *d) __asm__(OSTY_GC_SYMBOL("runtime.cihost.DiagnosticSeverity"));
 void *runtime_cihost_DiagnosticSeverity(void *d) {
   (void)d;
   return runtime_cihost_empty_string();
 }
 
 void *runtime_cihost_Synthetic(void *severity, void *code,
-                               void *msg) __asm__("runtime.cihost.Synthetic");
+                               void *msg) __asm__(OSTY_GC_SYMBOL("runtime.cihost.Synthetic"));
 void *runtime_cihost_Synthetic(void *severity, void *code, void *msg) {
   (void)severity;
   (void)code;
@@ -30536,8 +30545,7 @@ void *runtime_cihost_Synthetic(void *severity, void *code, void *msg) {
   return NULL;
 }
 
-void *runtime_cihost_LoadRunnerState(void *root, void *manifest) __asm__(
-    "runtime.cihost.LoadRunnerState");
+void *runtime_cihost_LoadRunnerState(void *root, void *manifest) __asm__(OSTY_GC_SYMBOL("runtime.cihost.LoadRunnerState"));
 void *runtime_cihost_LoadRunnerState(void *root, void *manifest) {
   (void)root;
   (void)manifest;
@@ -30546,7 +30554,7 @@ void *runtime_cihost_LoadRunnerState(void *root, void *manifest) {
 
 void *
 runtime_cihost_OstyFiles(void *root,
-                         void *packages) __asm__("runtime.cihost.OstyFiles");
+                         void *packages) __asm__(OSTY_GC_SYMBOL("runtime.cihost.OstyFiles"));
 void *runtime_cihost_OstyFiles(void *root, void *packages) {
   (void)root;
   (void)packages;
@@ -30555,7 +30563,7 @@ void *runtime_cihost_OstyFiles(void *root, void *packages) {
 
 void *
 runtime_cihost_CheckFormat(void *root,
-                           void *files) __asm__("runtime.cihost.CheckFormat");
+                           void *files) __asm__(OSTY_GC_SYMBOL("runtime.cihost.CheckFormat"));
 void *runtime_cihost_CheckFormat(void *root, void *files) {
   (void)root;
   (void)files;
@@ -30564,7 +30572,7 @@ void *runtime_cihost_CheckFormat(void *root, void *files) {
 
 void *
 runtime_cihost_CheckLint(void *manifest, void *packages,
-                         void *results) __asm__("runtime.cihost.CheckLint");
+                         void *results) __asm__(OSTY_GC_SYMBOL("runtime.cihost.CheckLint"));
 void *runtime_cihost_CheckLint(void *manifest, void *packages, void *results) {
   (void)manifest;
   (void)packages;
@@ -30572,22 +30580,19 @@ void *runtime_cihost_CheckLint(void *manifest, void *packages, void *results) {
   return NULL;
 }
 
-void *runtime_cihost_ManifestCoreOf(void *manifest) __asm__(
-    "runtime.cihost.ManifestCoreOf");
+void *runtime_cihost_ManifestCoreOf(void *manifest) __asm__(OSTY_GC_SYMBOL("runtime.cihost.ManifestCoreOf"));
 void *runtime_cihost_ManifestCoreOf(void *manifest) {
   (void)manifest;
   return NULL;
 }
 
-void *runtime_cihost_WorkspaceMembers(void *manifest) __asm__(
-    "runtime.cihost.WorkspaceMembers");
+void *runtime_cihost_WorkspaceMembers(void *manifest) __asm__(OSTY_GC_SYMBOL("runtime.cihost.WorkspaceMembers"));
 void *runtime_cihost_WorkspaceMembers(void *manifest) {
   (void)manifest;
   return runtime_cihost_empty_list();
 }
 
-void *runtime_cihost_DependencyCoreRows(void *manifest) __asm__(
-    "runtime.cihost.DependencyCoreRows");
+void *runtime_cihost_DependencyCoreRows(void *manifest) __asm__(OSTY_GC_SYMBOL("runtime.cihost.DependencyCoreRows"));
 void *runtime_cihost_DependencyCoreRows(void *manifest) {
   (void)manifest;
   return runtime_cihost_empty_list();
@@ -30595,38 +30600,34 @@ void *runtime_cihost_DependencyCoreRows(void *manifest) {
 
 void *runtime_cihost_CheckWorkspaceMemberPaths(
     void *root,
-    void *members) __asm__("runtime.cihost.CheckWorkspaceMemberPaths");
+    void *members) __asm__(OSTY_GC_SYMBOL("runtime.cihost.CheckWorkspaceMemberPaths"));
 void *runtime_cihost_CheckWorkspaceMemberPaths(void *root, void *members) {
   (void)root;
   (void)members;
   return runtime_cihost_empty_list();
 }
 
-void *runtime_cihost_CheckLockfile(void *root, void *manifest) __asm__(
-    "runtime.cihost.CheckLockfile");
+void *runtime_cihost_CheckLockfile(void *root, void *manifest) __asm__(OSTY_GC_SYMBOL("runtime.cihost.CheckLockfile"));
 void *runtime_cihost_CheckLockfile(void *root, void *manifest) {
   (void)root;
   (void)manifest;
   return NULL;
 }
 
-void *runtime_cihost_CheckReleaseLockfile(void *root, void *manifest) __asm__(
-    "runtime.cihost.CheckReleaseLockfile");
+void *runtime_cihost_CheckReleaseLockfile(void *root, void *manifest) __asm__(OSTY_GC_SYMBOL("runtime.cihost.CheckReleaseLockfile"));
 void *runtime_cihost_CheckReleaseLockfile(void *root, void *manifest) {
   (void)root;
   (void)manifest;
   return runtime_cihost_empty_list();
 }
 
-void *runtime_cihost_ReadSnapshotHost(void *path) __asm__(
-    "runtime.cihost.ReadSnapshotHost");
+void *runtime_cihost_ReadSnapshotHost(void *path) __asm__(OSTY_GC_SYMBOL("runtime.cihost.ReadSnapshotHost"));
 void *runtime_cihost_ReadSnapshotHost(void *path) {
   (void)path;
   return NULL;
 }
 
-void *runtime_cihost_WriteSnapshotHost(void *path, void *snapshot) __asm__(
-    "runtime.cihost.WriteSnapshotHost");
+void *runtime_cihost_WriteSnapshotHost(void *path, void *snapshot) __asm__(OSTY_GC_SYMBOL("runtime.cihost.WriteSnapshotHost"));
 void *runtime_cihost_WriteSnapshotHost(void *path, void *snapshot) {
   (void)path;
   (void)snapshot;
@@ -30635,7 +30636,7 @@ void *runtime_cihost_WriteSnapshotHost(void *path, void *snapshot) {
 
 void *runtime_cihost_NewSingleSnapshotHost(
     void *pkg, void *version,
-    void *edition) __asm__("runtime.cihost.NewSingleSnapshotHost");
+    void *edition) __asm__(OSTY_GC_SYMBOL("runtime.cihost.NewSingleSnapshotHost"));
 void *runtime_cihost_NewSingleSnapshotHost(void *pkg, void *version,
                                            void *edition) {
   (void)pkg;
@@ -30646,7 +30647,7 @@ void *runtime_cihost_NewSingleSnapshotHost(void *pkg, void *version,
 
 void *runtime_cihost_NewWorkspaceSnapshotHost(
     void *packages, void *version,
-    void *edition) __asm__("runtime.cihost.NewWorkspaceSnapshotHost");
+    void *edition) __asm__(OSTY_GC_SYMBOL("runtime.cihost.NewWorkspaceSnapshotHost"));
 void *runtime_cihost_NewWorkspaceSnapshotHost(void *packages, void *version,
                                               void *edition) {
   (void)packages;
@@ -30655,15 +30656,13 @@ void *runtime_cihost_NewWorkspaceSnapshotHost(void *packages, void *version,
   return NULL;
 }
 
-void *runtime_cihost_CapturePackageHost(void *pkg) __asm__(
-    "runtime.cihost.CapturePackageHost");
+void *runtime_cihost_CapturePackageHost(void *pkg) __asm__(OSTY_GC_SYMBOL("runtime.cihost.CapturePackageHost"));
 void *runtime_cihost_CapturePackageHost(void *pkg) {
   (void)pkg;
   return runtime_cihost_empty_list();
 }
 
-void *runtime_cihost_CompareSnapshots(void *baseline, void *current) __asm__(
-    "runtime.cihost.CompareSnapshots");
+void *runtime_cihost_CompareSnapshots(void *baseline, void *current) __asm__(OSTY_GC_SYMBOL("runtime.cihost.CompareSnapshots"));
 void *runtime_cihost_CompareSnapshots(void *baseline, void *current) {
   (void)baseline;
   (void)current;
@@ -30673,7 +30672,7 @@ void *runtime_cihost_CompareSnapshots(void *baseline, void *current) {
 /* --- Int arg --- */
 void *runtime_cihost_CheckPolicyFileSizes(
     void *root, void *files,
-    int64_t maxFileBytes) __asm__("runtime.cihost.CheckPolicyFileSizes");
+    int64_t maxFileBytes) __asm__(OSTY_GC_SYMBOL("runtime.cihost.CheckPolicyFileSizes"));
 void *runtime_cihost_CheckPolicyFileSizes(void *root, void *files,
                                           int64_t maxFileBytes) {
   (void)root;
@@ -30923,6 +30922,48 @@ int64_t osty_rt_audit_Char_len(const char *value) __asm__(
     OSTY_RT_AUDIT_SYMBOL("Char__len")) OSTY_RT_AUDIT_USED;
 int64_t osty_rt_audit_Char_len(const char *value) {
   return osty_rt_strings_ByteLen(value);
+}
+
+/* Char.isWhitespace(self) -> Bool — ASCII subset only (stdlib's
+ * `pub fn isWhitespace(self) -> Bool { false }` placeholder body
+ * reaches the linker as an extern reference under the production path;
+ * provide a real shim so install-self + cmd/osty-native-checker can link
+ * without going through stage0's "list all declines" stub mode). Full
+ * Unicode whitespace would need ICU — out of scope for the bootstrap
+ * runtime.
+ *
+ * Whitespace codepoints recognised: space (U+0020), tab (U+0009),
+ * newline (U+000A), carriage return (U+000D), form feed (U+000C),
+ * vertical tab (U+000B), no-break space (U+00A0). Anything else
+ * (including most Unicode whitespace) returns false. */
+bool osty_rt_audit_Char_isWhitespace(int32_t codepoint) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("Char__isWhitespace")) OSTY_RT_AUDIT_USED;
+bool osty_rt_audit_Char_isWhitespace(int32_t codepoint) {
+  switch (codepoint) {
+  case 0x09: /* tab */
+  case 0x0A: /* lf */
+  case 0x0B: /* vt */
+  case 0x0C: /* ff */
+  case 0x0D: /* cr */
+  case 0x20: /* space */
+  case 0xA0: /* nbsp */
+    return true;
+  default:
+    return false;
+  }
+}
+
+/* Char.toLower(self) -> Char — ASCII A-Z → a-z. Anything else passes
+ * through unchanged. Mirrors the same "ASCII subset" limitation as
+ * `Char__isWhitespace` above; production stdlib eventually wants full
+ * Unicode lowering via ICU. */
+int32_t osty_rt_audit_Char_toLower(int32_t codepoint) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("Char__toLower")) OSTY_RT_AUDIT_USED;
+int32_t osty_rt_audit_Char_toLower(int32_t codepoint) {
+  if (codepoint >= 'A' && codepoint <= 'Z') {
+    return codepoint + ('a' - 'A');
+  }
+  return codepoint;
 }
 
 /* std.strings.fromChar(c) — same semantics as Char.toString. */

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3275,25 +3275,23 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
             // Graceful fallback (R3 brick 4): unknown value type from
             // `<error>` propagation leak — treat as already typed by dest.
             value = LirOperand {typ: destType, value: value.value}
-        } else if lirTypeIsVoid(value.typ) {
-            // Cross-pkg call with unresolved signature: PR3-C/F's
-            // dispatch arm emits `declare void @<pkg>.<fn>()` when the
-            // consumer's checker env doesn't know the dep's signature.
-            // The call result reaches here as void; the dest local was
-            // resolved to a concrete consumer-side type (often aggregate
-            // because the source binding annotated it). No coercion
-            // exists for void → anything.
+        } else if lirTypeIsVoid(value.typ) && strings.startsWith(destLoc.name, "_") {
+            // Cross-pkg smoke-test convention: `let _typeRepr = tc.fn()`
+            // (PR3-C/F dispatch arm) emits `declare void @<pkg>.<fn>()`
+            // when the consumer's checker env doesn't know the dep's
+            // signature. The call result reaches here as void; the dest
+            // local was resolved to a concrete consumer-side type.
             //
-            // Allocate + zero-init the slot rather than skipping
-            // outright: a reader of the slot gets a well-defined zero
-            // value (LLVM `store zeroinitializer`) instead of
-            // uninitialized garbage. Cross-pkg paths typically bind to
-            // a leading-`_` "unused" local (smoke-test convention), so
-            // the zero value isn't read; if a real consumer does read,
-            // the LLVM verifier accepts the store and the runtime
-            // observes a deterministic zero instead of undefined
-            // behavior. Real semantic correctness requires proper
-            // cross-pkg signature resolution (PR-G3+ trajectory).
+            // PR-G3 (post #1908) narrows: zero-init ONLY when the dest
+            // local name starts with `_` — the Osty unused-binding
+            // convention. This preserves the cross-pkg smoke-test
+            // unblock (cmd/osty-native-checker `let _typeRepr = ...`)
+            // without silently zero-initing real bindings whose
+            // upstream type leak should surface as a loud error so
+            // downstream consumers see "missing IR" rather than
+            // "garbage output". List.first / Map.get / etc. whose dest
+            // is `let first = xs.first()` (no `_`) take the "assign
+            // coercion is not supported" diagnostic path below.
             let mut slot = lirMirLocalSlot(l, destLoc.id)
             if slot.slot == "" {
                 slot = LirLocalSlot {id: destLoc.id, slot: lirMirLocalSlotName(destLoc.id), typ: destType}
@@ -3335,23 +3333,15 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
                     let castName = lirFresh(l)
                     l.instrs.push(lirCast(castName, "inttoptr", value, destType))
                     value = LirOperand {typ: destType, value: castName}
-                } else if lirTypeIsVoid(value.typ) {
-                    // Cross-pkg call with unresolved signature: PR3-C/F
-                    // dispatch arm emits `declare void @<pkg>.<fn>()`
-                    // when the consumer's checker env doesn't know the
-                    // dep's signature. Call result arrives as void;
-                    // dest local was resolved to a concrete consumer-
-                    // side type (often aggregate because the source
-                    // binding annotated it). No coercion exists for
-                    // void → anything. Allocate + zero-init the slot
-                    // rather than declining the whole function: a
-                    // reader gets a deterministic zero value (LLVM
-                    // `store zeroinitializer`) instead of an SSA-
-                    // invalid skip. Cross-pkg paths typically bind to
-                    // a leading-`_` "unused" smoke-test local so the
-                    // zero is unread. Real semantic correctness
-                    // requires proper cross-pkg signature resolution
-                    // (PR-G3+ trajectory).
+                } else if lirTypeIsVoid(value.typ) && strings.startsWith(destLoc.name, "_") {
+                    // Cross-pkg smoke-test convention: see sibling arm
+                    // above (lirTypeIsVoid + `_`-prefix narrowing in
+                    // PR-G3). Only fires for `let _x = tc.fn()`-style
+                    // explicitly-unused bindings. Real bindings of
+                    // void → non-void take the "assign coercion is
+                    // not supported" diagnostic below — that loud
+                    // failure surfaces the upstream type-leak the
+                    // narrowing protects against silently masking.
                     let mut voidSlot = lirMirLocalSlot(l, destLoc.id)
                     if voidSlot.slot == "" {
                         voidSlot = LirLocalSlot {id: destLoc.id, slot: lirMirLocalSlotName(destLoc.id), typ: destType}


### PR DESCRIPTION
## Summary

세 가지 관련 fix 를 한 PR 에 묶음 (install-self end-to-end 통과의 연쇄 의존):

### 1. cihost shim asm names — Mach-O \`_\` prefix 누락

\`toolchain/ci.osty\` 의 \`use runtime.cihost as host { ... }\` 25+ 함수가 osty-self 빌드 시 \`_runtime.cihost.X\` 로 reference 되는데 (LLVM IR \`@runtime.cihost.X\` 가 macOS clang 의 C ABI 변환을 거치며 underscore 가 추가됨), C-side shims 는 \`__asm__(\"runtime.cihost.X\")\` 로 underscore 없이 정의 → Mach-O 링커에서 mismatch → 27건 undefined symbol 에러.

PR #1914 (debug 빌드 LTO drop) 후 가시화 — LTO 가 일부 케이스에서 ci.osty dead code 를 옵티마이저 단계에서 제거하면서 linker 전에 missing reference 가 사라지는 path 가 있었던 듯.

**수정**: 27 사이트 모두 기존 \`OSTY_GC_SYMBOL\` 매크로 사용 (\`__APPLE__\` 에서 \`_\` prefix 추가) — single source of truth.

### 2. \`Char.isWhitespace\` / \`Char.toLower\` C shims 추가

\`internal/stdlib/primitives/char.osty\` 의 두 함수 body 가 placeholder (\`{ false }\` 형태) — extern reference 로 linker 도달. ASCII subset 으로 실제 구현 추가 (full Unicode 는 ICU 필요, 별 trajectory). cihost mismatch 해결 직후 surface 된 walls.

### 3. PR #1908 void cascade narrow → \`_\`-prefix 만

[PR #1908](https://github.com/choiceoh/osty/pull/1908) 의 void → non-void graceful zero-init 가 너무 aggressive — cross-pkg unresolved signature 의도이지만 upstream stdlib call 의 type-leak 등 다른 패턴도 동일하게 silent zero-init → 함수 body collapse → binary runtime 에 잘못 동작.

PR #1908 의 두 cascade 분기 모두 dest local 이름이 \`_\` prefix 인 경우 (Osty 의 \"unused binding\" 규약) 로 narrow. 그 외 케이스는 loud diagnostic 으로 fall-through:
- cross-pkg smoke-test (\`let _typeRepr = tc.fn()\`) — 계속 zero-init
- stdlib call upstream leak — loud \`assign coercion <from> → <dest>\` 로 surface (silent corruption 대신)

## Test plan
- [x] \`osty install-self --force\` 클린 빌드 end-to-end 통과 (이전엔 cihost wall + Char wall 으로 link fail)
- [x] \`osty-self --selfhost-doctor\` exit 0
- [x] \`just osty-tests\` 33 tests passed
- [x] \`just prepush\` 통과
- [ ] CI 그린 확인

## 영향

**Positive:**
- install-self end-to-end UNBLOCK (이전엔 macOS 에서 link 실패)
- silent runtime corruption → loud build error (narrow 의 의도)

**Trade-off:**
- list.first / list.last / list.pop / cmd/osty-native-checker 일부 케이스가 build error 로 surface (이전엔 silent wrong output 으로 build 통과). 정직한 failure mode — upstream type-leak 의 다음 brick 으로 이관

🤖 Generated with [Claude Code](https://claude.com/claude-code)