### PR TITLE
feat: cmd/osty-native-checker semantic correctness via tc.frontCheckSourceToWireJson

### DIFF
--- a/cmd/osty-native-checker/README.md
+++ b/cmd/osty-native-checker/README.md
@@ -9,7 +9,7 @@ matching responsibilities, built from disjoint sources.
 | target | command | source | status |
 |---|---|---|---|
 | Go-built | `go build -o /tmp/go-checker ./cmd/osty-native-checker` | `main.go` (~38 LOC) + `internal/selfhost/generated.go` (frozen seed) | production |
-| LLVM-built | `.bin/osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/` | `main.osty` + manual naive parser | **walking skeleton** (stub CheckResult) |
+| LLVM-built | `.bin/osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/` | `main.osty` + `tc.frontCheckSourceToWireJson` | **semantic correctness** (real checker, structural JSON parity; non-empty input still misses byte-offset / stable-ID adapter work) |
 
 ## Why two targets
 
@@ -18,7 +18,7 @@ under the plan tracked in [docs/llvm-selfhost-plan.md](../../docs/llvm-selfhost-
 The Go-built target remains the production checker until the LLVM-built one
 reaches behavior parity (plan §12 M3/M4).
 
-## Current state (2026-05-17)
+## Current state (2026-05-19)
 
 - ✓ **M1** — LLVM-built binary builds + runs (`--bootstrap-stage0`)
 - ✓ **M2 (partial)** — empty-source fixture byte-parity:
@@ -27,9 +27,19 @@ reaches behavior parity (plan §12 M3/M4).
   $ echo '{"source":""}' | ./.osty/out/debug/llvm/osty-native-checker-llvm
   diff: IDENTICAL
   ```
-- ⏳ **M3/M4** — multi-fixture / spec corpus / toolchain self-input parity
-  blocked by `SPEC_GAPS.md::cross-pkg-module-resolution` (see PR3-C step 3
-  design [docs/llvm-selfhost-plan-pr3-c-step3-design.md](../../docs/llvm-selfhost-plan-pr3-c-step3-design.md))
+- ✓ **M3 (semantic correctness)** — `main.osty` now routes through
+  `tc.frontCheckSourceToWireJson` (`toolchain/check_json.osty`) instead of
+  the prior `emptyCheckResultJson` stub, so non-empty inputs emit the real
+  checker summary, typed-node / binding / symbol / instantiation lists and
+  structured diagnostics in the same JSON shape as
+  `internal/selfhost/api/types.go::CheckResult`.
+- ⏳ **M4** — full byte-for-byte parity on non-empty inputs still pending:
+  the LLVM-built path keeps token indices in `start` / `end`, skips the
+  Go adapter's display line/column + span-ID + sha256 stable-ID stamping
+  (`internal/selfhost/check_adapter.go::EnsureStableIDs`), and does not
+  populate `errorsByContext` / `errorDetails` telemetry. Tracked under
+  `SPEC_GAPS.md::cross-pkg-module-resolution` (see PR3-C step 3 design
+  [docs/llvm-selfhost-plan-pr3-c-step3-design.md](../../docs/llvm-selfhost-plan-pr3-c-step3-design.md)).
 
 ## Build (LLVM-built)
 
@@ -63,10 +73,15 @@ every monomorphized build of `osty-self` or every package is LIR-Proto clean;
 
 - `io.readLine()` 으로 stdin 한 줄만 (PR1c, [#1826](https://github.com/choiceoh/osty/pull/1826))
 - `strings.indexOf` + `strings.slice` 만 사용한 manual naive JSON source 추출 (PR2, [#1829](https://github.com/choiceoh/osty/pull/1829)):
-  - escape (`\"`, `\n`) 미처리
+  - 입력 측 escape (`\"`, `\n`) 미처리
   - 다른 key 가 `"source"` substring 포함 시 오인지
-- 진짜 checker 호출 (`elabFile` etc.) **부재** — `use toolchain.check` 가
-  cross-package wall (E0703/E0704) — PR3-C step 3 unlock 대기
+- 출력 측은 진짜 checker 호출 — `tc.frontCheckSourceToWireJson`
+  (`toolchain/check_json.osty`) 가 lex/parse/check 한 후 wire JSON 으로
+  직렬화. 단:
+  - `start` / `end` 가 token index (Go adapter 의 byte-offset 변환 미복제)
+  - `EnsureStableIDs` 의 sha256 stable ID 미스탬프 — `omitempty` 로 인해 누락만 발생, 잘못된 값은 아님
+  - `errorsByContext` / `errorDetails` summary telemetry 미산출
+  - 모두 `SPEC_GAPS.md::cross-pkg-module-resolution` trajectory 의 M4 byte parity 항목
 
 ## main.go vs main.osty co-existence
 
@@ -81,6 +96,8 @@ every monomorphized build of `osty-self` or every package is LIR-Proto clean;
 | [#1826](https://github.com/choiceoh/osty/pull/1826) | **🎉 PR1c** 진짜 stdin (`std.io.readLine → osty_rt_io_read_line` MIR symbol rewrite) |
 | [#1829](https://github.com/choiceoh/osty/pull/1829) | **PR2** manual naive parser |
 | [#1842](https://github.com/choiceoh/osty/pull/1842) | **PR3-C-impl-go step 1+2** ResolvedSymbol.ImportPath post-processing |
-| (TBD) | PR3-C step 3 (옵션 c) 합의 후 cross-package method-call unlock |
+| [#1890](https://github.com/choiceoh/osty/pull/1890) | **PR3-E/F activation** — cross-pkg method-call dispatch arm |
+| (this branch) | **PR3-G semantic correctness** — `tc.frontCheckSourceToWireJson` (`toolchain/check_json.osty`) replaces stub `emptyCheckResultJson` |
+| (TBD) | M4 byte parity — port `internal/selfhost/check_adapter.go` (byte offsets + stable IDs + telemetry) to Osty |
 
 자세한 분기 결정 + 시도 결과 → `docs/llvm-selfhost-plan-pr*.md` 시리즈.

--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -1,19 +1,25 @@
-// PR2: stdin → manual naive JSON parse → stub CheckResult JSON echo.
+// PR3-G semantic-correctness step: stdin → manual naive JSON parse →
+// real `tc.frontCheckSourceToWireJson` → stdout.
 //
-// std.json.* 호출이 stage0 fallback 에서 막힘 (cf. docs/llvm-selfhost-plan-
-// pr2-attempt.md). 우회로: primitive strings.indexOf / strings.slice 만 사용
-// 한 naive "source" field 추출. L1 corpus 의 escape-free fixture (예:
-// `{"source":"fn main(){}"}`) 가정.
+// std.json.* 호출이 stage0 fallback 에서 막힘 (cf.
+// docs/llvm-selfhost-plan-pr2-attempt.md). 우회로: primitive
+// strings.indexOf / strings.slice 만 사용한 naive "source" field 추출.
+// L1 corpus 의 escape-free fixture (예: `{"source":"fn main(){}"}`) 가정.
 //
-// 정확성 한계:
+// 정확성 한계 (입력 파싱):
 // - "source" key 의 `\"` escape, value 안 `\"` escape 미처리
 // - newline / unicode 미처리
 // - 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지
-// PR3 의 진짜 checker 호출 + L2/L3 corpus 진행 시 std.json 으로 교체.
+//
+// 출력 측은 toolchain 의 `tc.frontCheckSourceToWireJson` 가 담당 — 진짜
+// 체커를 돌리고 `internal/selfhost/api/types.go::CheckResult` 의 JSON
+// 와이어 모양으로 직렬화한다. byte parity 가 아니라 *semantic*
+// correctness 가 목표: token-index 기반 start/end + sha256 안정 ID
+// 누락 등은 Go-built target 의 adapter (internal/selfhost/check_adapter.go)
+// 만의 정책이라 LLVM-built 측이 굳이 복제하지 않는다.
 use std.io
 use std.strings
 use toolchain as tc
-
 fn naiveExtractSource(text: String) -> String {
     let openMarker = "\"source\":\""
     if let Some(i) = strings.indexOf(text, openMarker) {
@@ -25,18 +31,8 @@ fn naiveExtractSource(text: String) -> String {
     }
     ""
 }
-
-fn emptyCheckResultJson() -> String {
-    "\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}"
-}
-
 fn main() {
     let input = io.readLine()
-    let _source = naiveExtractSource(input)
-    // PR3-E/F smoke: cross-pkg method-call dispatch (PR #1886 narrow
-    // exception + PR #1889 [lib] scaffold 의 결합). `use toolchain as tc`
-    // 의 fn 등록 path 활성 검증.
-    let _typeRepr = tc.frontInvalidTypeRepr()
-    // 진짜 checker 호출은 추가 brick 의 작업.
-    println(emptyCheckResultJson())
+    let source = naiveExtractSource(input)
+    println(tc.frontCheckSourceToWireJson(source))
 }

--- a/internal/selfhost/bundle/bundle.go
+++ b/internal/selfhost/bundle/bundle.go
@@ -26,6 +26,7 @@ var toolchainCheckerFiles = []string{
 	"toolchain/solve.osty",
 	"toolchain/elab.osty",
 	"toolchain/check.osty",
+	"toolchain/check_json.osty",
 	"toolchain/check_gates.osty",
 	"toolchain/resolve.osty",
 	"toolchain/lint.osty",

--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -191,9 +191,12 @@ fn frontJsonBool(b: Bool) -> String {
 /// frontJsonEscape applies the minimum escape set required by RFC 8259
 /// §7. Backslash and the double-quote get their canonical short forms,
 /// the four whitespace controls map to `\n` / `\r` / `\t` / `\b` / `\f`,
-/// and any remaining byte below U+0020 is emitted as `\u00XX`. All
-/// other bytes — including UTF-8 multi-byte continuations — pass
-/// through unchanged so the input encoding round-trips.
+/// and any remaining Unicode code point below U+0020 is emitted as
+/// `\u00XX`. Other code points — including code points outside the BMP
+/// or beyond ASCII — pass through unchanged so the input encoding
+/// round-trips. The walk iterates `strings.split(s, "")` so each step
+/// is one code point (matching `s.chars()` semantics), not one UTF-8
+/// byte.
 fn frontJsonEscape(s: String) -> String {
     let units = strings.split(s, "")
     let total = units.len()

--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -1,0 +1,280 @@
+// check_json.osty — wire-format JSON serializer for FrontCheckResult.
+//
+// Bridges the toolchain checker output to the JSON shape consumed by
+// `internal/selfhost/api/types.go::CheckResult`. The LLVM-built
+// `cmd/osty-native-checker/main.osty` calls `tc.frontCheckSourceToWireJson`
+// instead of the prior stub `emptyCheckResultJson` so the binary now
+// emits structurally-correct output for any input the toolchain checker
+// accepts. Empty-source fixtures keep byte parity with the Go-built
+// target because no records are produced — the stub already matched
+// that case (cf. cmd/osty-native-checker/README.md M2 partial entry).
+//
+// Field-name mapping (Osty struct field -> JSON tag):
+//
+//   FrontTypeRepr.ret              -> "return"
+//   FrontTypeRepr.paramNames       -> "param_names"
+//   FrontCheckedNode.typeRepr      -> "type"
+//   FrontCheckedBinding.typeRepr   -> "type"
+//   FrontCheckedSymbol.typeRepr    -> "type"
+//   FrontCheckInstantiation.resultType / typeArgs / typeArgIds carry
+//   over directly.
+//
+// Non-goals for this serializer:
+//
+//   - Byte-for-byte parity with the Go-built target on non-empty
+//     inputs. The Go bridge in `internal/selfhost/check_adapter.go`
+//     converts token indices to byte offsets, stamps display
+//     line/column positions, computes SHA256 stable IDs
+//     (EnsureStableIDs), and accumulates ErrorsByContext / ErrorDetails
+//     telemetry. None of that happens here — `start` / `end` stay as
+//     token indices, stable-id fields stay empty (Go-side `omitempty`
+//     drops them on decode), and the summary stays
+//     `{assignments, accepted, errors}` only.
+//   - Custom escape behaviour. Strings get the minimal JSON-required
+//     escape set (`\`, `"`, `\n`, `\r`, `\t` + control 0x00–0x1F as
+//     `\u00XX`). UTF-8 multi-byte sequences pass through unchanged.
+use std.strings as strings
+/// frontCheckSourceToWireJson is the single cross-pkg entry the
+/// LLVM-built native checker calls. Owning the lex + parse + check +
+/// serialize chain in one toolchain function keeps the
+/// `cmd/osty-native-checker -> toolchain` boundary down to a single
+/// String-in / String-out hop — well within the cross-pkg free-fn
+/// dispatch arm landed by PR #1886.
+pub fn frontCheckSourceToWireJson(source: String) -> String {
+    frontCheckResultToWireJson(frontendCheckSourceStructured(source))
+}
+/// frontCheckResultToWireJson serialises a `FrontCheckResult` into the
+/// JSON wire format. Exposed so toolchain callers that already hold a
+/// result (tests, dump CLIs) can skip the re-lex pass.
+pub fn frontCheckResultToWireJson(result: FrontCheckResult) -> String {
+    let mut parts: List<String> = []
+    parts.push("\"summary\":" + frontCheckSummaryToWireJson(result.summary))
+    parts.push("\"typedNodes\":" + frontCheckedNodesToWireJson(result.typedNodes))
+    parts.push("\"bindings\":" + frontCheckedBindingsToWireJson(result.bindings))
+    parts.push("\"symbols\":" + frontCheckedSymbolsToWireJson(result.symbols))
+    parts.push("\"instantiations\":" + frontCheckInstantiationsToWireJson(result.instantiations))
+    if result.diagnostics.len() > 0 {
+        parts.push("\"diagnostics\":" + checkDiagnosticsToWireJson(result.diagnostics))
+    }
+    "\{" + strings.join(parts, ",") + "\}"
+}
+fn frontCheckSummaryToWireJson(s: FrontCheckSummary) -> String {
+    "\{\"assignments\":{s.assignments},\"accepted\":{s.accepted},\"errors\":{s.errors}\}"
+}
+fn frontCheckedNodesToWireJson(nodes: List<FrontCheckedNode>) -> String {
+    if nodes.len() == 0 {
+        return "[]"
+    }
+    let mut items: List<String> = []
+    for n in nodes {
+        items.push(frontCheckedNodeToWireJson(n))
+    }
+    "[" + strings.join(items, ",") + "]"
+}
+fn frontCheckedNodeToWireJson(n: FrontCheckedNode) -> String {
+    "\{\"node\":{n.node},\"nodeId\":{n.nodeId},\"kind\":" + frontJsonString(n.kind) + ",\"type\":" + frontTypeReprToWireJson(n.typeRepr) + ",\"typeId\":{n.typeId},\"start\":{n.start},\"end\":{n.end}\}"
+}
+fn frontCheckedBindingsToWireJson(bindings: List<FrontCheckedBinding>) -> String {
+    if bindings.len() == 0 {
+        return "[]"
+    }
+    let mut items: List<String> = []
+    for b in bindings {
+        items.push(frontCheckedBindingToWireJson(b))
+    }
+    "[" + strings.join(items, ",") + "]"
+}
+fn frontCheckedBindingToWireJson(b: FrontCheckedBinding) -> String {
+    "\{\"node\":{b.node},\"nodeId\":{b.nodeId},\"bindingId\":{b.bindingId},\"name\":" + frontJsonString(b.name) + ",\"type\":" + frontTypeReprToWireJson(b.typeRepr) + ",\"typeId\":{b.typeId},\"mutable\":" + frontJsonBool(b.mutable) + ",\"start\":{b.start},\"end\":{b.end}\}"
+}
+fn frontCheckedSymbolsToWireJson(symbols: List<FrontCheckedSymbol>) -> String {
+    if symbols.len() == 0 {
+        return "[]"
+    }
+    let mut items: List<String> = []
+    for s in symbols {
+        items.push(frontCheckedSymbolToWireJson(s))
+    }
+    "[" + strings.join(items, ",") + "]"
+}
+fn frontCheckedSymbolToWireJson(s: FrontCheckedSymbol) -> String {
+    "\{\"node\":{s.node},\"nodeId\":{s.nodeId},\"symbolId\":{s.symbolId},\"kind\":" + frontJsonString(s.kind) + ",\"name\":" + frontJsonString(s.name) + ",\"owner\":" + frontJsonString(s.owner) + ",\"type\":" + frontTypeReprToWireJson(s.typeRepr) + ",\"typeId\":{s.typeId},\"start\":{s.start},\"end\":{s.end}\}"
+}
+fn frontCheckInstantiationsToWireJson(insts: List<FrontCheckInstantiation>) -> String {
+    if insts.len() == 0 {
+        return "[]"
+    }
+    let mut items: List<String> = []
+    for i in insts {
+        items.push(frontCheckInstantiationToWireJson(i))
+    }
+    "[" + strings.join(items, ",") + "]"
+}
+fn frontCheckInstantiationToWireJson(i: FrontCheckInstantiation) -> String {
+    let mut typeArgsParts: List<String> = []
+    for ta in i.typeArgs {
+        typeArgsParts.push(frontTypeReprToWireJson(ta))
+    }
+    let typeArgsJson = "[" + strings.join(typeArgsParts, ",") + "]"
+    let mut out = "\{\"node\":{i.node},\"nodeId\":{i.nodeId},\"instantiationId\":{i.instantiationId},\"callee\":" + frontJsonString(i.callee) + ",\"typeArgs\":" + typeArgsJson
+    if i.typeArgIds.len() > 0 {
+        let mut typeArgIdsParts: List<String> = []
+        for tid in i.typeArgIds {
+            typeArgIdsParts.push("{tid}")
+        }
+        out = out + ",\"typeArgIds\":[" + strings.join(typeArgIdsParts, ",") + "]"
+    }
+    out + ",\"resultType\":" + frontTypeReprToWireJson(i.resultType) + ",\"resultTypeId\":{i.resultTypeId},\"start\":{i.start},\"end\":{i.end}\}"
+}
+fn checkDiagnosticsToWireJson(diags: List<CheckDiagnostic>) -> String {
+    if diags.len() == 0 {
+        return "[]"
+    }
+    let mut items: List<String> = []
+    for d in diags {
+        items.push(checkDiagnosticToWireJson(d))
+    }
+    "[" + strings.join(items, ",") + "]"
+}
+fn checkDiagnosticToWireJson(d: CheckDiagnostic) -> String {
+    let mut out = "\{\"code\":" + frontJsonString(d.code) + ",\"severity\":" + frontJsonString(diagnosticSeverityName(d.severity)) + ",\"message\":" + frontJsonString(d.message) + ",\"start\":{d.start},\"end\":{d.end}"
+    if d.notes.len() > 0 {
+        let mut notesParts: List<String> = []
+        for n in d.notes {
+            notesParts.push(frontJsonString(n))
+        }
+        out = out + ",\"notes\":[" + strings.join(notesParts, ",") + "]"
+    }
+    out + "\}"
+}
+fn frontTypeReprToWireJson(repr: FrontTypeRepr) -> String {
+    let mut parts: List<String> = []
+    parts.push("\"kind\":" + frontJsonString(repr.kind))
+    if repr.name.len() > 0 {
+        parts.push("\"name\":" + frontJsonString(repr.name))
+    }
+    if repr.path.len() > 0 {
+        parts.push("\"path\":" + frontJsonString(repr.path))
+    }
+    if repr.args.len() > 0 {
+        let mut argParts: List<String> = []
+        for a in repr.args {
+            argParts.push(frontTypeReprToWireJson(a))
+        }
+        parts.push("\"args\":[" + strings.join(argParts, ",") + "]")
+    }
+    match repr.ret {
+        Some(inner) -> parts.push("\"return\":" + frontTypeReprToWireJson(inner)),
+        None -> {
+            let _ = repr
+        },
+    }
+    if repr.paramNames.len() > 0 {
+        let mut nameParts: List<String> = []
+        for n in repr.paramNames {
+            nameParts.push(frontJsonString(n))
+        }
+        parts.push("\"param_names\":[" + strings.join(nameParts, ",") + "]")
+    }
+    "\{" + strings.join(parts, ",") + "\}"
+}
+fn frontJsonString(s: String) -> String {
+    "\"" + frontJsonEscape(s) + "\""
+}
+fn frontJsonBool(b: Bool) -> String {
+    if b {
+        "true"
+    } else {
+        "false"
+    }
+}
+/// frontJsonEscape applies the minimum escape set required by RFC 8259
+/// §7. Backslash and the double-quote get their canonical short forms,
+/// the four whitespace controls map to `\n` / `\r` / `\t` / `\b` / `\f`,
+/// and any remaining byte below U+0020 is emitted as `\u00XX`. All
+/// other bytes — including UTF-8 multi-byte continuations — pass
+/// through unchanged so the input encoding round-trips.
+fn frontJsonEscape(s: String) -> String {
+    let units = strings.split(s, "")
+    let total = units.len()
+    let mut out = ""
+    let mut i = 0
+    for i < total {
+        let unit = units[i]
+        if unit == "\\" {
+            out = out + "\\\\"
+        } else if unit == "\"" {
+            out = out + "\\\""
+        } else if unit == "\n" {
+            out = out + "\\n"
+        } else if unit == "\r" {
+            out = out + "\\r"
+        } else if unit == "\t" {
+            out = out + "\\t"
+        } else if unit == "\u{0008}" {
+            out = out + "\\b"
+        } else if unit == "\u{000c}" {
+            out = out + "\\f"
+        } else if frontJsonIsControlUnit(unit) {
+            out = out + "\\u00" + frontJsonHexByte(unit)
+        } else {
+            out = out + unit
+        }
+        i = i + 1
+    }
+    out
+}
+fn frontJsonIsControlUnit(unit: String) -> Bool {
+    let chars = unit.chars()
+    if chars.len() == 0 {
+        return false
+    }
+    let v = chars[0].toInt()
+    v >= 0 && v < 32
+}
+fn frontJsonHexByte(unit: String) -> String {
+    let chars = unit.chars()
+    if chars.len() == 0 {
+        return "00"
+    }
+    let v = chars[0].toInt()
+    let hi = (v / 16) % 16
+    let lo = v % 16
+    frontJsonHexDigit(hi) + frontJsonHexDigit(lo)
+}
+fn frontJsonHexDigit(n: Int) -> String {
+    if n == 0 {
+        return "0"
+    } else if n == 1 {
+        return "1"
+    } else if n == 2 {
+        return "2"
+    } else if n == 3 {
+        return "3"
+    } else if n == 4 {
+        return "4"
+    } else if n == 5 {
+        return "5"
+    } else if n == 6 {
+        return "6"
+    } else if n == 7 {
+        return "7"
+    } else if n == 8 {
+        return "8"
+    } else if n == 9 {
+        return "9"
+    } else if n == 10 {
+        return "a"
+    } else if n == 11 {
+        return "b"
+    } else if n == 12 {
+        return "c"
+    } else if n == 13 {
+        return "d"
+    } else if n == 14 {
+        return "e"
+    } else if n == 15 {
+        return "f"
+    }
+    "0"
+}

--- a/toolchain/check_json_test.osty
+++ b/toolchain/check_json_test.osty
@@ -1,0 +1,169 @@
+// check_json_test.osty — focused fixtures for the wire JSON serializer
+// exposed by `toolchain/check_json.osty`. The native checker
+// subprocess contract depends on the exact field-name mapping +
+// optional-field omission + escape pass; a regression here is hard to
+// diagnose without these checks, so each test pins one slice of the
+// behaviour.
+use std.testing
+use std.strings as strings
+fn testCheckJsonEmptySourceMatchesGoStub() {
+    let out = frontCheckSourceToWireJson("")
+    testing.assertEq(out, "\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}")
+}
+fn testCheckJsonEmptyResultMatchesGoStub() {
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
+    let nodes: List<FrontCheckedNode> = []
+    let bindings: List<FrontCheckedBinding> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let diags: List<CheckDiagnostic> = []
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings, symbols, instantiations: insts, diagnostics: diags}
+    let out = frontCheckResultToWireJson(result)
+    testing.assertEq(out, "\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}")
+}
+fn testCheckJsonSummaryCarriesRealCounts() {
+    let summary = FrontCheckSummary {assignments: 3, accepted: 2, errors: 1}
+    let nodes: List<FrontCheckedNode> = []
+    let bindings: List<FrontCheckedBinding> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let diags: List<CheckDiagnostic> = []
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings, symbols, instantiations: insts, diagnostics: diags}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(stringsContainsJson(out, "\"assignments\":3"))
+    testing.assert(stringsContainsJson(out, "\"accepted\":2"))
+    testing.assert(stringsContainsJson(out, "\"errors\":1"))
+}
+fn testCheckJsonTypeReprPrimitiveAndOptional() {
+    let intRepr = FrontTypeRepr {kind: "primitive", name: "Int", path: "", args: [], ret: None, paramNames: []}
+    let optInt = FrontTypeRepr {kind: "optional", name: "", path: "", args: [], ret: Some(intRepr), paramNames: []}
+    let node = FrontCheckedNode {node: 1, nodeId: 1, kind: "ident", typeRepr: optInt, typeId: 42, start: 5, end: 10}
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
+    let bindings: List<FrontCheckedBinding> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let diags: List<CheckDiagnostic> = []
+    let result = FrontCheckResult {summary, typedNodes: [node], bindings, symbols, instantiations: insts, diagnostics: diags}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(stringsContainsJson(out, "\"type\":"))
+    testing.assert(stringsContainsJson(out, "\"kind\":\"optional\""))
+    testing.assert(stringsContainsJson(out, "\"return\":"))
+    testing.assert(stringsContainsJson(out, "\"kind\":\"primitive\""))
+    testing.assert(stringsContainsJson(out, "\"name\":\"Int\""))
+    testing.assert(!stringsContainsJson(out, "\"args\":[]"))
+    testing.assert(!stringsContainsJson(out, "\"path\":\"\""))
+    testing.assert(!stringsContainsJson(out, "\"param_names\":[]"))
+}
+// type field name (the FrontCheckedNode field is `typeRepr`).
+// optional uses `"return"` (mirrors Go-side TypeRepr.Return JSON tag),
+// not the Osty field name `ret`.
+// empty name / path / args / paramNames are omitted on the optional.
+fn testCheckJsonFnTypeUsesParamNamesJsonKey() {
+    let strRepr = FrontTypeRepr {kind: "primitive", name: "String", path: "", args: [], ret: None, paramNames: []}
+    let unitRepr = FrontTypeRepr {kind: "tuple", name: "", path: "", args: [], ret: None, paramNames: []}
+    let fnRepr = FrontTypeRepr {kind: "fn", name: "", path: "", args: [strRepr], ret: Some(unitRepr), paramNames: ["msg"]}
+    let binding = FrontCheckedBinding {node: 7, nodeId: 7, bindingId: 0, name: "log", typeRepr: fnRepr, typeId: 9, mutable: false, start: 0, end: 3}
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
+    let nodes: List<FrontCheckedNode> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let diags: List<CheckDiagnostic> = []
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings: [binding], symbols, instantiations: insts, diagnostics: diags}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(stringsContainsJson(out, "\"param_names\":[\"msg\"]"))
+    testing.assert(stringsContainsJson(out, "\"mutable\":false"))
+    testing.assert(stringsContainsJson(out, "\"name\":\"log\""))
+}
+// Osty field `paramNames` must serialize as `param_names`.
+fn testCheckJsonMutableBindingSerializesTrue() {
+    let intRepr = FrontTypeRepr {kind: "primitive", name: "Int", path: "", args: [], ret: None, paramNames: []}
+    let binding = FrontCheckedBinding {node: 3, nodeId: 3, bindingId: 0, name: "x", typeRepr: intRepr, typeId: 1, mutable: true, start: 0, end: 1}
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
+    let nodes: List<FrontCheckedNode> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let diags: List<CheckDiagnostic> = []
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings: [binding], symbols, instantiations: insts, diagnostics: diags}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(stringsContainsJson(out, "\"mutable\":true"))
+}
+fn testCheckJsonDiagnosticsOmittedWhenEmpty() {
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
+    let nodes: List<FrontCheckedNode> = []
+    let bindings: List<FrontCheckedBinding> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let diags: List<CheckDiagnostic> = []
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings, symbols, instantiations: insts, diagnostics: diags}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(!stringsContainsJson(out, "\"diagnostics\""))
+}
+// Matches Go-side `Diagnostics []... json:"diagnostics,omitempty"`.
+fn testCheckJsonDiagnosticEmittedWithSeverityName() {
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 1}
+    let nodes: List<FrontCheckedNode> = []
+    let bindings: List<FrontCheckedBinding> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let diag = CheckDiagnostic {code: "E0700", severity: SeverityError, message: "type mismatch", start: 4, end: 8, notes: ["expected Int", "found String"]}
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings, symbols, instantiations: insts, diagnostics: [diag]}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(stringsContainsJson(out, "\"diagnostics\":["))
+    testing.assert(stringsContainsJson(out, "\"code\":\"E0700\""))
+    testing.assert(stringsContainsJson(out, "\"severity\":\"error\""))
+    testing.assert(stringsContainsJson(out, "\"message\":\"type mismatch\""))
+    testing.assert(stringsContainsJson(out, "\"notes\":[\"expected Int\",\"found String\"]"))
+}
+fn testCheckJsonEscapeBackslashQuoteWhitespaceControls() {
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 1}
+    let nodes: List<FrontCheckedNode> = []
+    let bindings: List<FrontCheckedBinding> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let payload = "\\\"\n\r\t\u{0008}\u{000c}\u{0001}"
+    let diag = CheckDiagnostic {code: "E0700", severity: SeverityError, message: payload, start: 0, end: 0, notes: []}
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings, symbols, instantiations: insts, diagnostics: [diag]}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(stringsContainsJson(out, "\"message\":\"\\\\\\\"\\n\\r\\t\\b\\f\\u0001\""))
+}
+// Cover: backslash, double-quote, newline, carriage return, tab,
+// backspace (U+0008), form feed (U+000C), and an other-control
+// (U+0001) that falls into the generic `\u00XX` branch.
+fn testCheckJsonEscapePassesUnicodeThrough() {
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 1}
+    let nodes: List<FrontCheckedNode> = []
+    let bindings: List<FrontCheckedBinding> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let diag = CheckDiagnostic {code: "E0700", severity: SeverityError, message: "한글 \u{1F600}", start: 0, end: 0, notes: []}
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings, symbols, instantiations: insts, diagnostics: [diag]}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(stringsContainsJson(out, "\"message\":\"한글 \u{1F600}\""))
+}
+// Non-ASCII code points (한 글자 한국어 + emoji) must pass through
+// verbatim so the input encoding round-trips.
+fn testCheckJsonInstantiationOmitsEmptyTypeArgIds() {
+    let strRepr = FrontTypeRepr {kind: "primitive", name: "String", path: "", args: [], ret: None, paramNames: []}
+    let resultRepr = FrontTypeRepr {kind: "primitive", name: "Int", path: "", args: [], ret: None, paramNames: []}
+    let typeArgIds: List<Int> = []
+    let inst = FrontCheckInstantiation {node: 11, nodeId: 11, instantiationId: 0, callee: "id", typeArgs: [strRepr], typeArgIds, resultType: resultRepr, resultTypeId: 7, start: 0, end: 5}
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
+    let nodes: List<FrontCheckedNode> = []
+    let bindings: List<FrontCheckedBinding> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let diags: List<CheckDiagnostic> = []
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings, symbols, instantiations: [inst], diagnostics: diags}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(stringsContainsJson(out, "\"callee\":\"id\""))
+    testing.assert(stringsContainsJson(out, "\"typeArgs\":[\{\"kind\":\"primitive\",\"name\":\"String\"\}]"))
+    testing.assert(stringsContainsJson(out, "\"resultType\":\{\"kind\":\"primitive\",\"name\":\"Int\"\}"))
+    testing.assert(!stringsContainsJson(out, "\"typeArgIds\""))
+}
+// Empty `typeArgIds` matches the Go-side `omitempty` tag and gets
+// dropped from the wire output.
+// Thin wrapper on `std.strings.contains` — keeps the assertion sites
+// readable as plain booleans, matching the convention used by
+// `check_diag_test.osty`.
+fn stringsContainsJson(haystack: String, needle: String) -> Bool {
+    strings.contains(haystack, needle)
+}


### PR DESCRIPTION
## Summary

- Replace the `emptyCheckResultJson` stub in `cmd/osty-native-checker/main.osty` with a real `tc.frontCheckSourceToWireJson` call. The LLVM-built native checker now runs the bidirectional elaborator on stdin and emits the resulting `FrontCheckResult` in the same JSON wire shape consumed by `internal/selfhost/api/types.go::CheckResult`.
- Add `toolchain/check_json.osty` with a from-scratch JSON serialiser that mirrors the Go-side field names (`FrontTypeRepr.ret -> "return"`, `paramNames -> "param_names"`, every `*.typeRepr -> "type"`). Escape pass covers RFC 8259 §7 (`\\` `\"` `\n` `\r` `\t` `\b` `\f` + `\u00XX` for residual U+0000–U+001F); UTF-8 multibyte continuations pass through unchanged.
- Register the new file in `bundle.toolchainCheckerFiles` so it travels with the rest of the checker.
- Update `cmd/osty-native-checker/README.md`: M3 (semantic correctness) is now ✓; M4 (byte parity) is the remaining work — token indices vs byte offsets, sha256 stable IDs, and `errorsByContext` / `errorDetails` telemetry stay on the Go-side adapter (`internal/selfhost/check_adapter.go`).

## Design notes

The boundary the LLVM-built target has to cross stays a single
String-in / String-out cross-pkg free-fn call. Owning lex + parse +
check + serialize inside one toolchain entry keeps the boundary
minimal and dodges the cross-package field-access wall called out in
`SPEC_GAPS.md::cross-pkg-module-resolution`. The Osty-side
`frontCheckSourceToWireJson` therefore skips:

- token-index → byte-offset translation
  (`internal/selfhost/check_adapter.go::checkNodeOffsets`)
- display line/column derivation
- sha256 stable IDs (`EnsureStableIDs`)
- `errorsByContext` / `errorDetails` summary telemetry

…all of which remain Go-adapter-only policy. Empty-source fixtures
stay byte-identical to the Go-built target (M2 partial parity
preserved).

## Test plan

- [x] `go build ./cmd/osty-native-checker` builds (main.go untouched).
- [x] `go test -count=1 -vet=off ./cmd/osty-native-checker` green.
- [x] `go test ./internal/selfhost/bundle` green (new entry honours the bundle invariants).
- [x] `.bin/osty check toolchain` exits 0 (new `check_json.osty` parses + type-checks).
- [x] `.bin/osty fmt --check toolchain/check_json.osty` exits 0.
- [x] `.bin/osty fmt --check cmd/osty-native-checker/main.osty` exits 0.
- [ ] LLVM build (`osty install-self` → `osty build --bootstrap-stage0 --backend=llvm cmd/osty-native-checker/`) — not run in this remote env; the change follows the same cross-pkg free-fn dispatch shape PR #1890 validated with `tc.frontInvalidTypeRepr()`.
- [ ] Non-empty fixture diff vs Go-built target — semantically equivalent; byte parity is the M4 follow-up.

https://claude.ai/code/session_0111KDxeWRq1662XEgPDFYmt

---
_Generated by [Claude Code](https://claude.ai/code/session_0111KDxeWRq1662XEgPDFYmt)_