### PR TITLE
[codex] Stabilize MIR JSON timeout handling

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -59,6 +59,10 @@ const selfForwardArgsEnv = "OSTY_SELF_REBUILD_FORWARD_ARGS"
 // self-hosted LIR Proto lowering. Use "0" to disable.
 const selfLowerTimeoutEnv = "OSTY_LIRPROTO_SELF_TIMEOUT"
 
+// selfTimeoutCompatMaxBytesEnv bounds the legacy stage0 retry after a
+// MIR JSON timeout. Use "0" to disable timeout compatibility retries.
+const selfTimeoutCompatMaxBytesEnv = "OSTY_LIRPROTO_TIMEOUT_COMPAT_MAX_BYTES"
+
 // selfSourceCompatMaxBytesEnv bounds the legacy source retry used
 // only when an older osty-self cannot handle MIR JSON directly.
 // Use "0" to disable the size guard.
@@ -117,11 +121,11 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 		args = append(args, "--target="+req.Target)
 	}
 
-	resp, declineReason, err := runSelfLower(selfBin, args)
+	resp, declineReason, err := runSelfLower(selfBin, args, stagedPath)
 	if err != nil || !resp.Declined {
 		return resp, err
 	}
-	if command == "lir-proto-lower-mir-json" && isMIRJSONFallbackReason(declineReason) {
+	if command == "lir-proto-lower-mir-json" && shouldAttemptMIRJSONFallback(declineReason, stagedPath) {
 		return lowerLegacyMIRJSON(req, selfBin)
 	}
 	return resp, nil
@@ -143,13 +147,13 @@ func lowerSourceCompat(selfBin string, req nativelirproto.Request) (nativelirpro
 	if req.Target != "" {
 		args = append(args, "--target="+req.Target)
 	}
-	resp, _, err := runSelfLower(selfBin, args)
+	resp, _, err := runSelfLower(selfBin, args, sourcePath)
 	return resp, err
 }
 
-func runSelfLower(selfBin string, args []string) (nativelirproto.Response, string, error) {
+func runSelfLower(selfBin string, args []string, stagedPath string) (nativelirproto.Response, string, error) {
 	ctx := context.Background()
-	timeout := selfLowerTimeout(args)
+	timeout := selfLowerTimeout(args, stagedPath)
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
@@ -195,7 +199,7 @@ func runSelfLower(selfBin string, args []string) (nativelirproto.Response, strin
 	return nativelirproto.Response{LLVMIR: ir}, "", nil
 }
 
-func selfLowerTimeout(args []string) time.Duration {
+func selfLowerTimeout(args []string, stagedPath string) time.Duration {
 	if len(args) == 0 {
 		return 0
 	}
@@ -212,7 +216,38 @@ func selfLowerTimeout(args []string) time.Duration {
 			return d
 		}
 	}
-	return 20 * time.Second
+	timeout := 20 * time.Second
+	if args[0] == "lir-proto-lower-mir-json" {
+		timeout += mirJSONSizeTimeoutBudget(stagedInputSize(stagedPath))
+	}
+	return timeout
+}
+
+func mirJSONSizeTimeoutBudget(size int64) time.Duration {
+	if size <= 0 {
+		return 0
+	}
+	const mib = int64(1 << 20)
+	chunks := size / mib
+	if chunks == 0 {
+		return 0
+	}
+	budget := time.Duration(chunks) * 5 * time.Second
+	if budget > 3*time.Minute {
+		return 3 * time.Minute
+	}
+	return budget
+}
+
+func stagedInputSize(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return 0
+	}
+	return info.Size()
 }
 
 func normalizeSelfHostedLLVMIR(ir string) string {
@@ -234,10 +269,23 @@ func isInvalidSelfHostedIR(msg string) bool {
 	return strings.Contains(msg, "produced invalid IR")
 }
 
-func isMIRJSONFallbackReason(msg string) bool {
-	return isUnsupportedSelfCommand(msg) ||
-		isInvalidSelfHostedIR(msg) ||
-		strings.Contains(msg, "timed out")
+func isSelfHostedTimeout(msg string) bool {
+	return strings.Contains(msg, "timed out")
+}
+
+func shouldAttemptMIRJSONFallback(msg, stagedPath string) bool {
+	if isUnsupportedSelfCommand(msg) || isInvalidSelfHostedIR(msg) {
+		return true
+	}
+	if !isSelfHostedTimeout(msg) {
+		return false
+	}
+	max := timeoutCompatMaxBytes()
+	if max <= 0 {
+		return false
+	}
+	size := stagedInputSize(stagedPath)
+	return size > 0 && size <= max
 }
 
 func validateSelfHostedLLVMIR(ir string) string {
@@ -364,6 +412,19 @@ func sourceCompatMaxBytes() int {
 			return 0
 		}
 		var n int
+		if _, err := fmt.Sscanf(raw, "%d", &n); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 1 << 20
+}
+
+func timeoutCompatMaxBytes() int64 {
+	if raw := os.Getenv(selfTimeoutCompatMaxBytesEnv); raw != "" {
+		if raw == "0" {
+			return 0
+		}
+		var n int64
 		if _, err := fmt.Sscanf(raw, "%d", &n); err == nil && n >= 0 {
 			return n
 		}

--- a/cmd/osty-native-lirproto/main_test.go
+++ b/cmd/osty-native-lirproto/main_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/osty/osty/internal/backend/stage0"
 	"github.com/osty/osty/internal/ir"
@@ -578,6 +579,71 @@ func TestRunMIRPayloadUsesStage0CompatWhenMirJSONTimesOut(t *testing.T) {
 	args := readCapturedArgs(t, captureArgs)
 	if len(args) < 2 || args[0] != "lir-proto-lower-mir-json" {
 		t.Fatalf("first args = %v, want MIR JSON attempt before compat", args)
+	}
+}
+
+func TestRunMIRPayloadSkipsTimeoutCompatWhenPayloadExceedsGuard(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	captureDir := t.TempDir()
+	captureArgs := filepath.Join(captureDir, "args.json")
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv(selfLowerTimeoutEnv, "100ms")
+	t.Setenv(selfTimeoutCompatMaxBytesEnv, "1")
+	t.Setenv("FAKE_OSTY_SELF_SLEEP_MS", "3000")
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		MIR: map[string]any{
+			"version":     1,
+			"packageName": "main",
+			"padding":     strings.Repeat("x", 2048),
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if !resp.Declined {
+		t.Fatalf("Declined = false, want timeout decline: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, "lir-proto-lower-mir-json timed out") {
+		t.Fatalf("Error = %q, want MIR JSON timeout", resp.Error)
+	}
+	args := readCapturedArgs(t, captureArgs)
+	if len(args) < 2 || args[0] != "lir-proto-lower-mir-json" {
+		t.Fatalf("args = %v, want only MIR JSON attempt", args)
+	}
+}
+
+func TestSelfLowerTimeoutScalesWithMirJSONSize(t *testing.T) {
+	dir := t.TempDir()
+	small := filepath.Join(dir, "small.mir.json")
+	large := filepath.Join(dir, "large.mir.json")
+	if err := os.WriteFile(small, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write small payload: %v", err)
+	}
+	if err := os.WriteFile(large, bytes.Repeat([]byte{'x'}, 3<<20), 0o644); err != nil {
+		t.Fatalf("write large payload: %v", err)
+	}
+
+	if got := selfLowerTimeout([]string{"lir-proto-lower-mir-json", small}, small); got != 20*time.Second {
+		t.Fatalf("small MIR timeout = %s, want 20s", got)
+	}
+	if got := selfLowerTimeout([]string{"lir-proto-lower-mir-json", large}, large); got != 35*time.Second {
+		t.Fatalf("large MIR timeout = %s, want 35s", got)
+	}
+	if got := selfLowerTimeout([]string{"lir-proto-lower", large}, large); got != 20*time.Second {
+		t.Fatalf("source timeout = %s, want 20s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Scale `osty-native-lirproto` selfhost MIR JSON lowering timeout with staged payload size instead of using a fixed 20s budget for every MIR input.
- Stop routing large MIR JSON timeouts into the legacy stage0/source compatibility fallback, which was the path that could burn memory after the real selfhost backend simply needed more time.
- Add regression tests for guarded timeout fallback and size-scaled timeout budgets.

## Root Cause

The repeated Windows `install-self --force` path built a ~10 MB selfhost MIR driver payload. Direct `osty-self lir-proto-lower-mir-json` completed successfully, but it took slightly longer than the wrapper's fixed 20s timeout. The wrapper then treated the timeout as a compatibility fallback case, causing stage0/source fallback attempts instead of letting the MIR JSON backend finish.

## Validation

- `go test -count=1 -vet=off ./cmd/osty-native-lirproto`
- `go test -count=1 -vet=off ./cmd/osty ./cmd/osty-native-lirproto ./internal/llvmabi`
- `go test -count=1 -vet=off -run TestCoreSnapshotParityWithOsty ./internal/ci -v`
- `go test -count=1 -vet=off -run TestPolicySnapshotParityWithOsty ./internal/runner -v`
- `go test -count=1 -vet=off ./cmd/osty ./internal/selfhost -run "Test(CheckCLIDefaultPathExitsZero|RunCheckFileDefaultPathIsAstbridgeFree|ProductionFrontendPathsDoNotCallFrontendRunFile)" -v`
- `go build -o .bin\osty.exe ./cmd/osty`
- `go build -o .osty\bin\osty-native-lirproto.exe ./cmd/osty-native-lirproto`
- Fallback-free `osty install-self --force --osty-bin .bin\osty.exe`, repeated successfully before the final cleanup and again after rebuilding from this commit
- `osty-self --selfhost-doctor`