### PR TITLE
test: narrow A13 #[pure] round-trip readnone assertions to @main()

### DIFF
--- a/toolchain/mir_json_test.osty
+++ b/toolchain/mir_json_test.osty
@@ -114,7 +114,10 @@ fn testMirJsonDecodePureFunctionEmitsReadnone() {
     let result = lirLowerMirModule(lirLowerConfig("main", "/tmp/mir_json_pure_test.mir.json", ""), m)
     testing.assert(lirLowerOK(result))
     let ir = lirRenderModule(result.module)
-    testing.assert(strings.contains(ir, "readnone"))
+    // Assert readnone lands on the @main() define line specifically,
+    // not just anywhere in the module — guards against false-positives
+    // if unrelated runtime declarations ever carry readnone.
+    testing.assert(strings.contains(ir, "@main() readnone"))
 }
 
 // Baseline guard: absent the `pure` JSON field, the decoded
@@ -164,5 +167,9 @@ fn testMirJsonDecodeNonPureFunctionSkipsReadnone() {
     let result = lirLowerMirModule(lirLowerConfig("main", "/tmp/mir_json_non_pure_test.mir.json", ""), m)
     testing.assert(lirLowerOK(result))
     let ir = lirRenderModule(result.module)
-    testing.assert(!strings.contains(ir, "readnone"))
+    // Mirror the positive test's narrow check: assert the @main()
+    // define line specifically lacks readnone. Searching the whole
+    // module would also fail if any runtime decl ever carries
+    // readnone, masking a regression here.
+    testing.assert(!strings.contains(ir, "@main() readnone"))
 }


### PR DESCRIPTION
## Summary
- Address Copilot review on [#1946](https://github.com/choiceoh/osty/pull/1946): negative readnone check used `!strings.contains(ir, "readnone")` over the whole rendered module, which would false-fail if any unrelated runtime declaration ever carried readnone.
- Both round-trip tests now assert against `"@main() readnone"` so the polarity is pinned to the @main() define line specifically — positive: present, negative: absent.

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)