### PR TITLE
[codex] selfhost: align full ratchet with cached stage1 seed

### DIFF
--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -1151,6 +1151,21 @@ func TestVerifySelfRebuildNormalizesMachORandomLinkMetadata(t *testing.T) {
 	}
 }
 
+func TestJustVerifySelfRebuildUsesCachedStage1Seed(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "justfile"))
+	if err != nil {
+		t.Fatalf("read justfile: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "verify-self-rebuild: build-all\n    bash scripts/verify-self-rebuild --reuse-stage1 {{bin}}") {
+		t.Fatalf("just verify-self-rebuild should use the cached stage1 seed, matching the production selfhost path")
+	}
+}
+
 func TestMirLowerVariantPayloadZeroSelectorIsRedundant(t *testing.T) {
 	root, err := filepath.Abs("../..")
 	if err != nil {

--- a/justfile
+++ b/justfile
@@ -220,7 +220,7 @@ verify-selfhost:
     go test {{test_flags}} -run 'SnapshotParity|CoreSnapshotParity' ./internal/ci ./internal/runner
 
 verify-self-rebuild: build-all
-    bash scripts/verify-self-rebuild {{bin}}
+    bash scripts/verify-self-rebuild --reuse-stage1 {{bin}}
 
 verify-self-rebuild-fast: build-all
     bash scripts/verify-self-rebuild --skip-gates --reuse-stage1 {{bin}}


### PR DESCRIPTION
## Summary
- route `just verify-self-rebuild` through the cached stage1 seed, matching the production selfhost path already used by the fast ratchet
- lock the recipe with a phase0 wiring guard so the full ratchet does not silently fall back to legacy fresh stage0 linking

## Verification
- go test -count=1 -vet=off ./internal/selfhost -run 'Test(JustVerifySelfRebuildUsesCachedStage1Seed|VerifySelfRebuildNormalizesMachORandomLinkMetadata|MirValidatorHotContextStringsAvoidInterpolation)' -v\n- just verify-self-rebuild\n- git diff --check\n- just front