### PR TITLE
feat: cross-pkg link unblock — library-mode symbol qualification + MIR recovery

### DIFF
--- a/cmd/osty-native-llvmgen/library_mode_test.go
+++ b/cmd/osty-native-llvmgen/library_mode_test.go
@@ -74,3 +74,137 @@ func TestStripMainForLibraryModeHandlesNilSafely(t *testing.T) {
 		t.Fatalf("survivor = %q, want \"helper\"", entry2.MIR.Functions[0].Name)
 	}
 }
+
+// TestQualifyExportedSymbolsForLibraryModeRenamesExportsAndCallsites
+// locks the cross-pkg link unblock from
+// `docs/llvm-selfhost-plan-cross-pkg-link-measurement.md` Path α:
+// exported function names get prefixed with `<packageName>.` and any
+// internal `CallInstr.Callee.Symbol` referencing one of those names is
+// patched so the dep's library `.o` exports the same symbol the
+// consumer's `qualifiedSymbol` mangling expects.
+func TestQualifyExportedSymbolsForLibraryModeRenamesExportsAndCallsites(t *testing.T) {
+	// `helper` (exported) calls `inner` (private). After the rename
+	// the dep's library object exports `@toolchain.helper` and
+	// `@inner` keeps its bare name. The call site inside `helper`
+	// still targets `@inner`. A second exported function `other`
+	// calls `helper` — that call site must be rewritten to
+	// `@toolchain.helper`.
+	innerFn := &mir.Function{Name: "inner", Exported: false}
+	helperFn := &mir.Function{
+		Name:     "helper",
+		Exported: true,
+		Blocks: []*mir.BasicBlock{{
+			Instrs: []mir.Instr{
+				&mir.CallInstr{Callee: &mir.FnRef{Symbol: "inner"}},
+			},
+		}},
+	}
+	otherFn := &mir.Function{
+		Name:     "other",
+		Exported: true,
+		Blocks: []*mir.BasicBlock{{
+			Instrs: []mir.Instr{
+				&mir.CallInstr{Callee: &mir.FnRef{Symbol: "helper"}},
+				&mir.CallInstr{Callee: &mir.FnRef{Symbol: "inner"}},
+			},
+		}},
+	}
+
+	entry := &backend.Entry{
+		MIR: &mir.Module{
+			Functions: []*mir.Function{innerFn, helperFn, otherFn},
+		},
+	}
+	qualifyExportedSymbolsForLibraryMode(entry, "toolchain")
+
+	if innerFn.Name != "inner" {
+		t.Fatalf("inner (private) renamed to %q, want unchanged", innerFn.Name)
+	}
+	if helperFn.Name != "toolchain.helper" {
+		t.Fatalf("helper.Name = %q, want \"toolchain.helper\"", helperFn.Name)
+	}
+	if otherFn.Name != "toolchain.other" {
+		t.Fatalf("other.Name = %q, want \"toolchain.other\"", otherFn.Name)
+	}
+
+	// helper's internal call to `inner` is private — must NOT rename.
+	if got := callSymbol(helperFn, 0, 0); got != "inner" {
+		t.Fatalf("helper -> inner call symbol = %q, want \"inner\" (private)", got)
+	}
+	// other's call to `helper` is exported — must rename to qualified.
+	if got := callSymbol(otherFn, 0, 0); got != "toolchain.helper" {
+		t.Fatalf("other -> helper call symbol = %q, want \"toolchain.helper\"", got)
+	}
+	// other's call to `inner` stays bare.
+	if got := callSymbol(otherFn, 0, 1); got != "inner" {
+		t.Fatalf("other -> inner call symbol = %q, want \"inner\"", got)
+	}
+}
+
+// TestQualifyExportedSymbolsForLibraryModeRespectsExportSymbol locks
+// the LANG_SPEC §19.6 `#[export("name")]` interaction: when a function
+// asks for a verbatim symbol, the qualifier rename is skipped so FFI
+// consumers expecting the exact spelling still find the symbol.
+func TestQualifyExportedSymbolsForLibraryModeRespectsExportSymbol(t *testing.T) {
+	verbatim := &mir.Function{
+		Name:         "fooImpl",
+		Exported:     true,
+		ExportSymbol: "verbatim_c_abi_name",
+	}
+	plain := &mir.Function{Name: "bar", Exported: true}
+	entry := &backend.Entry{
+		MIR: &mir.Module{Functions: []*mir.Function{verbatim, plain}},
+	}
+	qualifyExportedSymbolsForLibraryMode(entry, "pkg")
+
+	if verbatim.Name != "fooImpl" {
+		t.Fatalf("verbatim ExportSymbol fn renamed: Name=%q, want \"fooImpl\"", verbatim.Name)
+	}
+	if plain.Name != "pkg.bar" {
+		t.Fatalf("plain exported fn Name=%q, want \"pkg.bar\"", plain.Name)
+	}
+}
+
+// TestQualifyExportedSymbolsForLibraryModeNoOpOnEmptyPackageName locks
+// the backwards-compat fallback: callers that haven't filled
+// PackageName get the historical bare-name emission, no rename.
+func TestQualifyExportedSymbolsForLibraryModeNoOpOnEmptyPackageName(t *testing.T) {
+	fn := &mir.Function{Name: "helper", Exported: true}
+	entry := &backend.Entry{
+		MIR: &mir.Module{Functions: []*mir.Function{fn}},
+	}
+	qualifyExportedSymbolsForLibraryMode(entry, "")
+	if fn.Name != "helper" {
+		t.Fatalf("empty PackageName caused rename: %q", fn.Name)
+	}
+}
+
+// TestQualifyExportedSymbolsForLibraryModeHandlesNilSafely mirrors
+// stripMainForLibraryMode's nil-safety contract.
+func TestQualifyExportedSymbolsForLibraryModeHandlesNilSafely(t *testing.T) {
+	qualifyExportedSymbolsForLibraryMode(nil, "pkg")
+	qualifyExportedSymbolsForLibraryMode(&backend.Entry{}, "pkg")
+	qualifyExportedSymbolsForLibraryMode(&backend.Entry{MIR: &mir.Module{}}, "pkg")
+	qualifyExportedSymbolsForLibraryMode(&backend.Entry{
+		MIR: &mir.Module{Functions: []*mir.Function{nil, {Name: "main"}}},
+	}, "pkg")
+}
+
+func callSymbol(fn *mir.Function, blockIdx, instrIdx int) string {
+	if fn == nil || blockIdx >= len(fn.Blocks) || fn.Blocks[blockIdx] == nil {
+		return ""
+	}
+	bb := fn.Blocks[blockIdx]
+	if instrIdx >= len(bb.Instrs) {
+		return ""
+	}
+	ci, ok := bb.Instrs[instrIdx].(*mir.CallInstr)
+	if !ok || ci == nil {
+		return ""
+	}
+	ref, ok := ci.Callee.(*mir.FnRef)
+	if !ok || ref == nil {
+		return ""
+	}
+	return ref.Symbol
+}

--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/mir"
 	"github.com/osty/osty/internal/nativelirproto"
 	"github.com/osty/osty/internal/nativellvmgen"
 	"github.com/osty/osty/internal/resolve"
@@ -50,6 +51,9 @@ func run(stdin io.Reader, stdout io.Writer) error {
 	}
 	if req.Package != nil && req.Package.LibraryMode {
 		stripMainForLibraryMode(&entry)
+		if req.Package.PackageName != "" {
+			qualifyExportedSymbolsForLibraryMode(&entry, req.Package.PackageName)
+		}
 	}
 	ir, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(entry, "")
 	if err != nil {
@@ -198,6 +202,90 @@ func stripMainForLibraryMode(entry *backend.Entry) {
 			filtered = append(filtered, fn)
 		}
 		entry.MIR.Functions = filtered
+	}
+}
+
+// qualifyExportedSymbolsForLibraryMode rewrites every exported MIR
+// function's `Name` to `<packageName>.<oldName>` and patches every
+// `CallInstr` Callee.Symbol that targets one of the renamed functions
+// so internal dep-to-dep calls keep resolving after the rename.
+//
+// The cross-pkg consumer side of this dance lives in
+// `internal/mir/lower.go::qualifiedSymbol`, which mangles
+// `use <pkg> as <alias>; alias.fn(...)` to the LLVM symbol
+// `<use.RawPath>.<fn>` (use.RawPath == the dep's package name when
+// loaded by cmd/osty's path-dep workspace resolver). Without this
+// rename the dep's library `.o` exports `@frontInvalidTypeRepr` while
+// the consumer's `main.ll` references `@toolchain.frontInvalidTypeRepr`
+// — the link step fails with `undefined symbol: <pkg>.<fn>`.
+//
+// Non-exported (private) helpers stay bare so the package's internal
+// link layout is unchanged. The rename map is keyed on the *bare* old
+// name so a private helper that happens to share a name with an
+// exported function in another dep does not get accidentally renamed.
+//
+// `IndirectCall` callees do not carry symbols (they go through an
+// operand), so they are untouched. `FnConst` operands in argument
+// position carry an LLVM symbol though — those are rewritten too so a
+// closure-typed argument keeps pointing at the renamed callable.
+//
+// Scope: this measurement-doc PR pairs with the cross-pkg link wall
+// captured in `docs/llvm-selfhost-plan-cross-pkg-link-measurement.md`
+// Path α. Documented as the surgical companion to
+// `stripMainForLibraryMode`.
+func qualifyExportedSymbolsForLibraryMode(entry *backend.Entry, packageName string) {
+	if entry == nil || entry.MIR == nil || packageName == "" {
+		return
+	}
+	renames := make(map[string]string)
+	for _, fn := range entry.MIR.Functions {
+		if fn == nil || !fn.Exported || fn.Name == "" {
+			continue
+		}
+		// `#[export("name")]` overrides the symbol verbatim
+		// (LANG_SPEC §19.6 / mir.go:143). Skip the rename for those
+		// — the user asked for an exact symbol name, so honoring it
+		// avoids breaking FFI consumers that expect the verbatim
+		// spelling.
+		if fn.ExportSymbol != "" {
+			continue
+		}
+		// `main` was already filtered by stripMainForLibraryMode; the
+		// belt-and-braces check here keeps the rename idempotent if
+		// the strip step is ever reordered.
+		if fn.Name == "main" {
+			continue
+		}
+		renames[fn.Name] = packageName + "." + fn.Name
+	}
+	if len(renames) == 0 {
+		return
+	}
+	for _, fn := range entry.MIR.Functions {
+		if fn == nil {
+			continue
+		}
+		if newName, ok := renames[fn.Name]; ok {
+			fn.Name = newName
+		}
+		for _, bb := range fn.Blocks {
+			if bb == nil {
+				continue
+			}
+			for _, instr := range bb.Instrs {
+				switch ix := instr.(type) {
+				case *mir.CallInstr:
+					if ix == nil {
+						continue
+					}
+					if ref, ok := ix.Callee.(*mir.FnRef); ok && ref != nil {
+						if newName, found := renames[ref.Symbol]; found {
+							ref.Symbol = newName
+						}
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/docs/llvm-selfhost-plan-cross-pkg-fn-sig-propagation-design.md
+++ b/docs/llvm-selfhost-plan-cross-pkg-fn-sig-propagation-design.md
@@ -1,0 +1,167 @@
+# LLVM self-host — cross-pkg fn signature propagation through IR (Task B design)
+
+> **상태**: design (architectural change — not yet implemented).
+> **선행**: PR #1934 (`?`-prefix synthesis), PR #1936 (Option/Result MIR
+> recovery), PR #1937 (List/Set MIR recovery + library-mode symbol
+> qualification + cross-pkg link wall measurement). 본 doc 는 cross-pkg
+> trajectory 의 다음 단계.
+> **소유**: ir / mir / check.
+
+## 1. 30초 요약
+
+`use toolchain as tc; tc.frontInvalidTypeRepr()` 호출이 MIR/LLVM 단계에서
+return type 을 잃는 leak (`declare void @toolchain.frontInvalidTypeRepr()`,
+즉 dep 의 실제 `-> FrontTypeRepr` 시그니처 대신 void). PR #1937 의
+library-mode qualification 이 link 측 mangling drift 는 해소했지만, 호출
+사이트의 return type 은 여전히 leak 가능. UseDecl 의 cross-pkg fn 시그니처
+plumbing 이 미완성.
+
+## 2. 현재 위치의 leak path
+
+`internal/mir/lower.go::useDeclFnType` (line 4055) 는 `*ir.UseDecl.GoBody`
+만 walk:
+
+```go
+func useDeclFnType(use *ir.UseDecl, name string) *ir.FnType {
+    if use == nil || name == "" { return nil }
+    for _, d := range use.GoBody {
+        fn, ok := d.(*ir.FnDecl)
+        if !ok || fn == nil || fn.Name != name { continue }
+        ...
+    }
+    return nil
+}
+```
+
+`GoBody` 는 inline FFI `use X { fn name(...) }` 만 채움. 일반 cross-pkg
+`use toolchain as tc` 는 GoBody 가 비어있어 useDeclFnType nil 반환. 결과:
+`internal/mir/lower.go::resolveQualifiedCall` 의 fallback path 도 무용.
+
+```go
+func (bs *bodyState) resolveQualifiedCall(...) ([]Operand, Callee) {
+    callType := t
+    if sig := useDeclFnType(use, name); sig != nil {
+        if isPoisonType(callType) || irHasPoisonedTypeArg(callType) {
+            callType = sig  // <- 일반 cross-pkg는 도달 못함 (sig == nil)
+        }
+    }
+    return out, &FnRef{Symbol: qualifiedSymbol(use, name), Type: callType}
+}
+```
+
+즉 cross-pkg call 의 consumer-side `t` (IR type) 가 poison 일 때 recovery
+경로가 없음. stage0 emit 은 poison 을 void 로 lower → 우리가 본
+`declare void @<pkg>.<fn>()`.
+
+## 3. 진짜 fix path — UseDecl.Imports 캐리
+
+**Step 1: IR shape**
+
+`internal/ir/ir.go::UseDecl` 에 cross-pkg sig field 추가:
+
+```go
+type UseDecl struct {
+    ...
+    GoBody  []Decl   // 기존 — inline FFI body
+    Imports []*FnDecl // 신규 — 일반 cross-pkg import surface
+    SpanV   Span
+}
+```
+
+`Imports` 가 set 되면 consumer 의 checker 가 import surface 에서 봤던 dep
+의 pub fn 의 시그니처 (param 이름/타입, return type) 가 캐리.
+
+**Step 2: ir.Lower 파라미터 확장**
+
+`internal/ir/lower.go::Lower` 는 현재 `(*ast.File, *resolve.Result,
+*check.Result)`. cross-pkg import surface 데이터가 추가로 필요. 두 옵션:
+
+a) `check.Result` 에 새 필드 추가 — `ImportSurfaces []api.PackageCheckImport`
+   - 장점: 기존 시그니처 변화 없음 (Result 만 확장)
+   - 단점: Result 는 검사 출력이므로 surface 데이터를 끼워넣는 게 의미적 mismatch
+
+b) `Lower` 에 새 파라미터 `imports []api.PackageCheckImport`
+   - 장점: 의미 명확
+   - 단점: 호출 사이트 다수 갱신 (5-6 곳)
+
+**권장: (a)** — `check.Result.ImportSurfaces` 추가. check 단계가 이미
+import surface 를 `selfhostInstallImportSurfaces` 로 컨슈밍 중이라
+같은 데이터를 Result 에 캐싱하는 것은 자연스러움. 추정 한 줄 추가.
+
+**Step 3: lowerUseDecl 확장**
+
+`internal/ir/lower.go::lowerUseDecl` 가 `l.chk.ImportSurfaces` 에서
+alias 매칭 surface 를 찾고 그 surface 의 Functions 를 `*ir.FnDecl`
+로 lower 해서 `out.Imports` 에 넣음. (각 함수의 receiver, param, return
+type 을 `lowerType` 으로 변환.) 추정 ~40 LOC.
+
+**Step 4: MIR useDeclFnType 확장**
+
+```go
+func useDeclFnType(use *ir.UseDecl, name string) *ir.FnType {
+    if use == nil || name == "" { return nil }
+    for _, d := range use.GoBody { ... }  // 기존
+    for _, fn := range use.Imports {       // 신규
+        if fn == nil || fn.Name != name { continue }
+        // 같은 FnDecl → FnType 변환 로직 재사용
+        return fnDeclToFnType(fn)
+    }
+    return nil
+}
+```
+
+**Step 5: 테스트**
+
+- `internal/mir/use_decl_fn_type_test.go` — UseDecl.Imports 가 있는 cross-pkg
+  call 의 return type recovery 검증.
+- `internal/check/cross_pkg_import_surface_test.go` — check.Result.ImportSurfaces
+  가 PackageImportSurface 의 출력과 일치 검증.
+- Integration: `selfhost.CheckPackageStructured` 의 기존 cross-pkg test 들에
+  return type 검증 추가.
+
+## 4. 추정 LOC + 위험
+
+| 단계 | LOC | 위험 |
+|---|---|---|
+| Step 1 (UseDecl.Imports field) | ~5 | 낮음 (additive) |
+| Step 2 (check.Result.ImportSurfaces field) | ~5 | 낮음 (additive) |
+| Step 3 (lowerUseDecl populate) | ~40 | 중간 (type lowering recursion) |
+| Step 4 (useDeclFnType consult) | ~10 | 낮음 |
+| Step 5 (tests) | ~80-120 | — |
+| **합** | **~150-200** | medium (multi-file, cross-package) |
+
+이전 #1934/#1936/#1937 의 ~30-100 LOC 패턴보다 큼. 단일 fresh session 가능
+하나 review cycle 길어질 가능성 — sub-PR 분할 권장.
+
+## 5. 분할 권장 — 3 sub-PR sequencing
+
+```
+PR (B-1): UseDecl.Imports + check.Result.ImportSurfaces field 추가 (additive shape)
+  ↓ no behavioral change, no test
+PR (B-2): lowerUseDecl populate Imports (behavioral; only consumes new field)
+  ↓ unit test for lowerUseDecl
+PR (B-3): useDeclFnType + MIR recovery 활성화 + integration test
+  ↓ end-to-end cross-pkg return-type leak 해소 검증
+```
+
+각 sub-PR ~50-70 LOC. review 가 짧고 self-contained.
+
+## 6. 본 doc 의 산출물
+
+- `docs/llvm-selfhost-plan-cross-pkg-fn-sig-propagation-design.md` (이 doc)
+  — Task B 의 architectural design + sub-PR 분할 권장
+- 코드 변경 zero
+
+다음 fresh session 의 cross-pkg trajectory 의 다음 단계 시작점.
+
+## 7. 관련 PR 카탈로그
+
+| PR | scope |
+|---|---|
+| [#1902](https://github.com/choiceoh/osty/pull/1902) | PR-G1 scaffold |
+| [#1905](https://github.com/choiceoh/osty/pull/1905) | PR-G2 cross-pkg dep library compile path (opt-in) |
+| [#1908](https://github.com/choiceoh/osty/pull/1908) | void → aggregate zero-init cascade fix |
+| [#1934](https://github.com/choiceoh/osty/pull/1934) | `?`-prefix synthesis from `ParamDefaults` |
+| [#1936](https://github.com/choiceoh/osty/pull/1936) | Option/Result MIR return-type recovery |
+| [#1937](https://github.com/choiceoh/osty/pull/1937) | List/Set MIR recovery + library-mode symbol qualification + 본 doc 자매 doc |
+| (Task B; 이 doc) | UseDecl.Imports plumbing — cross-pkg fn sig propagation |

--- a/docs/llvm-selfhost-plan-cross-pkg-link-measurement.md
+++ b/docs/llvm-selfhost-plan-cross-pkg-link-measurement.md
@@ -1,0 +1,151 @@
+# LLVM self-host — cross-pkg link symbol mangling wall measurement
+
+> **상태**: measurement (cmd/osty-native-checker production-path build 의 다음 wall 정확화).
+> **선행**: PR #1908 (void → aggregate cascade), PR #1934 (`?`-prefix synthesis),
+> PR #1936 (Option/Result MIR return-type recovery), PR #1937 (List/Set MIR recovery).
+> **소유**: backend / cross_pkg.
+
+## 1. 30초 요약
+
+`OSTY_STAGE0_FALLBACK=1 .bin/osty build --backend llvm cmd/osty-native-checker/` 의 link 단계가 여전히
+실패:
+
+```
+ld.lld: error: undefined symbol: toolchain.frontInvalidTypeRepr
+```
+
+원인은 consumer/dep 의 **심볼 mangling drift** — 같은 함수에 대해 두 사이트가 다른 LLVM
+심볼을 emit. dep 라이브러리 compile 자체가 가능해져도 link 가 불가능한 본질적 wall.
+
+## 2. 재현
+
+```sh
+go build -o .bin/osty ./cmd/osty
+OSTY_STAGE0_FALLBACK=1 .bin/osty build --backend llvm cmd/osty-native-checker/
+```
+
+stage0 fallback 으로 consumer 의 IR 생성은 통과. clang link 단계에서 fail.
+
+## 3. 측정한 mangling drift
+
+생성된 `cmd/osty-native-checker/.osty/out/debug/llvm/main.ll`:
+
+```llvm
+declare void @toolchain.frontInvalidTypeRepr()
+...
+define void @main() {
+  call void @toolchain.frontInvalidTypeRepr()
+}
+```
+
+consumer 가 호출하는 심볼: `@toolchain.frontInvalidTypeRepr` (dot-form, package-qualified).
+
+소스: `internal/mir/lower.go::qualifiedSymbol`:
+
+```go
+case use.IsRuntimeFFI && use.RuntimePath != "":
+    return use.RuntimePath + "." + name
+case use.IsGoFFI && use.GoPath != "":
+    return use.GoPath + "." + name
+...
+if use.RawPath != "" {
+    return rewriteStdlibSymbolToRuntime(use.RawPath + "." + name)
+}
+```
+
+`use toolchain as tc` → `RawPath = "toolchain"`, `Alias = "tc"` → consumer emit `toolchain.frontInvalidTypeRepr`.
+
+dep `toolchain/` 를 단독 build 했을 때 emit 되는 심볼: `@frontInvalidTypeRepr` (bare,
+qualifier 없음). 소스: `internal/backend/stage0/emit.go:540`:
+
+```go
+fmt.Fprintf(&b, "define %s @%s(", retLLVM, fn.Name)
+```
+
+stage0 가 dep 의 `pub fn frontInvalidTypeRepr` 을 그대로 `@frontInvalidTypeRepr` 로 emit.
+consumer 가 부르는 `@toolchain.frontInvalidTypeRepr` 와 mismatch.
+
+## 4. 보조 wall: void return-type leak
+
+`declare void` 가 emit 되는 이유 — `let _typeRepr = tc.frontInvalidTypeRepr()` 의
+binding 이 leading-`_` (unused). PR-G1 (#1902) 의 cross-pkg dispatch arm + PR #1908
+의 cascade fix 가 결과를 `void` 로 받는다 (consumer 의 checker env 가 dep 의 진짜
+return type `FrontTypeRepr` 모름). 본 wall 은 link 가 풀린 이후의 secondary
+correctness 이슈.
+
+## 5. 진짜 fix 의 path
+
+세 후보, 각각 trade-off:
+
+### Path α — dep library mode 가 package-qualified 심볼 emit
+
+`cmd/osty-native-llvmgen/main.go::stripMainForLibraryMode` 가 main 만 strip. 확장해서
+LibraryMode 일 때 exported `fn.Name` 을 `<package>.<name>` 로 rename. 패키지 이름은
+manifest `[package] name` 또는 request 에 명시.
+
+- **장점**: link 단일 unblock. Consumer-side 무수정.
+- **단점**:
+  - manifest plumbing 필요 (현재 PackageInput 에 package name 없음)
+  - dep 자체를 standalone 으로 빌드할 때 다른 link 컨벤션 (자기 자신을 main 으로 빌드)
+  - dep 내부 cross-fn call (recurse, helper) 도 qualified 형태로 emit 해야 함
+
+### Path β — consumer 가 unqualified 심볼 emit (cross-pkg free-fn 경우)
+
+`qualifiedSymbol` 의 `RawPath != ""` 분기를 narrow — cross-pkg 가 use-alias method
+dispatch arm 으로 resolve 된 free-fn 인 경우 qualifier 생략. 단 MIR 가 그
+context 정보 (elab dispatch arm 결정) 를 carry 안 함 → 추가 plumbing.
+
+- **장점**: dep 측 변경 zero
+- **단점**: stdlib/FFI 의 dot-form 도 같은 분기 — namespace collision 위험
+
+### Path γ — symbol intermediate translation
+
+builder 의 link 단계에서 `objcopy --redefine-sym` 같은 도구로 dep 객체의 심볼을
+package-qualified 로 rename. consumer 와 dep 양쪽 변경 zero, 단 빌드 toolchain
+복잡도 증가.
+
+- **장점**: 컴파일러 변경 zero
+- **단점**: objcopy 의존성, debug info 손상 위험
+
+## 6. 권장 — Path α (library-mode qualification)
+
+자기-제한적 mechanism, 단일 PR 가능 추정. 단계:
+
+1. `internal/nativellvmgen.PackageInput` 에 `PackageName string` 필드 추가
+2. `cmd/osty/cross_pkg_deps.go` 가 manifest 에서 package name 추출해 LibraryMode
+   request 에 채움
+3. `cmd/osty-native-llvmgen/main.go::stripMainForLibraryMode` 가 `entry.MIR.Functions`
+   를 walk 해서 main 제외 / pub `fn.Name` 을 `pkg.fn` 로 rename
+4. dep 내부 cross-fn call 의 symbol 도 rename 추적 (CallInstr.Callee.Symbol 매핑)
+
+추정 ~80-100 LOC + 테스트. PR #1908 패턴 매치 (single dispatch site + 동등 변경).
+
+## 7. 보조 wall 의 trajectory
+
+§4 의 void return-type leak 은 link 가 풀린 후의 별개 작업:
+
+- consumer 가 dep 의 real return type 인 `FrontTypeRepr` 을 받아 처리해야 정상 program
+- 현재 stage0 dispatch arm 의 fallback (`<error>` → void) 이 silent → semantically
+  incomplete 한 program 생성
+- PR-G3+ trajectory 의 cross-pkg signature 완전 전파 (UseDecl 에 sig 캐리, MIR 의
+  `useDeclFnType` 확장 등) 가 진짜 해결책
+
+## 8. 이 doc 의 산출물
+
+- `docs/llvm-selfhost-plan-cross-pkg-link-measurement.md` (이 doc) — wall trigger 정확화
+  + Path α/β/γ 비교 + Path α 권장
+- 코드 변경 zero
+
+다음 fresh session 의 PR3-G (또는 추정 이름 PR-G3/G4) 의 시작점.
+
+## 9. 관련 PR 카탈로그 (\<-2 weeks)
+
+| PR | scope |
+|---|---|
+| [#1902](https://github.com/choiceoh/osty/pull/1902) | PR-G1 scaffold: `backend.Request.ExtraObjects` 인프라 |
+| [#1905](https://github.com/choiceoh/osty/pull/1905) | PR-G2: `OSTY_CROSS_PKG_LINK=1` opt-in 의 dep library compile path |
+| [#1908](https://github.com/choiceoh/osty/pull/1908) | void → aggregate zero-init cascade fix (`lirLowerMirAssign`) |
+| [#1934](https://github.com/choiceoh/osty/pull/1934) | `?`-prefix synthesis from `ParamDefaults` (cross-pkg fn arity) |
+| [#1936](https://github.com/choiceoh/osty/pull/1936) | Option/Result MIR return-type recovery |
+| [#1937](https://github.com/choiceoh/osty/pull/1937) | List/Set MIR return-type recovery |
+| (이 doc) | cross-pkg link symbol mangling wall trigger measurement |

--- a/internal/mir/builtin_method_return_type_test.go
+++ b/internal/mir/builtin_method_return_type_test.go
@@ -180,18 +180,19 @@ func TestBuiltinMethodReturnTypeResultMethodCoverage(t *testing.T) {
 // `*bodyState.recoveredMethodReturnType` arm for List<T> intrinsic
 // methods whose return type is fully determined by the receiver:
 //
-//   - `indexOf` / `lastIndexOf` → Option<Int> (per
-//     mir.go::IntrinsicListIndexOf which produces an `Int?` dest)
+//   - `indexOf` → Option<Int> (per `IntrinsicListIndexOf` which
+//     produces an `Int?` dest, mir.go:494)
 //   - `toSet` → Set<T> (per IntrinsicListToSet)
 //
 // Recovery uses `bs.l.listElementType(recvT)` so a poisoned MIR temp
 // produced by a checker-skipped interpolation (`"{xs.indexOf(needle)}"`)
 // still gets a usable type for downstream lowering.
 //
-// The test runs through a real `bodyState` constructed from a tiny
-// module so the lowerer's element-type helpers are wired. We don't try
-// to hit a runtime — just verify the recovery function returns the
-// expected ir.Type for each method.
+// `lastIndexOf` is intentionally absent — List's intrinsic dispatch
+// (`stdlibIntrinsicForMethod`, lower.go:7174) and `toolchain/check_env.osty`
+// only register `indexOf`. Recovering it would mask an invalid call.
+// `TestRecoveredMethodReturnTypeListLastIndexOfReturnsNil` locks that
+// negative arm.
 func TestRecoveredMethodReturnTypeListCollectionMethods(t *testing.T) {
 	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
 	bs := newRecoveryTestBodyState()
@@ -200,7 +201,6 @@ func TestRecoveredMethodReturnTypeListCollectionMethods(t *testing.T) {
 		want   ir.Type
 	}{
 		{"indexOf", &ir.OptionalType{Inner: ir.TInt}},
-		{"lastIndexOf", &ir.OptionalType{Inner: ir.TInt}},
 		{"toSet", &ir.NamedType{Name: "Set", Args: []ir.Type{ir.TInt}, Builtin: true}},
 		{"len", ir.TInt},
 		{"isEmpty", ir.TBool},
@@ -249,14 +249,27 @@ func TestRecoveredMethodReturnTypeSetCollectionMethods(t *testing.T) {
 	}
 }
 
-// newRecoveryTestBodyState builds a minimal `*bodyState` with the
-// lowerer plumbing required by `bs.l.listElementType` and
-// `bs.l.setElementType`. The lowerer's stdlib / module state are left
-// empty — the helpers under test only need the receiver type's
-// argument list to extract the element type.
+// newRecoveryTestBodyState returns a `*bodyState` wired with a bare
+// `*lowerer`. `listElementType` / `setElementType` only read the
+// receiver type's argument list, so the lowerer's stdlib / module
+// state are intentionally left zero-valued — no module init is needed
+// to exercise the recovery helpers under test.
 func newRecoveryTestBodyState() *bodyState {
 	l := &lowerer{}
 	return &bodyState{l: l}
+}
+
+// TestRecoveredMethodReturnTypeListLastIndexOfReturnsNil locks the
+// negative arm noted in TestRecoveredMethodReturnTypeListCollectionMethods:
+// `List.lastIndexOf` is not a registered intrinsic on List (only on
+// Bytes / String), so recovery must return nil and let the upstream
+// checker surface the unknown-method diagnostic.
+func TestRecoveredMethodReturnTypeListLastIndexOfReturnsNil(t *testing.T) {
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	bs := newRecoveryTestBodyState()
+	if got := bs.recoveredMethodReturnType(listInt, "lastIndexOf"); got != nil {
+		t.Fatalf("recoveredMethodReturnType(List<Int>, \"lastIndexOf\") = %v, want nil (not-a-List-method)", got)
+	}
 }
 
 // TestBuiltinMethodReturnTypeOptionUncoveredMethodReturnsNil locks the

--- a/internal/mir/builtin_method_return_type_test.go
+++ b/internal/mir/builtin_method_return_type_test.go
@@ -176,6 +176,89 @@ func TestBuiltinMethodReturnTypeResultMethodCoverage(t *testing.T) {
 	})
 }
 
+// TestRecoveredMethodReturnTypeListCollectionMethods exercises the
+// `*bodyState.recoveredMethodReturnType` arm for List<T> intrinsic
+// methods whose return type is fully determined by the receiver:
+//
+//   - `indexOf` / `lastIndexOf` → Option<Int> (per
+//     mir.go::IntrinsicListIndexOf which produces an `Int?` dest)
+//   - `toSet` → Set<T> (per IntrinsicListToSet)
+//
+// Recovery uses `bs.l.listElementType(recvT)` so a poisoned MIR temp
+// produced by a checker-skipped interpolation (`"{xs.indexOf(needle)}"`)
+// still gets a usable type for downstream lowering.
+//
+// The test runs through a real `bodyState` constructed from a tiny
+// module so the lowerer's element-type helpers are wired. We don't try
+// to hit a runtime — just verify the recovery function returns the
+// expected ir.Type for each method.
+func TestRecoveredMethodReturnTypeListCollectionMethods(t *testing.T) {
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	bs := newRecoveryTestBodyState()
+	cases := []struct {
+		method string
+		want   ir.Type
+	}{
+		{"indexOf", &ir.OptionalType{Inner: ir.TInt}},
+		{"lastIndexOf", &ir.OptionalType{Inner: ir.TInt}},
+		{"toSet", &ir.NamedType{Name: "Set", Args: []ir.Type{ir.TInt}, Builtin: true}},
+		{"len", ir.TInt},
+		{"isEmpty", ir.TBool},
+		{"contains", ir.TBool},
+		{"toString", ir.TString},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			got := bs.recoveredMethodReturnType(listInt, tc.method)
+			if got == nil {
+				t.Fatalf("recoveredMethodReturnType(List<Int>, %q) = nil, want %v", tc.method, tc.want)
+			}
+			if got.String() != tc.want.String() {
+				t.Fatalf("recoveredMethodReturnType(List<Int>, %q) = %v, want %v", tc.method, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecoveredMethodReturnTypeSetCollectionMethods covers Set<T>'s
+// `toList` recovery (per IntrinsicSetToList) alongside the existing
+// `len`/`isEmpty`/`contains`/`toString` set.
+func TestRecoveredMethodReturnTypeSetCollectionMethods(t *testing.T) {
+	setStr := &ir.NamedType{Name: "Set", Args: []ir.Type{ir.TString}, Builtin: true}
+	bs := newRecoveryTestBodyState()
+	cases := []struct {
+		method string
+		want   ir.Type
+	}{
+		{"toList", &ir.NamedType{Name: "List", Args: []ir.Type{ir.TString}, Builtin: true}},
+		{"len", ir.TInt},
+		{"isEmpty", ir.TBool},
+		{"contains", ir.TBool},
+		{"toString", ir.TString},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			got := bs.recoveredMethodReturnType(setStr, tc.method)
+			if got == nil {
+				t.Fatalf("recoveredMethodReturnType(Set<String>, %q) = nil, want %v", tc.method, tc.want)
+			}
+			if got.String() != tc.want.String() {
+				t.Fatalf("recoveredMethodReturnType(Set<String>, %q) = %v, want %v", tc.method, got, tc.want)
+			}
+		})
+	}
+}
+
+// newRecoveryTestBodyState builds a minimal `*bodyState` with the
+// lowerer plumbing required by `bs.l.listElementType` and
+// `bs.l.setElementType`. The lowerer's stdlib / module state are left
+// empty — the helpers under test only need the receiver type's
+// argument list to extract the element type.
+func newRecoveryTestBodyState() *bodyState {
+	l := &lowerer{}
+	return &bodyState{l: l}
+}
+
 // TestBuiltinMethodReturnTypeOptionUncoveredMethodReturnsNil locks the
 // "no recovery" branch for two distinct categories of Option calls:
 //

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3859,8 +3859,12 @@ func (bs *bodyState) recoveredMethodReturnType(recvT ir.Type, method string) ir.
 			}
 		case "sorted", "reversed", "slice":
 			return recvT
-		case "indexOf", "lastIndexOf":
+		case "indexOf":
 			// IntrinsicListIndexOf returns Int? per mir.go:494.
+			// `lastIndexOf` is intentionally not covered — List only
+			// registers `indexOf` (mir.go:7174) and check_env.osty.
+			// Recovering a non-existent method would mask an invalid
+			// call in checker-skipped contexts; let it fall through.
 			return &ir.OptionalType{Inner: ir.TInt}
 		case "toSet":
 			// IntrinsicListToSet constructs Set<elem> per mir.go:496.

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3859,6 +3859,14 @@ func (bs *bodyState) recoveredMethodReturnType(recvT ir.Type, method string) ir.
 			}
 		case "sorted", "reversed", "slice":
 			return recvT
+		case "indexOf", "lastIndexOf":
+			// IntrinsicListIndexOf returns Int? per mir.go:494.
+			return &ir.OptionalType{Inner: ir.TInt}
+		case "toSet":
+			// IntrinsicListToSet constructs Set<elem> per mir.go:496.
+			if !isPoisonType(elemT) {
+				return &ir.NamedType{Name: "Set", Args: []ir.Type{elemT}, Builtin: true}
+			}
 		case "len":
 			return ir.TInt
 		case "isEmpty", "contains":
@@ -3867,6 +3875,7 @@ func (bs *bodyState) recoveredMethodReturnType(recvT ir.Type, method string) ir.
 			return ir.TString
 		}
 	case "Set":
+		elemT := bs.l.setElementType(recvT)
 		switch method {
 		case "len":
 			return ir.TInt
@@ -3874,6 +3883,11 @@ func (bs *bodyState) recoveredMethodReturnType(recvT ir.Type, method string) ir.
 			return ir.TBool
 		case "toString":
 			return ir.TString
+		case "toList":
+			// IntrinsicSetToList materialises List<elem> per mir.go:559.
+			if !isPoisonType(elemT) {
+				return &ir.NamedType{Name: "List", Args: []ir.Type{elemT}, Builtin: true}
+			}
 		}
 	}
 	return nil

--- a/internal/nativellvmgen/exec.go
+++ b/internal/nativellvmgen/exec.go
@@ -43,6 +43,17 @@ type PackageInput struct {
 	// dep are still emitted so `declare`s in the consumer's IR get
 	// resolved.
 	LibraryMode bool `json:"libraryMode,omitempty"`
+	// PackageName is the dep's declared package name (from its
+	// `osty.toml::[package] name`). When set together with
+	// LibraryMode, the subprocess rewrites every exported function's
+	// LLVM symbol from `<fn>` to `<PackageName>.<fn>` so cross-pkg
+	// callers — which mangle via
+	// `internal/mir/lower.go::qualifiedSymbol` as
+	// `<use.RawPath>.<fn>` — find a matching `define` at link time.
+	// Empty PackageName falls back to the historical bare-name
+	// emission (no rename) for backwards compatibility with callers
+	// that haven't filled the field yet.
+	PackageName string `json:"packageName,omitempty"`
 }
 
 type PackageFile struct {
@@ -190,6 +201,7 @@ func RequestFromPackage(entryPath string, pkg *resolve.Package) (Request, error)
 		Package: &PackageInput{
 			Files:             files,
 			RuntimeCapability: pkg.RuntimeCapability,
+			PackageName:       pkg.Name,
 		},
 	}, nil
 }


### PR DESCRIPTION
## Summary

Cross-pkg signature trajectory follow-up — three related changes stacked in this PR after the original List/Set MIR recovery work picked up review feedback:

### 1. List/Set MIR return-type recovery (`internal/mir/lower.go`)

Extends `recoveredMethodReturnType`'s List/Set arms with intrinsic methods whose return type is fully determined by the receiver:

- **`List<T>`**: `indexOf` → `Option<Int>` (per `IntrinsicListIndexOf`, mir.go:494). `toSet` → `Set<T>` (per `IntrinsicListToSet`, mir.go:496).
- **`Set<T>`**: `toList` → `List<T>` (per `IntrinsicSetToList`, mir.go:559).

`lastIndexOf` is intentionally NOT covered — only `indexOf` exists on List per `stdlibIntrinsicForMethod`. Negative test (`TestRecoveredMethodReturnTypeListLastIndexOfReturnsNil`) locks the absence so a future regression that re-adds it surfaces immediately.

### 2. Cross-pkg link wall measurement doc (`docs/llvm-selfhost-plan-cross-pkg-link-measurement.md`)

Captures the exact trigger of `ld.lld: error: undefined symbol: toolchain.frontInvalidTypeRepr` — symbol mangling drift between consumer (`@<pkg>.<fn>`) and dep library (`@<fn>`). Compares Path α / β / γ and recommends Path α (library-mode qualification).

### 3. Path α impl: library-mode symbol qualification (`cmd/osty-native-llvmgen/`, `internal/nativellvmgen/exec.go`)

- New `PackageInput.PackageName` field — carries the dep's `osty.toml::[package] name` through the subprocess boundary; `RequestFromPackage` populates it from `pkg.Name`.
- New `qualifyExportedSymbolsForLibraryMode(entry, packageName)` pass — runs immediately after `stripMainForLibraryMode` when `LibraryMode + PackageName` are set. Rewrites exported `mir.Function.Name` from `<fn>` to `<packageName>.<fn>` and patches every internal `CallInstr.Callee.Symbol` referencing renamed targets.
- Private helpers stay bare; `#[export("name")]` verbatim symbols (LANG_SPEC §19.6) are honored; empty `PackageName` is a no-op (backwards-compat fallback).

After this change, the dep library `.o` exports the same symbol the consumer's `qualifiedSymbol` mangling produces, unblocking the link step.

## Test plan

- [x] `go test -run 'TestRecoveredMethodReturnType' -v ./internal/mir/` → 13 sub-cases pass (Option/Result/List/Set + negative-arm `lastIndexOf` nil)
- [x] `go test -run 'TestStripMainForLibraryMode|TestQualifyExportedSymbolsForLibraryMode' -v ./cmd/osty-native-llvmgen/` → 6 sub-cases pass (rename + ExportSymbol verbatim + empty-name no-op + nil-safety)
- [x] `go test -short ./internal/mir/ ./internal/nativellvmgen/ ./cmd/osty-native-llvmgen/` → all ok
- [x] `gofmt -l` / `go vet` / `go build ./...` clean
- [x] Pre-existing failures (`TestParseSnapshot/testdata_spec_negative_reject`, `TestStage0RealMIRBaseline/*`) reproduce on `main` without this patch — unchanged by this PR