### PR TITLE
fix: pointer-keyed TypeRefsByID lookup eliminates 262 cross-file IR mismaps + drops PR #1919 guard

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -945,6 +945,17 @@ func (l *lowerer) typeRef(nt *ast.NamedType) *resolve.Symbol {
 	if nt == nil {
 		return nil
 	}
+	// `l.res == nil` is the "bypass the resolver entirely" signal
+	// (see `lowerStdlibType`, which sets it temporarily so stdlib
+	// stub nodes lower via pure AST-shape classification). Honour
+	// that contract by skipping the pointer-keyed map too —
+	// otherwise a stdlib stub nt that happens to be registered in
+	// `typeRefByPtr` (e.g. when the outer lowerer was built from a
+	// stdlib `*resolve.Result`) would still receive a resolver
+	// answer.
+	if l.res == nil {
+		return nil
+	}
 	// Prefer the pointer-keyed map when populated: it is immune to
 	// `NodeID` collisions across files, so foreign-file NamedTypes
 	// reached via `sym.Decl` walks (see `recoverFnDeclReturnType`)
@@ -954,9 +965,6 @@ func (l *lowerer) typeRef(nt *ast.NamedType) *resolve.Symbol {
 		if sym, ok := l.typeRefByPtr[nt]; ok {
 			return sym
 		}
-	}
-	if l.res == nil {
-		return nil
 	}
 	return l.res.TypeRefsByID[nt.ID]
 }

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -33,7 +33,12 @@ func LowerFnDecl(pkgName string, fn *ast.FnDecl, res *resolve.Result, chk *check
 	if fn == nil {
 		return nil, nil
 	}
-	l := &lowerer{pkgName: pkgName, res: res, chk: chk}
+	l := &lowerer{
+		pkgName:      pkgName,
+		res:          res,
+		chk:          chk,
+		typeRefByPtr: buildSingleFileTypeRefMap(res),
+	}
 	out := l.lowerFnDecl(fn)
 	return out, l.issues
 }
@@ -48,7 +53,12 @@ func LowerLetDecl(pkgName string, ld *ast.LetDecl, res *resolve.Result, chk *che
 	if ld == nil {
 		return nil, nil
 	}
-	l := &lowerer{pkgName: pkgName, res: res, chk: chk}
+	l := &lowerer{
+		pkgName:      pkgName,
+		res:          res,
+		chk:          chk,
+		typeRefByPtr: buildSingleFileTypeRefMap(res),
+	}
 	out := l.lowerLetDecl(ld)
 	return out, l.issues
 }
@@ -67,7 +77,13 @@ func LowerLetDecl(pkgName string, ld *ast.LetDecl, res *resolve.Result, chk *che
 // The returned Module is always non-nil — it just contains ErrorStmt /
 // ErrorExpr nodes in positions that failed.
 func Lower(pkgName string, file *ast.File, res *resolve.Result, chk *check.Result) (*Module, []error) {
-	l := &lowerer{pkgName: pkgName, file: file, res: res, chk: chk}
+	l := &lowerer{
+		pkgName:      pkgName,
+		file:         file,
+		res:          res,
+		chk:          chk,
+		typeRefByPtr: buildSingleFileTypeRefMap(res),
+	}
 	return l.run()
 }
 
@@ -95,6 +111,14 @@ func LowerPackage(pkgName string, pkg *resolve.Package, chk *check.Result) (*Mod
 	}
 	mod := &Module{Package: pkgName}
 	var issues []error
+	// Build the package-wide pointer-keyed `TypeRefsByID` shadow
+	// once so every per-file lowerer shares the same view. Cross-
+	// file recovery paths (`recoverFnDeclReturnType` etc.) reach
+	// foreign-file `*ast.NamedType` nodes whose `NodeID` collides
+	// with unrelated nodes in the lowerer's current file; the
+	// pointer-keyed map disambiguates them by node identity rather
+	// than ID.
+	typeRefByPtr := buildPkgTypeRefMap(pkg)
 	for i, pf := range pkg.Files {
 		if pf == nil {
 			continue
@@ -110,7 +134,13 @@ func LowerPackage(pkgName string, pkg *resolve.Package, chk *check.Result) (*Mod
 			TypeRefIdents: pf.TypeRefIdents,
 			FileScope:     pf.FileScope,
 		}
-		l := &lowerer{pkgName: pkgName, file: file, res: res, chk: chk}
+		l := &lowerer{
+			pkgName:      pkgName,
+			file:         file,
+			res:          res,
+			chk:          chk,
+			typeRefByPtr: typeRefByPtr,
+		}
 		fileMod, fileIssues := l.run()
 		if i == 0 {
 			mod.SpanV = fileMod.SpanV
@@ -150,6 +180,21 @@ type lowerer struct {
 
 	// native caches structured selfhost checker facts for this lowering pass.
 	native nativeCheckCache
+
+	// typeRefByPtr is a pointer-keyed shadow of `res.TypeRefsByID`.
+	// `TypeRefsByID` is per-file and keyed by `ast.NodeID`, which is
+	// only unique within one `*ast.File`. When the lowerer crosses
+	// into a foreign file's AST (e.g. via
+	// `recoverFnDeclReturnType`'s `sym.Decl.(*ast.FnDecl).ReturnType`
+	// walk), the ID-keyed lookup against the current file's
+	// `res.TypeRefsByID` collides with whatever node happens to
+	// share the same `NodeID` in the current file. The
+	// pointer-keyed map keys by the `*ast.NamedType` itself, so
+	// foreign-file NamedTypes route to the correct symbol regardless
+	// of the lowerer's "current file" context. Populated by
+	// `LowerPackage` and per-file `Lower` from each file's
+	// `pf.TypeRefIdents` / `pf.TypeRefsByID` pair.
+	typeRefByPtr map[*ast.NamedType]*resolve.Symbol
 }
 
 // ==== Top level ====
@@ -834,19 +879,13 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 
 	// Consult the resolver for the head symbol so we can classify
 	// builtins vs user declarations vs generic parameters. The
-	// `resolverSymbolMatchesSourceName` guard rejects answers whose
-	// `Name` doesn't match the source's bare ident (a `TypeRefsByID`
-	// mismapping that has been observed in multi-file packages —
-	// see the helper's doc and PR #1919); rejected lookups fall
-	// through to source-name-based classification at the bottom of
-	// the function. Each rejection is also logged through the
-	// `OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD` env-gated trace so the
-	// underlying resolver bug stays observable.
+	// pointer-keyed `typeRef` lookup is safe across files (see
+	// `typeRefByPtr`), so the previous defensive name-match guard
+	// added in PR #1919 is no longer needed — cross-file leaks via
+	// `recoverFnDeclReturnType` and siblings used to surface as
+	// wrong-name symbols here, but the package-wide pointer map
+	// disambiguates them by node identity.
 	sym := l.typeRef(nt)
-	if sym != nil && !resolverSymbolMatchesSourceName(sym, pkg, name, nt.Path) {
-		traceLowerNamedTypeGuardReject(name, sym.Name, pkg)
-		sym = nil
-	}
 	if sym != nil {
 		symName := sym.Name
 		if pkg != "" && len(nt.Path) > 0 && symName == nt.Path[0] {
@@ -887,92 +926,6 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 	return &NamedType{Package: pkg, Name: name, Args: args}
 }
 
-// resolverSymbolMatchesSourceName guards `lowerNamedType`'s
-// resolver-driven path against `TypeRefsByID` mismappings that
-// have been observed in multi-file packages — for example, the
-// `List` head ident in `hintTupleElems`'s return type signature
-// (toolchain/inspect_hint.osty) resolves to the `FrontCheckResult`
-// symbol (toolchain/check.osty) instead of `List`, producing a
-// downstream `FrontCheckResult__len` undefined symbol at
-// install-self link. See PR #1916 / #1917 / #1918 for the three
-// stages of the bisection that pinpointed this site.
-//
-// The guard accepts the resolver-returned symbol when either:
-//
-//   - the source is **bare** (no package qualifier) AND the
-//     symbol's `Name` matches the source path's last component.
-//     Bare paths must round-trip through the resolver under their
-//     source name; anything else is a TypeRefsByID mismapping.
-//   - the source is **package-qualified** (`pkg != ""`).
-//     Cross-package type references legitimately route through
-//     arbitrarily-named symbols (e.g. `use foo as bar` +
-//     `bar.Baz` resolves through package alias machinery), so
-//     trust the resolver in that path.
-//
-// When the guard rejects, `lowerNamedType` skips the resolver
-// path and falls through to the source-name-based builtin /
-// generic-name resolution at the bottom of the function, which
-// correctly classifies `List` / `Map` / `Set` / `Option` /
-// `Result` as builtin containers and everything else as a user-
-// named type. Each rejection is also logged through
-// `traceLowerNamedTypeGuardReject` (env-gated) so the underlying
-// resolver `TypeRefsByID` bug remains observable for follow-up
-// investigation rather than silently masked.
-func resolverSymbolMatchesSourceName(sym *resolve.Symbol, pkg, name string, path []string) bool {
-	if sym == nil {
-		return false
-	}
-	if pkg == "" {
-		return sym.Name == name
-	}
-	// Package-qualified path: trust the resolver. Cross-package
-	// type references legitimately route through arbitrarily-named
-	// symbols, so accepting the resolver answer avoids false-
-	// positives on legitimate aliases. The `path` parameter is
-	// retained on the signature for parity with the qualified-path
-	// caller — future tightening of this branch can use it to
-	// require `sym.Name == path[0]` instead of the unconditional
-	// trust, but doing so today would regress on the
-	// `pub use std.X as Y` rename machinery.
-	_ = path
-	return true
-}
-
-// ==== lowerNamedType guard-reject trace (env-gated diagnostic) ====
-//
-// `OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD=1` enables a stderr line
-// each time `resolverSymbolMatchesSourceName` rejects a resolver-
-// returned symbol. Used so the underlying resolver `TypeRefsByID`
-// bug (`List` AST node → `FrontCheckResult` symbol etc.) remains
-// observable when the IR-layer guard masks its downstream
-// FrontCheckResult__len failure mode.
-
-var lowerNamedTypeGuardTraceWriter io.Writer = os.Stderr
-
-func lowerNamedTypeGuardTraceEnabled() bool {
-	switch os.Getenv("OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD") {
-	case "", "0", "false", "off":
-		return false
-	default:
-		return true
-	}
-}
-
-// traceLowerNamedTypeGuardReject records each guard rejection
-// (source name vs resolver-returned symbol name mismatch).
-// `sourceName` is the source path's last component, `symName` is
-// the rejected resolver answer, `pkg` is the source path's
-// package prefix (empty for bare).
-func traceLowerNamedTypeGuardReject(sourceName, symName, pkg string) {
-	if !lowerNamedTypeGuardTraceEnabled() {
-		return
-	}
-	fmt.Fprintf(lowerNamedTypeGuardTraceWriter,
-		"ir lowerNamedType guard reject: sourceName=%q symName=%q pkg=%q\n",
-		sourceName, symName, pkg,
-	)
-}
-
 // joinDottedPath joins a non-empty string slice with '.'.
 func joinDottedPath(parts []string) string {
 	switch len(parts) {
@@ -989,10 +942,73 @@ func joinDottedPath(parts []string) string {
 }
 
 func (l *lowerer) typeRef(nt *ast.NamedType) *resolve.Symbol {
-	if l.res == nil || nt == nil {
+	if nt == nil {
+		return nil
+	}
+	// Prefer the pointer-keyed map when populated: it is immune to
+	// `NodeID` collisions across files, so foreign-file NamedTypes
+	// reached via `sym.Decl` walks (see `recoverFnDeclReturnType`)
+	// resolve to the correct symbol even though the lowerer's
+	// current `res` covers a different file.
+	if l.typeRefByPtr != nil {
+		if sym, ok := l.typeRefByPtr[nt]; ok {
+			return sym
+		}
+	}
+	if l.res == nil {
 		return nil
 	}
 	return l.res.TypeRefsByID[nt.ID]
+}
+
+// buildPkgTypeRefMap assembles a pointer-keyed `*ast.NamedType` →
+// `*resolve.Symbol` map from every file in pkg. The map short-
+// circuits the ID-keyed lookup against the lowerer's current
+// `res.TypeRefsByID`, which fails when a foreign-file recovery
+// (`recoverFnDeclReturnType` and siblings) reaches a NamedType
+// whose `NodeID` collides with an unrelated node in the lowerer's
+// current file. Each `pf` carries `TypeRefIdents` as the canonical
+// list of resolved NamedTypes alongside `TypeRefsByID`; we walk
+// that slice once and pair every node pointer with the symbol
+// recorded for it.
+func buildPkgTypeRefMap(pkg *resolve.Package) map[*ast.NamedType]*resolve.Symbol {
+	if pkg == nil {
+		return nil
+	}
+	out := map[*ast.NamedType]*resolve.Symbol{}
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		for _, nt := range pf.TypeRefIdents {
+			if nt == nil {
+				continue
+			}
+			if sym := pf.TypeRefsByID[nt.ID]; sym != nil {
+				out[nt] = sym
+			}
+		}
+	}
+	return out
+}
+
+// buildSingleFileTypeRefMap is the single-file analogue of
+// `buildPkgTypeRefMap`. Same shape, fed directly from a
+// `*resolve.Result` rather than a Package.
+func buildSingleFileTypeRefMap(res *resolve.Result) map[*ast.NamedType]*resolve.Symbol {
+	if res == nil {
+		return nil
+	}
+	out := map[*ast.NamedType]*resolve.Symbol{}
+	for _, nt := range res.TypeRefIdents {
+		if nt == nil {
+			continue
+		}
+		if sym := res.TypeRefsByID[nt.ID]; sym != nil {
+			out[nt] = sym
+		}
+	}
+	return out
 }
 
 // primitiveByName maps a scalar type name to the IR singleton.

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -207,6 +207,55 @@ func TestLowerNamedTypeFallsBackToResWhenPointerMapAbsent(t *testing.T) {
 	}
 }
 
+// TestLowerNamedTypeRespectsResolverBypassWhenResIsNil locks the
+// invariant `lowerStdlibType` depends on: setting `l.res = nil`
+// must bypass *all* resolver-driven lookup, including the new
+// pointer-keyed `typeRefByPtr` shadow. Otherwise a stdlib stub
+// nt that happens to be registered in `typeRefByPtr` (e.g. when
+// the outer lowerer was hydrated from a stdlib module's
+// `*resolve.Result`) would still receive a resolver answer, and
+// the stub fallback's "pure AST-shape" contract would be broken.
+//
+// The simulated shape: `typeRefByPtr` carries a wrong sym for
+// the stub nt (the stdlib module's view of the world), and
+// `lowerStdlibType` nils out `l.res`. Even with `typeRefByPtr`
+// non-nil, `lowerNamedType` must fall through to source-name
+// classification, which correctly tags `List<String>` as a
+// builtin container.
+func TestLowerNamedTypeRespectsResolverBypassWhenResIsNil(t *testing.T) {
+	stubAST := &ast.NamedType{
+		ID:   ast.NodeID(50),
+		Path: []string{"List"},
+		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
+	}
+	wrongSym := &resolve.Symbol{
+		Name: "FrontCheckResult",
+		Kind: resolve.SymStruct,
+		Decl: &ast.StructDecl{Name: "FrontCheckResult"},
+	}
+	l := &lowerer{
+		// res deliberately nil — mirrors `lowerStdlibType`'s
+		// temporary bypass.
+		res: nil,
+		// typeRefByPtr carries a wrong symbol for the stub. The
+		// bypass must skip it.
+		typeRefByPtr: map[*ast.NamedType]*resolve.Symbol{
+			stubAST: wrongSym,
+		},
+	}
+	got := l.lowerNamedType(stubAST)
+	nt, ok := got.(*NamedType)
+	if !ok {
+		t.Fatalf("lowerNamedType returned %T, want *NamedType", got)
+	}
+	if nt.Name != "List" {
+		t.Errorf("bypass failed: NamedType.Name = %q, want %q (l.res=nil must skip both res.TypeRefsByID and typeRefByPtr)", nt.Name, "List")
+	}
+	if !nt.Builtin {
+		t.Errorf("List<String> should be marked Builtin: true; got %+v", nt)
+	}
+}
+
 // TestRecoverFnDeclReturnTypeTraceDefaultSilent locks the
 // off-by-default behaviour of the OSTY_IR_TRACE_FN_DECL_RECOVERY
 // env-gated diagnostic: without the env var set even the

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -103,49 +103,59 @@ func TestLowerPreludeVariantCallBecomesVariantLit(t *testing.T) {
 	}
 }
 
-// TestLowerNamedTypeRejectsResolverNameMismatch locks the
-// defensive guard added to `lowerNamedType` for the
-// FrontCheckResult<String> class of resolver TypeRefsByID
-// mismappings. The bug: in multi-file packages the resolver
-// occasionally records the wrong `*resolve.Symbol` against an
-// `*ast.NamedType` node's ID — e.g. the `List` head ident in
-// `hintTupleElems`'s return type signature
-// (toolchain/inspect_hint.osty) resolves to the
-// `FrontCheckResult` struct symbol (toolchain/check.osty) instead
-// of `List`, producing a downstream `FrontCheckResult__len`
-// undefined symbol at install-self link.
+// TestLowerNamedTypeUsesPointerKeyedLookupAcrossFiles locks the
+// structural fix for the FrontCheckResult<String> class of
+// `TypeRefsByID` mismappings (originally masked by the defensive
+// `resolverSymbolMatchesSourceName` guard added in PR #1919, now
+// removed). Bug shape: in multi-file packages, cross-file recovery
+// paths such as `recoverFnDeclReturnType` follow `sym.Decl` into a
+// foreign file's AST and then call `l.lowerType(fn.ReturnType)` to
+// lower a NamedType node that belongs to the foreign file. The
+// foreign nt's `NodeID` is local to its file's AST, so the lookup
+// `l.res.TypeRefsByID[nt.ID]` against the lowerer's *current* file
+// resolves to whatever unrelated node happens to share that ID in
+// the current file — producing the wrong-name symbol downstream.
 //
-// The fix: when the resolver returns a symbol whose name doesn't
-// match the source path's last component AND the source is bare
-// (no package qualifier), `lowerNamedType` skips the resolver
-// path and falls back to source-name-based resolution, which
-// correctly classifies `List<X>`, `Map<K,V>`, etc. as builtin
-// containers via the name table at the bottom of the function.
+// Fix: the lowerer additionally carries `typeRefByPtr`, a pointer-
+// keyed shadow of every file's `TypeRefsByID` built once at
+// `LowerPackage` time. `typeRef(nt)` consults `typeRefByPtr` first
+// so foreign-file NamedTypes route to the symbol the resolver
+// actually recorded for them.
 //
-// This test simulates the exact bug shape by hand-building a
-// `resolve.Result` whose `TypeRefsByID` maps the `List` AST
-// node's ID to a `FrontCheckResult` struct symbol. With the
-// guard in place, `lowerNamedType` returns
-// `&NamedType{Name: "List", Args: [String], Builtin: true}`
-// instead of `&NamedType{Name: "FrontCheckResult", ...}`.
-func TestLowerNamedTypeRejectsResolverNameMismatch(t *testing.T) {
-	// Simulate the resolver's TypeRefsByID returning a wrong
-	// `FrontCheckResult` symbol for a `List` AST node.
+// This test simulates the cross-file shape: two `*ast.NamedType`
+// nodes that happen to share the same `NodeID` (42) but belong to
+// different files (one is `List`, the other is `FrontCheckResult`).
+// The current-file `res.TypeRefsByID` only knows about the local
+// `FrontCheckResult` mapping; the package-wide `typeRefByPtr`
+// disambiguates by node identity so lowering the `List` node still
+// produces a List builtin instead of the wrong `FrontCheckResult`.
+func TestLowerNamedTypeUsesPointerKeyedLookupAcrossFiles(t *testing.T) {
+	// Foreign-file List nt (shares NodeID with the current file's
+	// FrontCheckResult nt, which is the bug shape).
 	listAST := &ast.NamedType{
 		ID:   ast.NodeID(42),
 		Path: []string{"List"},
 		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
 	}
-	wrongSym := &resolve.Symbol{
+	currentFileWrongSym := &resolve.Symbol{
 		Name: "FrontCheckResult",
 		Kind: resolve.SymStruct,
 		Decl: &ast.StructDecl{Name: "FrontCheckResult"},
 	}
+	correctListSym := &resolve.Symbol{Name: "List", Kind: resolve.SymBuiltin}
 	l := &lowerer{
 		res: &resolve.Result{
+			// Current file's ID-keyed map carries the *wrong*
+			// FrontCheckResult symbol for ID=42 — this is the
+			// cross-file collision the bug exploited.
 			TypeRefsByID: map[ast.NodeID]*resolve.Symbol{
-				listAST.ID: wrongSym,
+				listAST.ID: currentFileWrongSym,
 			},
+		},
+		// Package-wide pointer map routes the actual List
+		// node-pointer to the correct List symbol.
+		typeRefByPtr: map[*ast.NamedType]*resolve.Symbol{
+			listAST: correctListSym,
 		},
 	}
 	got := l.lowerNamedType(listAST)
@@ -154,121 +164,38 @@ func TestLowerNamedTypeRejectsResolverNameMismatch(t *testing.T) {
 		t.Fatalf("lowerNamedType returned %T, want *NamedType", got)
 	}
 	if nt.Name != "List" {
-		t.Errorf("guard failed: NamedType.Name = %q, want %q (resolver returned wrong symbol but bare source name is List)", nt.Name, "List")
+		t.Errorf("pointer-keyed lookup failed: NamedType.Name = %q, want %q (current-file ID-keyed map carried wrong FrontCheckResult sym but the pointer-keyed map should win)", nt.Name, "List")
 	}
 	if !nt.Builtin {
 		t.Errorf("List<String> should be marked Builtin: true; got %+v", nt)
 	}
-	if len(nt.Args) != 1 {
-		t.Fatalf("List<String> should have 1 arg; got %d", len(nt.Args))
-	}
-	if nt.Args[0] != TString {
-		t.Errorf("List<String> arg[0] = %v, want TString", nt.Args[0])
+	if len(nt.Args) != 1 || nt.Args[0] != TString {
+		t.Errorf("List<String> args = %+v, want [TString]", nt.Args)
 	}
 }
 
-// TestLowerNamedTypeGuardRejectionEmitsTrace locks the
-// observability guarantee Copilot review #1919 asked for: when the
-// IR-layer guard rejects a resolver-returned symbol, the env-gated
-// `OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD` trace must fire so the
-// underlying resolver `TypeRefsByID` mismapping stays observable
-// rather than being silently masked.
-func TestLowerNamedTypeGuardRejectionEmitsTrace(t *testing.T) {
-	prev := lowerNamedTypeGuardTraceWriter
-	defer func() { lowerNamedTypeGuardTraceWriter = prev }()
-	var buf bytes.Buffer
-	lowerNamedTypeGuardTraceWriter = &buf
-
-	t.Setenv("OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD", "1")
-
-	listAST := &ast.NamedType{
-		ID:   ast.NodeID(44),
-		Path: []string{"List"},
-		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
-	}
-	wrongSym := &resolve.Symbol{
-		Name: "FrontCheckResult",
-		Kind: resolve.SymStruct,
-		Decl: &ast.StructDecl{Name: "FrontCheckResult"},
-	}
-	l := &lowerer{
-		res: &resolve.Result{
-			TypeRefsByID: map[ast.NodeID]*resolve.Symbol{
-				listAST.ID: wrongSym,
-			},
-		},
-	}
-	_ = l.lowerNamedType(listAST)
-
-	got := buf.String()
-	for _, want := range []string{
-		`sourceName="List"`,
-		`symName="FrontCheckResult"`,
-		`pkg=""`,
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("guard-reject trace missing %q\nfull output:\n%s", want, got)
-		}
-	}
-}
-
-// TestLowerNamedTypeGuardTraceDefaultSilent locks the
-// off-by-default behaviour of the guard trace: without
-// OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD set, even a rejection
-// emits no stderr noise (production `osty build` runs see nothing).
-func TestLowerNamedTypeGuardTraceDefaultSilent(t *testing.T) {
-	prev := lowerNamedTypeGuardTraceWriter
-	defer func() { lowerNamedTypeGuardTraceWriter = prev }()
-	var buf bytes.Buffer
-	lowerNamedTypeGuardTraceWriter = &buf
-
-	t.Setenv("OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD", "")
-
-	listAST := &ast.NamedType{
-		ID:   ast.NodeID(45),
-		Path: []string{"List"},
-		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
-	}
-	wrongSym := &resolve.Symbol{
-		Name: "FrontCheckResult",
-		Kind: resolve.SymStruct,
-		Decl: &ast.StructDecl{Name: "FrontCheckResult"},
-	}
-	l := &lowerer{
-		res: &resolve.Result{
-			TypeRefsByID: map[ast.NodeID]*resolve.Symbol{
-				listAST.ID: wrongSym,
-			},
-		},
-	}
-	_ = l.lowerNamedType(listAST)
-
-	if buf.Len() != 0 {
-		t.Fatalf("guard trace writer received output despite env off: %q", buf.String())
-	}
-}
-
-// TestLowerNamedTypeAcceptsResolverNameMatch locks the
-// positive-case half of the guard: when the resolver-returned
-// symbol's name DOES match the source path's last component, the
-// resolver-driven classification (Builtin / Generic / TypeAlias)
-// continues to work as before.
-func TestLowerNamedTypeAcceptsResolverNameMatch(t *testing.T) {
+// TestLowerNamedTypeFallsBackToResWhenPointerMapAbsent locks the
+// degraded path the lowerer still supports: when `typeRefByPtr` is
+// nil (e.g. single-file `Lower` with no resolve.Result, or a
+// hand-built lowerer in tests), `typeRef` falls back to the
+// classic `res.TypeRefsByID[nt.ID]` lookup. The fallback exists so
+// existing call sites (LowerFnDecl with a partial res, stdlib
+// injection, etc.) continue to work without populating the
+// pointer map.
+func TestLowerNamedTypeFallsBackToResWhenPointerMapAbsent(t *testing.T) {
 	listAST := &ast.NamedType{
 		ID:   ast.NodeID(43),
 		Path: []string{"List"},
 		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
 	}
-	rightSym := &resolve.Symbol{
-		Name: "List",
-		Kind: resolve.SymBuiltin,
-	}
+	rightSym := &resolve.Symbol{Name: "List", Kind: resolve.SymBuiltin}
 	l := &lowerer{
 		res: &resolve.Result{
 			TypeRefsByID: map[ast.NodeID]*resolve.Symbol{
 				listAST.ID: rightSym,
 			},
 		},
+		// typeRefByPtr deliberately nil — exercise the fallback.
 	}
 	got := l.lowerNamedType(listAST)
 	nt, ok := got.(*NamedType)
@@ -276,7 +203,7 @@ func TestLowerNamedTypeAcceptsResolverNameMatch(t *testing.T) {
 		t.Fatalf("lowerNamedType returned %T, want *NamedType", got)
 	}
 	if nt.Name != "List" || !nt.Builtin {
-		t.Errorf("resolver-name-match path failed: got %+v, want List builtin", nt)
+		t.Errorf("ID-keyed fallback failed: got %+v, want List builtin", nt)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Root-causes the **262 residual IR-layer guard rejects** PR #1920 left unresolved (the "same-file collisions" caveat in its description) and replaces the PR #1919 defensive guard with a structural fix.
- The fix is one new pointer-keyed map (`typeRefByPtr`) on the lowerer plus a one-time build at `LowerPackage` / `Lower` entry; the `lowerNamedType` resolver-name-match guard, the `resolverSymbolMatchesSourceName` helper, and the `OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD` env-gated trace are all removed as dead code.
- Net delta: **+172 / −229 LOC** across `internal/ir/lower.go` + `internal/ir/lower_test.go`.

## Bug shape (traced end-to-end)

`pf.TypeRefsByID` is per-file and keyed by `ast.NodeID`, but `NodeID`s are local to each `*ast.File` — `ast.AssignIDs` runs over each file independently, so two unrelated `*ast.NamedType` nodes in different files routinely share the same ID. The IR-layer recovery paths (`recoverFnDeclReturnType` and the `recover*` siblings) follow a call site's `sym.Decl` into a *foreign* file's AST, then call `l.lowerType(fn.ReturnType)`. The foreign NamedType's `NodeID` looked up via `l.res.TypeRefsByID[nt.ID]` resolves against the lowerer's *current* file map and collides with whatever happened to occupy that ID locally.

Concrete shape isolated during this PR's bisection: lowering `astParseLexedSource(...) -> AstFile` in `toolchain/check_bridge.osty` while `l.res` covered `toolchain/check.osty` (`TypeRefsByID[4]` = `String` sym locally) returned a String symbol for an `AstFile` source ident. Same ID collision pattern produced `AstFile -> Int`, `CheckEnv -> FrontTypeRepr`, `CheckDiagnostic -> ElabCx`, etc.

`OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD=1` measurement on a clean `install-self -force` rebuild: **262 rejects** (down from 291 in the original PR #1919 measurement because PR #1920 eliminated the pure cross-file-overlap subset).

## Fix

The lowerer now carries `typeRefByPtr`, a pointer-keyed `*ast.NamedType -> *resolve.Symbol` map built once at `LowerPackage` time from every file's `pf.TypeRefIdents` + `pf.TypeRefsByID` pair. `l.typeRef(nt)` consults the pointer map first so foreign-file NamedTypes route to the symbol the resolver actually recorded for them — by node identity rather than by colliding ID. The ID-keyed `res.TypeRefsByID` lookup remains as a fallback for nodes not seen by the bridge (e.g. synthesized NamedTypes that never reached `TypeRefIdents`).

With the structural fix in place, the `lowerNamedType` guard becomes dead code. This PR removes:

- `resolverSymbolMatchesSourceName` (lower.go old line 921)
- the guard call site in `lowerNamedType` (lower.go old line 846)
- the env-gated `traceLowerNamedTypeGuardReject` machinery
  (`OSTY_IR_TRACE_LOWER_NAMED_TYPE_GUARD`,
  `lowerNamedTypeGuardTraceWriter`, etc.)

The pointer map is also wired into `LowerFnDecl` / `LowerLetDecl` / `Lower` (single-file path) via `buildSingleFileTypeRefMap` so the stdlib injection pipeline and standalone IR lowerings get the same cross-file safety even though they only operate on one file at a time.

## Verification

End-to-end:

```
$ rm -rf .osty/cache/self-host toolchain/.osty/cache toolchain/.osty/out
$ OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP=1 OSTY_STAGE0_FALLBACK=1 \
    .bin/osty install-self -force
Profile: debug  Target: host  Features: none
Built /home/user/osty/toolchain/.osty/out/debug/llvm/osty-self (debug)
installed: .osty/cache/self-host/9fadb17...-linux-amd64/osty-self
```

Pre-removal measurement (guard re-instrumented for the trace count only): **262 → 0 rejects** after the fix.

Tests run (all green except pre-existing failures on `main`):

- `go test ./internal/ir ./internal/mir ./internal/check ./internal/resolve ./internal/lsp ./internal/format ./internal/parser ./internal/diag ./internal/lint`
- `go test ./internal/speccorpus ./internal/stdlib ./internal/nativellvmgen ./internal/llvmabi ./internal/toolchain/... ./internal/lsp`
- `go test ./cmd/osty -short`
- Pre-existing failures unchanged: `TestLLVMBackendBinaryResultUnitErrUsesReturnContext`, `TestLLVMBackendBinaryBuiltinResultConstructorsTrackLocalContext`, `TestLLVMBackendBinaryRunsListSafeGetOption|Match` (all reproduce identically on `origin/main` without this PR's diff).

## Test plan

- [x] `go test ./internal/ir/ -count=1 -run TestLowerNamedType` — the new `TestLowerNamedTypeUsesPointerKeyedLookupAcrossFiles` locks the cross-file pointer-keyed lookup; `TestLowerNamedTypeFallsBackToResWhenPointerMapAbsent` locks the degraded ID-keyed fallback used by `LowerFnDecl` / `LowerLetDecl` callers that bypass the package builder.
- [x] `osty install-self -force` (clean cache) — completes end-to-end; `osty-self` lands in the self-host cache.
- [x] Broader sweep: ir / mir / check / resolve / lsp / format / parser / speccorpus / stdlib / nativellvmgen / llvmabi / toolchain / cmd/osty short — pass.

https://claude.ai/code/session_018pLktiZwrTAanaojgwGRoP

---
_Generated by [Claude Code](https://claude.ai/code/session_018pLktiZwrTAanaojgwGRoP)_