### PR TITLE
feat: M4 brick A — byte offsets + diagnostic line/column for native checker

### DIFF
--- a/cmd/osty-native-checker/README.md
+++ b/cmd/osty-native-checker/README.md
@@ -9,7 +9,7 @@ matching responsibilities, built from disjoint sources.
 | target | command | source | status |
 |---|---|---|---|
 | Go-built | `go build -o /tmp/go-checker ./cmd/osty-native-checker` | `main.go` (~38 LOC) + `internal/selfhost/generated.go` (frozen seed) | production |
-| LLVM-built | `.bin/osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/` | `main.osty` + `tc.frontCheckSourceToWireJson` | **semantic correctness** (real checker, structural JSON parity; non-empty input still misses byte-offset / stable-ID adapter work) |
+| LLVM-built | `.bin/osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/` | `main.osty` + `tc.frontCheckSourceToWireJson` | **M4 brick A — byte offsets + diagnostic line/column wired; stable-ID + telemetry adapter bricks still pending** |
 
 ## Why two targets
 
@@ -33,13 +33,23 @@ reaches behavior parity (plan §12 M3/M4).
   checker summary, typed-node / binding / symbol / instantiation lists and
   structured diagnostics in the same JSON shape as
   `internal/selfhost/api/types.go::CheckResult`.
-- ⏳ **M4** — full byte-for-byte parity on non-empty inputs still pending:
-  the LLVM-built path keeps token indices in `start` / `end`, skips the
-  Go adapter's display line/column + span-ID + sha256 stable-ID stamping
-  (`internal/selfhost/check_adapter.go::EnsureStableIDs`), and does not
-  populate `errorsByContext` / `errorDetails` telemetry. Tracked under
-  `SPEC_GAPS.md::cross-pkg-module-resolution` (see PR3-C step 3 design
-  [docs/llvm-selfhost-plan-pr3-c-step3-design.md](../../docs/llvm-selfhost-plan-pr3-c-step3-design.md)).
+- ✓ **M4 brick A (byte offsets + diagnostic line/column)** —
+  `tc.frontCheckSourceToWireJson` lexes the input, builds a rune→byte
+  table, and threads a `FrontWireMapper` so every `start` / `end` carries
+  the same UTF-8 byte offset the Go adapter
+  (`internal/selfhost/check_adapter.go::checkNodeOffsets`) emits.
+  Diagnostics additionally get `startLine` / `startColumn` / `endLine` /
+  `endColumn` from `FrontLexToken.start.line`+`column`.
+- ⏳ **M4 remaining bricks** — full byte-for-byte parity on non-empty
+  inputs still pending two adapter responsibilities:
+  - sha256 `EnsureStableIDs` stamping (the `id` / `nodeKey` / `typeKey`
+    string fields stay empty → Go-side `omitempty` drops them on decode).
+  - `errorsByContext` / `errorDetails` summary telemetry (the
+    `selfhostDiagnosticTelemetry` aggregation in
+    `internal/selfhost/check_telemetry.go`).
+
+  Both are tracked under `SPEC_GAPS.md::cross-pkg-module-resolution` and
+  the LLVM self-host plan §12 M4 trajectory.
 
 ## Build (LLVM-built)
 
@@ -77,11 +87,11 @@ every monomorphized build of `osty-self` or every package is LIR-Proto clean;
   - 다른 key 가 `"source"` substring 포함 시 오인지
 - 출력 측은 진짜 checker 호출 — `tc.frontCheckSourceToWireJson`
   (`toolchain/check_json.osty`) 가 lex/parse/check 한 후 wire JSON 으로
-  직렬화. 단:
-  - `start` / `end` 가 token index (Go adapter 의 byte-offset 변환 미복제)
+  직렬화. M4 brick A 까지 wired (byte offsets + diagnostic
+  startLine/startColumn/endLine/endColumn). 남은 brick:
   - `EnsureStableIDs` 의 sha256 stable ID 미스탬프 — `omitempty` 로 인해 누락만 발생, 잘못된 값은 아님
   - `errorsByContext` / `errorDetails` summary telemetry 미산출
-  - 모두 `SPEC_GAPS.md::cross-pkg-module-resolution` trajectory 의 M4 byte parity 항목
+  - 두 항목 모두 `SPEC_GAPS.md::cross-pkg-module-resolution` trajectory 의 M4 byte parity 후속 brick
 
 ## main.go vs main.osty co-existence
 
@@ -97,7 +107,9 @@ every monomorphized build of `osty-self` or every package is LIR-Proto clean;
 | [#1829](https://github.com/choiceoh/osty/pull/1829) | **PR2** manual naive parser |
 | [#1842](https://github.com/choiceoh/osty/pull/1842) | **PR3-C-impl-go step 1+2** ResolvedSymbol.ImportPath post-processing |
 | [#1890](https://github.com/choiceoh/osty/pull/1890) | **PR3-E/F activation** — cross-pkg method-call dispatch arm |
-| (this branch) | **PR3-G semantic correctness** — `tc.frontCheckSourceToWireJson` (`toolchain/check_json.osty`) replaces stub `emptyCheckResultJson` |
-| (TBD) | M4 byte parity — port `internal/selfhost/check_adapter.go` (byte offsets + stable IDs + telemetry) to Osty |
+| [#1938](https://github.com/choiceoh/osty/pull/1938) | **PR3-G semantic correctness** — `tc.frontCheckSourceToWireJson` (`toolchain/check_json.osty`) replaces stub `emptyCheckResultJson` |
+| (this branch) | **M4 brick A** — byte offsets + diagnostic line/column (`FrontWireMapper`) |
+| (TBD) | M4 brick B — sha256 stable IDs (`EnsureStableIDs`) |
+| (TBD) | M4 brick C — `errorsByContext` / `errorDetails` telemetry |
 
 자세한 분기 결정 + 시도 결과 → `docs/llvm-selfhost-plan-pr*.md` 시리즈.

--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -13,10 +13,12 @@
 //
 // 출력 측은 toolchain 의 `tc.frontCheckSourceToWireJson` 가 담당 — 진짜
 // 체커를 돌리고 `internal/selfhost/api/types.go::CheckResult` 의 JSON
-// 와이어 모양으로 직렬화한다. byte parity 가 아니라 *semantic*
-// correctness 가 목표: token-index 기반 start/end + sha256 안정 ID
-// 누락 등은 Go-built target 의 adapter (internal/selfhost/check_adapter.go)
-// 만의 정책이라 LLVM-built 측이 굳이 복제하지 않는다.
+// 와이어 모양으로 직렬화한다. M4 brick A 까지 wired: `start` / `end` 가
+// UTF-8 byte offset (rune→byte 변환), diagnostic 마다 `startLine` /
+// `startColumn` / `endLine` / `endColumn` 부착. 남은 M4 brick (sha256
+// `EnsureStableIDs`, `errorsByContext` / `errorDetails` telemetry) 은
+// Go-built adapter (internal/selfhost/check_adapter.go) 측 정책으로
+// 별도 brick 에서 포팅 예정.
 use std.io
 use std.strings
 use toolchain as tc

--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -4,12 +4,24 @@
 // std.json.* 호출이 stage0 fallback 에서 막힘 (cf.
 // docs/llvm-selfhost-plan-pr2-attempt.md). 우회로: primitive
 // strings.indexOf / strings.slice 만 사용한 naive "source" field 추출.
-// L1 corpus 의 escape-free fixture (예: `{"source":"fn main(){}"}`) 가정.
+// L1 corpus 의 escape-free + single-line fixture
+// (예: `{"source":"fn main(){}"}`) 만 정확히 처리한다.
 //
-// 정확성 한계 (입력 파싱):
-// - "source" key 의 `\"` escape, value 안 `\"` escape 미처리
-// - newline / unicode 미처리
-// - 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지
+// 정확성 한계 (입력 파싱) — 모두 std.json wall 이 풀려야 해소 가능:
+//
+//   1. `io.readLine()` 만 호출: stdin 의 첫 줄만 읽는다. 보기 좋게
+//      줄바꿈된 JSON request 는 첫 줄에 `"source"` 가 없으면 빈
+//      문자열로 fallback (false-success 위험).
+//   2. value 안 escape (`\"`, `\n`, `\\` 등) 미처리: closing quote 를
+//      첫 `"` 로 인식해서 source body 가 잘못 잘리거나 값이 raw escape
+//      sequence 로 검사된다.
+//   3. JSON 공백 비허용: 정확한 substring `"source":"` 만 일치. 표준
+//      JSON 의 `"source": "..."` (콜론 뒤 공백) 형식은 매치 실패 →
+//      빈 문자열 fallback.
+//   4. 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지.
+//   5. `CheckRequest` 의 `package` 모드 (`{"package":{...}}`) 미인지:
+//      각 파일이 `source` 필드를 가지므로 첫 file 의 source 만 검사된다.
+//      `package` 모드 지원은 진짜 JSON parser 필요.
 //
 // 출력 측은 toolchain 의 `tc.frontCheckSourceToWireJson` 가 담당 — 진짜
 // 체커를 돌리고 `internal/selfhost/api/types.go::CheckResult` 의 JSON

--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -19,20 +19,29 @@
 //   FrontCheckInstantiation.resultType / typeArgs / typeArgIds carry
 //   over directly.
 //
-// Non-goals for this serializer:
+// Position handling (M4 brick A):
 //
-//   - Byte-for-byte parity with the Go-built target on non-empty
-//     inputs. The Go bridge in `internal/selfhost/check_adapter.go`
-//     converts token indices to byte offsets, stamps display
-//     line/column positions, computes SHA256 stable IDs
-//     (EnsureStableIDs), and accumulates ErrorsByContext / ErrorDetails
-//     telemetry. None of that happens here — `start` / `end` stay as
-//     token indices, stable-id fields stay empty (Go-side `omitempty`
-//     drops them on decode), and the summary stays
-//     `{assignments, accepted, errors}` only.
-//   - Custom escape behaviour. Strings get the minimal JSON-required
-//     escape set (`\`, `"`, `\n`, `\r`, `\t` + control 0x00–0x1F as
-//     `\u00XX`). UTF-8 multi-byte sequences pass through unchanged.
+//   The shared entry `frontCheckSourceToWireJson(source)` now lexes the
+//   input, builds a rune→byte table, and threads a `FrontWireMapper`
+//   into the serializers so every `start`/`end` field carries the same
+//   byte offset the Go adapter
+//   (`internal/selfhost/check_adapter.go::checkNodeOffsets`) emits.
+//   Diagnostics additionally get the `startLine`/`startColumn`/
+//   `endLine`/`endColumn` fields from `FrontLexToken.start.line` etc.
+//
+//   The legacy entry `frontCheckResultToWireJson(result)` keeps the
+//   pre-M4 behaviour (token indices, no line/column) by passing an
+//   identity mapper. Callers that already constructed a
+//   `FrontCheckResult` outside the lex chain still get a stable output.
+//
+// Remaining M4 work (separate bricks):
+//
+//   - sha256 stable IDs (`EnsureStableIDs`): unique `id` / `nodeKey` /
+//     `typeKey` per record.
+//   - `errorsByContext` / `errorDetails` summary telemetry.
+//
+//   Both are independent of byte-offset conversion; punted to follow-up
+//   PRs.
 use std.strings as strings
 /// frontCheckSourceToWireJson is the single cross-pkg entry the
 /// LLVM-built native checker calls. Owning the lex + parse + check +
@@ -41,76 +50,202 @@ use std.strings as strings
 /// String-in / String-out hop — well within the cross-pkg free-fn
 /// dispatch arm landed by PR #1886.
 pub fn frontCheckSourceToWireJson(source: String) -> String {
-    frontCheckResultToWireJson(frontendCheckSourceStructured(source))
+    let lexed = ostyLexSource(source)
+    let result = frontendCheckLexedSourceStructured(lexed)
+    frontCheckResultToWireJsonForLexed(result, lexed)
 }
 /// frontCheckResultToWireJson serialises a `FrontCheckResult` into the
-/// JSON wire format. Exposed so toolchain callers that already hold a
-/// result (tests, dump CLIs) can skip the re-lex pass.
+/// JSON wire format using token indices as start/end (no byte-offset
+/// conversion, no display line/column). Preserved for callers that hold
+/// a result without the lex stream — toolchain tests etc.
 pub fn frontCheckResultToWireJson(result: FrontCheckResult) -> String {
+    frontCheckResultToWireJsonInner(result, frontWireMapperIdentity())
+}
+/// frontCheckResultToWireJsonForLexed serialises a `FrontCheckResult`
+/// using the lex stream to convert token indices into byte offsets and
+/// stamp display line/column on every diagnostic. Mirrors the Go-side
+/// `internal/selfhost/check_adapter.go::adaptCheckResultFromRuneStream`
+/// pipeline.
+pub fn frontCheckResultToWireJsonForLexed(result: FrontCheckResult, lexed: OstyLexedSource) -> String {
+    frontCheckResultToWireJsonInner(result, frontWireMapperFromLexed(lexed))
+}
+fn frontCheckResultToWireJsonInner(result: FrontCheckResult, mapper: FrontWireMapper) -> String {
     let mut parts: List<String> = []
     parts.push("\"summary\":" + frontCheckSummaryToWireJson(result.summary))
-    parts.push("\"typedNodes\":" + frontCheckedNodesToWireJson(result.typedNodes))
-    parts.push("\"bindings\":" + frontCheckedBindingsToWireJson(result.bindings))
-    parts.push("\"symbols\":" + frontCheckedSymbolsToWireJson(result.symbols))
-    parts.push("\"instantiations\":" + frontCheckInstantiationsToWireJson(result.instantiations))
+    parts.push("\"typedNodes\":" + frontCheckedNodesToWireJson(result.typedNodes, mapper))
+    parts.push("\"bindings\":" + frontCheckedBindingsToWireJson(result.bindings, mapper))
+    parts.push("\"symbols\":" + frontCheckedSymbolsToWireJson(result.symbols, mapper))
+    parts.push("\"instantiations\":" + frontCheckInstantiationsToWireJson(result.instantiations, mapper))
     if result.diagnostics.len() > 0 {
-        parts.push("\"diagnostics\":" + checkDiagnosticsToWireJson(result.diagnostics))
+        parts.push("\"diagnostics\":" + checkDiagnosticsToWireJson(result.diagnostics, mapper))
     }
     "\{" + strings.join(parts, ",") + "\}"
 }
+// ---------------------------------------------------------------------
+// FrontWireMapper — token-index -> byte-offset + display-line/column.
+//
+// The identity mapper short-circuits the offset lookup so legacy
+// callers that pass byte offsets directly (or token indices that
+// happen to be the desired wire start/end) keep working unchanged.
+// ---------------------------------------------------------------------
+pub struct FrontWireMapper {
+    pub identity: Bool,
+    pub byteStart: List<Int>,
+    pub byteTotal: Int,
+    pub tokens: List<FrontLexToken>,
+}
+pub struct FrontWireRange {
+    pub start: Int,
+    pub end: Int,
+    pub startLine: Int,
+    pub startColumn: Int,
+    pub endLine: Int,
+    pub endColumn: Int,
+}
+pub fn frontWireMapperIdentity() -> FrontWireMapper {
+    let emptyStart: List<Int> = []
+    let emptyTokens: List<FrontLexToken> = []
+    FrontWireMapper {identity: true, byteStart: emptyStart, byteTotal: 0, tokens: emptyTokens}
+}
+pub fn frontWireMapperFromLexed(lexed: OstyLexedSource) -> FrontWireMapper {
+    let byteStart = frontWireBuildByteStart(lexed.source)
+    let byteTotal = if byteStart.len() == 0 {
+        0
+    } else {
+        byteStart[byteStart.len() - 1]
+    }
+    FrontWireMapper {identity: false, byteStart, byteTotal, tokens: lexed.stream.tokens}
+}
+fn frontWireBuildByteStart(source: String) -> List<Int> {
+    let mut byteStart: List<Int> = []
+    let mut off = 0
+    for ch in source.chars() {
+        byteStart.push(off)
+        off = off + frontWireUtf8ByteLen(ch.toInt())
+    }
+    byteStart.push(off)
+    byteStart
+}
+fn frontWireUtf8ByteLen(codepoint: Int) -> Int {
+    if codepoint < 0 {
+        return 1
+    }
+    if codepoint < 128 {
+        return 1
+    }
+    if codepoint < 2048 {
+        return 2
+    }
+    if codepoint < 65536 {
+        return 3
+    }
+    4
+}
+fn frontWireRuneToByte(m: FrontWireMapper, runeOff: Int) -> Int {
+    if runeOff <= 0 {
+        return 0
+    }
+    let len = m.byteStart.len()
+    if len == 0 {
+        return 0
+    }
+    if runeOff >= len {
+        return m.byteTotal
+    }
+    m.byteStart[runeOff]
+}
+fn frontWireMapperOffsets(m: FrontWireMapper, startToken: Int, endToken: Int) -> FrontWireRange {
+    if m.identity {
+        return FrontWireRange {start: startToken, end: endToken, startLine: 0, startColumn: 0, endLine: 0, endColumn: 0}
+    }
+    let tokensLen = m.tokens.len()
+    if tokensLen == 0 {
+        return FrontWireRange {start: 0, end: 0, startLine: 0, startColumn: 0, endLine: 0, endColumn: 0}
+    }
+    let mut startIdx = startToken
+    if startIdx < 0 {
+        startIdx = 0
+    }
+    if startIdx >= tokensLen {
+        startIdx = tokensLen - 1
+    }
+    let mut endIdx = endToken - 1
+    if endIdx < startIdx {
+        endIdx = startIdx
+    }
+    if endIdx >= tokensLen {
+        endIdx = tokensLen - 1
+    }
+    let startTok = m.tokens[startIdx]
+    let endTok = m.tokens[endIdx]
+    let startByte = frontWireRuneToByte(m, startTok.start.offset)
+    let mut endByte = frontWireRuneToByte(m, endTok.end.offset)
+    if endByte < startByte {
+        endByte = startByte
+    }
+    FrontWireRange {start: startByte, end: endByte, startLine: startTok.start.line, startColumn: startTok.start.column, endLine: endTok.end.line, endColumn: endTok.end.column}
+}
+// ---------------------------------------------------------------------
+// Serializer body — each item carries (start, end) explicitly so the
+// mapped + identity callers share the same emit path.
+// ---------------------------------------------------------------------
 fn frontCheckSummaryToWireJson(s: FrontCheckSummary) -> String {
     "\{\"assignments\":{s.assignments},\"accepted\":{s.accepted},\"errors\":{s.errors}\}"
 }
-fn frontCheckedNodesToWireJson(nodes: List<FrontCheckedNode>) -> String {
+fn frontCheckedNodesToWireJson(nodes: List<FrontCheckedNode>, m: FrontWireMapper) -> String {
     if nodes.len() == 0 {
         return "[]"
     }
     let mut items: List<String> = []
     for n in nodes {
-        items.push(frontCheckedNodeToWireJson(n))
+        let r = frontWireMapperOffsets(m, n.start, n.end)
+        items.push(frontCheckedNodeBodyJson(n, r.start, r.end))
     }
     "[" + strings.join(items, ",") + "]"
 }
-fn frontCheckedNodeToWireJson(n: FrontCheckedNode) -> String {
-    "\{\"node\":{n.node},\"nodeId\":{n.nodeId},\"kind\":" + frontJsonString(n.kind) + ",\"type\":" + frontTypeReprToWireJson(n.typeRepr) + ",\"typeId\":{n.typeId},\"start\":{n.start},\"end\":{n.end}\}"
+fn frontCheckedNodeBodyJson(n: FrontCheckedNode, start: Int, end: Int) -> String {
+    "\{\"node\":{n.node},\"nodeId\":{n.nodeId},\"kind\":" + frontJsonString(n.kind) + ",\"type\":" + frontTypeReprToWireJson(n.typeRepr) + ",\"typeId\":{n.typeId},\"start\":{start},\"end\":{end}\}"
 }
-fn frontCheckedBindingsToWireJson(bindings: List<FrontCheckedBinding>) -> String {
+fn frontCheckedBindingsToWireJson(bindings: List<FrontCheckedBinding>, m: FrontWireMapper) -> String {
     if bindings.len() == 0 {
         return "[]"
     }
     let mut items: List<String> = []
     for b in bindings {
-        items.push(frontCheckedBindingToWireJson(b))
+        let r = frontWireMapperOffsets(m, b.start, b.end)
+        items.push(frontCheckedBindingBodyJson(b, r.start, r.end))
     }
     "[" + strings.join(items, ",") + "]"
 }
-fn frontCheckedBindingToWireJson(b: FrontCheckedBinding) -> String {
-    "\{\"node\":{b.node},\"nodeId\":{b.nodeId},\"bindingId\":{b.bindingId},\"name\":" + frontJsonString(b.name) + ",\"type\":" + frontTypeReprToWireJson(b.typeRepr) + ",\"typeId\":{b.typeId},\"mutable\":" + frontJsonBool(b.mutable) + ",\"start\":{b.start},\"end\":{b.end}\}"
+fn frontCheckedBindingBodyJson(b: FrontCheckedBinding, start: Int, end: Int) -> String {
+    "\{\"node\":{b.node},\"nodeId\":{b.nodeId},\"bindingId\":{b.bindingId},\"name\":" + frontJsonString(b.name) + ",\"type\":" + frontTypeReprToWireJson(b.typeRepr) + ",\"typeId\":{b.typeId},\"mutable\":" + frontJsonBool(b.mutable) + ",\"start\":{start},\"end\":{end}\}"
 }
-fn frontCheckedSymbolsToWireJson(symbols: List<FrontCheckedSymbol>) -> String {
+fn frontCheckedSymbolsToWireJson(symbols: List<FrontCheckedSymbol>, m: FrontWireMapper) -> String {
     if symbols.len() == 0 {
         return "[]"
     }
     let mut items: List<String> = []
     for s in symbols {
-        items.push(frontCheckedSymbolToWireJson(s))
+        let r = frontWireMapperOffsets(m, s.start, s.end)
+        items.push(frontCheckedSymbolBodyJson(s, r.start, r.end))
     }
     "[" + strings.join(items, ",") + "]"
 }
-fn frontCheckedSymbolToWireJson(s: FrontCheckedSymbol) -> String {
-    "\{\"node\":{s.node},\"nodeId\":{s.nodeId},\"symbolId\":{s.symbolId},\"kind\":" + frontJsonString(s.kind) + ",\"name\":" + frontJsonString(s.name) + ",\"owner\":" + frontJsonString(s.owner) + ",\"type\":" + frontTypeReprToWireJson(s.typeRepr) + ",\"typeId\":{s.typeId},\"start\":{s.start},\"end\":{s.end}\}"
+fn frontCheckedSymbolBodyJson(s: FrontCheckedSymbol, start: Int, end: Int) -> String {
+    "\{\"node\":{s.node},\"nodeId\":{s.nodeId},\"symbolId\":{s.symbolId},\"kind\":" + frontJsonString(s.kind) + ",\"name\":" + frontJsonString(s.name) + ",\"owner\":" + frontJsonString(s.owner) + ",\"type\":" + frontTypeReprToWireJson(s.typeRepr) + ",\"typeId\":{s.typeId},\"start\":{start},\"end\":{end}\}"
 }
-fn frontCheckInstantiationsToWireJson(insts: List<FrontCheckInstantiation>) -> String {
+fn frontCheckInstantiationsToWireJson(insts: List<FrontCheckInstantiation>, m: FrontWireMapper) -> String {
     if insts.len() == 0 {
         return "[]"
     }
     let mut items: List<String> = []
     for i in insts {
-        items.push(frontCheckInstantiationToWireJson(i))
+        let r = frontWireMapperOffsets(m, i.start, i.end)
+        items.push(frontCheckInstantiationBodyJson(i, r.start, r.end))
     }
     "[" + strings.join(items, ",") + "]"
 }
-fn frontCheckInstantiationToWireJson(i: FrontCheckInstantiation) -> String {
+fn frontCheckInstantiationBodyJson(i: FrontCheckInstantiation, start: Int, end: Int) -> String {
     let mut typeArgsParts: List<String> = []
     for ta in i.typeArgs {
         typeArgsParts.push(frontTypeReprToWireJson(ta))
@@ -124,20 +259,33 @@ fn frontCheckInstantiationToWireJson(i: FrontCheckInstantiation) -> String {
         }
         out = out + ",\"typeArgIds\":[" + strings.join(typeArgIdsParts, ",") + "]"
     }
-    out + ",\"resultType\":" + frontTypeReprToWireJson(i.resultType) + ",\"resultTypeId\":{i.resultTypeId},\"start\":{i.start},\"end\":{i.end}\}"
+    out + ",\"resultType\":" + frontTypeReprToWireJson(i.resultType) + ",\"resultTypeId\":{i.resultTypeId},\"start\":{start},\"end\":{end}\}"
 }
-fn checkDiagnosticsToWireJson(diags: List<CheckDiagnostic>) -> String {
+fn checkDiagnosticsToWireJson(diags: List<CheckDiagnostic>, m: FrontWireMapper) -> String {
     if diags.len() == 0 {
         return "[]"
     }
     let mut items: List<String> = []
     for d in diags {
-        items.push(checkDiagnosticToWireJson(d))
+        let r = frontWireMapperOffsets(m, d.start, d.end)
+        items.push(checkDiagnosticBodyJson(d, r))
     }
     "[" + strings.join(items, ",") + "]"
 }
-fn checkDiagnosticToWireJson(d: CheckDiagnostic) -> String {
-    let mut out = "\{\"code\":" + frontJsonString(d.code) + ",\"severity\":" + frontJsonString(diagnosticSeverityName(d.severity)) + ",\"message\":" + frontJsonString(d.message) + ",\"start\":{d.start},\"end\":{d.end}"
+fn checkDiagnosticBodyJson(d: CheckDiagnostic, r: FrontWireRange) -> String {
+    let mut out = "\{\"code\":" + frontJsonString(d.code) + ",\"severity\":" + frontJsonString(diagnosticSeverityName(d.severity)) + ",\"message\":" + frontJsonString(d.message) + ",\"start\":{r.start},\"end\":{r.end}"
+    if r.startLine > 0 {
+        out = out + ",\"startLine\":{r.startLine}"
+    }
+    if r.startColumn > 0 {
+        out = out + ",\"startColumn\":{r.startColumn}"
+    }
+    if r.endLine > 0 {
+        out = out + ",\"endLine\":{r.endLine}"
+    }
+    if r.endColumn > 0 {
+        out = out + ",\"endColumn\":{r.endColumn}"
+    }
     if d.notes.len() > 0 {
         let mut notesParts: List<String> = []
         for n in d.notes {

--- a/toolchain/check_json_test.osty
+++ b/toolchain/check_json_test.osty
@@ -161,6 +161,73 @@ fn testCheckJsonInstantiationOmitsEmptyTypeArgIds() {
 }
 // Empty `typeArgIds` matches the Go-side `omitempty` tag and gets
 // dropped from the wire output.
+fn testCheckJsonByteOffsetsForAsciiSource() {
+    let out = frontCheckSourceToWireJson("fn id<T>(value: T) -> T { value }")
+    testing.assert(stringsContainsJson(out, "\"name\":\"value\""))
+    let emptyOut = frontCheckSourceToWireJson("")
+    testing.assertEq(emptyOut, "\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}")
+}
+// ASCII-only source: byte offsets == rune offsets. Sanity-check
+// that a non-empty input produces an integer `start`/`end` derived
+// from the lex stream rather than the raw token index.
+// Wire JSON must surface real wire offsets (non-negative integer
+// fields). We can't pin exact spans without locking the parser AST
+// ordering, but the binding `value` is guaranteed to appear since
+// generic id elaborates cleanly.
+// Empty-source byte parity sanity: with no tokens at all, the
+// mapper short-circuits start=0, end=0.
+fn testCheckJsonByteOffsetsForMultiByteSource() {
+    let src = "// \u{1F600}\nfn id<T>(value: T) -> T { value }"
+    let out = frontCheckSourceToWireJson(src)
+    testing.assert(stringsContainsJson(out, "\"name\":\"value\""))
+    testing.assert(stringsContainsJson(out, "\"summary\":"))
+}
+// Source with multi-byte UTF-8 characters: `value`'s byte offset
+// must reflect the actual UTF-8 byte position past the leading
+// 4-byte emoji + ASCII bytes, not its rune index. The identifier
+// sits past one 4-byte sequence (`\u{1F600}` = 0xF0 0x9F 0x98 0x80)
+// plus the ASCII prefix `// ` (3 bytes) + newline (1 byte) +
+// `fn id<T>(` (9 bytes) = 17 bytes. We only verify that *some*
+// byte offset >= 17 surfaces for one of the records below, since
+// the precise span depends on which AST nodes the elaborator
+// tagged.
+// The emoji-bearing source still produces valid JSON (no escape
+// mishap on the U+1F600 character, which is outside BMP).
+fn testCheckJsonDiagnosticEmitsLineColumnWhenLexed() {
+    let src = "fn main() \{ let x: Int = \"hello\" \}"
+    let out = frontCheckSourceToWireJson(src)
+    testing.assert(stringsContainsJson(out, "\"diagnostics\":["))
+    testing.assert(stringsContainsJson(out, "\"startLine\":1"))
+    testing.assert(stringsContainsJson(out, "\"startColumn\":"))
+}
+// Force an E0700 diagnostic by mismatching a let binding: the
+// mapper attaches startLine/startColumn/endLine/endColumn to every
+// diagnostic record. Identity-mapper callers (legacy
+// `frontCheckResultToWireJson`) don't emit these — only the
+// lex-aware entry does.
+// At least one diagnostic-line position must surface. The mapper
+// assigns 1-based line numbers via FrontPos.line, so a successful
+// attach produces "startLine":1 for this single-line input.
+fn testCheckJsonLegacyEntryStillOmitsLineColumn() {
+    let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 1}
+    let nodes: List<FrontCheckedNode> = []
+    let bindings: List<FrontCheckedBinding> = []
+    let symbols: List<FrontCheckedSymbol> = []
+    let insts: List<FrontCheckInstantiation> = []
+    let diag = CheckDiagnostic {code: "E0700", severity: SeverityError, message: "x", start: 4, end: 8, notes: []}
+    let result = FrontCheckResult {summary, typedNodes: nodes, bindings, symbols, instantiations: insts, diagnostics: [diag]}
+    let out = frontCheckResultToWireJson(result)
+    testing.assert(!stringsContainsJson(out, "\"startLine\""))
+    testing.assert(!stringsContainsJson(out, "\"endLine\""))
+    testing.assert(!stringsContainsJson(out, "\"startColumn\""))
+    testing.assert(!stringsContainsJson(out, "\"endColumn\""))
+    testing.assert(stringsContainsJson(out, "\"start\":4"))
+    testing.assert(stringsContainsJson(out, "\"end\":8"))
+}
+// The identity-mapper legacy entry must NOT inject
+// startLine/endLine — callers depend on the legacy shape to stay
+// free of position metadata.
+// start/end still appear with the values caller supplied.
 // Thin wrapper on `std.strings.contains` — keeps the assertion sites
 // readable as plain booleans, matching the convention used by
 // `check_diag_test.osty`.

--- a/toolchain/check_json_test.osty
+++ b/toolchain/check_json_test.osty
@@ -162,37 +162,67 @@ fn testCheckJsonInstantiationOmitsEmptyTypeArgIds() {
 // Empty `typeArgIds` matches the Go-side `omitempty` tag and gets
 // dropped from the wire output.
 fn testCheckJsonByteOffsetsForAsciiSource() {
-    let out = frontCheckSourceToWireJson("fn id<T>(value: T) -> T { value }")
+    let out = frontCheckSourceToWireJson("fn id<T>(value: T) -> T \{ value \}")
     testing.assert(stringsContainsJson(out, "\"name\":\"value\""))
+    testing.assertEq(extractIntFieldAfter(out, "\"name\":\"value\"", "\"start\":"), "9")
+    testing.assertEq(extractIntFieldAfter(out, "\"name\":\"value\"", "\"end\":"), "14")
     let emptyOut = frontCheckSourceToWireJson("")
     testing.assertEq(emptyOut, "\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}")
 }
-// ASCII-only source: byte offsets == rune offsets. Sanity-check
-// that a non-empty input produces an integer `start`/`end` derived
-// from the lex stream rather than the raw token index.
-// Wire JSON must surface real wire offsets (non-negative integer
-// fields). We can't pin exact spans without locking the parser AST
-// ordering, but the binding `value` is guaranteed to appear since
-// generic id elaborates cleanly.
+// ASCII source — byte offsets == rune offsets. The `value`
+// parameter identifier starts at character 9 (`fn id<T>(`is 9
+// chars), so the binding's `start` field must be 9. Asserting on
+// the extracted number value pins the mapper attach; a regression
+// to raw token indices would surface a much smaller number (token
+// index of `value` is 6).
 // Empty-source byte parity sanity: with no tokens at all, the
 // mapper short-circuits start=0, end=0.
 fn testCheckJsonByteOffsetsForMultiByteSource() {
-    let src = "// \u{1F600}\nfn id<T>(value: T) -> T { value }"
+    let src = "// \u{1F600}\nfn id<T>(value: T) -> T \{ value \}"
     let out = frontCheckSourceToWireJson(src)
     testing.assert(stringsContainsJson(out, "\"name\":\"value\""))
-    testing.assert(stringsContainsJson(out, "\"summary\":"))
+    testing.assertEq(extractIntFieldAfter(out, "\"name\":\"value\"", "\"start\":"), "17")
+    testing.assertEq(extractIntFieldAfter(out, "\"name\":\"value\"", "\"end\":"), "22")
+    testing.assert(extractIntFieldAfter(out, "\"name\":\"value\"", "\"start\":") != "14")
 }
-// Source with multi-byte UTF-8 characters: `value`'s byte offset
-// must reflect the actual UTF-8 byte position past the leading
-// 4-byte emoji + ASCII bytes, not its rune index. The identifier
-// sits past one 4-byte sequence (`\u{1F600}` = 0xF0 0x9F 0x98 0x80)
-// plus the ASCII prefix `// ` (3 bytes) + newline (1 byte) +
-// `fn id<T>(` (9 bytes) = 17 bytes. We only verify that *some*
-// byte offset >= 17 surfaces for one of the records below, since
-// the precise span depends on which AST nodes the elaborator
-// tagged.
-// The emoji-bearing source still produces valid JSON (no escape
-// mishap on the U+1F600 character, which is outside BMP).
+// Multi-byte source — `value` parameter sits past a leading 4-byte
+// emoji (U+1F600 = `F0 9F 98 80`) plus ASCII bytes. Char positions:
+//   `// ` = 3 chars,  emoji = 1 char,  `\nfn id<T>(` = 10 chars
+// = 14 runes before `value`. Byte positions over the same prefix
+// are 3 + 4 + 10 = 17. Asserting `start` == 17 (not 14) proves the
+// mapper applied the rune→byte conversion rather than handing the
+// rune offset through verbatim.
+// Catch a hypothetical mapper regression that emits rune offsets:
+// the binding's `start` would surface 14 instead of 17.
+// extractIntFieldAfter finds `marker` in `haystack`, then scans for the
+// nearest `field` (e.g. `"start":`) past it and returns the digits
+// following the field as a string. Empty string when either marker is
+// missing. Used to pin the byte-offset assertions to a specific
+// record (the binding for "value") without parsing the wire JSON.
+fn extractIntFieldAfter(haystack: String, marker: String, field: String) -> String {
+    match strings.indexOf(haystack, marker) {
+        Some(markerIdx) -> {
+            let afterMarker = strings.slice(haystack, markerIdx + strings.len(marker), strings.len(haystack))
+            match strings.indexOf(afterMarker, field) {
+                Some(fieldIdx) -> {
+                    let valStart = fieldIdx + strings.len(field)
+                    let after = strings.slice(afterMarker, valStart, strings.len(afterMarker))
+                    let mut digits = ""
+                    for ch in after.chars() {
+                        let c = "{ch}"
+                        if c == "," || c == "\}" {
+                            return digits
+                        }
+                        digits = digits + c
+                    }
+                    digits
+                },
+                None -> "",
+            }
+        },
+        None -> "",
+    }
+}
 fn testCheckJsonDiagnosticEmitsLineColumnWhenLexed() {
     let src = "fn main() \{ let x: Int = \"hello\" \}"
     let out = frontCheckSourceToWireJson(src)


### PR DESCRIPTION
## Summary

- M4 brick A: switch `tc.frontCheckSourceToWireJson(source)` from token indices to **UTF-8 byte offsets**, matching the Go adapter (`internal/selfhost/check_adapter.go::checkNodeOffsets`).
- Diagnostics additionally get `startLine` / `startColumn` / `endLine` / `endColumn` from `FrontLexToken.start.line`+`column`, mirroring `adaptCheckResultWithTokenMapper`'s display-position pass.
- New `FrontWireMapper` (rune→byte table + tokens) threads through every record serializer; an identity mapper preserves the legacy `frontCheckResultToWireJson(result)` shape for toolchain callers that hold a result without the lex stream.
- Tests pin: byte-offset attach on ASCII + multi-byte UTF-8 input, diagnostic line/column emission, legacy entry still omits all line/column fields, empty-source byte parity preserved.

## Remaining M4 bricks (separate PRs)

- **Brick B**: `errorsByContext` / `errorDetails` summary telemetry (aggregate diagnostics by code + message).
- **Brick C**: `EnsureStableIDs` sha256 stamping (`id` / `nodeKey` / `typeKey`).

Both are independent of byte-offset conversion landed here.

## Test plan

- [x] `.bin/osty check toolchain` exits 0
- [x] `.bin/osty fmt --check` clean on `check_json.osty` + `check_json_test.osty`
- [x] `go test ./internal/selfhost/bundle ./cmd/osty-native-checker` green
- [x] Empty-source byte parity (M2) preserved via identity-mapper short-circuit
- [ ] LLVM-built non-empty-input byte parity vs Go-built target — needs `osty-self` cache to verify

https://claude.ai/code/session_0111KDxeWRq1662XEgPDFYmt

---
_Generated by [Claude Code](https://claude.ai/code/session_0111KDxeWRq1662XEgPDFYmt)_