### PR TITLE
[codex] selfhost: stabilize stage3 parity

### DIFF
--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -1071,6 +1071,41 @@ func TestMirValidatorReturnMismatchDiagnosticIsBootstrapSafe(t *testing.T) {
 	}
 }
 
+func TestMirValidatorHotContextStringsAvoidInterpolation(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "mir_validator.osty"))
+	if err != nil {
+		t.Fatalf("read mir_validator.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		`mirValidateIndexCtx("aggregateRV.fields[", fi, "]")`,
+		`mirValidateIndexCtx("call.args[", ai, "]")`,
+		`mirValidateIndexCtx("intrinsic.args[", ai, "]")`,
+		`mirValidateIndexedChildCtx(ctx, "projections", pi)`,
+		`mirValidateChildCtx(ctx, "place")`,
+		`prefix + mirIntToString(idx) + suffix`,
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("mir_validator.osty missing bootstrap-safe context helper use %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		`"aggregateRV.fields[{fi}]"`,
+		`"call.args[{ai}]"`,
+		`"intrinsic.args[{ai}]"`,
+		`"{ctx}.place"`,
+		`"{ctx}.projections[{pi}]"`,
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("mir_validator.osty reintroduced hot-path interpolation %q", forbidden)
+		}
+	}
+}
+
 func TestVerifySelfRebuildStage1IgnoresStaleInTreeSelfBinary(t *testing.T) {
 	root, err := filepath.Abs("../..")
 	if err != nil {
@@ -1088,6 +1123,30 @@ func TestVerifySelfRebuildStage1IgnoresStaleInTreeSelfBinary(t *testing.T) {
 	} {
 		if !strings.Contains(text, needle) {
 			t.Fatalf("verify-self-rebuild missing stage1 stale self-binary guard %q", needle)
+		}
+	}
+}
+
+func TestVerifySelfRebuildNormalizesMachORandomLinkMetadata(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "scripts", "verify-self-rebuild"))
+	if err != nil {
+		t.Fatalf("read verify-self-rebuild: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"normalized_sha256_file()",
+		"LC_UUID = 0x1B",
+		"LC_CODE_SIGNATURE = 0x1D",
+		`data[off + 8:off + 24] = b"\0" * 16`,
+		`data[dataoff:dataoff + datasize] = b"\0" * datasize`,
+		"byte parity OK (Mach-O UUID/signature normalized)",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("verify-self-rebuild missing Mach-O parity normalization guard %q", needle)
 		}
 	}
 }

--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -140,6 +140,44 @@ sha256_file() {
 	fi
 }
 
+normalized_sha256_file() {
+	local path="$1"
+	if command -v python3 >/dev/null 2>&1; then
+		python3 - "$path" <<'PY' && return
+import hashlib
+import struct
+import sys
+
+path = sys.argv[1]
+data = bytearray(open(path, "rb").read())
+
+LC_UUID = 0x1B
+LC_CODE_SIGNATURE = 0x1D
+MH_MAGIC_64 = 0xFEEDFACF
+
+if len(data) >= 32 and struct.unpack_from("<I", data, 0)[0] == MH_MAGIC_64:
+    ncmds = struct.unpack_from("<I", data, 16)[0]
+    off = 32
+    for _ in range(ncmds):
+        if off + 8 > len(data):
+            break
+        cmd, cmdsize = struct.unpack_from("<II", data, off)
+        if cmdsize < 8 or off + cmdsize > len(data):
+            break
+        if cmd == LC_UUID and cmdsize >= 24:
+            data[off + 8:off + 24] = b"\0" * 16
+        elif cmd == LC_CODE_SIGNATURE and cmdsize >= 16:
+            dataoff, datasize = struct.unpack_from("<II", data, off + 8)
+            if dataoff <= len(data) and dataoff + datasize <= len(data):
+                data[dataoff:dataoff + datasize] = b"\0" * datasize
+        off += cmdsize
+
+print(hashlib.sha256(data).hexdigest())
+PY
+	fi
+	sha256_file "$path"
+}
+
 snapshot_binaries() {
 	local out="$1"
 	: >"$out"
@@ -619,9 +657,17 @@ build_self_binary_with_host_mir_backend "$stage2" "stage3" "$stage3"
 smoke_self_driver "$stage3" "stage3"
 
 if ! cmp -s "$stage2" "$stage3"; then
+	stage2_norm="$(normalized_sha256_file "$stage2")"
+	stage3_norm="$(normalized_sha256_file "$stage3")"
+	if [[ "$stage2_norm" == "$stage3_norm" ]]; then
+		log "byte parity OK (Mach-O UUID/signature normalized): $stage2_norm"
+		exit 0
+	fi
 	printf 'self-rebuild: byte parity failed\n' >&2
 	printf '  osty-self-2 %s  %s\n' "$(sha256_file "$stage2")" "$stage2" >&2
 	printf '  osty-self-3 %s  %s\n' "$(sha256_file "$stage3")" "$stage3" >&2
+	printf '  normalized osty-self-2 %s\n' "$stage2_norm" >&2
+	printf '  normalized osty-self-3 %s\n' "$stage3_norm" >&2
 	exit 1
 fi
 

--- a/toolchain/mir_validator.osty
+++ b/toolchain/mir_validator.osty
@@ -239,7 +239,7 @@ fn mirValidateBlock(func: MirFunction, bb: MirBasicBlock) -> List<String> {
         let mut seenVals: List<Int> = []
         let mut ci = 0
         for c in bb.termCases {
-            let rErrs = mirValidateBlockRef(func, bb, c.target, "switchInt.cases[{ci}]")
+            let rErrs = mirValidateBlockRef(func, bb, c.target, mirValidateIndexCtx("switchInt.cases[", ci, "]"))
             for e in rErrs {
                 errs.push(e)
             }
@@ -288,7 +288,7 @@ fn mirValidateInstr(func: MirFunction, bb: MirBasicBlock, idx: Int, instr: MirIn
         }
         let mut ai = 0
         for op in instr.args {
-            let oErrs = mirValidateOperand(func, bb, op, "call.args[{ai}]")
+            let oErrs = mirValidateOperand(func, bb, op, mirValidateIndexCtx("call.args[", ai, "]"))
             for e in oErrs {
                 errs.push(e)
             }
@@ -308,7 +308,7 @@ fn mirValidateInstr(func: MirFunction, bb: MirBasicBlock, idx: Int, instr: MirIn
         }
         let mut ai = 0
         for op in instr.args {
-            let oErrs = mirValidateOperand(func, bb, op, "intrinsic.args[{ai}]")
+            let oErrs = mirValidateOperand(func, bb, op, mirValidateIndexCtx("intrinsic.args[", ai, "]"))
             for e in oErrs {
                 errs.push(e)
             }
@@ -415,7 +415,7 @@ fn mirValidateRValue(func: MirFunction, bb: MirBasicBlock, rv: MirRValue) -> Lis
         }
         let mut fi = 0
         for op in rv.aggFields {
-            let oErrs = mirValidateOperand(func, bb, op, "aggregateRV.fields[{fi}]")
+            let oErrs = mirValidateOperand(func, bb, op, mirValidateIndexCtx("aggregateRV.fields[", fi, "]"))
             for e in oErrs {
                 errs.push(e)
             }
@@ -497,14 +497,14 @@ fn mirValidateOperand(func: MirFunction, bb: MirBasicBlock, op: MirOperand, ctx:
         errs.push("function \"{func.name}\" bb{bb.id} {ctx}: operand has empty typ")
     }
     if op.kind == MirOpCopy {
-        let pErrs = mirValidatePlace(func, bb, op.place, "{ctx}.place")
+        let pErrs = mirValidatePlace(func, bb, op.place, mirValidateChildCtx(ctx, "place"))
         for e in pErrs {
             errs.push(e)
         }
         return errs
     }
     if op.kind == MirOpMove {
-        let pErrs = mirValidatePlace(func, bb, op.place, "{ctx}.place")
+        let pErrs = mirValidatePlace(func, bb, op.place, mirValidateChildCtx(ctx, "place"))
         for e in pErrs {
             errs.push(e)
         }
@@ -527,7 +527,7 @@ fn mirValidatePlace(func: MirFunction, bb: MirBasicBlock, p: MirPlace, ctx: Stri
     }
     let mut pi = 0
     for proj in p.projections {
-        let projErrs = mirValidateProjection(func, bb, proj, "{ctx}.projections[{pi}]")
+        let projErrs = mirValidateProjection(func, bb, proj, mirValidateIndexedChildCtx(ctx, "projections", pi))
         for e in projErrs {
             errs.push(e)
         }
@@ -616,7 +616,7 @@ fn mirValidateTerm(func: MirFunction, bb: MirBasicBlock, t: MirTerm) -> List<Str
         let mut seenVals: List<Int> = []
         let mut ci = 0
         for c in t.cases {
-            let rErrs = mirValidateBlockRef(func, bb, c.target, "switchInt.cases[{ci}]")
+            let rErrs = mirValidateBlockRef(func, bb, c.target, mirValidateIndexCtx("switchInt.cases[", ci, "]"))
             for e in rErrs {
                 errs.push(e)
             }
@@ -649,4 +649,16 @@ fn mirValidateBlockRef(func: MirFunction, bb: MirBasicBlock, target: Int, ctx: S
         errs.push("function \"{func.name}\" bb{bb.id} {ctx}: target bb{target} out of range (blocks={blockCount})")
     }
     errs
+}
+
+fn mirValidateIndexCtx(prefix: String, idx: Int, suffix: String) -> String {
+    prefix + mirIntToString(idx) + suffix
+}
+
+fn mirValidateChildCtx(parent: String, child: String) -> String {
+    parent + "." + child
+}
+
+fn mirValidateIndexedChildCtx(parent: String, child: String, idx: Int) -> String {
+    parent + "." + child + "[" + mirIntToString(idx) + "]"
 }


### PR DESCRIPTION
## Summary
- avoid bootstrap-unsafe string interpolation on MIR validator hot context paths
- normalize Mach-O LC_UUID and linker ad-hoc signature bytes for self-rebuild parity comparison
- add structural guards for validator context strings and self-rebuild Mach-O normalization

## Verification
- shellcheck scripts/verify-self-rebuild
- go test -count=1 -vet=off ./internal/selfhost -run 'Test(MirValidatorHotContextStringsAvoidInterpolation|MirValidatorReturnMismatchDiagnosticIsBootstrapSafe|Stage2SeedDriverAvoidsBootstrapUnsafeMatchDispatch|VerifySelfRebuildStage1IgnoresStaleInTreeSelfBinary|VerifySelfRebuildNormalizesMachORandomLinkMetadata)' -v
- go test -count=1 -vet=off ./internal/llvmabi -run 'TestClang(LinkBinaryArgsAddsPthreadOnLinux|LinkBinaryArgsOmitsPthreadOnWindows|LinkBinaryArgsReleaseProfileKeepsLTO|LinkBinaryArgsNoLTOProfilesDropLTO)' -v
- git diff --check
- just front
- just verify-self-rebuild-fast