### PR TITLE
feat: env-gated build-phase wall-clock timing (osty build + install-self)

### DIFF
--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -43,6 +43,11 @@ import (
 //	2   usage error or manifest validation failure
 //	3   dependency resolution failure
 func runBuild(args []string, flags cliFlags) {
+	// Print accumulated backend phase timings at exit when
+	// `OSTY_BUILD_PHASE_TIMING=1`. No-op otherwise. Wired here so
+	// every runBuild return path (success or fail) flushes the
+	// markers recorded inside `LLVMBackend.Emit` / `emitPrebuiltIR`.
+	defer backend.EmitPhaseTimings()
 	fs := flag.NewFlagSet("build", flag.ExitOnError)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: osty build [--offline | --locked | --frozen] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [--backend NAME] [--emit MODE] [--force] [--airepair=false] [--airepair-mode MODE] [PATH]")

--- a/cmd/osty/install_self.go
+++ b/cmd/osty/install_self.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/backend/stage0"
 	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
@@ -37,6 +38,10 @@ import (
 //
 // Exit codes match the rest of the CLI: 0 success, 1 failure.
 func runInstallSelf(args []string, _ cliFlags) {
+	// Flush accumulated phase timings (including any recorded in the
+	// forked `osty build` if it inherited the env gate) at exit when
+	// `OSTY_BUILD_PHASE_TIMING=1`. No-op otherwise.
+	defer backend.EmitPhaseTimings()
 	fs := flag.NewFlagSet("install-self", flag.ExitOnError)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: osty install-self [--force] [--toolchain-dir DIR] [--osty-bin PATH]")
@@ -52,12 +57,15 @@ func runInstallSelf(args []string, _ cliFlags) {
 		os.Exit(2)
 	}
 
+	endLocate := backend.BeginPhase("install-self.locate-and-key")
 	root, err := selfhostcache.LocateProjectRoot(".")
 	if err != nil {
+		endLocate()
 		fmt.Fprintf(os.Stderr, "osty install-self: locate project root: %v\n", err)
 		os.Exit(1)
 	}
 	key, err := selfhostcache.ComputeKey(root)
+	endLocate()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty install-self: compute key: %v\n", err)
 		os.Exit(1)
@@ -120,23 +128,30 @@ func runInstallSelf(args []string, _ cliFlags) {
 	builtBin := ""
 	var buildErr error
 	if force && resolveErr == nil {
+		endSelfhostBuild := backend.BeginPhase("install-self.build-via-selfhost")
 		builtBin, buildErr = buildOstySelfWithSelfhost(context.Background(), resolvedSelf, hostOsty, root, tcAbs)
+		endSelfhostBuild()
 		if buildErr != nil {
 			fmt.Fprintf(os.Stderr, "osty install-self: selfhost build failed; retrying source bootstrap: %v\n", buildErr)
 		}
 	}
 	if builtBin == "" {
+		endStage0Build := backend.BeginPhase("install-self.build-via-stage0")
 		builtBin, buildErr = buildOstySelf(context.Background(), hostOsty, root, tcAbs)
+		endStage0Build()
 	}
 	if buildErr != nil {
 		fmt.Fprintf(os.Stderr, "osty install-self: build: %v\n", buildErr)
 		printInstallSelfBootstrapHint()
 		os.Exit(1)
 	}
+	endPromote := backend.BeginPhase("install-self.cache-promote")
 	if err := selfhostcache.Install(root, key, builtBin); err != nil {
+		endPromote()
 		fmt.Fprintf(os.Stderr, "osty install-self: cache install: %v\n", err)
 		os.Exit(1)
 	}
+	endPromote()
 	fmt.Printf("installed:   %s\n", cachedPath)
 }
 

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -51,7 +51,9 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	if err := ValidateEmit(NameLLVM, req.Emit); err != nil {
 		return nil, err
 	}
+	endGen := BeginPhase("backend.generate-ir")
 	irOut, warnings, genErr := generateLLVMIR(req.Entry, req.Layout.Target, req.Features, req.Emit, req.BootstrapStage0)
+	endGen()
 	if genErr == nil {
 		return b.emitPrebuiltIR(ctx, req, irOut, warnings)
 	}
@@ -119,7 +121,9 @@ func (b LLVMBackend) emitPrebuiltIR(ctx context.Context, req Request, irOut []by
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	endWriteIR := BeginPhase("backend.write-ir")
 	out, err := b.preparePrebuiltIRResult(req, irOut, warnings)
+	endWriteIR()
 	if err != nil {
 		return nil, err
 	}
@@ -127,16 +131,21 @@ func (b LLVMBackend) emitPrebuiltIR(ctx context.Context, req Request, irOut []by
 		return out, nil
 	}
 	tc := b.llvmToolchain()
+	endCompile := BeginPhase("backend.compile-object")
 	if err := tc.CompileObject(ctx, out.Artifacts.LLVMIR, out.Artifacts.Object, req.Layout.Target, req.Layout.Profile); err != nil {
+		endCompile()
 		return out, err
 	}
+	endCompile()
 	if !llvmabi.NeedsBinaryArtifact(req.Emit.String()) {
 		return out, nil
 	}
 	if out.Artifacts.Binary == "" {
 		return out, fmt.Errorf("%s", llvmabi.MissingBinaryArtifactMessage())
 	}
+	endRuntime := BeginPhase("backend.compile-runtime")
 	runtimeObject, err := ensureLocalGCRuntimeObject(ctx, tc, out.Artifacts, req.Layout.Target, req.Layout.Profile)
+	endRuntime()
 	if err != nil {
 		return out, err
 	}
@@ -149,9 +158,12 @@ func (b LLVMBackend) emitPrebuiltIR(ctx context.Context, req Request, irOut []by
 	if runtimeObject != "" {
 		linkObjects = append(linkObjects, runtimeObject)
 	}
+	endLink := BeginPhase("backend.link-binary")
 	if err := tc.LinkBinary(ctx, linkObjects, out.Artifacts.Binary, req.Layout.Target, req.Layout.Profile, req.LinkLibraries); err != nil {
+		endLink()
 		return out, err
 	}
+	endLink()
 	return out, nil
 }
 

--- a/internal/backend/phase_timing.go
+++ b/internal/backend/phase_timing.go
@@ -1,0 +1,160 @@
+package backend
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+// PhaseTimingEnv gates the build-phase timing instrumentation.
+// `OSTY_BUILD_PHASE_TIMING=1` (or any truthy value) opts in. When unset
+// every Begin/End pair is a no-op and the accumulator stays empty so the
+// hot path pays only a single env-cached bool check per marker.
+//
+// The intended consumer is the install-self bootstrap critical path,
+// where the wall-clock breakdown (front-end vs MIR/IR lowering vs
+// stage0 emit vs LLVM toolchain link) decides which phase to attack
+// next. The env gate keeps the noise out of production builds; CI and
+// local profiling sessions opt in explicitly.
+const PhaseTimingEnv = "OSTY_BUILD_PHASE_TIMING"
+
+// phaseTimingEnabled is computed once at process start so each
+// BeginPhase call does a single boolean load instead of re-parsing the
+// env var. Tests that need to toggle the gate use SetPhaseTimingEnabled
+// to update it deterministically.
+var (
+	phaseTimingMu       sync.Mutex
+	phaseTimingEnabled  = phaseTimingOnFromEnv()
+	phaseTimingMarkers  []PhaseMarker
+	phaseTimingWriter   io.Writer = os.Stderr
+	phaseTimingResetSeq uint64
+)
+
+// PhaseMarker is one completed phase's name + wall-clock duration.
+// Exported so tests can assert against the accumulated set.
+type PhaseMarker struct {
+	Name     string
+	Duration time.Duration
+}
+
+func phaseTimingOnFromEnv() bool {
+	switch os.Getenv(PhaseTimingEnv) {
+	case "1", "true", "TRUE", "True", "yes", "YES", "on", "ON":
+		return true
+	}
+	return false
+}
+
+// SetPhaseTimingEnabled toggles the gate at runtime. Tests use this to
+// flip the gate without mutating the process env. Returns the previous
+// value so callers can restore it in a defer.
+func SetPhaseTimingEnabled(on bool) bool {
+	phaseTimingMu.Lock()
+	prev := phaseTimingEnabled
+	phaseTimingEnabled = on
+	phaseTimingMu.Unlock()
+	return prev
+}
+
+// PhaseTimingEnabled reports whether instrumentation is active. Most
+// callers do not need this — they call BeginPhase directly and let it
+// no-op. Surfaced for tests and for call sites that want to skip
+// expensive bookkeeping (e.g. timestamping IR-substring matches) that
+// would itself be dead under a no-op marker.
+func PhaseTimingEnabled() bool {
+	phaseTimingMu.Lock()
+	defer phaseTimingMu.Unlock()
+	return phaseTimingEnabled
+}
+
+// BeginPhase records the start of a build phase. The returned func
+// must be invoked when the phase ends — `defer backend.BeginPhase("…")()`
+// is the canonical shape. The cost is one boolean check + one time.Now
+// call when enabled, and a single boolean load when disabled.
+//
+// Each completed phase is also streamed immediately to the configured
+// writer in the form `phase-timing: <name> <duration>` so that even
+// when the calling subcommand bails via `os.Exit` (which skips
+// `EmitPhaseTimings`) the markers up to the failure point are still
+// visible. The accumulator still collects every marker for the
+// sorted summary at clean exits.
+func BeginPhase(name string) func() {
+	if !PhaseTimingEnabled() {
+		return phaseTimingNoop
+	}
+	start := time.Now()
+	return func() {
+		d := time.Since(start)
+		phaseTimingMu.Lock()
+		phaseTimingMarkers = append(phaseTimingMarkers, PhaseMarker{Name: name, Duration: d})
+		w := phaseTimingWriter
+		phaseTimingMu.Unlock()
+		fmt.Fprintf(w, "phase-timing: %-32s %12s\n", name, d.Round(time.Millisecond))
+	}
+}
+
+func phaseTimingNoop() {}
+
+// EmitPhaseTimings prints every accumulated marker to stderr (or the
+// configured writer) sorted by duration descending, then clears the
+// accumulator. No-op when the gate is off or nothing was recorded so
+// callers can wire it unconditionally at process exit.
+//
+// The output layout is single-column human-readable — the consumer is
+// a developer reading stderr, not a parser. Stable enough that grep /
+// awk pipelines stay simple but not documented as a wire format.
+func EmitPhaseTimings() {
+	phaseTimingMu.Lock()
+	if !phaseTimingEnabled || len(phaseTimingMarkers) == 0 {
+		phaseTimingMu.Unlock()
+		return
+	}
+	markers := append([]PhaseMarker(nil), phaseTimingMarkers...)
+	phaseTimingMarkers = nil
+	phaseTimingResetSeq++
+	w := phaseTimingWriter
+	phaseTimingMu.Unlock()
+
+	sort.SliceStable(markers, func(i, j int) bool {
+		return markers[i].Duration > markers[j].Duration
+	})
+
+	fmt.Fprintln(w, "-- build phase timing --")
+	var total time.Duration
+	for _, m := range markers {
+		fmt.Fprintf(w, "  %-32s %12s\n", m.Name, m.Duration.Round(time.Millisecond))
+		total += m.Duration
+	}
+	fmt.Fprintf(w, "  %-32s %12s\n", "(sum of phases)", total.Round(time.Millisecond))
+}
+
+// CollectPhaseTimings drains the accumulator and returns the markers
+// in recorded order. Used by tests to assert on the captured set
+// without touching the writer.
+func CollectPhaseTimings() []PhaseMarker {
+	phaseTimingMu.Lock()
+	defer phaseTimingMu.Unlock()
+	if len(phaseTimingMarkers) == 0 {
+		return nil
+	}
+	out := append([]PhaseMarker(nil), phaseTimingMarkers...)
+	phaseTimingMarkers = nil
+	return out
+}
+
+// SetPhaseTimingWriter redirects EmitPhaseTimings output. Tests use this
+// to capture into a buffer; production leaves it as os.Stderr.
+func SetPhaseTimingWriter(w io.Writer) io.Writer {
+	phaseTimingMu.Lock()
+	prev := phaseTimingWriter
+	if w == nil {
+		phaseTimingWriter = os.Stderr
+	} else {
+		phaseTimingWriter = w
+	}
+	phaseTimingMu.Unlock()
+	return prev
+}

--- a/internal/backend/phase_timing_test.go
+++ b/internal/backend/phase_timing_test.go
@@ -1,0 +1,139 @@
+package backend
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withPhaseTimingEnabled toggles the gate for one test and restores the
+// previous state on cleanup. Use this rather than mutating
+// os.Setenv(PhaseTimingEnv) because phaseTimingEnabled is sampled once
+// at package init.
+func withPhaseTimingEnabled(t *testing.T, on bool) {
+	t.Helper()
+	prev := SetPhaseTimingEnabled(on)
+	t.Cleanup(func() { SetPhaseTimingEnabled(prev) })
+	_ = CollectPhaseTimings()
+}
+
+func TestBeginPhaseRecordsDurationWhenEnabled(t *testing.T) {
+	withPhaseTimingEnabled(t, true)
+
+	end := BeginPhase("stage0.emit")
+	time.Sleep(2 * time.Millisecond)
+	end()
+
+	markers := CollectPhaseTimings()
+	if len(markers) != 1 {
+		t.Fatalf("CollectPhaseTimings returned %d markers, want 1: %#v", len(markers), markers)
+	}
+	if markers[0].Name != "stage0.emit" {
+		t.Fatalf("marker name = %q, want %q", markers[0].Name, "stage0.emit")
+	}
+	if markers[0].Duration < 2*time.Millisecond {
+		t.Fatalf("marker duration = %s, want >= 2ms", markers[0].Duration)
+	}
+}
+
+func TestBeginPhaseNoopsWhenDisabled(t *testing.T) {
+	withPhaseTimingEnabled(t, false)
+
+	end := BeginPhase("backend.link")
+	time.Sleep(time.Millisecond)
+	end()
+
+	if got := CollectPhaseTimings(); got != nil {
+		t.Fatalf("CollectPhaseTimings returned %#v while disabled, want nil", got)
+	}
+}
+
+func TestEmitPhaseTimingsSortsDescAndClears(t *testing.T) {
+	withPhaseTimingEnabled(t, true)
+
+	var buf bytes.Buffer
+	prev := SetPhaseTimingWriter(&buf)
+	t.Cleanup(func() { SetPhaseTimingWriter(prev) })
+
+	fastEnd := BeginPhase("backend.link")
+	time.Sleep(time.Millisecond)
+	fastEnd()
+	slowEnd := BeginPhase("stage0.emit")
+	time.Sleep(8 * time.Millisecond)
+	slowEnd()
+
+	// Streaming output (the `phase-timing:` lines) fires as each
+	// marker ends — both phases must appear in recorded order.
+	out := buf.String()
+	streamLink := strings.Index(out, "phase-timing: backend.link")
+	streamStage := strings.Index(out, "phase-timing: stage0.emit")
+	switch {
+	case streamLink < 0:
+		t.Fatalf("streaming row missing backend.link:\n%s", out)
+	case streamStage < 0:
+		t.Fatalf("streaming row missing stage0.emit:\n%s", out)
+	case streamLink > streamStage:
+		t.Fatalf("streaming rows not in record order — backend.link should precede stage0.emit:\n%s", out)
+	}
+
+	EmitPhaseTimings()
+
+	out = buf.String()
+	header := strings.Index(out, "-- build phase timing --")
+	if header < 0 {
+		t.Fatalf("output missing summary header:\n%s", out)
+	}
+	summary := out[header:]
+	if !strings.Contains(summary, "(sum of phases)") {
+		t.Fatalf("summary missing sum-of-phases row:\n%s", summary)
+	}
+	// Inside the summary block specifically, the slower phase must
+	// come first (desc by duration).
+	summStage := strings.Index(summary, "stage0.emit")
+	summLink := strings.Index(summary, "backend.link")
+	if summStage < 0 || summLink < 0 || summStage > summLink {
+		t.Fatalf("summary not sorted desc by duration — stage0.emit should precede backend.link:\n%s", summary)
+	}
+
+	// Accumulator is cleared after emit so a second EmitPhaseTimings
+	// call produces no new summary header.
+	buf.Reset()
+	EmitPhaseTimings()
+	if strings.Contains(buf.String(), "-- build phase timing --") {
+		t.Fatalf("EmitPhaseTimings re-emitted summary after clear:\n%s", buf.String())
+	}
+}
+
+func TestEmitPhaseTimingsNoopsWhenDisabled(t *testing.T) {
+	withPhaseTimingEnabled(t, true)
+	// Record one marker, then disable before emitting.
+	BeginPhase("disabled-before-emit")()
+	withPhaseTimingEnabled(t, false)
+
+	var buf bytes.Buffer
+	prev := SetPhaseTimingWriter(&buf)
+	t.Cleanup(func() { SetPhaseTimingWriter(prev) })
+
+	EmitPhaseTimings()
+
+	if buf.Len() != 0 {
+		t.Fatalf("EmitPhaseTimings emitted output while disabled:\n%s", buf.String())
+	}
+}
+
+func TestCollectPhaseTimingsPreservesRecordedOrder(t *testing.T) {
+	withPhaseTimingEnabled(t, true)
+
+	BeginPhase("first")()
+	BeginPhase("second")()
+	BeginPhase("third")()
+
+	markers := CollectPhaseTimings()
+	names := []string{markers[0].Name, markers[1].Name, markers[2].Name}
+	want := []string{"first", "second", "third"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("recorded order = %v, want %v", names, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/backend/phase_timing` — a thread-safe Begin/End marker helper gated by `OSTY_BUILD_PHASE_TIMING=1`. Markers stream `phase-timing: <name> <duration>` to stderr the instant each phase ends (survives `os.Exit` in error paths) and also accumulate into a sorted summary printed by `EmitPhaseTimings()` at clean exits.
- Instrumented phases:
  - **backend**: `generate-ir` (MIR → LLVM IR text via lirproto subprocess or stage0), `write-ir`, `compile-object`, `compile-runtime`, `link-binary`
  - **install-self**: `locate-and-key`, `build-via-selfhost`, `build-via-stage0`, `cache-promote`
- Wired `defer backend.EmitPhaseTimings()` at the top of `runBuild` + `runInstallSelf` for the sorted summary. Streaming output handles the many `os.Exit` exit paths.

## Motivation
First cost breakdown for the install-self bootstrap critical path — `front-end → MIR/IR lowering → stage0 emit → LLVM toolchain link` — so subsequent perf work can target the actual hot phase instead of guessing. Default behaviour is unchanged (the gate is off).

## Test plan
- [x] `go test ./internal/backend -run 'Phase'` — 5 unit tests (record/no-op gating, streaming order, summary sort + clear, disabled-after-record)
- [x] `just prepush` 로컬 통과
- [x] e2e smoke: `OSTY_BUILD_PHASE_TIMING=1 .bin/osty build --backend=llvm --emit=llvm-ir --force benchmarks/programs/big-map/osty` 가 `phase-timing: backend.generate-ir   1.346s` 를 stderr 로 emit 확인
- [ ] CI 그린 확인

## Usage
```
OSTY_BUILD_PHASE_TIMING=1 osty install-self
# … per-phase streaming lines …
-- build phase timing --
  install-self.build-via-stage0     5m12.345s
  backend.compile-object             1m02.111s
  backend.link-binary                  12.345s
  backend.generate-ir                  10.234s
  backend.write-ir                      0.987s
  install-self.cache-promote            0.045s
  (sum of phases)                   6m37.067s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)