### PR TITLE
[codex] selfhost: advance stage2 LIR follow-up

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -28584,6 +28584,19 @@ typedef struct osty_rt_os_exec_result {
   void *error_text;
 } osty_rt_os_exec_result;
 
+typedef struct osty_rt_os_exec_result_box {
+  int64_t tag;
+  void *ok_payload;
+  void *err_payload;
+} osty_rt_os_exec_result_box;
+
+typedef struct osty_rt_os_exec_output_payload {
+  int64_t exit_code;
+  void *stdout_text;
+  void *stderr_text;
+  bool timed_out;
+} osty_rt_os_exec_output_payload;
+
 typedef struct osty_rt_os_string_result {
   int64_t tag;
   void *value_text;
@@ -29832,24 +29845,65 @@ osty_rt_os_exec_result *osty_rt_os_exec_input(const char *cmd, void *args,
  * variant of osty_rt_os_exec_options. Wired through MIR symbol rewrite for
  * the LLVM self-host source-bootstrap path (cf. SPEC_GAPS::cross-pkg-module-
  * resolution path #5; PR3-C trajectory). */
-osty_rt_os_exec_result *osty_rt_os_exec_with(const char *cmd, void *args,
-                                             const char *cwd,
-                                             void *env_overrides,
-                                             int64_t timeout_ms) {
-  return osty_rt_os_exec_options(cmd, args, /*shell=*/false, cwd,
-                                 env_overrides, timeout_ms);
+static void *osty_rt_os_exec_box_exec_output(osty_rt_os_exec_result *raw,
+                                             const char *site) {
+  osty_rt_os_exec_result_box *box =
+      (osty_rt_os_exec_result_box *)osty_rt_stage0_alloc(
+          (int64_t)sizeof(osty_rt_os_exec_result_box));
+  if (box == NULL) {
+    if (raw != NULL) {
+      free(raw);
+    }
+    return NULL;
+  }
+  box->tag = 1;
+  box->ok_payload = NULL;
+  box->err_payload = NULL;
+  if (raw == NULL) {
+    box->err_payload =
+        osty_rt_os_error_message("failed to launch process", "unknown error",
+                                 site);
+    return box;
+  }
+  if (raw->tag == 0) {
+    osty_rt_os_exec_output_payload *out =
+        (osty_rt_os_exec_output_payload *)osty_rt_stage0_alloc(
+            (int64_t)sizeof(osty_rt_os_exec_output_payload));
+    if (out == NULL) {
+      free(raw);
+      return NULL;
+    }
+    out->exit_code = raw->exit_code;
+    out->stdout_text = raw->stdout_text;
+    out->stderr_text = raw->stderr_text;
+    out->timed_out = raw->timed_out;
+    box->tag = 0;
+    box->ok_payload = out;
+  } else {
+    box->tag = 1;
+    box->err_payload = raw->error_text;
+  }
+  free(raw);
+  return box;
+}
+
+void *osty_rt_os_exec_with(const char *cmd, void *args, const char *cwd,
+                           void *env_overrides, int64_t timeout_ms) {
+  return osty_rt_os_exec_box_exec_output(
+      osty_rt_os_exec_options(cmd, args, /*shell=*/false, cwd, env_overrides,
+                              timeout_ms),
+      "runtime.os.execWith.result");
 }
 
 /* std.os.execInputWith(cmd, args, stdin, cwd, env, timeoutMillis) —
  * `shell=false` variant with stdin pipe. */
-osty_rt_os_exec_result *osty_rt_os_exec_input_with(const char *cmd,
-                                                   void *args,
-                                                   const char *stdin_text,
-                                                   const char *cwd,
-                                                   void *env_overrides,
-                                                   int64_t timeout_ms) {
-  return osty_rt_os_exec_input_options(cmd, args, /*shell=*/false, cwd,
-                                       env_overrides, timeout_ms, stdin_text);
+void *osty_rt_os_exec_input_with(const char *cmd, void *args,
+                                 const char *stdin_text, const char *cwd,
+                                 void *env_overrides, int64_t timeout_ms) {
+  return osty_rt_os_exec_box_exec_output(
+      osty_rt_os_exec_input_options(cmd, args, /*shell=*/false, cwd,
+                                    env_overrides, timeout_ms, stdin_text),
+      "runtime.os.execInputWith.result");
 }
 
 /* std.os.execOutput(exitCode, stdout, stderr, timedOut) constructs an

--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -538,6 +538,10 @@ func TestPhase0SelfHostWiringExists(t *testing.T) {
 				"mirJsonLayouts(",
 				"fn mirJsonLayoutsInto(value: MirJsonValue, out: MirLayoutTable) -> Result<Bool, String>",
 				"fn mirJsonLayoutStructsInto(items: List<MirJsonValue>, pos: Int, out: MirLayoutTable) -> Result<Bool, String>",
+				"fn mirJsonModuleObjectInto(obj: List<MirJsonEntry>, m: MirModule) -> Result<Bool, String>",
+				"Ok(MirUse {rawPath, alias, isGoFFI, isRuntimeFFI, goPath, runtimePath, span})",
+				"Ok(MirGlobal {name, typ, mutable, hasInit, initSymbol, span})",
+				"Ok(MirLocal {id, name, typ, mutable, isParam, isReturn, span})",
 			},
 		},
 	}
@@ -826,6 +830,89 @@ func TestMirGeneratorProjectionWriteTempsUseBlockQualifiedNames(t *testing.T) {
 	}
 }
 
+func TestMirLowerStage2SeedDiscardsStatementCalls(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "mir_lower.osty"))
+	if err != nil {
+		t.Fatalf("read mir_lower.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"if s.exprValue.kind == HirExprCall",
+		"mirLowerCallExprInto(bs, s.exprValue, mirPlace(-1), hirTUnit())",
+		"if s.exprValue.kind == HirExprMethod",
+		"mirLowerMethodCallInto(bs, s.exprValue, mirPlace(-1), hirTUnit())",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("mir_lower.osty missing statement-call discard guard %q", needle)
+		}
+	}
+}
+
+func TestMirConstructorsAvoidProjectedScalarAssigns(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "mir.osty"))
+	if err != nil {
+		t.Fatalf("read mir.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"MirConst {kind: MirConstInt",
+		"MirProjection {kind: MirProjField",
+		"MirOperand {kind: MirOpCopy",
+		"MirRValue {kind: MirRVAggregate",
+		"MirRValue {kind: MirRVNullary",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("mir.osty missing direct constructor literal %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"let mut c = mirConstInvalid()",
+		"let mut p = mirProjInvalid()",
+		"let mut op = mirOperandInvalid()",
+		"let mut rv = mirRValueInvalid()",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("mir.osty reintroduced projected scalar constructor assignment %q", forbidden)
+		}
+	}
+}
+
+func TestMirJsonStage2SeedAvoidsProjectedScalarAssigns(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "mir_json.osty"))
+	if err != nil {
+		t.Fatalf("read mir_json.osty: %v", err)
+	}
+	text := string(src)
+	for _, forbidden := range []string{
+		"m.packageName =",
+		"m.span =",
+		"u.isGoFFI =",
+		"u.isRuntimeFFI =",
+		"u.goPath =",
+		"u.runtimePath =",
+		"g.hasInit =",
+		"g.initSymbol =",
+		"l.isParam =",
+		"l.isReturn =",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("mir_json.osty reintroduced projected scalar assignment %q", forbidden)
+		}
+	}
+}
+
 func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 	root, err := filepath.Abs("../..")
 	if err != nil {
@@ -858,6 +945,8 @@ func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 		"out = strings.replaceAll(out, \" \", \"\")",
 		"fn lirEncodedCStringByteLen(encoded: String) -> Int",
 		"lirEncodedCStringByteLen(encoded)",
+		"fn lirNoTypeParams() -> List<LirType>",
+		"fn lirNoOperands() -> List<LirOperand>",
 		`out = strings.replaceAll(out, "\\5C", "_")`,
 		`out = strings.replaceAll(out, "\\7B", "_")`,
 		`out = strings.replaceAll(out, "\\7D", "_")`,
@@ -870,21 +959,33 @@ func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 		"l.tempNames.push(name)",
 		`if !(loc.isParam) && typ.className == LirTypePtr`,
 		`l.prologue.push(lirStore(lirOperand(typ, "null"), slot, 0))`,
-			`value.typ.className == LirTypePtr && destType.className == LirTypeInt`,
-			`value.typ.className == LirTypeInt && destType.className == LirTypePtr`,
-			"value = lirCoerceValueToType(l, value, arg.typ, paramLocal.typ, paramType, \"direct call arg\")",
-			"fn lirRuntimePanicDecl() -> LirRuntimeDecl",
-			"lirRuntimeDeclWithAttrs(\"osty_rt_panic\", lirVoidType(), [lirPtrType()], false, lirRuntimePanicAttrs())",
-			"if kind == MirIntrinsicAbort",
-			"fn lirLowerMirAbort(l: LirMirFunctionLowerer, instr: MirInstr)",
-			"l.instrs.push(lirCallWithAttrs(\"\", lirVoidType(), \"@osty_rt_panic\", args, \"\", lirRuntimePanicAttrs()))",
-			"let fields: List<MirFieldLayout> = []",
-			"MirStructLayout {name: \"\", mangled: \"\", fields, size: 0, align: 0}",
-			"MirTupleLayout {key: \"\", mangled: \"\", fields}",
-		} {
+		`value.typ.className == LirTypePtr && destType.className == LirTypeInt`,
+		`value.typ.className == LirTypeInt && destType.className == LirTypePtr`,
+		"value = lirCoerceValueToType(l, value, arg.typ, paramLocal.typ, paramType, \"direct call arg\")",
+		"fn lirRuntimePanicDecl() -> LirRuntimeDecl",
+		"lirRuntimeDeclWithAttrs(\"osty_rt_panic\", lirVoidType(), [lirPtrType()], false, lirRuntimePanicAttrs())",
+		"if kind == MirIntrinsicAbort",
+		"fn lirLowerMirAbort(l: LirMirFunctionLowerer, instr: MirInstr)",
+		"l.instrs.push(lirCallWithAttrs(\"\", lirVoidType(), \"@osty_rt_panic\", args, \"\", lirRuntimePanicAttrs()))",
+		"let fields: List<MirFieldLayout> = []",
+		"MirStructLayout {name: \"\", mangled: \"\", fields, size: 0, align: 0}",
+		"MirTupleLayout {key: \"\", mangled: \"\", fields}",
+		"return lirLowerMirStringRuntimeCall(l, instr, llvmSetRuntimeNewSymbol(), lirPtrType(), lirNoTypeParams(), \"set.new\")",
+		"l.instrs.push(lirCall(listReg, lirPtrType(), \"@\" + newSym, lirNoOperands()))",
+		"fn lirLowerMirStdOsExecResultCall(l: LirMirFunctionLowerer, instr: MirInstr)",
+		"symbol == \"osty_rt_os_exec_with\" || symbol == \"osty_rt_os_exec_input_with\"",
+		"lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(instr.calleeSymbol, lirPtrType(), paramTypes, false))",
+		"let boxType = lirRawType(lirBraced(\"i64, ptr, ptr\"))",
+		"l.instrs.push(lirSelect(payloadI64, lirIntType(64), isOk, okPayloadI64, errPayloadI64))",
+		"let comma = lirFirstTopLevelComma(args)",
+		"strings.trim(strings.slice(args, 0, comma))",
+	} {
 		if !strings.Contains(text, needle) {
 			t.Fatalf("lir_proto.osty missing stage2-seed LIR Proto guard %q", needle)
 		}
+	}
+	if strings.Contains(text, "strings.fromChar(ch)") {
+		t.Fatalf("lir_proto.osty reintroduced stage2-unsafe strings.fromChar(ch) in generic arg splitting")
 	}
 }
 

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -153,6 +153,14 @@ pub fn lirOperand(typ: LirType, value: String) -> LirOperand {
 pub fn lirOperandInvalid() -> LirOperand {
     LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
 }
+fn lirNoTypeParams() -> List<LirType> {
+    let params: List<LirType> = []
+    return params
+}
+fn lirNoOperands() -> List<LirOperand> {
+    let args: List<LirOperand> = []
+    return args
+}
 pub fn lirOperandString(op: LirOperand) -> String {
     lirTypeString(op.typ) + " " + op.value
 }
@@ -2461,23 +2469,11 @@ fn lirOptionResultPayloadInner(name: String) -> String {
 // bracket depth so nested generics are not split mid-arg
 // ("Map<K, V>, Error" -> "Map<K, V>").
 fn lirSplitFirstGenericArg(args: String) -> String {
-    let mut depth = 0
-    let mut out = ""
-    let chars = strings.chars(args)
-    for ch in chars {
-        if ch == '<' {
-            depth = depth + 1
-            out = out + strings.fromChar(ch)
-        } else if ch == '>' {
-            depth = depth - 1
-            out = out + strings.fromChar(ch)
-        } else if ch == ',' && depth == 0 {
-            return strings.trim(out)
-        } else {
-            out = out + strings.fromChar(ch)
-        }
+    let comma = lirFirstTopLevelComma(args)
+    if comma < 0 {
+        return strings.trim(args)
     }
-    strings.trim(out)
+    strings.trim(strings.slice(args, 0, comma))
 }
 // `lirMirStructTypeRefByName` returns the LLVM type reference (`%Mangled`)
 // for a named struct in `mir.layouts.structs`, or "" when not found. Used
@@ -3035,7 +3031,15 @@ fn lirMirBlockTermKind(bb: MirBasicBlock) -> MirTermKind {
 // is `fn_.entry`. Production runs the same emit order
 // (LANG_SPEC §3.8.6 + RUNTIME_GC_DELTA §10.1).
 fn lirLowerError(l: LirMirFunctionLowerer, kind: LirDiagnosticKind, message: String, path: String) {
-    l.diagnostics.push(lirDiagnosticError(kind, message, path))
+    let fnPath = lirRenderedMirFunctionNameOrMain(l.fn_)
+    let diagPath = if path == "" {
+        fnPath
+    } else if fnPath == "" {
+        path
+    } else {
+        fnPath + "." + path
+    }
+    l.diagnostics.push(lirDiagnosticError(kind, message, diagPath))
 }
 fn lirRenderedMirFunctionName(fn_: MirFunction) -> String {
     if fn_.exportSymbol.len() != 0 {
@@ -3396,7 +3400,7 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
                 } else if value.typ.className == LirTypeAggregate && destType.className == LirTypeAggregate {
                     let rebuilt = lirRebuildDefaultI64Aggregate(l, value, destType)
                     if rebuilt.value == "" {
-                        lirLowerError(l, LirDiagUnsupported, "assign coercion `" + value.typ.llvm + "` → `" + destType.llvm + "` is not supported", "assign")
+                        lirLowerError(l, LirDiagUnsupported, "assign coercion `" + value.typ.llvm + "` → `" + destType.llvm + "` is not supported (dest `" + destLoc.name + ":" + destLoc.typ + "`, src `" + instr.src.typ + "`)", "assign")
                         return
                     }
                     value = rebuilt
@@ -3418,7 +3422,7 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
                     l.instrs.push(lirStore(lirOperand(destType, "zeroinitializer"), voidSlot.slot, 0))
                     return
                 } else {
-                    lirLowerError(l, LirDiagUnsupported, "assign coercion `" + value.typ.llvm + "` → `" + destType.llvm + "` is not supported", "assign")
+                    lirLowerError(l, LirDiagUnsupported, "assign coercion `" + value.typ.llvm + "` → `" + destType.llvm + "` is not supported (dest `" + destLoc.name + ":" + destLoc.typ + "`, src `" + instr.src.typ + "`)", "assign")
                     return
                 }
             } else {
@@ -3727,6 +3731,10 @@ fn lirLowerMirCall(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerMirStdFsReadToStringCall(l, instr)
         return
     }
+    if lirIsStdOsExecResultSymbol(instr.calleeSymbol) {
+        lirLowerMirStdOsExecResultCall(l, instr)
+        return
+    }
     if lirTryLowerMirIntMethodIntrinsic(l, instr) {
         return
     }
@@ -3914,6 +3922,74 @@ fn lirLowerMirCrossModuleCall(l: LirMirFunctionLowerer, instr: MirInstr) {
         let loc = mirFunctionLocal(l.fn_, instr.dest.local)
         lirStoreMirResult(l, instr.dest, lirOperand(retType, destName), loc.typ, "cross-module call result")
     }
+}
+fn lirIsStdOsExecResultSymbol(symbol: String) -> Bool {
+    symbol == "osty_rt_os_exec_with" || symbol == "osty_rt_os_exec_input_with"
+}
+fn lirLowerMirStdOsExecResultCall(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if !instr.hasDest {
+        lirLowerError(l, LirDiagInvalidInput, "std.os exec call requires a destination", "call.std.os.exec")
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "std.os exec destination local out of range", "call.std.os.exec")
+        return
+    }
+    let resultType = lirLowerMirType(l, loc.typ)
+    if resultType.className != LirTypeAggregate {
+        lirLowerError(l, LirDiagUnsupported, "std.os exec destination must be Result<...>, got `" + loc.typ + "`", "call.std.os.exec")
+        return
+    }
+    if lirAggregateHasWidenedPayload(l.out, resultType) {
+        lirLowerError(l, LirDiagUnsupported, "std.os exec widened Result payload is not implemented", "call.std.os.exec")
+        return
+    }
+    let mut paramTypes: List<LirType> = []
+    let mut args: List<LirOperand> = []
+    for arg in instr.args {
+        let paramType = lirLowerMirType(l, arg.typ)
+        if lirTypeIsZero(paramType) {
+            lirLowerError(l, LirDiagUnsupported, "std.os exec arg type `" + arg.typ + "` is not implemented (" + lirTypeLowerTraceMessage(l.mirModule, arg.typ) + ")", "call.std.os.exec")
+            return
+        }
+        let value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, paramType)
+        if value.value == "" {
+            return
+        }
+        paramTypes.push(paramType)
+        args.push(lirOperand(paramType, value.value))
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(instr.calleeSymbol, lirPtrType(), paramTypes, false))
+    let boxed = lirFresh(l)
+    l.instrs.push(lirCall(boxed, lirPtrType(), "@" + instr.calleeSymbol, args))
+    let boxType = lirRawType(lirBraced("i64, ptr, ptr"))
+    let zero = lirOperand(lirIntType(32), "0")
+    let tagPtr = lirFresh(l)
+    l.instrs.push(lirGep(tagPtr, boxType, boxed, [zero, lirOperand(lirIntType(32), "0")], true))
+    let tag = lirFresh(l)
+    l.instrs.push(lirLoad(tag, lirIntType(64), tagPtr, 8))
+    let okPtrSlot = lirFresh(l)
+    l.instrs.push(lirGep(okPtrSlot, boxType, boxed, [zero, lirOperand(lirIntType(32), "1")], true))
+    let okPayload = lirFresh(l)
+    l.instrs.push(lirLoad(okPayload, lirPtrType(), okPtrSlot, 8))
+    let errPtrSlot = lirFresh(l)
+    l.instrs.push(lirGep(errPtrSlot, boxType, boxed, [zero, lirOperand(lirIntType(32), "2")], true))
+    let errPayload = lirFresh(l)
+    l.instrs.push(lirLoad(errPayload, lirPtrType(), errPtrSlot, 8))
+    let okPayloadI64 = lirFresh(l)
+    l.instrs.push(lirCast(okPayloadI64, "ptrtoint", lirOperand(lirPtrType(), okPayload), lirIntType(64)))
+    let errPayloadI64 = lirFresh(l)
+    l.instrs.push(lirCast(errPayloadI64, "ptrtoint", lirOperand(lirPtrType(), errPayload), lirIntType(64)))
+    let isOk = lirFresh(l)
+    l.instrs.push(lirBinary(isOk, "icmp eq", lirIntType(64), tag, "0"))
+    let payloadI64 = lirFresh(l)
+    l.instrs.push(lirSelect(payloadI64, lirIntType(64), isOk, okPayloadI64, errPayloadI64))
+    let withTag = lirFresh(l)
+    l.instrs.push(lirInsertValue(withTag, resultType, "undef", lirOperand(lirIntType(64), tag), [0]))
+    let resultValue = lirFresh(l)
+    l.instrs.push(lirInsertValue(resultValue, resultType, withTag, lirOperand(lirIntType(64), payloadI64), [1]))
+    lirStoreMirResult(l, instr.dest, lirOperand(resultType, resultValue), loc.typ, "std.os exec result")
 }
 fn lirLowerMirStdFsReadToStringCall(l: LirMirFunctionLowerer, instr: MirInstr) {
     if !instr.hasDest {
@@ -4447,7 +4523,7 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         return lirLowerMirMapRemove(l, instr)
     }
     if kind == MirIntrinsicSetNew {
-        return lirLowerMirStringRuntimeCall(l, instr, llvmSetRuntimeNewSymbol(), lirPtrType(), [], "set.new")
+        return lirLowerMirStringRuntimeCall(l, instr, llvmSetRuntimeNewSymbol(), lirPtrType(), lirNoTypeParams(), "set.new")
     }
     if kind == MirIntrinsicSetLen {
         return lirLowerMirStringRuntimeCall(l, instr, llvmSetRuntimeLenSymbol(), lirIntType(64), [lirPtrType()], "set.len")
@@ -4483,7 +4559,7 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         return lirLowerMirChanRecv(l, instr)
     }
     if kind == MirIntrinsicYield {
-        return lirLowerMirStringRuntimeCall(l, instr, "osty_rt_task_yield", lirVoidType(), [], "task.yield")
+        return lirLowerMirStringRuntimeCall(l, instr, "osty_rt_task_yield", lirVoidType(), lirNoTypeParams(), "task.yield")
     }
     if kind == MirIntrinsicSleep {
         return lirLowerMirStringRuntimeCall(l, instr, mirRtThreadSleepSymbol(), lirVoidType(), [lirPtrType()], "task.sleep")
@@ -4543,7 +4619,7 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         return lirLowerMirBytesValidatedResult(l, instr, mirRtBytesIsValidHexSymbol(), mirRtBytesFromHexSymbol(), "bytes.fromHex")
     }
     if kind == MirIntrinsicIsCancelled {
-        return lirLowerMirStringRuntimeCall(l, instr, "osty_rt_cancel_is_cancelled", lirIntType(1), [], "cancel.isCancelled")
+        return lirLowerMirStringRuntimeCall(l, instr, "osty_rt_cancel_is_cancelled", lirIntType(1), lirNoTypeParams(), "cancel.isCancelled")
     }
     if kind == MirIntrinsicStringIndexOf {
         return lirLowerMirIndexOf(l, instr, mirRtStringSymbol("IndexOf"), [lirPtrType(), lirPtrType()], "string.indexOf")
@@ -6365,9 +6441,9 @@ fn lirLowerMirCheckCancelled(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let symbol = mirRtCancelCheckCancelledSymbol()
     let rawType = lirRawType(lirBraced("i64, i64"))
-    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, rawType, [], false))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, rawType, lirNoTypeParams(), false))
     if !(instr.hasDest) {
-        l.instrs.push(lirCall("", rawType, "@" + symbol, []))
+        l.instrs.push(lirCall("", rawType, "@" + symbol, lirNoOperands()))
         return
     }
     let loc = mirFunctionLocal(l.fn_, instr.dest.local)
@@ -6381,7 +6457,7 @@ fn lirLowerMirCheckCancelled(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     lirLowerMirType(l, loc.typ)
     let dest = lirFresh(l)
-    l.instrs.push(lirCall(dest, rawType, "@" + symbol, []))
+    l.instrs.push(lirCall(dest, rawType, "@" + symbol, lirNoOperands()))
     let slot = lirMirLocalSlot(l, loc.id)
     if slot.slot == "" {
         lirLowerError(l, LirDiagLoweringBug, "cancel.check destination has no LIR slot", "cancel.check")
@@ -7032,8 +7108,8 @@ fn lirLowerMirAlgebraicUnwrap(l: LirMirFunctionLowerer, instr: MirInstr, absentT
     let absentLabel = lirFreshAuxLabel(l, label + ".absent")
     let presentLabel = lirFreshAuxLabel(l, label + ".present")
     lirCutBlockCondBr(l, isAbsentReg, absentLabel, presentLabel, absentLabel)
-    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(abortSym, lirVoidType(), [], false))
-    l.instrs.push(lirCall("", lirVoidType(), "@" + abortSym, []))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(abortSym, lirVoidType(), lirNoTypeParams(), false))
+    l.instrs.push(lirCall("", lirVoidType(), "@" + abortSym, lirNoOperands()))
     lirCutBlockUnreachable(l, presentLabel)
     let payloadI64 = lirFresh(l)
     l.instrs.push(lirExtractValue(payloadI64, aggType, aggValue.value, [1]))
@@ -8142,9 +8218,9 @@ fn lirLowerMirListAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName: S
         return lirOperandInvalid()
     }
     let newSym = llvmListRuntimeNewSymbol()
-    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(newSym, lirPtrType(), [], false))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(newSym, lirPtrType(), lirNoTypeParams(), false))
     let listReg = lirFresh(l)
-    l.instrs.push(lirCall(listReg, lirPtrType(), "@" + newSym, []))
+    l.instrs.push(lirCall(listReg, lirPtrType(), "@" + newSym, lirNoOperands()))
     let elemLir = lirContainerElemLaneType(elemName)
     if lirTypeIsZero(elemLir) {
         let elemType = lirLowerMirType(l, elemName)

--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -336,72 +336,34 @@ pub fn mirConstInvalid() -> MirConst {
     MirConst {kind: MirConstInvalid, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ: ""}
 }
 pub fn mirConstInt(value: Int, typ: String) -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstInt
-    c.intValue = value
-    c.typ = typ
-    c
+    MirConst {kind: MirConstInt, intValue: value, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ}
 }
 pub fn mirConstBool(value: Bool) -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstBool
-    c.boolValue = value
-    c.typ = "Bool"
-    c
+    MirConst {kind: MirConstBool, intValue: 0, boolValue: value, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ: "Bool"}
 }
 pub fn mirConstFloat(text: String, typ: String) -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstFloat
-    c.floatText = text
-    c.typ = typ
-    c
+    MirConst {kind: MirConstFloat, intValue: 0, boolValue: false, floatText: text, strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ}
 }
 pub fn mirConstString(value: String) -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstString
-    c.strValue = value
-    c.typ = "String"
-    c
+    MirConst {kind: MirConstString, intValue: 0, boolValue: false, floatText: "", strValue: value, charValue: 0, byteValue: 0, fnSymbol: "", typ: "String"}
 }
 pub fn mirConstBytes(value: String) -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstBytes
-    c.strValue = value
-    c.typ = "Bytes"
-    c
+    MirConst {kind: MirConstBytes, intValue: 0, boolValue: false, floatText: "", strValue: value, charValue: 0, byteValue: 0, fnSymbol: "", typ: "Bytes"}
 }
 pub fn mirConstChar(codePoint: Int) -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstChar
-    c.charValue = codePoint
-    c.typ = "Char"
-    c
+    MirConst {kind: MirConstChar, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: codePoint, byteValue: 0, fnSymbol: "", typ: "Char"}
 }
 pub fn mirConstByte(value: Int) -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstByte
-    c.byteValue = value
-    c.typ = "Byte"
-    c
+    MirConst {kind: MirConstByte, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: value, fnSymbol: "", typ: "Byte"}
 }
 pub fn mirConstUnit() -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstUnit
-    c.typ = "Unit"
-    c
+    MirConst {kind: MirConstUnit, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ: "Unit"}
 }
 pub fn mirConstNull(typ: String) -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstNull
-    c.typ = typ
-    c
+    MirConst {kind: MirConstNull, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: "", typ}
 }
 pub fn mirConstFn(symbol: String, typ: String) -> MirConst {
-    let mut c = mirConstInvalid()
-    c.kind = MirConstFn
-    c.fnSymbol = symbol
-    c.typ = typ
-    c
+    MirConst {kind: MirConstFn, intValue: 0, boolValue: false, floatText: "", strValue: "", charValue: 0, byteValue: 0, fnSymbol: symbol, typ}
 }
 // ====================================================================
 // Projections and Places
@@ -435,49 +397,22 @@ pub fn mirProjInvalid() -> MirProjection {
     MirProjection {kind: MirProjInvalid, index: 0, name: "", variantField: -1, indexLocal: -1, indexConst: 0, typ: ""}
 }
 pub fn mirFieldProj(index: Int, name: String, typ: String) -> MirProjection {
-    let mut p = mirProjInvalid()
-    p.kind = MirProjField
-    p.index = index
-    p.name = name
-    p.typ = typ
-    p
+    MirProjection {kind: MirProjField, index, name, variantField: -1, indexLocal: -1, indexConst: 0, typ}
 }
 pub fn mirTupleProj(index: Int, typ: String) -> MirProjection {
-    let mut p = mirProjInvalid()
-    p.kind = MirProjTuple
-    p.index = index
-    p.typ = typ
-    p
+    MirProjection {kind: MirProjTuple, index, name: "", variantField: -1, indexLocal: -1, indexConst: 0, typ}
 }
 pub fn mirVariantProj(variantIndex: Int, name: String, fieldIdx: Int, typ: String) -> MirProjection {
-    let mut p = mirProjInvalid()
-    p.kind = MirProjVariant
-    p.index = variantIndex
-    p.name = name
-    p.variantField = fieldIdx
-    p.typ = typ
-    p
+    MirProjection {kind: MirProjVariant, index: variantIndex, name, variantField: fieldIdx, indexLocal: -1, indexConst: 0, typ}
 }
 pub fn mirIndexProjLocal(localId: Int, elemTyp: String) -> MirProjection {
-    let mut p = mirProjInvalid()
-    p.kind = MirProjIndex
-    p.indexLocal = localId
-    p.typ = elemTyp
-    p
+    MirProjection {kind: MirProjIndex, index: 0, name: "", variantField: -1, indexLocal: localId, indexConst: 0, typ: elemTyp}
 }
 pub fn mirIndexProjConst(value: Int, elemTyp: String) -> MirProjection {
-    let mut p = mirProjInvalid()
-    p.kind = MirProjIndex
-    p.indexLocal = -1
-    p.indexConst = value
-    p.typ = elemTyp
-    p
+    MirProjection {kind: MirProjIndex, index: 0, name: "", variantField: -1, indexLocal: -1, indexConst: value, typ: elemTyp}
 }
 pub fn mirDerefProj(typ: String) -> MirProjection {
-    let mut p = mirProjInvalid()
-    p.kind = MirProjDeref
-    p.typ = typ
-    p
+    MirProjection {kind: MirProjDeref, index: 0, name: "", variantField: -1, indexLocal: -1, indexConst: 0, typ}
 }
 /// MirPlace identifies a storage location: a local, optionally refined
 /// by a chain of projections.
@@ -519,25 +454,13 @@ pub fn mirOperandInvalid() -> MirOperand {
     MirOperand {kind: MirOpInvalid, place: mirPlace(-1), const: mirConstInvalid(), typ: ""}
 }
 pub fn mirOperandCopy(place: MirPlace, typ: String) -> MirOperand {
-    let mut op = mirOperandInvalid()
-    op.kind = MirOpCopy
-    op.place = place
-    op.typ = typ
-    op
+    MirOperand {kind: MirOpCopy, place, const: mirConstInvalid(), typ}
 }
 pub fn mirOperandMove(place: MirPlace, typ: String) -> MirOperand {
-    let mut op = mirOperandInvalid()
-    op.kind = MirOpMove
-    op.place = place
-    op.typ = typ
-    op
+    MirOperand {kind: MirOpMove, place, const: mirConstInvalid(), typ}
 }
 pub fn mirOperandConst(c: MirConst) -> MirOperand {
-    let mut op = mirOperandInvalid()
-    op.kind = MirOpConst
-    op.const = c
-    op.typ = c.typ
-    op
+    MirOperand {kind: MirOpConst, place: mirPlace(-1), const: c, typ: c.typ}
 }
 // ====================================================================
 // RValues
@@ -579,98 +502,50 @@ pub fn mirRValueInvalid() -> MirRValue {
     MirRValue {kind: MirRVInvalid, typ: "", unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVUse(op: MirOperand) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVUse
-    rv.arg = op
-    rv.typ = op.typ
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVUse, typ: op.typ, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: op, right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVUnary(op: MirUnaryOp, arg: MirOperand, typ: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVUnary
-    rv.unaryOp = op
-    rv.arg = arg
-    rv.typ = typ
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVUnary, typ, unaryOp: op, binaryOp: MirBinInvalid, arg, right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVBinary(op: MirBinaryOp, left: MirOperand, right: MirOperand, typ: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVBinary
-    rv.binaryOp = op
-    rv.arg = left
-    rv.right = right
-    rv.typ = typ
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVBinary, typ, unaryOp: MirUnInvalid, binaryOp: op, arg: left, right, aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVAggregate(kind: MirAggregateKind, fields: List<MirOperand>, typ: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVAggregate
-    rv.aggKind = kind
-    rv.aggFields = fields
-    rv.typ = typ
-    rv
+    MirRValue {kind: MirRVAggregate, typ, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: kind, aggFields: fields, aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVVariant(variantIdx: Int, variantTag: String, fields: List<MirOperand>, typ: String) -> MirRValue {
-    let mut rv = mirRVAggregate(MirAggEnumVariant, fields, typ)
-    rv.aggVariantIdx = variantIdx
-    rv.aggVariantTag = variantTag
-    rv
+    MirRValue {kind: MirRVAggregate, typ, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggEnumVariant, aggFields: fields, aggVariantIdx: variantIdx, aggVariantTag: variantTag, place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVDiscriminant(place: MirPlace, typ: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVDiscriminant
-    rv.place = place
-    rv.hasPlace = true
-    rv.typ = typ
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVDiscriminant, typ, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place, hasPlace: true, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVLen(place: MirPlace, typ: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVLen
-    rv.place = place
-    rv.hasPlace = true
-    rv.typ = typ
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVLen, typ, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place, hasPlace: true, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVCast(kind: MirCastKind, arg: MirOperand, from: String, to: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVCast
-    rv.castKind = kind
-    rv.arg = arg
-    rv.castFrom = from
-    rv.castTo = to
-    rv.typ = to
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVCast, typ: to, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg, right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: kind, castFrom: from, castTo: to, globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVRef(place: MirPlace, typ: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVRef
-    rv.place = place
-    rv.hasPlace = true
-    rv.typ = typ
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVRef, typ, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place, hasPlace: true, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVAddressOf(place: MirPlace, typ: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVAddressOf
-    rv.place = place
-    rv.hasPlace = true
-    rv.typ = typ
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVAddressOf, typ, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place, hasPlace: true, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVGlobalRef(name: String, typ: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVGlobalRef
-    rv.globalName = name
-    rv.typ = typ
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVGlobalRef, typ, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: name, nullaryKind: MirNullaryInvalid}
 }
 pub fn mirRVNullary(kind: MirNullaryRVKind, typ: String) -> MirRValue {
-    let mut rv = mirRValueInvalid()
-    rv.kind = MirRVNullary
-    rv.nullaryKind = kind
-    rv.typ = typ
-    rv
+    let aggFields: List<MirOperand> = []
+    MirRValue {kind: MirRVNullary, typ, unaryOp: MirUnInvalid, binaryOp: MirBinInvalid, arg: mirOperandInvalid(), right: mirOperandInvalid(), aggKind: MirAggInvalid, aggFields, aggVariantIdx: 0, aggVariantTag: "", place: mirPlace(-1), hasPlace: false, castKind: MirCastInvalid, castFrom: "", castTo: "", globalName: "", nullaryKind: kind}
 }
 // ====================================================================
 // Instructions

--- a/toolchain/mir_json.osty
+++ b/toolchain/mir_json.osty
@@ -891,9 +891,10 @@ fn mirJsonSpan(value: MirJsonValue) -> Result<MirSpan, String> {
 }
 
 pub fn mirJsonParseModule(text: String) -> Result<MirModule, String> {
-    let mut m = mirModule("main")
-    mirJsonParseModuleInto(text, m)?
-    Ok(m)
+    match mirJsonParseValue(text) {
+        Ok(v) -> mirJsonModule(v),
+        Err(_) -> Err("mir-json: invalid JSON"),
+    }
 }
 
 pub fn mirJsonParseModuleInto(text: String, m: MirModule) -> Result<Bool, String> {
@@ -904,9 +905,16 @@ pub fn mirJsonParseModuleInto(text: String, m: MirModule) -> Result<Bool, String
 }
 
 fn mirJsonModule(value: MirJsonValue) -> Result<MirModule, String> {
-    let mut m = mirModule("main")
-    mirJsonModuleInto(value, m)?
-    Ok(m)
+    let obj = mirJsonObject(value, "module")?
+    let version = mirJsonIntField(obj, 7064748, "version", 1)?
+    if version != 0 && version != 1 {
+        return Err("mir-json: unsupported version")
+    }
+    let packageName = mirJsonStringField(obj, 11154812, "packageName", "main")?
+    let span = mirJsonSpanField(obj, 4020328, "span")?
+    let mut m = mirModule(packageName)
+    mirJsonModuleObjectInto(obj, m)?
+    Ok(MirModule {packageName, functions: m.functions, globals: m.globals, uses: m.uses, layouts: m.layouts, span})
 }
 
 fn mirJsonModuleInto(value: MirJsonValue, m: MirModule) -> Result<Bool, String> {
@@ -915,8 +923,10 @@ fn mirJsonModuleInto(value: MirJsonValue, m: MirModule) -> Result<Bool, String> 
     if version != 0 && version != 1 {
         return Err("mir-json: unsupported version")
     }
-    m.packageName = mirJsonStringField(obj, 11154812, "packageName", "main")?
-    m.span = mirJsonSpanField(obj, 4020328, "span")?
+    mirJsonModuleObjectInto(obj, m)
+}
+
+fn mirJsonModuleObjectInto(obj: List<MirJsonEntry>, m: MirModule) -> Result<Bool, String> {
     mirJsonLayoutsInto(match mirJsonObjectGetNamed(obj, 7067238, "layouts") {
         Some(v) -> v,
         None -> mirJsonEmptyObject(),
@@ -956,20 +966,25 @@ fn mirJsonModuleGlobals(items: List<MirJsonValue>, pos: Int, m: MirModule) -> Re
 
 fn mirJsonUse(value: MirJsonValue) -> Result<MirUse, String> {
     let obj = mirJsonObject(value, "use")?
-    let mut u = mirUse(mirJsonStringField(obj, 7060875, "rawPath", "")?, mirJsonStringField(obj, 5031372, "alias", "")?, mirJsonSpanField(obj, 4020328, "span")?)
-    u.isGoFFI = mirJsonBoolField(obj, 7047216, "isGoFFI", false)?
-    u.isRuntimeFFI = mirJsonBoolField(obj, 12170933, "isRuntimeFFI", false)?
-    u.goPath = mirJsonStringField(obj, 6043993, "goPath", "")?
-    u.runtimePath = mirJsonStringField(obj, 11161640, "runtimePath", "")?
-    Ok(u)
+    let rawPath = mirJsonStringField(obj, 7060875, "rawPath", "")?
+    let alias = mirJsonStringField(obj, 5031372, "alias", "")?
+    let span = mirJsonSpanField(obj, 4020328, "span")?
+    let isGoFFI = mirJsonBoolField(obj, 7047216, "isGoFFI", false)?
+    let isRuntimeFFI = mirJsonBoolField(obj, 12170933, "isRuntimeFFI", false)?
+    let goPath = mirJsonStringField(obj, 6043993, "goPath", "")?
+    let runtimePath = mirJsonStringField(obj, 11161640, "runtimePath", "")?
+    Ok(MirUse {rawPath, alias, isGoFFI, isRuntimeFFI, goPath, runtimePath, span})
 }
 
 fn mirJsonGlobal(value: MirJsonValue) -> Result<MirGlobal, String> {
     let obj = mirJsonObject(value, "global")?
-    let mut g = mirGlobal(mirJsonStringField(obj, 4019667, "name", "")?, mirJsonTypeField(obj, 4020804, "type")?, mirJsonBoolField(obj, 3012686, "mut", false)?, mirJsonSpanField(obj, 4020328, "span")?)
-    g.hasInit = mirJsonBoolField(obj, 7061762, "hasInit", false)?
-    g.initSymbol = mirJsonStringField(obj, 10135147, "initSymbol", "")?
-    Ok(g)
+    let name = mirJsonStringField(obj, 4019667, "name", "")?
+    let typ = mirJsonTypeField(obj, 4020804, "type")?
+    let mutable = mirJsonBoolField(obj, 3012686, "mut", false)?
+    let span = mirJsonSpanField(obj, 4020328, "span")?
+    let hasInit = mirJsonBoolField(obj, 7061762, "hasInit", false)?
+    let initSymbol = mirJsonStringField(obj, 10135147, "initSymbol", "")?
+    Ok(MirGlobal {name, typ, mutable, hasInit, initSymbol, span})
 }
 
 fn mirJsonFunction(value: MirJsonValue) -> Result<MirFunction, String> {
@@ -1078,10 +1093,14 @@ fn mirJsonInlineMode(value: Int) -> MirInlineMode {
 
 fn mirJsonLocal(value: MirJsonValue) -> Result<MirLocal, String> {
     let obj = mirJsonObject(value, "local")?
-    let mut l = mirLocal(mirJsonIntField(obj, 2005391, "id", 0)?, mirJsonStringField(obj, 4019667, "name", "")?, mirJsonTypeField(obj, 4020804, "type")?, mirJsonBoolField(obj, 3012686, "mut", false)?, mirJsonSpanField(obj, 4020328, "span")?)
-    l.isParam = mirJsonBoolField(obj, 7060589, "isParam", false)?
-    l.isReturn = mirJsonBoolField(obj, 8085801, "isReturn", false)?
-    Ok(l)
+    let id = mirJsonIntField(obj, 2005391, "id", 0)?
+    let name = mirJsonStringField(obj, 4019667, "name", "")?
+    let typ = mirJsonTypeField(obj, 4020804, "type")?
+    let mutable = mirJsonBoolField(obj, 3012686, "mut", false)?
+    let span = mirJsonSpanField(obj, 4020328, "span")?
+    let isParam = mirJsonBoolField(obj, 7060589, "isParam", false)?
+    let isReturn = mirJsonBoolField(obj, 8085801, "isReturn", false)?
+    Ok(MirLocal {id, name, typ, mutable, isParam, isReturn, span})
 }
 
 fn mirJsonBlock(value: MirJsonValue) -> Result<MirBasicBlock, String> {

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -2080,6 +2080,14 @@ pub fn mirLowerLetStmt(bs: MirLowerBodyState, s: HirStmt) {
 /// mirLowerExprStmtInner handles expressions used as statements. The
 /// value is discarded; side effects survive via operand lowering.
 pub fn mirLowerExprStmtInner(bs: MirLowerBodyState, s: HirStmt) {
+    if s.exprValue.kind == HirExprCall {
+        mirLowerCallExprInto(bs, s.exprValue, mirPlace(-1), hirTUnit())
+        return
+    }
+    if s.exprValue.kind == HirExprMethod {
+        mirLowerMethodCallInto(bs, s.exprValue, mirPlace(-1), hirTUnit())
+        return
+    }
     let _ = mirLowerExprAsOperand(bs, s.exprValue)
 }
 /// mirLowerReturnStmt lowers `return` / `return value`. Values are


### PR DESCRIPTION
## Summary
- address the PR #1926 exec Result ABI review by returning boxed runtime exec results and lowering std.os exec calls as ptr-box values rebuilt into canonical Result aggregates
- keep stage2-seed on the LIR Proto path while removing several selfhost source/MIR JSON bootstrap hazards: typed empty LIR args, stage2-safe generic arg splitting, direct MIR JSON scalar construction, and discarded statement calls
- convert MIR constructor helpers to direct literals and add structural guards so projected scalar assignments do not re-enter the selfhost path

## Current selfhost boundary
- `just verify-self-rebuild-fast` now gets past the prior stage2-seed `void -> i64` wall: stage1 builds, stage2-seed compiles lowered LLVM IR, stage2-seed doctor passes, and stage2 doctor passes
- the remaining wall has moved to stage3: the self-host backend subprocess still segfaults while handling MIR JSON for the stage3 build

## Validation
- `go test -count=1 -vet=off ./internal/selfhost -run 'Test(MirConstructorsAvoidProjectedScalarAssigns|MirLowerStage2SeedDiscardsStatementCalls|MirJsonStage2SeedAvoidsProjectedScalarAssigns|LirProtoStage2SeedCoercionAndIndexStoreGuards|Phase0SelfHostWiringExists)' -v`\n- `go test -count=1 -vet=off ./internal/backend -run 'TestBundledRuntime(Stage0AuditAliasesLinkWithThinLTO|StdOsExecWithReturnsResultBox)' -v`\n- `git diff --check`\n- `just front`\n- `just verify-self-rebuild-fast` (fails at the new stage3 self-host MIR JSON subprocess segfault boundary)