### PR TITLE
feat: complete Char primitive method C shims (6 new + 1 audit-bridge)

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -30966,6 +30966,64 @@ int32_t osty_rt_audit_Char_toLower(int32_t codepoint) {
   return codepoint;
 }
 
+/* Char.toUpper(self) -> Char — ASCII a-z → A-Z, pass-through otherwise.
+ * Sibling of `Char__toLower`. Bootstrap subset; ICU handles full
+ * Unicode case mapping in production. */
+int32_t osty_rt_audit_Char_toUpper(int32_t codepoint) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("Char__toUpper")) OSTY_RT_AUDIT_USED;
+int32_t osty_rt_audit_Char_toUpper(int32_t codepoint) {
+  if (codepoint >= 'a' && codepoint <= 'z') {
+    return codepoint - ('a' - 'A');
+  }
+  return codepoint;
+}
+
+/* Char.isUpper(self) -> Bool — ASCII A-Z only. */
+bool osty_rt_audit_Char_isUpper(int32_t codepoint) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("Char__isUpper")) OSTY_RT_AUDIT_USED;
+bool osty_rt_audit_Char_isUpper(int32_t codepoint) {
+  return codepoint >= 'A' && codepoint <= 'Z';
+}
+
+/* Char.isLower(self) -> Bool — ASCII a-z only. */
+bool osty_rt_audit_Char_isLower(int32_t codepoint) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("Char__isLower")) OSTY_RT_AUDIT_USED;
+bool osty_rt_audit_Char_isLower(int32_t codepoint) {
+  return codepoint >= 'a' && codepoint <= 'z';
+}
+
+/* Char.isDigit(self) -> Bool — ASCII 0-9 only. */
+bool osty_rt_audit_Char_isDigit(int32_t codepoint) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("Char__isDigit")) OSTY_RT_AUDIT_USED;
+bool osty_rt_audit_Char_isDigit(int32_t codepoint) {
+  return codepoint >= '0' && codepoint <= '9';
+}
+
+/* Char.isAlpha(self) -> Bool — ASCII letter test. */
+bool osty_rt_audit_Char_isAlpha(int32_t codepoint) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("Char__isAlpha")) OSTY_RT_AUDIT_USED;
+bool osty_rt_audit_Char_isAlpha(int32_t codepoint) {
+  return (codepoint >= 'A' && codepoint <= 'Z') ||
+         (codepoint >= 'a' && codepoint <= 'z');
+}
+
+/* Char.isAlphanumeric(self) -> Bool — `isAlpha || isDigit`. */
+bool osty_rt_audit_Char_isAlphanumeric(int32_t codepoint) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("Char__isAlphanumeric")) OSTY_RT_AUDIT_USED;
+bool osty_rt_audit_Char_isAlphanumeric(int32_t codepoint) {
+  return (codepoint >= 'A' && codepoint <= 'Z') ||
+         (codepoint >= 'a' && codepoint <= 'z') ||
+         (codepoint >= '0' && codepoint <= '9');
+}
+
+/* Char.toInt(self) -> Int — total scalar conversion. Codepoints are
+ * stored as i32 already; widen to i64 for the Osty `Int` ABI. */
+int64_t osty_rt_audit_Char_toInt(int32_t codepoint) __asm__(
+    OSTY_RT_AUDIT_SYMBOL("Char__toInt")) OSTY_RT_AUDIT_USED;
+int64_t osty_rt_audit_Char_toInt(int32_t codepoint) {
+  return (int64_t)codepoint;
+}
+
 /* std.strings.fromChar(c) — same semantics as Char.toString. */
 void *osty_rt_audit_strings_fromChar(int32_t codepoint) __asm__(
     OSTY_RT_AUDIT_SYMBOL("std.strings.fromChar")) OSTY_RT_AUDIT_USED;


### PR DESCRIPTION
## Summary

[PR #1922](https://github.com/choiceoh/osty/pull/1922) 가 \`Char__isWhitespace\` / \`Char__toLower\` 두 개를 추가 — 나머지 6 개 (\`isDigit\`, \`isAlpha\`, \`isAlphanumeric\`, \`isUpper\`, \`isLower\`, \`toUpper\`) + \`Char__toInt\` (i32→i64 widen) 추가.

\`internal/stdlib/primitives/char.osty::__CharMethods\` 의 8 메서드 중 PR #1922 에서 2 개만 cover — 나머지 6 개는 stdlib body placeholder (\`{ false }\` / \`{ '\\0' }\`) 로 정의되어 있어서 production path 가 호출 시 extern reference 로 linker 에 도달 → undefined symbol fail.

본 PR 은 ASCII subset 으로 6 + 1 = 7 개 shim 추가. 모두 PR #1922 의 동일 패턴: \`OSTY_RT_AUDIT_SYMBOL\` macro 로 Mach-O \`_\` prefix 자동 처리.

## 추가된 shims

| symbol | 동작 |
|---|---|
| \`Char__toInt\` | i32 codepoint → i64 (total) |
| \`Char__toUpper\` | a-z → A-Z, else pass-through |
| \`Char__isUpper\` | A-Z 만 true |
| \`Char__isLower\` | a-z 만 true |
| \`Char__isDigit\` | 0-9 만 true |
| \`Char__isAlpha\` | A-Z / a-z 만 true |
| \`Char__isAlphanumeric\` | isAlpha \|\| isDigit |

ASCII A-Z / a-z / 0-9 만 — full Unicode 는 ICU 필요 (별 trajectory).

## Test plan
- [x] \`osty install-self --force\` 클린 빌드 통과
- [x] \`osty_runtime.o\` 에 \`_Char__is{Upper,Lower,Digit,Alpha,Alphanumeric}\` + \`_Char__to{Upper,Int}\` 심볼 정의 확인 (nm)
- [x] \`just osty-tests\` 33 tests passed (회귀 없음)
- [x] \`just prepush\` 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)