### PR TITLE
[codex] Fix Windows selfhost install force path

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -298,14 +298,16 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    진짜 production capability 확장 path: generated.go 직접 수정 — 옵션 c' (narrow exception 한도 확대) / γ (deep type-propagation fix) / frozen seed regen 모델 재고 셋 중 선택.
 
-   **🎉 2026-05-17 source bootstrap UNLOCK**: `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 OSTY_STDLIB_BODY_LOWER=1 .bin/osty install-self` **통과**! `osty-self` binary 가 `.osty/cache/self-host/<hash>-darwin-arm64/osty-self` 에 install. 조합:
+   **🎉 2026-05-17 source bootstrap UNLOCK**: `OSTY_STAGE0_FALLBACK=1 .bin/osty install-self` **통과**! `osty-self` binary 가 `.osty/cache/self-host/<hash>-darwin-arm64/osty-self` 에 install. 조합:
    - stage0 100% (PR #1858)
    - execWith / execInputWith C wrappers (PR #1861)
-   - `OSTY_STDLIB_BODY_LOWER=1` 활성 → execOutput body lower + tyToRepr 의 monomorph cover
+   - execOutput C wrapper 경유 → `OSTY_STDLIB_BODY_LOWER=1` 없이 source bootstrap 가능
 
    plan §10.1 R2 (stage0 cover) **완전 종결**.
 
-   **2026-05-17 execOutput C wrapper (이 PR)**: `osty_rt_os_exec_output(int64_t exit_code, void *stdout, void *stderr, bool timed_out)` C wrapper + `rewriteStdlibSymbolToRuntime` 매핑 `std.os.execOutput → osty_rt_os_exec_output` 추가. ExecOutput struct ABI = `{i64, ptr, ptr, i1}` (stage0KnownStdlibStructLayout 와 일치). 효과: source bootstrap 명령에서 `OSTY_STDLIB_BODY_LOWER=1` flag **의존성 제거** — `OSTY_STAGE0_FALLBACK=1 OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 .bin/osty install-self` 만으로 통과. minimum-flag combination 으로 source bootstrap path 안정화. PR #1861 의 PR1c 옵션 1 패턴 확장 — 위 §"옵션 5 next wall" 의 첫 path ("C wrapper") 채택.
+   **2026-05-17 execOutput C wrapper (이 PR)**: `osty_rt_os_exec_output(int64_t exit_code, void *stdout, void *stderr, bool timed_out)` C wrapper + `rewriteStdlibSymbolToRuntime` 매핑 `std.os.execOutput → osty_rt_os_exec_output` 추가. ExecOutput struct ABI = `{i64, ptr, ptr, i1}` (stage0KnownStdlibStructLayout 와 일치). 효과: source bootstrap 명령에서 `OSTY_STDLIB_BODY_LOWER=1` flag **의존성 제거** — `OSTY_STAGE0_FALLBACK=1 .bin/osty install-self` 만으로 통과. minimum-flag combination 으로 source bootstrap path 안정화. PR #1861 의 PR1c 옵션 1 패턴 확장 — 위 §"옵션 5 next wall" 의 첫 path ("C wrapper") 채택.
+
+   **2026-05-19 source-bootstrap opt-in collapse**: `OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP` is retired. `OSTY_STAGE0_FALLBACK=1` is now the single explicit opt-in for fresh-clone source bootstrap; `osty install-self` attempts the source build directly when cache/registry lookup fails under that env.
 
    **2026-05-17 R3 trajectory brick 진척** (PR #1873 + #1874 + brick 3a 시도):
    - **Brick 1 (PR #1873)**: `builtinMethodReturnType` 의 PrimInt/PrimByte case 에 `__IntMethods` fan-out cover (abs/min/max/clamp/signum/pow + wrapping*/saturating*/checked*/toString). MIR generator 의 type-propagation gap 의 일부 해소 — recoverOperandType 의 MethodCall path 가 더 많은 receiver type 에서 retrun type 추정 가능.
@@ -327,7 +329,7 @@ String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/mod
 
    세 path 모두 깊은 작업. cross-package import (struct literal + type / method / field) 전체가 single root cause.
 
-   **2026-05-17 옵션 5 (source bootstrap) 시도 — next layer wall**: stage0 100% 통과 후 `OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 osty install-self` 시도 시 link 단계에서:
+   **2026-05-17 옵션 5 (source bootstrap) 시도 — next layer wall**: stage0 100% 통과 후 `OSTY_STAGE0_FALLBACK=1 osty install-self` 시도 시 link 단계에서:
    ```
    Undefined symbols for architecture arm64:
      "_std.os.execInputWith", referenced from: _selfRebuildWriteString

--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -59,6 +59,11 @@ const selfForwardArgsEnv = "OSTY_SELF_REBUILD_FORWARD_ARGS"
 // self-hosted LIR Proto lowering. Use "0" to disable.
 const selfLowerTimeoutEnv = "OSTY_LIRPROTO_SELF_TIMEOUT"
 
+// selfSourceCompatMaxBytesEnv bounds the legacy source retry used
+// only when an older osty-self cannot handle MIR JSON directly.
+// Use "0" to disable the size guard.
+const selfSourceCompatMaxBytesEnv = "OSTY_LIRPROTO_SOURCE_COMPAT_MAX_BYTES"
+
 func main() {
 	if err := run(os.Stdin, os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -191,7 +196,12 @@ func runSelfLower(selfBin string, args []string) (nativelirproto.Response, strin
 }
 
 func selfLowerTimeout(args []string) time.Duration {
-	if len(args) == 0 || args[0] != "lir-proto-lower-mir-json" {
+	if len(args) == 0 {
+		return 0
+	}
+	switch args[0] {
+	case "lir-proto-lower-mir-json", "lir-proto-lower":
+	default:
 		return 0
 	}
 	if raw := os.Getenv(selfLowerTimeoutEnv); raw != "" {
@@ -254,6 +264,19 @@ func lowerLegacyMIRJSON(req nativelirproto.Request, selfBin string) (nativelirpr
 			return stage0Resp, nil
 		}
 		return nativelirproto.Response{Declined: true, Error: "legacy osty-self does not support MIR JSON requests"}, nil
+	}
+	if max := sourceCompatMaxBytes(); max > 0 && len([]byte(req.Source)) > max {
+		sourceResp := nativelirproto.Response{
+			Declined: true,
+			Error:    fmt.Sprintf("legacy source compat skipped: source is %d bytes, exceeds %d byte guard", len([]byte(req.Source)), max),
+		}
+		if !triedStage0 {
+			return sourceResp, nil
+		}
+		return nativelirproto.Response{
+			Declined: true,
+			Error:    combineDeclineErrors(stage0Resp.Error, sourceResp.Error),
+		}, nil
 	}
 	sourceReq := req
 	sourceReq.MIR = nil
@@ -333,6 +356,19 @@ func combineDeclineErrors(primary, secondary string) string {
 	default:
 		return primary + "; source compat: " + secondary
 	}
+}
+
+func sourceCompatMaxBytes() int {
+	if raw := os.Getenv(selfSourceCompatMaxBytesEnv); raw != "" {
+		if raw == "0" {
+			return 0
+		}
+		var n int
+		if _, err := fmt.Sscanf(raw, "%d", &n); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 1 << 20
 }
 
 // resolveOstySelfBin returns the path to the self-host `osty-self`

--- a/cmd/osty-native-lirproto/main_test.go
+++ b/cmd/osty-native-lirproto/main_test.go
@@ -549,8 +549,8 @@ func TestRunMIRPayloadUsesStage0CompatWhenMirJSONTimesOut(t *testing.T) {
 	}
 
 	t.Setenv(SelfBinEnv, bin)
-	t.Setenv(selfLowerTimeoutEnv, "10ms")
-	t.Setenv("FAKE_OSTY_SELF_SLEEP_MS", "100")
+	t.Setenv(selfLowerTimeoutEnv, "500ms")
+	t.Setenv("FAKE_OSTY_SELF_SLEEP_MS", "3000")
 	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
 
 	body, err := json.Marshal(nativelirproto.Request{
@@ -578,6 +578,80 @@ func TestRunMIRPayloadUsesStage0CompatWhenMirJSONTimesOut(t *testing.T) {
 	args := readCapturedArgs(t, captureArgs)
 	if len(args) < 2 || args[0] != "lir-proto-lower-mir-json" {
 		t.Fatalf("first args = %v, want MIR JSON attempt before compat", args)
+	}
+}
+
+func TestRunSourceLowerTimesOut(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv(selfLowerTimeoutEnv, "100ms")
+	t.Setenv("FAKE_OSTY_SELF_SLEEP_MS", "3000")
+	t.Setenv("FAKE_OSTY_SELF_STDOUT", "; should not arrive\ndefine i64 @main() {\n  ret i64 1\n}\n")
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		Source:      "fn main() -> Int { 1 }\n",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if !resp.Declined {
+		t.Fatalf("Declined = false, want timeout decline: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, "lir-proto-lower timed out") {
+		t.Fatalf("Error = %q, want source lower timeout", resp.Error)
+	}
+}
+
+func TestRunMIRPayloadSkipsLargeLegacySourceCompat(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	captureDir := t.TempDir()
+	captureArgs := filepath.Join(captureDir, "args.json")
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_REJECT_MIR_JSON", "1")
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
+	t.Setenv("FAKE_OSTY_SELF_STDOUT", "; source compat should not run\ndefine i64 @main() {\n  ret i64 9\n}\n")
+	t.Setenv(selfSourceCompatMaxBytesEnv, "8")
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		Source:      strings.Repeat("fn x() {}\n", 4),
+		MIR: map[string]any{
+			"version":     1,
+			"packageName": "main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if !resp.Declined {
+		t.Fatalf("Declined = false, want guarded decline: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, "legacy source compat skipped") {
+		t.Fatalf("Error = %q, want source compat guard", resp.Error)
+	}
+	args := readCapturedArgs(t, captureArgs)
+	if len(args) < 2 || args[0] != "lir-proto-lower-mir-json" {
+		t.Fatalf("args = %v, want only MIR JSON attempt", args)
 	}
 }
 

--- a/cmd/osty/cache_self_test.go
+++ b/cmd/osty/cache_self_test.go
@@ -55,7 +55,7 @@ func TestCacheSelfPathPrintsCanonicalLocation(t *testing.T) {
 		t.Fatalf("cache-self: %v\n%s", err, out)
 	}
 	got := strings.TrimSpace(string(out))
-	if !strings.Contains(got, ".osty/cache/self-host/") {
+	if !strings.Contains(filepath.ToSlash(got), ".osty/cache/self-host/") {
 		t.Errorf("path missing canonical prefix: %s", got)
 	}
 	if !strings.HasSuffix(got, selfhostcache.BinaryName()) {

--- a/cmd/osty/install_self.go
+++ b/cmd/osty/install_self.go
@@ -5,15 +5,16 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
+	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
-
-const installSelfAllowSourceBootstrapEnv = "OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP"
 
 // runInstallSelf orchestrates the bootstrap "build osty-self →
 // promote into cache" sequence. It:
@@ -93,6 +94,12 @@ func runInstallSelf(args []string, _ cliFlags) {
 	}
 
 	resolvedSelf, _, resolveErr := selfhostcache.ResolveBinaryWithFetch(context.Background(), root, selfhostcache.EnvFetcher())
+	if resolveErr != nil && force {
+		if bootstrapSelf, err := findLocalSelfhostBootstrap(root); err == nil {
+			resolvedSelf = bootstrapSelf
+			resolveErr = nil
+		}
+	}
 	if resolveErr == nil {
 		if !force {
 			if resolvedSelf != cachedPath {
@@ -106,21 +113,29 @@ func runInstallSelf(args []string, _ cliFlags) {
 			fmt.Printf("up-to-date:  %s\n", cachedPath)
 			return
 		}
-	} else if !installSelfSourceBootstrapAllowed() {
+	} else if !installSelfSourceBootstrapRequested() {
 		fmt.Fprintf(os.Stderr, "osty install-self: no osty-self bootstrap source available: %v\n", resolveErr)
-		if os.Getenv("OSTY_STAGE0_FALLBACK") == "" {
-			printInstallSelfBootstrapHint()
-		} else {
-			fmt.Fprintln(os.Stderr, "")
-			fmt.Fprintln(os.Stderr, "stage0 fallback is enabled, but a full source bootstrap currently requires opt-in because it can exceed memory/time limits before the emergency emitter is reached.")
-		}
-		fmt.Fprintf(os.Stderr, "to attempt the heavy source bootstrap anyway, set %s=1.\n", installSelfAllowSourceBootstrapEnv)
+		printInstallSelfBootstrapHint()
 		os.Exit(1)
 	}
 
-	builtBin, err := buildOstySelf(context.Background(), hostOsty, root, tcAbs)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "osty install-self: build: %v\n", err)
+	builtBin := ""
+	var buildErr error
+	if force && resolveErr == nil {
+		builtBin, buildErr = buildOstySelfWithSelfhost(context.Background(), resolvedSelf, hostOsty, root, tcAbs)
+		if buildErr != nil && !installSelfSourceBootstrapRequested() {
+			fmt.Fprintf(os.Stderr, "osty install-self: selfhost build: %v\n", buildErr)
+			os.Exit(1)
+		}
+		if buildErr != nil {
+			fmt.Fprintf(os.Stderr, "osty install-self: selfhost build failed; retrying source bootstrap: %v\n", buildErr)
+		}
+	}
+	if builtBin == "" {
+		builtBin, buildErr = buildOstySelf(context.Background(), hostOsty, root, tcAbs)
+	}
+	if buildErr != nil {
+		fmt.Fprintf(os.Stderr, "osty install-self: build: %v\n", buildErr)
 		// The chicken-egg: a fresh clone has no osty-self in cache,
 		// no in-tree build, and (by default) no registry URL. The
 		// host osty's LLVM backend forks `osty-self lir-proto-lower`
@@ -131,7 +146,7 @@ func runInstallSelf(args []string, _ cliFlags) {
 		// emergency path but not yet for the full toolchain. Surface
 		// the workflow options so the user does not have to hunt
 		// through the resolver chain in the dark.
-		if os.Getenv("OSTY_STAGE0_FALLBACK") == "" {
+		if os.Getenv(backend.Stage0FallbackEnv) == "" {
 			printInstallSelfBootstrapHint()
 		}
 
@@ -144,16 +159,8 @@ func runInstallSelf(args []string, _ cliFlags) {
 	fmt.Printf("installed:   %s\n", cachedPath)
 }
 
-// buildOstySelf invokes the host `osty` binary with the standard
-// build flags used by the self-rebuild ratchet. Returns the absolute
-// path to the produced osty-self binary.
-func installSelfSourceBootstrapAllowed() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(installSelfAllowSourceBootstrapEnv))) {
-	case "1", "true", "yes", "on":
-		return true
-	default:
-		return false
-	}
+func installSelfSourceBootstrapRequested() bool {
+	return backend.Stage0FallbackEnabled()
 }
 
 func printInstallSelfBootstrapHint() {
@@ -165,6 +172,9 @@ func printInstallSelfBootstrapHint() {
 	fmt.Fprintln(os.Stderr, "    (subset coverage; see docs/osty_self_bootstrap_design.md).")
 }
 
+// buildOstySelf invokes the host `osty` binary with the standard
+// build flags used by the self-rebuild ratchet. Returns the absolute
+// path to the produced osty-self binary.
 func buildOstySelf(ctx context.Context, hostOsty, root, toolchainDir string) (string, error) {
 	cmd := exec.CommandContext(ctx, hostOsty, "build", "--backend=llvm", "--emit", "binary", "--force", toolchainDir)
 	// Forward env vars set by the user (OSTY_STAGE0_FALLBACK,
@@ -177,7 +187,7 @@ func buildOstySelf(ctx context.Context, hostOsty, root, toolchainDir string) (st
 	// behaviour of the covered code paths. Users wanting strict mode
 	// can still override by setting OSTY_STAGE0_LIST_ALL_DECLINES=0.
 	cmd.Env = os.Environ()
-	if os.Getenv("OSTY_STAGE0_FALLBACK") != "" && os.Getenv("OSTY_STAGE0_LIST_ALL_DECLINES") == "" {
+	if backend.Stage0FallbackEnabled() && os.Getenv("OSTY_STAGE0_LIST_ALL_DECLINES") == "" {
 		cmd.Env = append(cmd.Env, "OSTY_STAGE0_LIST_ALL_DECLINES=1")
 	}
 	cmd.Dir = root
@@ -186,6 +196,231 @@ func buildOstySelf(ctx context.Context, hostOsty, root, toolchainDir string) (st
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("osty build toolchain/: %w", err)
 	}
+	return findBuiltOstySelf(root, toolchainDir)
+}
+
+func findLocalSelfhostBootstrap(root string) (string, error) {
+	cacheRoot := filepath.Join(root, selfhostcache.CacheDirName)
+	entries, err := os.ReadDir(cacheRoot)
+	if err != nil {
+		return "", err
+	}
+	type candidate struct {
+		path    string
+		modTime int64
+	}
+	candidates := []candidate{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(cacheRoot, entry.Name(), selfhostcache.BinaryName())
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			path:    path,
+			modTime: info.ModTime().UnixNano(),
+		})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].modTime > candidates[j].modTime
+	})
+	if len(candidates) == 0 {
+		return "", selfhostcache.ErrNotCached
+	}
+	return candidates[0].path, nil
+}
+
+const installSelfTryDirectBuildEnv = "OSTY_INSTALL_SELF_TRY_DIRECT_BUILD"
+
+func buildOstySelfWithSelfhost(ctx context.Context, selfOsty, hostOsty, root, toolchainDir string) (string, error) {
+	if installSelfTryDirectBuildRequested() {
+		return buildOstySelfWithSelfhostCommand(ctx, selfOsty, root, toolchainDir)
+	}
+	return buildOstySelfWithSelfhostMIRDriver(ctx, selfOsty, hostOsty, root, toolchainDir)
+}
+
+func installSelfTryDirectBuildRequested() bool {
+	raw := strings.TrimSpace(os.Getenv(installSelfTryDirectBuildEnv))
+	return raw == "1" || strings.EqualFold(raw, "true") || strings.EqualFold(raw, "yes") || strings.EqualFold(raw, "on")
+}
+
+func buildOstySelfWithSelfhostCommand(ctx context.Context, selfOsty, root, toolchainDir string) (string, error) {
+	cmd := exec.CommandContext(ctx, selfOsty, "build", "--backend", "llvm", "--emit", "binary", "--force", toolchainDir)
+	cmd.Env = os.Environ()
+	cmd.Dir = root
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("osty-self build toolchain/: %w", err)
+	}
+	return findBuiltOstySelf(root, toolchainDir)
+}
+
+func buildOstySelfWithSelfhostMIRDriver(ctx context.Context, selfOsty, hostOsty, root, toolchainDir string) (string, error) {
+	if hostOsty == "" {
+		return "", errors.New("host osty binary is required to build the selfhost MIR driver")
+	}
+	outDir := filepath.Join(toolchainDir, ".osty", "out", "debug", "llvm")
+	workDir := filepath.Join(outDir, "selfhost-mir-driver-pkg")
+	bundlePath := filepath.Join(workDir, "main.osty")
+	manifestPath := filepath.Join(workDir, "osty.toml")
+	binaryPath := filepath.Join(outDir, selfhostcache.BinaryName())
+
+	if err := os.RemoveAll(workDir); err != nil {
+		return "", fmt.Errorf("clean selfhost MIR driver work dir: %w", err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir selfhost MIR driver work dir: %w", err)
+	}
+	source, err := selfhostMIRDriverBundleSource(root)
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(bundlePath, []byte(source), 0o644); err != nil {
+		return "", fmt.Errorf("write selfhost MIR driver bundle: %w", err)
+	}
+	if err := os.WriteFile(manifestPath, []byte(selfhostMIRDriverManifest()), 0o644); err != nil {
+		return "", fmt.Errorf("write selfhost MIR driver manifest: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, hostOsty, "build", "--backend=llvm", "--emit", "binary", "--force", workDir)
+	cmd.Env = installSelfEnvWith(os.Environ(),
+		selfhostcache.SelfBinEnv, selfOsty,
+		"OSTY_SELF_REGISTRY_OFFLINE", "1",
+	)
+	cmd.Dir = root
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("host build selfhost MIR driver: %w", err)
+	}
+	candidate, err := findBuiltOstySelf(root, workDir)
+	if err != nil {
+		return "", fmt.Errorf("host build selfhost MIR driver: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		return "", fmt.Errorf("mkdir selfhost binary dir: %w", err)
+	}
+	if err := copySelfhostBinary(candidate, binaryPath); err != nil {
+		return "", err
+	}
+	return findBuiltOstySelf(root, toolchainDir)
+}
+
+func selfhostMIRDriverManifest() string {
+	return strings.TrimLeft(`
+[package]
+name = "selfhost-mir-driver"
+version = "0.1.0"
+edition = "0.3"
+
+[bin]
+name = "osty-self"
+path = "main.osty"
+
+[capabilities]
+runtime = true
+`, "\n")
+}
+
+func selfhostMIRDriverBundleSource(root string) (string, error) {
+	parts := []string{"use std.env", "use std.fs", "use std.os", "use std.process", "use std.strings", ""}
+	for _, rel := range selfhostMIRDriverSourceFiles() {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read selfhost source %s: %w", path, err)
+		}
+		parts = append(parts, "// ---- "+filepath.ToSlash(rel)+" ----")
+		parts = append(parts, selfhostStripDriverImports(string(src)))
+		parts = append(parts, "")
+	}
+	parts = append(parts, "fn main() {", "    selfhostMirDriverMain()", "}", "")
+	return strings.Join(parts, "\n"), nil
+}
+
+func selfhostMIRDriverSourceFiles() []string {
+	return []string{
+		"toolchain/mir.osty",
+		"toolchain/mir_validator.osty",
+		"toolchain/mir_json.osty",
+		"scripts/selfhost_mir_support.osty",
+		"toolchain/lir_proto.osty",
+		"toolchain/selfhost_mir_driver.osty",
+	}
+}
+
+func selfhostStripDriverImports(src string) string {
+	src = strings.ReplaceAll(src, "\r\n", "\n")
+	src = strings.ReplaceAll(src, "\r", "\n")
+	lines := strings.Split(src, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		switch line {
+		case "use std.env", "use std.fs", "use std.os", "use std.process", "use std.strings", "use std.strings as strings":
+			continue
+		default:
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+func installSelfEnvWith(env []string, pairs ...string) []string {
+	out := append([]string{}, env...)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		key, value := pairs[i], pairs[i+1]
+		prefix := key + "="
+		replaced := false
+		for j, item := range out {
+			eq := strings.IndexByte(item, '=')
+			if eq < 0 {
+				continue
+			}
+			existing := item[:eq]
+			if existing == key || (os.PathSeparator == '\\' && strings.EqualFold(existing, key)) {
+				out[j] = prefix + value
+				replaced = true
+			}
+		}
+		if !replaced {
+			out = append(out, prefix+value)
+		}
+	}
+	return out
+}
+
+func copySelfhostBinary(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open selfhost MIR driver binary: %w", err)
+	}
+	defer in.Close()
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("create selfhost MIR driver binary: %w", err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("copy selfhost MIR driver binary: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close selfhost MIR driver binary: %w", err)
+	}
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("replace old selfhost MIR driver binary: %w", err)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		return fmt.Errorf("install selfhost MIR driver binary: %w", err)
+	}
+	return nil
+}
+
+func findBuiltOstySelf(root, toolchainDir string) (string, error) {
 	for _, candidate := range []string{
 		filepath.Join(toolchainDir, ".osty", "out", "debug", "llvm", selfhostcache.BinaryName()),
 		filepath.Join(toolchainDir, ".osty", "out", "release", "llvm", selfhostcache.BinaryName()),

--- a/cmd/osty/install_self_test.go
+++ b/cmd/osty/install_self_test.go
@@ -29,6 +29,28 @@ func TestInstallSelfUsageMessage(t *testing.T) {
 	}
 }
 
+func TestInstallSelfSourceBootstrapFollowsStage0FallbackParser(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"on", true},
+		{"0", false},
+		{"false", false},
+		{"", false},
+	} {
+		t.Run(tc.value, func(t *testing.T) {
+			t.Setenv("OSTY_STAGE0_FALLBACK", tc.value)
+			if got := installSelfSourceBootstrapRequested(); got != tc.want {
+				t.Fatalf("installSelfSourceBootstrapRequested() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // fakeOstyBin builds a minimal Go shim that pretends to be the
 // `osty` binary for the duration of the test. It accepts any
 // arguments and writes a synthetic osty-self binary into the
@@ -60,17 +82,143 @@ func main() {
 	if err := os.WriteFile(src, []byte(prog), 0o644); err != nil {
 		t.Fatalf("write fake osty: %v", err)
 	}
-	binName := "fake-osty"
-	if runtime.GOOS == "windows" {
-		binName += ".exe"
-	}
-	bin := filepath.Join(dir, binName)
+	bin := filepath.Join(dir, fakeOstyBinName("fake-osty"))
 	cmd := exec.Command("go", "build", "-o", bin, src)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("build fake osty: %v\n%s", err, out)
 	}
 	return bin
+}
+
+func fakeOstyBinName(base string) string {
+	if runtime.GOOS == "windows" {
+		return base + ".exe"
+	}
+	return base
+}
+
+func fakeSelfhostBin(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	prog := `package main
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+)
+func main() {
+    cwd, _ := os.Getwd()
+    if err := os.WriteFile(filepath.Join(cwd, "selfhost-args.txt"), []byte(strings.Join(os.Args[1:], "\n")), 0o644); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    want := []string{"build", "--backend", "llvm", "--emit", "binary", "--force"}
+    if len(os.Args) != len(want)+2 {
+        fmt.Fprintf(os.Stderr, "args length = %d, want %d: %v\n", len(os.Args)-1, len(want)+1, os.Args[1:])
+        os.Exit(1)
+    }
+    for i, arg := range want {
+        if os.Args[i+1] != arg {
+            fmt.Fprintf(os.Stderr, "arg %d = %q, want %q\n", i, os.Args[i+1], arg)
+            os.Exit(1)
+        }
+    }
+    toolchainDir := os.Args[len(os.Args)-1]
+    if !filepath.IsAbs(toolchainDir) {
+        toolchainDir = filepath.Join(cwd, toolchainDir)
+    }
+    out := filepath.Join(toolchainDir, ".osty", "out", "debug", "llvm", ` + "\"" + selfhostcache.BinaryName() + "\"" + `)
+    if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    if err := os.WriteFile(out, []byte(` + "`" + body + "`" + `), 0o755); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+}
+`
+	if err := os.WriteFile(src, []byte(prog), 0o644); err != nil {
+		t.Fatalf("write fake osty-self: %v", err)
+	}
+	bin := filepath.Join(dir, fakeOstyBinName("fake-osty-self"))
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build fake osty-self: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func fakeMIRDriverHostBin(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	prog := `package main
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+)
+func main() {
+    cwd, _ := os.Getwd()
+    if err := os.WriteFile(filepath.Join(cwd, "host-self-bin.txt"), []byte(os.Getenv("OSTY_SELF_BIN")), 0o644); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    if len(os.Args) < 6 {
+        fmt.Fprintf(os.Stderr, "args too short: %v\n", os.Args[1:])
+        os.Exit(1)
+    }
+    got := strings.Join(os.Args[1:len(os.Args)-1], "\n")
+    want := "build\n--backend=llvm\n--emit\nbinary\n--force"
+    if got != want {
+        fmt.Fprintf(os.Stderr, "args = %q, want %q\n", got, want)
+        os.Exit(1)
+    }
+    workDir := os.Args[len(os.Args)-1]
+    out := filepath.Join(workDir, ".osty", "out", "debug", "llvm", ` + "\"" + selfhostcache.BinaryName() + "\"" + `)
+    if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    if err := os.WriteFile(out, []byte(` + "`" + body + "`" + `), 0o755); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+}
+`
+	if err := os.WriteFile(src, []byte(prog), 0o644); err != nil {
+		t.Fatalf("write fake MIR driver host: %v", err)
+	}
+	bin := filepath.Join(dir, fakeOstyBinName("fake-mir-driver-host"))
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build fake MIR driver host: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func writeSelfhostMIRDriverSourceStubs(t *testing.T, root string) {
+	t.Helper()
+	for _, rel := range selfhostMIRDriverSourceFiles() {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		body := "// " + filepath.ToSlash(rel) + "\n"
+		if strings.HasSuffix(rel, "selfhost_mir_driver.osty") {
+			body += "fn selfhostMirDriverMain() {}\n"
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
 }
 
 // TestBuildOstySelfRunsHostBinary covers the lower-level helper
@@ -101,6 +249,38 @@ func TestBuildOstySelfRunsHostBinary(t *testing.T) {
 	}
 }
 
+func TestBuildOstySelfWithSelfhostRunsResolvedBinary(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("mkdir toolchain: %v", err)
+	}
+	selfBin := fakeSelfhostBin(t, "resolved osty-self body")
+	t.Setenv(installSelfTryDirectBuildEnv, "1")
+
+	got, err := buildOstySelfWithSelfhost(t.Context(), selfBin, "", root, filepath.Join(root, "toolchain"))
+	if err != nil {
+		t.Fatalf("buildOstySelfWithSelfhost: %v", err)
+	}
+	want := filepath.Join(root, "toolchain", ".osty", "out", "debug", "llvm", selfhostcache.BinaryName())
+	if got != want {
+		t.Fatalf("got = %q, want %q", got, want)
+	}
+	body, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("read built bin: %v", err)
+	}
+	if string(body) != "resolved osty-self body" {
+		t.Fatalf("body mismatch: %q", body)
+	}
+	args, err := os.ReadFile(filepath.Join(root, "selfhost-args.txt"))
+	if err != nil {
+		t.Fatalf("read selfhost args: %v", err)
+	}
+	if gotArgs := string(args); !strings.Contains(gotArgs, "build\n--backend\nllvm\n--emit\nbinary\n--force\n") {
+		t.Fatalf("selfhost args = %q", gotArgs)
+	}
+}
+
 func TestBuildOstySelfFailsWhenHostExits(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
@@ -114,7 +294,7 @@ func main() { os.Exit(7) }
 `), 0o644); err != nil {
 		t.Fatalf("write fake osty: %v", err)
 	}
-	bin := filepath.Join(dir, "fake-osty-fail")
+	bin := filepath.Join(dir, fakeOstyBinName("fake-osty-fail"))
 	out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput()
 	if err != nil {
 		t.Fatalf("build: %v\n%s", err, out)
@@ -161,7 +341,7 @@ func main() { os.Exit(1) }
 
 	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", stub)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(), "OSTY_STAGE0_FALLBACK=") // explicitly unset
+	cmd.Env = append(os.Environ(), "OSTY_STAGE0_FALLBACK=", "OSTY_SELF_REGISTRY_OFFLINE=1") // explicitly unset
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected install-self to fail\n%s", out)
@@ -209,13 +389,172 @@ func main() { os.Exit(1) }
 
 	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", stub)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(), "OSTY_STAGE0_FALLBACK=1")
+	cmd.Env = append(os.Environ(), "OSTY_STAGE0_FALLBACK=1", "OSTY_SELF_REGISTRY_OFFLINE=1")
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected install-self to fail\n%s", out)
 	}
 	if strings.Contains(string(out), "hint: bootstrap from a fresh clone") {
 		t.Errorf("hint should be suppressed when stage0 already set:\n%s", out)
+	}
+}
+
+func TestRunInstallSelfStage0FallbackAttemptsSourceBootstrap(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	hostBin := fakeOstyBin(t, root, "fresh stage0 osty-self")
+
+	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", hostBin)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"OSTY_STAGE0_FALLBACK=1",
+		"OSTY_SELF_REGISTRY_OFFLINE=1",
+		"OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install-self should source-bootstrap when stage0 fallback is set: %v\n%s", err, out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "installed:") {
+		t.Fatalf("install-self did not report cache install:\n%s", got)
+	}
+	key, err := selfhostcache.ComputeKey(root)
+	if err != nil {
+		t.Fatalf("compute key: %v", err)
+	}
+	cachedPath := selfhostcache.CachePath(root, key)
+	body, err := os.ReadFile(cachedPath)
+	if err != nil {
+		t.Fatalf("read cached osty-self: %v", err)
+	}
+	if string(body) != "fresh stage0 osty-self" {
+		t.Fatalf("cached body = %q", body)
+	}
+}
+
+func TestRunInstallSelfForceUsesResolvedSelfhostWithoutStage0Fallback(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	writeSelfhostMIRDriverSourceStubs(t, root)
+	hostBin := fakeMIRDriverHostBin(t, "force selfhost osty-self")
+	selfBin := fakeSelfhostBin(t, "force selfhost osty-self")
+
+	cmd := exec.Command(ostyBin, "install-self", "--force", "--osty-bin", hostBin)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"OSTY_SELF_BIN="+selfBin,
+		"OSTY_STAGE0_FALLBACK=",
+		"OSTY_STAGE0_LIST_ALL_DECLINES=",
+		"OSTY_SELF_REGISTRY_OFFLINE=1",
+		"OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install-self should force-rebuild with resolved osty-self: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "installed:") {
+		t.Fatalf("install-self did not report cache install:\n%s", out)
+	}
+	key, err := selfhostcache.ComputeKey(root)
+	if err != nil {
+		t.Fatalf("compute key: %v", err)
+	}
+	cachedPath := selfhostcache.CachePath(root, key)
+	body, err := os.ReadFile(cachedPath)
+	if err != nil {
+		t.Fatalf("read cached osty-self: %v", err)
+	}
+	if string(body) != "force selfhost osty-self" {
+		t.Fatalf("cached body = %q", body)
+	}
+	hostSelfBin, err := os.ReadFile(filepath.Join(root, "host-self-bin.txt"))
+	if err != nil {
+		t.Fatalf("host build was not invoked: %v", err)
+	}
+	if string(hostSelfBin) != selfBin {
+		t.Fatalf("host OSTY_SELF_BIN = %q, want %q", hostSelfBin, selfBin)
+	}
+}
+
+func TestRunInstallSelfForceUsesStaleLocalSelfhostWithoutStage0Fallback(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// new source key\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	writeSelfhostMIRDriverSourceStubs(t, root)
+	hostBin := fakeMIRDriverHostBin(t, "stale cache osty-self")
+	selfBin := fakeSelfhostBin(t, "stale cache osty-self")
+	staleDir := filepath.Join(root, selfhostcache.CacheDirName, "stale-key-"+selfhostcache.HostTriple())
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatalf("mkdir stale cache: %v", err)
+	}
+	selfBytes, err := os.ReadFile(selfBin)
+	if err != nil {
+		t.Fatalf("read fake selfhost: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staleDir, selfhostcache.BinaryName()), selfBytes, 0o755); err != nil {
+		t.Fatalf("write stale selfhost: %v", err)
+	}
+
+	cmd := exec.Command(ostyBin, "install-self", "--force", "--osty-bin", hostBin)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"OSTY_STAGE0_FALLBACK=",
+		"OSTY_STAGE0_LIST_ALL_DECLINES=",
+		"OSTY_SELF_BIN=",
+		"OSTY_SELF_REGISTRY_OFFLINE=1",
+		"OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install-self should force-rebuild with stale local osty-self: %v\n%s", err, out)
+	}
+	key, err := selfhostcache.ComputeKey(root)
+	if err != nil {
+		t.Fatalf("compute key: %v", err)
+	}
+	body, err := os.ReadFile(selfhostcache.CachePath(root, key))
+	if err != nil {
+		t.Fatalf("read cached osty-self: %v", err)
+	}
+	if string(body) != "stale cache osty-self" {
+		t.Fatalf("cached body = %q", body)
+	}
+	hostSelfBin, err := os.ReadFile(filepath.Join(root, "host-self-bin.txt"))
+	if err != nil {
+		t.Fatalf("host build was not invoked: %v", err)
+	}
+	if !strings.Contains(string(hostSelfBin), filepath.Join("stale-key-"+selfhostcache.HostTriple(), selfhostcache.BinaryName())) {
+		t.Fatalf("host OSTY_SELF_BIN = %q, want stale cache binary", hostSelfBin)
 	}
 }
 
@@ -231,7 +570,7 @@ func main() {}
 `), 0o644); err != nil {
 		t.Fatalf("write fake osty: %v", err)
 	}
-	bin := filepath.Join(dir, "fake-osty-noop")
+	bin := filepath.Join(dir, fakeOstyBinName("fake-osty-noop"))
 	out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput()
 	if err != nil {
 		t.Fatalf("build: %v\n%s", err, out)

--- a/cmd/osty/main_gen_test.go
+++ b/cmd/osty/main_gen_test.go
@@ -252,10 +252,15 @@ func TestGenCLIMultiFilePackageEmitsLLVMIR(t *testing.T) {
 
 	got := runOstyCLI(t, "gen", "--emit", "llvm-ir", target)
 	if got.exit == 0 {
-		t.Fatal("osty gen should exit non-zero with Go MIR emitter removed")
+		for _, want := range []string{"define i64 @helper()", "define i64 @main()", "call i64 @helper()"} {
+			if !strings.Contains(got.stdout, want) {
+				t.Fatalf("stdout missing %q from self-hosted LLVM IR:\n%s", want, got.stdout)
+			}
+		}
+		return
 	}
 	if !strings.Contains(got.stdout, "LLVM000") || !strings.Contains(got.stdout, "backend skeleton") {
-		t.Fatalf("stdout should contain unsupported skeleton:\n%s", got.stdout)
+		t.Fatalf("stdout should contain unsupported skeleton when no osty-self is available:\n%s", got.stdout)
 	}
 }
 

--- a/cmd/osty/sign_self_test.go
+++ b/cmd/osty/sign_self_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -72,7 +73,7 @@ func TestSignSelfGenKeyProducesValidPair(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Errorf("key file perm = %v, want 0600", info.Mode().Perm())
 	}
 

--- a/docs/llvm-selfhost-next-session-handoff.md
+++ b/docs/llvm-selfhost-next-session-handoff.md
@@ -19,7 +19,7 @@
   - PR-G1 scaffold ([#1902](https://github.com/choiceoh/osty/pull/1902)) — backend.Request.ExtraObjects link plumbing
 - **남은 unlock 후보**:
   1. **declined messages 그대로** — `term.branch i1, got %Option.Int` + `assign.dest <error>`. brick 11/12 머지 후 PR #1898 같은 외부 fix wave 가 추가로 cover 확장해야 osty-self runtime 에 반영. Chicken-and-egg: 우리 변경이 binary 에 들어가지만 stage0 cover gap 으로 wrong code emit
-  2. **doctor SEGFAULT** — `osty-self --selfhost-doctor` exit 139. main baseline issue, R3 무관
+  2. **doctor direct smoke** — 2026-05-19 Windows/clang path now dispatches `osty-self --selfhost-doctor` directly and exits 0 after runtime argv capture + self-rebuild file/link portability fixes.
   3. **PR-G2~G3 (link plumbing 활성화)** — PR #1902 scaffold 후 multi-file dep 의 .o link 활성. cross-pkg fn call 의 진짜 link wall 해소
 - **합의 없이 자율 진행 가능**: §6.
 
@@ -38,8 +38,6 @@ diff <(echo "$LLVM_OUT") <(echo "$GO_OUT") && echo IDENTICAL
 
 # 🎉 source bootstrap UNLOCK 재현 (osty-self install, PR #1863)
 OSTY_STAGE0_FALLBACK=1 \
-  OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 \
-  OSTY_STDLIB_BODY_LOWER=1 \
   .bin/osty install-self
 
 # stage0 audit (현재 100.0% — 8240/8241, PR #1858 머지 후)

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -584,6 +584,9 @@ func clangCompileCObjectArgs(target, profile, sourcePath, objectPath string) []s
 // Windows OS component. Empty triples mean "host"; the caller passes
 // the runtime.GOOS-derived default in that case.
 func isWindowsTarget(target string) bool {
+	if target == "" {
+		return runtime.GOOS == "windows"
+	}
 	return strings.Contains(target, "windows")
 }
 

--- a/internal/backend/llvm_runtime_fs_test.go
+++ b/internal/backend/llvm_runtime_fs_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -31,6 +33,9 @@ func TestBundledRuntimeFsToolingHelpers(t *testing.T) {
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
 	harnessPath := filepath.Join(dir, "runtime_fs_harness.c")
 	binaryPath := filepath.Join(dir, "runtime_fs_harness")
+	if runtime.GOOS == "windows" {
+		binaryPath += ".exe"
+	}
 	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
 	}
@@ -74,11 +79,31 @@ static void require_no_error(void *err, const char *label) {
     }
 }
 
+static void normalize_slashes(char *path) {
+    for (char *p = path; *p != '\0'; p++) {
+        if (*p == '\\') {
+            *p = '/';
+        }
+    }
+}
+
 static int list_contains(void *list, const char *needle) {
+    char want[4096];
+    int wrote = snprintf(want, sizeof(want), "%s", needle);
+    if (wrote < 0 || (size_t)wrote >= sizeof(want)) {
+        fail("path too long");
+    }
+    normalize_slashes(want);
     int64_t n = osty_rt_list_len(list);
     for (int64_t i = 0; i < n; i++) {
         const char *item = osty_rt_list_get_string(list, i);
-        if (item != NULL && strcmp(item, needle) == 0) {
+        char got[4096];
+        wrote = snprintf(got, sizeof(got), "%s", item == NULL ? "" : item);
+        if (wrote < 0 || (size_t)wrote >= sizeof(got)) {
+            fail("path too long");
+        }
+        normalize_slashes(got);
+        if (strcmp(got, want) == 0) {
             return 1;
         }
     }
@@ -166,7 +191,7 @@ int main(int argc, char **argv) {
 	if err != nil {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
-	if got := string(runOutput); got != "ok\n" {
+	if got := strings.TrimSpace(string(runOutput)); got != "ok" {
 		t.Fatalf("runtime fs stdout = %q, want ok", got)
 	}
 }

--- a/internal/backend/llvm_runtime_stage0_audit_symbols_test.go
+++ b/internal/backend/llvm_runtime_stage0_audit_symbols_test.go
@@ -1,13 +1,27 @@
 package backend
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/osty/osty/internal/llvmabi"
 )
+
+func stage0RuntimeTestBinaryPath(dir, name string) string {
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(dir, name)
+}
+
+func stage0RuntimeTestCStringGlobal(name, value string) string {
+	return fmt.Sprintf("@%s = private unnamed_addr constant [%d x i8] c\"%s\\00\"", name, len(value)+1, value)
+}
 
 func TestBundledRuntimeStage0AuditAliasesLinkWithThinLTO(t *testing.T) {
 	parallelClangBackendTest(t)
@@ -17,7 +31,7 @@ func TestBundledRuntimeStage0AuditAliasesLinkWithThinLTO(t *testing.T) {
 	runtimeObjectPath := filepath.Join(dir, bundledRuntimeObjectName)
 	irPath := filepath.Join(dir, "stage0_audit_aliases.ll")
 	irObjectPath := filepath.Join(dir, "stage0_audit_aliases.o")
-	binaryPath := filepath.Join(dir, "stage0_audit_aliases")
+	binaryPath := stage0RuntimeTestBinaryPath(dir, "stage0_audit_aliases")
 
 	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
@@ -25,9 +39,8 @@ func TestBundledRuntimeStage0AuditAliasesLinkWithThinLTO(t *testing.T) {
 
 	ir := `@.path = private unnamed_addr constant [2 x i8] c".\00"
 @.missing = private unnamed_addr constant [26 x i8] c"stage0-alias-missing-path\00"
-@.fmt = private unnamed_addr constant [6 x i8] c"%lld\0A\00"
-@stderr = external global ptr
-@llvm.used = appending global [23 x ptr] [
+@.one = private unnamed_addr constant [2 x i8] c"1\00"
+@llvm.used = appending global [22 x ptr] [
   ptr @Char__toString,
   ptr @Char__len,
   ptr @std.strings.fromChar,
@@ -49,8 +62,7 @@ func TestBundledRuntimeStage0AuditAliasesLinkWithThinLTO(t *testing.T) {
   ptr @runtime.path.filepath.Base,
   ptr @runtime.path.filepath.Ext,
   ptr @__interp,
-  ptr @i64,
-  ptr @stderr
+  ptr @i64
 ], section "llvm.metadata"
 
 declare ptr @Char__toString(i32)
@@ -75,7 +87,7 @@ declare ptr @runtime.path.filepath.Base(ptr)
 declare ptr @runtime.path.filepath.Ext(ptr)
 declare ptr @__interp()
 declare ptr @i64()
-declare i32 @fprintf(ptr, ptr, ...)
+declare void @osty_rt_io_write(ptr, i1, i1)
 
 define i32 @main() {
 entry:
@@ -98,8 +110,7 @@ entry:
   %ext = call ptr @runtime.path.filepath.Ext(ptr @.path)
   %interp = call ptr @__interp()
   %type_name = call ptr @i64()
-  %stderr = load ptr, ptr @stderr
-  %printed = call i32 (ptr, ptr, ...) @fprintf(ptr %stderr, ptr @.fmt, i64 %len)
+  call void @osty_rt_io_write(ptr @.one, i1 true, i1 false)
   ret i32 0
 }
 `
@@ -125,8 +136,63 @@ entry:
 	if err != nil {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, out)
 	}
-	if got, want := string(out), "1\n"; got != want {
+	if got, want := strings.TrimSpace(string(out)), "1"; got != want {
 		t.Fatalf("stage0 alias harness output = %q, want %q", got, want)
+	}
+}
+
+func TestBundledRuntimeStage0EnvArgsCapturesProcessArgv(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	runtimeObjectPath := filepath.Join(dir, bundledRuntimeObjectName)
+	irPath := filepath.Join(dir, "stage0_env_args.ll")
+	irObjectPath := filepath.Join(dir, "stage0_env_args.o")
+	binaryPath := stage0RuntimeTestBinaryPath(dir, "stage0_env_args")
+
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+
+	ir := `declare ptr @std.env.args()
+declare i64 @osty_rt_list_len(ptr)
+
+define i32 @main() {
+entry:
+  %args = call ptr @std.env.args()
+  %len = call i64 @osty_rt_list_len(ptr %args)
+  %ok = icmp sge i64 %len, 3
+  br i1 %ok, label %good, label %bad
+
+good:
+  ret i32 0
+
+bad:
+  ret i32 42
+}
+`
+	if err := os.WriteFile(irPath, []byte(ir), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", irPath, err)
+	}
+
+	runClang := func(label string, args []string) {
+		t.Helper()
+		out, err := exec.Command("clang", args...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("clang %s failed: %v\n%s", label, err, out)
+		}
+	}
+
+	runClang("compile runtime", clangCompileCObjectArgs("", "", runtimePath, runtimeObjectPath))
+	runClang("compile stage0 env args IR", llvmabi.ClangCompileObjectArgs("", irPath, irObjectPath))
+	linkArgs := llvmabi.ClangLinkBinaryArgs("", []string{irObjectPath, runtimeObjectPath}, binaryPath)
+	linkArgs = append(linkArgs, clangPlatformRuntimeLinkArgs("")...)
+	runClang("link stage0 env args binary", linkArgs)
+
+	out, err := exec.Command(binaryPath, "alpha", "beta").CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q with argv failed: %v\n%s", binaryPath, err, out)
 	}
 }
 
@@ -138,7 +204,7 @@ func TestBundledRuntimeCIHostAliasesLinkWithHostObjects(t *testing.T) {
 	runtimeObjectPath := filepath.Join(dir, bundledRuntimeObjectName)
 	irPath := filepath.Join(dir, "cihost_aliases.ll")
 	irObjectPath := filepath.Join(dir, "cihost_aliases.o")
-	binaryPath := filepath.Join(dir, "cihost_aliases")
+	binaryPath := stage0RuntimeTestBinaryPath(dir, "cihost_aliases")
 
 	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
@@ -181,16 +247,21 @@ func TestBundledRuntimeStdOsExecWithReturnsResultBox(t *testing.T) {
 	runtimeObjectPath := filepath.Join(dir, bundledRuntimeObjectName)
 	irPath := filepath.Join(dir, "exec_with_result_box.ll")
 	irObjectPath := filepath.Join(dir, "exec_with_result_box.o")
-	binaryPath := filepath.Join(dir, "exec_with_result_box")
+	binaryPath := stage0RuntimeTestBinaryPath(dir, "exec_with_result_box")
 
 	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
 	}
 
+	execProgram := "cat"
+	if runtime.GOOS == "windows" {
+		execProgram = "more.com"
+	}
+
 	ir := `%Result = type { i64, ptr }
 %ExecOutput = type { i64, ptr, ptr, i1 }
 
-@.cat = private unnamed_addr constant [4 x i8] c"cat\00"
+` + stage0RuntimeTestCStringGlobal(".exec_program", execProgram) + `
 @.input = private unnamed_addr constant [6 x i8] c"probe\00"
 @.empty = private unnamed_addr constant [1 x i8] c"\00"
 
@@ -198,7 +269,7 @@ declare ptr @osty_rt_os_exec_input_with(ptr, ptr, ptr, ptr, ptr, i64)
 
 define i32 @main() {
 entry:
-  %res = call ptr @osty_rt_os_exec_input_with(ptr @.cat, ptr null, ptr @.input, ptr @.empty, ptr null, i64 0)
+  %res = call ptr @osty_rt_os_exec_input_with(ptr @.exec_program, ptr null, ptr @.input, ptr @.empty, ptr null, i64 0)
   %tagp = getelementptr inbounds %Result, ptr %res, i32 0, i32 0
   %tag = load i64, ptr %tagp
   %is_ok = icmp eq i64 %tag, 0

--- a/internal/backend/llvm_runtime_test_helpers_test.go
+++ b/internal/backend/llvm_runtime_test_helpers_test.go
@@ -8,6 +8,8 @@ import (
 func runtimeClangCommand(args ...string) *exec.Cmd {
 	if runtime.GOOS != "windows" {
 		args = append(args, "-lz", "-lm")
+	} else {
+		args = append(args, "-ladvapi32")
 	}
 	return exec.Command("clang", args...)
 }

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -246,6 +247,12 @@ func TestClangLinkLibraryArgs(t *testing.T) {
 func TestClangPlatformRuntimeLinkArgs(t *testing.T) {
 	t.Parallel()
 
+	hostWant := []string{"-lm"}
+	if runtime.GOOS == "darwin" {
+		hostWant = []string{"-lm", "-framework", "Security", "-framework", "CoreFoundation"}
+	} else if runtime.GOOS == "windows" {
+		hostWant = []string{"-ladvapi32"}
+	}
 	cases := []struct {
 		name   string
 		target string
@@ -265,6 +272,11 @@ func TestClangPlatformRuntimeLinkArgs(t *testing.T) {
 			name:   "linux",
 			target: "x86_64-unknown-linux-gnu",
 			want:   []string{"-lm"},
+		},
+		{
+			name:   "host",
+			target: "",
+			want:   hostWant,
 		},
 	}
 	for _, tt := range cases {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -25,6 +25,15 @@
 #endif
 #endif
 
+#if defined(_WIN32)
+#ifndef _CRT_RAND_S
+#define _CRT_RAND_S 1
+#endif
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS 1
+#endif
+#endif
+
 #include <errno.h>
 #include <limits.h>
 #include <math.h>
@@ -127,8 +136,8 @@
 #include <io.h>
 #include <process.h>
 #include <signal.h> /* sig_atomic_t for SIGURG TLS flag */
-#include <wincred.h>
 #include <windows.h>
+#include <wincred.h>
 #define OSTY_RT_TLS __declspec(thread)
 typedef HANDLE osty_rt_thread_t;
 typedef SRWLOCK osty_rt_mu_t;
@@ -27823,6 +27832,221 @@ static int osty_rt_fs_copy_dir_posix(const char *from, const char *to) {
 }
 #endif
 
+#if defined(OSTY_RT_PLATFORM_WIN32)
+static int osty_rt_fs_win32_errno(DWORD code) {
+  switch (code) {
+  case ERROR_FILE_NOT_FOUND:
+  case ERROR_PATH_NOT_FOUND:
+    return ENOENT;
+  case ERROR_DIRECTORY:
+    return ENOTDIR;
+  case ERROR_ACCESS_DENIED:
+  case ERROR_SHARING_VIOLATION:
+  case ERROR_LOCK_VIOLATION:
+    return EACCES;
+  case ERROR_INVALID_NAME:
+  case ERROR_BAD_PATHNAME:
+    return EINVAL;
+  default:
+    return EIO;
+  }
+}
+
+static int osty_rt_fs_set_win32_errno(DWORD code) {
+  errno = osty_rt_fs_win32_errno(code);
+  return -1;
+}
+
+static int64_t osty_rt_fs_win32_filetime_unix_sec(FILETIME ft) {
+  ULARGE_INTEGER raw;
+  const uint64_t windows_unix_epoch_delta_100ns = 116444736000000000ULL;
+
+  raw.LowPart = ft.dwLowDateTime;
+  raw.HighPart = ft.dwHighDateTime;
+  if (raw.QuadPart < windows_unix_epoch_delta_100ns) {
+    return 0;
+  }
+  return (int64_t)((raw.QuadPart - windows_unix_epoch_delta_100ns) /
+                   10000000ULL);
+}
+
+static int osty_rt_fs_collect_path_win32(const char *path, DWORD attrs,
+                                         uint64_t size, FILETIME mtime,
+                                         osty_rt_fs_path_vec *out,
+                                         bool snapshot) {
+  bool is_dir = (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+  bool is_link = (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+  char *display =
+      osty_rt_strndup(path == NULL ? "" : path,
+                      strlen(path == NULL ? "" : path),
+                      "runtime.fs.walk.path.win32");
+  char *stored = NULL;
+
+  osty_rt_fs_normalize_slashes(display);
+  if (snapshot) {
+    char kind = is_dir ? 'D' : (is_link ? 'L' : 'F');
+    stored = osty_rt_fs_snapshot_row(
+        kind, display, is_dir ? 0 : (int64_t)size,
+        osty_rt_fs_win32_filetime_unix_sec(mtime));
+    free(display);
+  } else {
+    stored = display;
+  }
+  osty_rt_fs_path_vec_push_take(out, stored);
+  return is_dir && !is_link ? 1 : 0;
+}
+
+static int osty_rt_fs_walk_dir_children_win32(const char *dir_path,
+                                              osty_rt_fs_path_vec *out,
+                                              bool snapshot) {
+  char *pattern = osty_rt_fs_join_path(dir_path, "*", false);
+  WIN32_FIND_DATAA data;
+  HANDLE find = FindFirstFileA(pattern, &data);
+
+  free(pattern);
+  if (find == INVALID_HANDLE_VALUE) {
+    DWORD code = GetLastError();
+    if (code == ERROR_FILE_NOT_FOUND) {
+      return 0;
+    }
+    return osty_rt_fs_set_win32_errno(code);
+  }
+
+  for (;;) {
+    const char *name = data.cFileName;
+    if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0) {
+      DWORD attrs = data.dwFileAttributes;
+      bool is_dir = (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+      uint64_t size =
+          ((uint64_t)data.nFileSizeHigh << 32U) | (uint64_t)data.nFileSizeLow;
+      char *child = osty_rt_fs_join_path(dir_path, name, false);
+      char *visible = child;
+      int recurse;
+
+      if (is_dir) {
+        visible = osty_rt_fs_join_path(child, "", false);
+      }
+      recurse = osty_rt_fs_collect_path_win32(
+          visible, attrs, size, data.ftLastWriteTime, out, snapshot);
+      if (visible != child) {
+        free(visible);
+      }
+      if (recurse > 0) {
+        if (osty_rt_fs_walk_dir_children_win32(child, out, snapshot) != 0) {
+          DWORD code = GetLastError();
+          free(child);
+          FindClose(find);
+          if (errno == 0 && code != ERROR_SUCCESS) {
+            return osty_rt_fs_set_win32_errno(code);
+          }
+          return -1;
+        }
+      }
+      free(child);
+    }
+
+    if (!FindNextFileA(find, &data)) {
+      DWORD code = GetLastError();
+      FindClose(find);
+      if (code == ERROR_NO_MORE_FILES) {
+        return 0;
+      }
+      return osty_rt_fs_set_win32_errno(code);
+    }
+  }
+}
+
+static int osty_rt_fs_walk_root_win32(const char *root,
+                                      osty_rt_fs_path_vec *out,
+                                      bool snapshot) {
+  WIN32_FILE_ATTRIBUTE_DATA data;
+  DWORD attrs;
+  uint64_t size;
+
+  if (!GetFileAttributesExA(root, GetFileExInfoStandard, &data)) {
+    return osty_rt_fs_set_win32_errno(GetLastError());
+  }
+  attrs = data.dwFileAttributes;
+  size = ((uint64_t)data.nFileSizeHigh << 32U) | (uint64_t)data.nFileSizeLow;
+  if ((attrs & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+    (void)osty_rt_fs_collect_path_win32(root, attrs, size, data.ftLastWriteTime,
+                                       out, snapshot);
+    return 0;
+  }
+  return osty_rt_fs_walk_dir_children_win32(root, out, snapshot);
+}
+
+static int osty_rt_fs_copy_dir_win32(const char *from, const char *to) {
+  DWORD attrs = GetFileAttributesA(from);
+  char *pattern;
+  WIN32_FIND_DATAA data;
+  HANDLE find;
+
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    return osty_rt_fs_set_win32_errno(GetLastError());
+  }
+  if ((attrs & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+    osty_rt_fs_set_last_error_literal("source is not a directory");
+    errno = 0;
+    return -1;
+  }
+  if (osty_rt_fs_mkdir_p(to) != 0) {
+    return -1;
+  }
+
+  pattern = osty_rt_fs_join_path(from, "*", false);
+  find = FindFirstFileA(pattern, &data);
+  free(pattern);
+  if (find == INVALID_HANDLE_VALUE) {
+    DWORD code = GetLastError();
+    if (code == ERROR_FILE_NOT_FOUND) {
+      return 0;
+    }
+    return osty_rt_fs_set_win32_errno(code);
+  }
+
+  for (;;) {
+    const char *name = data.cFileName;
+    if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0) {
+      char *src = osty_rt_fs_join_path(from, name, false);
+      char *dst = osty_rt_fs_join_path(to, name, false);
+      bool is_dir = (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+      int rc = 0;
+
+      if (is_dir) {
+        if ((data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
+          rc = osty_rt_fs_mkdir_p(dst);
+        } else {
+          rc = osty_rt_fs_copy_dir_win32(src, dst);
+        }
+      } else {
+        void *err = osty_rt_fs_copy(src, dst);
+        rc = err == NULL ? 0 : -1;
+      }
+      free(src);
+      free(dst);
+      if (rc != 0) {
+        DWORD code = GetLastError();
+        FindClose(find);
+        if (errno == 0 && code != ERROR_SUCCESS) {
+          return osty_rt_fs_set_win32_errno(code);
+        }
+        return -1;
+      }
+    }
+
+    if (!FindNextFileA(find, &data)) {
+      DWORD code = GetLastError();
+      FindClose(find);
+      if (code == ERROR_NO_MORE_FILES) {
+        return 0;
+      }
+      return osty_rt_fs_set_win32_errno(code);
+    }
+  }
+}
+#endif
+
 static bool osty_rt_fs_glob_has_wildcard(const char *pattern) {
   if (pattern == NULL) {
     return false;
@@ -28302,6 +28526,11 @@ void *osty_rt_fs_walk(const char *root) {
     osty_rt_fs_path_vec_free(&vec);
     return NULL;
   }
+#elif defined(OSTY_RT_PLATFORM_WIN32)
+  if (osty_rt_fs_walk_root_win32(root, &vec, false) != 0) {
+    osty_rt_fs_path_vec_free(&vec);
+    return NULL;
+  }
 #else
   osty_rt_fs_path_vec_free(&vec);
   osty_rt_fs_set_last_error_literal("walk is not supported on this platform");
@@ -28341,6 +28570,25 @@ void *osty_rt_fs_glob(const char *pattern) {
   osty_rt_fs_path_vec_init(&candidates);
 #if defined(OSTY_RT_PLATFORM_POSIX)
   if (osty_rt_fs_walk_root_posix(root, &candidates, false) != 0) {
+    int err = errno;
+    if (err == ENOENT || err == ENOTDIR) {
+      osty_rt_fs_path_vec_free(&candidates);
+      free(root);
+      void *out =
+          osty_rt_fs_path_vec_to_list(&matches, "runtime.fs.glob.entry");
+      osty_rt_fs_path_vec_free(&matches);
+      osty_rt_fs_clear_last_error();
+      errno = 0;
+      return out;
+    }
+    osty_rt_fs_path_vec_free(&candidates);
+    osty_rt_fs_path_vec_free(&matches);
+    free(root);
+    errno = err;
+    return NULL;
+  }
+#elif defined(OSTY_RT_PLATFORM_WIN32)
+  if (osty_rt_fs_walk_root_win32(root, &candidates, false) != 0) {
     int err = errno;
     if (err == ENOENT || err == ENOTDIR) {
       osty_rt_fs_path_vec_free(&candidates);
@@ -28398,6 +28646,11 @@ void *osty_rt_fs_watch(const char *root) {
   osty_rt_fs_path_vec_init(&vec);
 #if defined(OSTY_RT_PLATFORM_POSIX)
   if (osty_rt_fs_walk_root_posix(root, &vec, true) != 0) {
+    osty_rt_fs_path_vec_free(&vec);
+    return NULL;
+  }
+#elif defined(OSTY_RT_PLATFORM_WIN32)
+  if (osty_rt_fs_walk_root_win32(root, &vec, true) != 0) {
     osty_rt_fs_path_vec_free(&vec);
     return NULL;
   }
@@ -28487,6 +28740,12 @@ void *osty_rt_fs_copy_dir(const char *from, const char *to) {
   osty_rt_fs_clear_last_error();
 #if defined(OSTY_RT_PLATFORM_POSIX)
   if (osty_rt_fs_copy_dir_posix(from, to) != 0) {
+    return osty_rt_fs_error_message("failed to copy directory",
+                                    "runtime.fs.copy_dir.error");
+  }
+  return NULL;
+#elif defined(OSTY_RT_PLATFORM_WIN32)
+  if (osty_rt_fs_copy_dir_win32(from, to) != 0) {
     return osty_rt_fs_error_message("failed to copy directory",
                                     "runtime.fs.copy_dir.error");
   }
@@ -31107,9 +31366,10 @@ osty_rt_stage0_init_stderr_global(void) {
 /* Captured process argv. Populated once before main() runs via a
  * platform-specific initialiser (`.init_array` on glibc/musl,
  * `__attribute__((constructor))` + Apple's `_NSGetArg{c,v}` on
- * macOS). `std.env.args` reads from here so a stage0-produced
- * binary can route argv into toolchain CLI dispatch instead of
- * falling through to the unsupported-command banner.
+ * macOS) or lazily from the CRT on Windows. `std.env.args` reads
+ * from here so a stage0-produced binary can route argv into
+ * toolchain CLI dispatch instead of falling through to the
+ * unsupported-command banner.
  *
  * Both globals default to 0/NULL; if the platform-specific
  * initialiser fails to run (or the host isn't covered below),
@@ -31117,6 +31377,16 @@ osty_rt_stage0_init_stderr_global(void) {
  * the pre-capture stub. */
 static int osty_rt_saved_argc;
 static char **osty_rt_saved_argv;
+
+#if defined(_WIN32)
+extern int __argc;
+extern char **__argv;
+
+static void osty_rt_audit_capture_argv_windows(void) {
+  osty_rt_saved_argc = __argc;
+  osty_rt_saved_argv = __argv;
+}
+#endif
 
 #if defined(__APPLE__)
 /* macOS exposes the captured argv via dyld-provided indirection.
@@ -31163,6 +31433,11 @@ void *osty_rt_audit_env_args(void) __asm__(OSTY_RT_AUDIT_SYMBOL("std.env.args"))
     OSTY_RT_AUDIT_USED;
 void *osty_rt_audit_env_args(void) {
   void *list = osty_rt_list_new();
+#if defined(_WIN32)
+  if (osty_rt_saved_argv == NULL) {
+    osty_rt_audit_capture_argv_windows();
+  }
+#endif
   if (list == NULL || osty_rt_saved_argv == NULL) {
     return list;
   }

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -203,24 +203,10 @@ func emitMIR(module *mir.Module, opts llvmabi.Options, requireMain bool) ([]byte
 	// declare, format strings, string literal globals, …).
 	mctx := newModuleCtx(module)
 
-	// Pre-scan for print-family intrinsics so printf/fprintf declares
-	// and format strings land in extraDecls before any function body.
+	// Pre-scan for print-family intrinsics so runtime print declares
+	// land in extraDecls before any function body.
 	needs := scanPrintNeeds(module, mctx)
-	if needs.int {
-		mctx.extraDecls.WriteString("@.fmt.stage0.print.int = private unnamed_addr constant [5 x i8] c\"%lld\\00\"\n")
-		mctx.extraDecls.WriteString("@.fmt.stage0.println.int = private unnamed_addr constant [6 x i8] c\"%lld\\0A\\00\"\n")
-	}
-	if needs.str {
-		mctx.extraDecls.WriteString("@.fmt.stage0.print.str = private unnamed_addr constant [3 x i8] c\"%s\\00\"\n")
-		mctx.extraDecls.WriteString("@.fmt.stage0.println.str = private unnamed_addr constant [4 x i8] c\"%s\\0A\\00\"\n")
-	}
-	if needs.stdout {
-		mctx.extraDecls.WriteString("declare i32 @printf(ptr, ...)\n")
-	}
-	if needs.stderr {
-		mctx.extraDecls.WriteString("@stderr = external global ptr\n")
-		mctx.extraDecls.WriteString("declare i32 @fprintf(ptr, ptr, ...)\n")
-	}
+	emitPrintPrelude(mctx, needs)
 
 	listAll := listAllDeclinesEnabled()
 	if !listAll {
@@ -321,21 +307,7 @@ func emitMIR(module *mir.Module, opts llvmabi.Options, requireMain bool) ([]byte
 	mctx = newModuleCtx(module)
 	mctx.definedFnSyms = declareSuppressSet
 	// Re-do the print-needs prelude on the fresh context.
-	if needs.int {
-		mctx.extraDecls.WriteString("@.fmt.stage0.print.int = private unnamed_addr constant [5 x i8] c\"%lld\\00\"\n")
-		mctx.extraDecls.WriteString("@.fmt.stage0.println.int = private unnamed_addr constant [6 x i8] c\"%lld\\0A\\00\"\n")
-	}
-	if needs.str {
-		mctx.extraDecls.WriteString("@.fmt.stage0.print.str = private unnamed_addr constant [3 x i8] c\"%s\\00\"\n")
-		mctx.extraDecls.WriteString("@.fmt.stage0.println.str = private unnamed_addr constant [4 x i8] c\"%s\\0A\\00\"\n")
-	}
-	if needs.stdout {
-		mctx.extraDecls.WriteString("declare i32 @printf(ptr, ...)\n")
-	}
-	if needs.stderr {
-		mctx.extraDecls.WriteString("@stderr = external global ptr\n")
-		mctx.extraDecls.WriteString("declare i32 @fprintf(ptr, ptr, ...)\n")
-	}
+	emitPrintPrelude(mctx, needs)
 
 	var fnBodies strings.Builder
 	emittedMain := false
@@ -1099,6 +1071,18 @@ type printNeeds struct {
 	str    bool
 	stdout bool
 	stderr bool
+}
+
+func emitPrintPrelude(mctx *moduleCtx, needs printNeeds) {
+	if mctx == nil {
+		return
+	}
+	if needs.int {
+		declareRuntimePrototype(mctx, "osty_rt_int_to_string", scalarString, []callArg{{ty: "i64"}})
+	}
+	if needs.stdout || needs.stderr {
+		declareVoidFunctionPrototype(mctx, "osty_rt_io_write", []callArg{{ty: "ptr"}, {ty: "i1"}, {ty: "i1"}})
+	}
 }
 
 func scanPrintNeeds(module *mir.Module, mctx *moduleCtx) printNeeds {
@@ -2028,36 +2012,37 @@ func classifyPrintIntrinsicLine(fn *mir.Function, ii *mir.IntrinsicInstr, bindin
 	if !ok {
 		return "", false
 	}
-	fmtGlobal, argTy, ok := printFormatFor(ii.Kind, ty)
+	line, ok := renderPrintRuntimeLine(mctx, ii.Kind, expr, ty)
 	if !ok {
 		return "", false
 	}
-	if isStderrPrintIntrinsic(ii.Kind) {
-		stderrReg := mctx.freshTempName("stderr")
-		// fprintf returns i32; capture into a named SSA so its result
-		// doesn't consume an anonymous slot (cluster-1 SSA collision).
-		fprintfDiscard := mctx.freshTempName("discard")
-		return prelude +
-			fmt.Sprintf("  %s = load ptr, ptr @stderr\n", stderrReg) +
-			fmt.Sprintf("  %s = call i32 (ptr, ptr, ...) @fprintf(ptr %s, ptr %s, %s %s)\n", fprintfDiscard, stderrReg, fmtGlobal, argTy, expr), true
-	}
-	// printf returns i32 — same SSA-capture pattern.
-	printfDiscard := mctx.freshTempName("discard")
-	return prelude + fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr %s, %s %s)\n", printfDiscard, fmtGlobal, argTy, expr), true
+	return prelude + line, true
 }
 
-func printFormatFor(kind mir.IntrinsicKind, ty scalarType) (string, string, bool) {
-	prefix := "@.fmt.stage0.print"
+func renderPrintRuntimeLine(mctx *moduleCtx, kind mir.IntrinsicKind, expr string, ty scalarType) (string, bool) {
+	if mctx == nil || expr == "" {
+		return "", false
+	}
+	declareVoidFunctionPrototype(mctx, "osty_rt_io_write", []callArg{{ty: "ptr"}, {ty: "i1"}, {ty: "i1"}})
+	newline := "false"
 	if kind == mir.IntrinsicPrintln || kind == mir.IntrinsicEprintln {
-		prefix = "@.fmt.stage0.println"
+		newline = "true"
+	}
+	toStderr := "false"
+	if isStderrPrintIntrinsic(kind) {
+		toStderr = "true"
 	}
 	switch ty {
-	case scalarInt:
-		return prefix + ".int", "i64", true
 	case scalarString:
-		return prefix + ".str", "ptr", true
+		return fmt.Sprintf("  call void @osty_rt_io_write(ptr %s, i1 %s, i1 %s)\n", expr, newline, toStderr), true
+	case scalarInt:
+		declareRuntimePrototype(mctx, "osty_rt_int_to_string", scalarString, []callArg{{ty: "i64"}})
+		textReg := mctx.freshTempName("print.int")
+		return fmt.Sprintf("  %s = call ptr @osty_rt_int_to_string(i64 %s)\n", textReg, expr) +
+			fmt.Sprintf("  call void @osty_rt_io_write(ptr %s, i1 %s, i1 %s)\n", textReg, newline, toStderr), true
+	default:
+		return "", false
 	}
-	return "", "", false
 }
 
 func resolveFixedScalarArgs(fn *mir.Function, ops []mir.Operand, bindings map[mir.LocalID]localBinding, mctx *moduleCtx, want []scalarType) ([]callArg, string, bool) {
@@ -9102,19 +9087,11 @@ func emitWhilePrintIntrinsic(ctx *whileLoopEmitCtx, out *strings.Builder, ii *mi
 	if !ok {
 		return false
 	}
-	fmtGlobal, argTy, ok := printFormatFor(ii.Kind, ty)
+	line, ok := renderPrintRuntimeLine(ctx.mctx, ii.Kind, expr, ty)
 	if !ok {
 		return false
 	}
-	if isStderrPrintIntrinsic(ii.Kind) {
-		stderrReg := ctx.mctx.freshTempName("stderr")
-		fprintfDiscard := ctx.mctx.freshTempName("discard")
-		fmt.Fprintf(out, "  %s = load ptr, ptr @stderr\n", stderrReg)
-		fmt.Fprintf(out, "  %s = call i32 (ptr, ptr, ...) @fprintf(ptr %s, ptr %s, %s %s)\n", fprintfDiscard, stderrReg, fmtGlobal, argTy, expr)
-		return true
-	}
-	printfDiscard := ctx.mctx.freshTempName("discard")
-	fmt.Fprintf(out, "  %s = call i32 (ptr, ...) @printf(ptr %s, %s %s)\n", printfDiscard, fmtGlobal, argTy, expr)
+	out.WriteString(line)
 	return true
 }
 

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -4138,17 +4138,14 @@ func TestStage0P27PrintFamilyAndAbortIntrinsics(t *testing.T) {
 	)
 	got := emit(t, trivialMainFn(), fn)
 	for _, want := range []string{
-		"@.fmt.stage0.print.int = private unnamed_addr constant [5 x i8] c\"%lld\\00\"",
-		"@.fmt.stage0.print.str = private unnamed_addr constant [3 x i8] c\"%s\\00\"",
-		"@.fmt.stage0.println.int = private unnamed_addr constant [6 x i8] c\"%lld\\0A\\00\"",
-		"@.fmt.stage0.println.str = private unnamed_addr constant [4 x i8] c\"%s\\0A\\00\"",
-		"@stderr = external global ptr",
-		"declare i32 @fprintf(ptr, ptr, ...)",
+		"declare ptr @osty_rt_int_to_string(i64)",
+		"declare void @osty_rt_io_write(ptr, i1, i1)",
 		"declare void @osty_rt_panic(ptr)",
-		"call i32 (ptr, ...) @printf(ptr @.fmt.stage0.print.int, i64 %n)",
-		"call i32 (ptr, ...) @printf(ptr @.fmt.stage0.println.str, ptr %msg)",
-		"load ptr, ptr @stderr",
-		"call i32 (ptr, ptr, ...) @fprintf",
+		"call ptr @osty_rt_int_to_string(i64 %n)",
+		"call void @osty_rt_io_write(ptr %stage0.print.int.0, i1 false, i1 false)",
+		"call void @osty_rt_io_write(ptr %msg, i1 true, i1 false)",
+		"call void @osty_rt_io_write(ptr %msg, i1 false, i1 true)",
+		"call void @osty_rt_io_write(ptr %stage0.print.int.1, i1 true, i1 true)",
 		"call void @osty_rt_panic(ptr @.str.0)",
 		"ret void",
 	} {
@@ -5251,11 +5248,13 @@ func TestStage0P27WhileVoidIntrinsics(t *testing.T) {
 	got := emit(t, trivialMainFn(), fn)
 	for _, want := range []string{
 		"declare void @osty_rt_list_push_i64(ptr, i64)",
-		"@.fmt.stage0.println.int = private unnamed_addr constant [6 x i8] c\"%lld\\0A\\00\"",
+		"declare ptr @osty_rt_int_to_string(i64)",
+		"declare void @osty_rt_io_write(ptr, i1, i1)",
 		"define i64 @pushWhileCounting(ptr %items, i64 %n)",
 		"body.2:",
 		"call void @osty_rt_list_push_i64(ptr %items, i64",
-		"call i32 (ptr, ...) @printf(ptr @.fmt.stage0.println.int, i64",
+		"call ptr @osty_rt_int_to_string(i64",
+		"call void @osty_rt_io_write(ptr %stage0.print.int.0, i1 true, i1 false)",
 		"ret i64",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -1296,14 +1296,12 @@ func runStage0AuditFixedPointVerify(t *testing.T, module *mir.Module, clangPath 
 // the audit doesn't burn iterations on link errors that aren't
 // actually stage0 bugs (Keychain frameworks, zlib, libm).
 func stage0AuditPlatformLinkArgs() []string {
-	args := []string{"-pthread", "-lz"}
 	switch runtime.GOOS {
 	case "windows":
-		args = append(args, "-ladvapi32")
+		return []string{"-ladvapi32"}
 	case "darwin":
-		args = append(args, "-lm", "-framework", "Security", "-framework", "CoreFoundation")
+		return []string{"-pthread", "-lz", "-lm", "-framework", "Security", "-framework", "CoreFoundation"}
 	default:
-		args = append(args, "-lm")
+		return []string{"-pthread", "-lz", "-lm"}
 	}
-	return args
 }

--- a/internal/llvmabi/api.go
+++ b/internal/llvmabi/api.go
@@ -201,8 +201,15 @@ func ClangLinkBinaryArgsForProfile(target, profile string, objectPaths []string,
 		// produce a (slightly less aggressively-inlined) binary instead of
 		// failing the bootstrap link outright.
 		if hasLLD() {
-			args = append(args, "-fuse-ld=lld", "-Wl,-mllvm,-import-instr-limit=500")
+			args = append(args, "-fuse-ld=lld")
+			if !isWindowsLLVMTarget(target) {
+				args = append(args, "-Wl,-mllvm,-import-instr-limit=500")
+			}
 		}
+	}
+	if isWindowsLLVMTarget(target) {
+		args = append(args, "-Wl,/subsystem:console")
+		args = append(args, "-Wl,/stack:67108864")
 	}
 	args = append(args, objectPaths...)
 	if !strings.Contains(target, "windows") {
@@ -224,6 +231,10 @@ func ProfileSkipsLTO(profile string) bool {
 		return true
 	}
 	return false
+}
+
+func isWindowsLLVMTarget(target string) bool {
+	return strings.Contains(target, "-windows-") || strings.Contains(target, "-pc-windows-") || strings.Contains(target, "windows")
 }
 
 func hasLLD() bool {

--- a/internal/llvmabi/api_test.go
+++ b/internal/llvmabi/api_test.go
@@ -201,6 +201,15 @@ func TestClangLinkBinaryArgsOmitsPthreadOnWindows(t *testing.T) {
 	if strings.Contains(got, "-pthread") {
 		t.Errorf("link args should not include -pthread on windows: %s", got)
 	}
+	if !strings.Contains(got, "-Wl,/subsystem:console") {
+		t.Errorf("link args missing Windows console subsystem: %s", got)
+	}
+	if !strings.Contains(got, "-Wl,/stack:67108864") {
+		t.Errorf("link args missing Windows selfhost stack reserve: %s", got)
+	}
+	if strings.Contains(got, "import-instr-limit") {
+		t.Errorf("link args should not pass ELF LLD import tuning to lld-link: %s", got)
+	}
 }
 
 func TestClangCompileObjectArgsNoLTOProfilesDropLTO(t *testing.T) {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2020,7 +2020,12 @@ pub fn llvmClangLinkBinaryArgs(target: String, objectPaths: List<String>, binary
     }
     args.push("-O3")
     args.push("-flto=thin")
-    args.push("-Wl,-mllvm,-import-instr-limit=500")
+    if target.contains("windows") {
+        args.push("-Wl,/subsystem:console")
+        args.push("-Wl,/stack:67108864")
+    } else {
+        args.push("-Wl,-mllvm,-import-instr-limit=500")
+    }
     for objectPath in objectPaths {
         args.push(objectPath)
     }

--- a/toolchain/llvmgen_test.osty
+++ b/toolchain/llvmgen_test.osty
@@ -77,6 +77,8 @@ fn testLlvmToolchainPlanIsOstyOwned() {
     testing.assert(!(llvmTestStrings.contains(link, "-target")))
     let linkWin = llvmTestStrings.join(llvmClangLinkBinaryArgs("x86_64-pc-windows-msvc", ["/tmp/main.o"], "/tmp/app.exe"), " ")
     testing.assert(!(llvmTestStrings.contains(linkWin, "-pthread")))
+    testing.assert(llvmTestStrings.contains(linkWin, "-Wl,/subsystem:console"))
+    testing.assert(!(llvmTestStrings.contains(linkWin, "import-instr-limit")))
     let linkPosix = llvmTestStrings.join(llvmClangLinkBinaryArgs("aarch64-unknown-linux-gnu", ["/tmp/main.o"], "/tmp/app"), " ")
     assertLlvmContains(linkPosix, "-pthread")
     assertLlvmContains(llvmMissingClangMessage(), "clang not found")

--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -69,52 +69,42 @@ fn selfRebuildCommandError(action: String, command: String, stdout: String, stde
     action + " failed: " + command + "\n" + msg
 }
 fn selfRebuildMkdirAll(path: String) -> String {
-    let out = match os.execWith("mkdir", ["-p", path], "", {:}, 0) {
-        Ok(o) -> o,
-        Err(e) -> {
-            let _ = e
-            return "mkdir failed to start"
+    match fs.mkdirAll(path) {
+        Ok(_) -> "",
+        Err(_) -> {
+            "mkdir failed: " + path
         },
     }
-    if out.exitCode == 0 && !out.timedOut {
-        return ""
-    }
-    selfRebuildCommandError("mkdir", "mkdir -p " + path, out.stdout, out.stderr)
 }
 fn selfRebuildWriteString(path: String, contents: String) -> String {
-    let out = match os.execInputWith("sh", ["-c", "cat > \"$1\"", "osty-self-write", path], contents, "", {:}, 0) {
-        Ok(o) -> o,
-        Err(e) -> {
-            let _ = e
-            return "write failed to start"
+    match fs.writeString(path, contents) {
+        Ok(_) -> "",
+        Err(_) -> {
+            "write failed: " + path
         },
     }
-    if out.exitCode == 0 && !out.timedOut {
-        return ""
-    }
-    selfRebuildCommandError("write", "cat > " + path, out.stdout, out.stderr)
 }
 fn selfRebuildToolchainSourcePaths(toolchainDir: String) -> Result<List<String>, String> {
-    let script = "cd \"$1\" && find . -type f -name '*.osty' ! -name '*_test.osty' ! -name 'ci.osty' ! -path './.osty/*' | sort"
-    let out = match os.execWith("sh", ["-c", script, "osty-self-list", toolchainDir], "", {:}, 0) {
-        Ok(o) -> o,
-        Err(e) -> {
-            let _ = e
-            return Err("source list command failed to start")
+    let entries = match fs.walk(toolchainDir) {
+        Ok(paths) -> paths,
+        Err(_) -> {
+            return Err("source list walk failed: " + toolchainDir)
         },
     }
-    if out.exitCode != 0 || out.timedOut {
-        return Err(selfRebuildCommandError("source list", "find toolchain sources", out.stdout, out.stderr))
-    }
     let mut paths: List<String> = []
-    for line in strings.split(out.stdout, "\n") {
-        let trimmed = strings.trimSpace(line)
-        if trimmed != "" {
-            let rel = strings.trimPrefix(trimmed, "./")
-            paths.push(selfRebuildPath(toolchainDir, rel))
+    for path in entries {
+        if selfRebuildIsToolchainSource(path) {
+            paths.push(path)
         }
     }
     Ok(paths)
+}
+fn selfRebuildTempPath(name: String) -> String {
+    let tmp = env.get("TMP") ?? (env.get("TEMP") ?? "")
+    if tmp != "" {
+        return selfRebuildPath(tmp, name)
+    }
+    selfRebuildPath("/tmp", name)
 }
 fn currentExecutable() -> String {
     let args = env.args()
@@ -170,8 +160,7 @@ fn selfRebuildBundleSource(toolchainDir: String) -> String {
         if selfRebuildIsToolchainSource(path) {
             let src = match fs.readToString(path) {
                 Ok(s) -> s,
-                Err(e) -> {
-                    let _ = e
+                Err(_) -> {
                     eprint("osty-self rebuild: read source failed: " + path + "\n")
                     return ""
                 },
@@ -206,7 +195,7 @@ fn selfRebuildClangCompileRuntimeArgs(target: String, sourcePath: String, object
         args.push("-target")
         args.push(target)
     }
-    if !(strings.contains(target, "windows")) {
+    if !(selfRebuildIsWindowsTarget(target)) {
         args.push("-pthread")
     }
     args.push("-O3")
@@ -224,11 +213,29 @@ fn selfRebuildHostIsDarwin() -> Bool {
         Err(_) -> false,
     }
 }
+fn selfRebuildHostIsWindows() -> Bool {
+    match os.execWith("cmd", ["/C", "ver"], "", {:}, 0) {
+        Ok(_) -> true,
+        Err(_) -> false,
+    }
+}
+fn selfRebuildIsWindowsTarget(target: String) -> Bool {
+    if target == "" {
+        return selfRebuildHostIsWindows()
+    }
+    strings.contains(target, "windows")
+}
 fn selfRebuildIsDarwinTarget(target: String) -> Bool {
     if target == "" {
         return selfRebuildHostIsDarwin()
     }
     strings.contains(target, "darwin") || strings.contains(target, "apple")
+}
+fn selfRebuildBinaryName(target: String) -> String {
+    if selfRebuildIsWindowsTarget(target) {
+        return "osty-self.exe"
+    }
+    "osty-self"
 }
 fn selfRebuildClangLinkArgs(target: String, objectPath: String, runtimeObjectPath: String, binaryPath: String) -> List<String> {
     let mut args: List<String> = []
@@ -238,15 +245,19 @@ fn selfRebuildClangLinkArgs(target: String, objectPath: String, runtimeObjectPat
     }
     args.push("-O3")
     args.push("-flto=thin")
+    if selfRebuildIsWindowsTarget(target) {
+        args.push("-Wl,/subsystem:console")
+        args.push("-Wl,/stack:67108864")
+    }
     args.push(objectPath)
     args.push(runtimeObjectPath)
-    if !(strings.contains(target, "windows")) {
+    if !(selfRebuildIsWindowsTarget(target)) {
         args.push("-pthread")
         args.push("-lz")
     }
     args.push("-o")
     args.push(binaryPath)
-    if !(strings.contains(target, "windows")) {
+    if !(selfRebuildIsWindowsTarget(target)) {
         args.push("-lm")
     }
     if selfRebuildIsDarwinTarget(target) {
@@ -255,7 +266,7 @@ fn selfRebuildClangLinkArgs(target: String, objectPath: String, runtimeObjectPat
         args.push("-framework")
         args.push("CoreFoundation")
     }
-    if strings.contains(target, "windows") {
+    if selfRebuildIsWindowsTarget(target) {
         args.push("-ladvapi32")
     }
     args
@@ -263,8 +274,7 @@ fn selfRebuildClangLinkArgs(target: String, objectPath: String, runtimeObjectPat
 fn selfRebuildRunClang(action: String, args: List<String>) -> String {
     let out = match os.execWith("clang", args, "", {:}, 0) {
         Ok(o) -> o,
-        Err(e) -> {
-            let _ = e
+        Err(_) -> {
             return "clang " + action + " failed to start"
         },
     }
@@ -281,8 +291,7 @@ fn selfRebuildRunSelfLower(exe: String, bundlePath: String, target: String) -> S
     }
     let out = match os.execWith(exe, args, "", {:}, 0) {
         Ok(o) -> o,
-        Err(e) -> {
-            let _ = e
+        Err(_) -> {
             eprint("osty-self rebuild: self LIR Proto lower failed to start\n")
             return ""
         },
@@ -306,7 +315,7 @@ fn runSelfRebuild(args: List<String>) -> Int {
     let runtimeSourceInRepo = selfRebuildPath(repoRoot, "internal/backend/runtime/osty_runtime.c")
     let runtimeSourcePath = selfRebuildPath(runtimeDir, "osty_runtime.c")
     let runtimeObjectPath = selfRebuildPath(runtimeDir, "osty_runtime.o")
-    let binaryPath = selfRebuildPath(outDir, "osty-self")
+    let binaryPath = selfRebuildPath(outDir, selfRebuildBinaryName(target))
     let mkdirErr = selfRebuildMkdirAll(runtimeDir)
     if mkdirErr != "" {
         eprint("osty-self rebuild: " + mkdirErr + "\n")
@@ -337,8 +346,7 @@ fn runSelfRebuild(args: List<String>) -> Int {
     }
     let runtimeSource = match fs.readToString(runtimeSourceInRepo) {
         Ok(s) -> s,
-        Err(e) -> {
-            let _ = e
+        Err(_) -> {
             eprint("osty-self rebuild: read runtime source failed\n")
             return 1
         },
@@ -402,17 +410,16 @@ fn selfhostProbeError() -> String {
     ""
 }
 fn selfhostDoctorProbeError(exe: String) -> String {
-    let probePath = "/tmp/osty-self-doctor-probe.osty"
+    let probePath = selfRebuildTempPath("osty-self-doctor-probe.osty")
     let writeErr = selfRebuildWriteString(probePath, selfhostProbeSource())
     if writeErr != "" {
         return "write probe failed: " + writeErr
     }
     let out = match os.execWith(exe, ["lir-proto-lower", probePath, "--package-name=main"], "", {:}, 0) {
         Ok(o) -> o,
-        Err(e) -> {
-            let _ = e
-            return "lir-proto-lower probe failed to start"
-        },
+            Err(_) -> {
+                return "lir-proto-lower probe failed to start"
+            },
     }
     if out.exitCode != 0 || out.timedOut {
         let msg = strings.trimSpace(out.stderr + "\n" + out.stdout)
@@ -442,7 +449,7 @@ fn runSelfhostDoctor() -> Int {
         eprint("osty-self self-rebuild probe failed: executable not found\n")
         return 2
     }
-    let probePath = "/tmp/osty-self-doctor-probe.osty"
+    let probePath = selfRebuildTempPath("osty-self-doctor-probe.osty")
     let mut probeError = ""
     let writeErr = selfRebuildWriteString(probePath, selfhostProbeSource())
     if writeErr != "" {
@@ -450,8 +457,7 @@ fn runSelfhostDoctor() -> Int {
     } else {
         let out = match os.execWith(exe, ["lir-proto-lower", probePath, "--package-name=main"], "", {:}, 0) {
             Ok(o) -> o,
-            Err(e) -> {
-                let _ = e
+            Err(_) -> {
                 probeError = "lir-proto-lower probe failed to start"
                 os.execOutput(1, "", "", false)
             },


### PR DESCRIPTION
## Summary

- Route `install-self --force` through the bounded MIR JSON selfhost driver bundle instead of feeding the full toolchain source bundle to stale selfhost binaries.
- Add guards around legacy LIR Proto source compatibility retries so stale binaries cannot consume unbounded memory.
- Fix Windows selfhost runtime/link portability, including filesystem traversal/copy support and an explicit stack reserve for selfhost-generated executables.

## Validation

- `go test -count=1 -vet=off ./cmd/osty ./cmd/osty-native-lirproto`
- `go test -count=1 -vet=off ./internal/llvmabi`
- `go build -o .bin\osty.exe ./cmd/osty`
- `.\.bin\osty.exe install-self --force --osty-bin .\.bin\osty.exe` twice without stage0 fallback
- cached `osty-self.exe --selfhost-doctor` exits 0

## Root Cause

The previous force-install recovery path could fall back to lowering a full toolchain source bundle through an older `osty-self`, which could explode memory usage on Windows. The newly built MIR driver also needed a larger Windows stack reserve to process MIR JSON reliably on the next selfhost run.