### PR TITLE
perf: parallelize ir.LowerPackage per-file loop (toolchain build -19%)

### DIFF
--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -146,7 +146,9 @@ func LowerPackageIR(packageName, sourcePath string, pkg *resolve.Package, entryF
 			FileScope: entryFile.FileScope,
 		}
 	}
+	endLowerPkg := BeginPhase("ir.LowerPackage")
 	mod, issues := ir.LowerPackage(packageName, pkg, chk)
+	endLowerPkg()
 	entry.IRIssues = append(entry.IRIssues, issues...)
 	if mod == nil {
 		return entry, fmt.Errorf("backend: ir.LowerPackage returned nil module")
@@ -184,6 +186,7 @@ func LowerGraphPackageIR(packageName, sourcePath string, graph *resolve.PackageG
 // PreparePackage behavior for existing callers.
 func finalizeEntryIR(entry Entry, mod *ir.Module) (Entry, error) {
 	if stdlibBodyLoweringEnabled() {
+		endInject := BeginPhase("ir.injectStdlib")
 		reg := stdlib.LoadCached()
 		injected, injectionErrs := injectReachableStdlibBodies(mod, reg)
 		entry.IRIssues = append(entry.IRIssues, injectionErrs...)
@@ -197,14 +200,22 @@ func finalizeEntryIR(entry Entry, mod *ir.Module) (Entry, error) {
 		injectedTypes, typeIssues := injectReachableStdlibTypes(mod, reg)
 		entry.IRIssues = append(entry.IRIssues, typeIssues...)
 		mod.Decls = append(mod.Decls, injectedTypes...)
+		endInject()
 	}
+	endMono := BeginPhase("ir.Monomorphize")
 	if monoMod, monoErrs := ir.Monomorphize(mod); monoMod != nil {
 		mod = monoMod
 		entry.IRIssues = append(entry.IRIssues, monoErrs...)
 	}
+	endMono()
+	endOpt := BeginPhase("ir.Optimize")
 	mod = ir.Optimize(mod, ir.OptimizeOptions{})
+	endOpt()
 	entry.IR = mod
-	if validateErrs := ir.Validate(mod); len(validateErrs) != 0 {
+	endValidate := BeginPhase("ir.Validate")
+	validateErrs := ir.Validate(mod)
+	endValidate()
+	if len(validateErrs) != 0 {
 		entry.IRIssues = append(entry.IRIssues, validateErrs...)
 		return entry, errors.Join(validateErrs...)
 	}
@@ -216,15 +227,22 @@ func finalizeEntryIR(entry Entry, mod *ir.Module) (Entry, error) {
 // Any MIR coverage issue is fatal because backend dispatch no longer retries a
 // legacy HIR path.
 func LowerEntryMIR(entry Entry) (Entry, error) {
+	endMirLower := BeginPhase("mir.Lower")
 	mirMod := mir.Lower(entry.IR)
+	endMirLower()
 	if mirMod == nil {
 		return entry, errors.Join(ErrMIRCoverageIncomplete, fmt.Errorf("mir.Lower returned nil module"))
 	}
 	if mirOptimizeEnabled() {
+		endMirOpt := BeginPhase("mir.Optimize")
 		mir.Optimize(mirMod)
+		endMirOpt()
 	}
 	entry.MIRIssues = append(entry.MIRIssues, mirMod.Issues...)
-	if mirValidateErrs := mir.Validate(mirMod); len(mirValidateErrs) != 0 {
+	endMirValidate := BeginPhase("mir.Validate")
+	mirValidateErrs := mir.Validate(mirMod)
+	endMirValidate()
+	if len(mirValidateErrs) != 0 {
 		entry.MIRIssues = append(entry.MIRIssues, mirValidateErrs...)
 	}
 	entry.MIR = mirMod

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -2,8 +2,10 @@ package ir
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -120,40 +122,101 @@ func LowerPackage(pkgName string, pkg *resolve.Package, chk *check.Result) (*Mod
 	// `*ast.Ident` nodes whose `NodeID` collides with unrelated
 	// nodes in the lowerer's current file; the pointer-keyed maps
 	// disambiguate them by node identity rather than ID.
+	endMaps := beginIRPhase("ir.LowerPackage.buildMaps")
 	typeRefByPtr := buildPkgTypeRefMap(pkg)
 	refByPtr := buildPkgRefMap(pkg)
-	for i, pf := range pkg.Files {
-		if pf == nil {
-			continue
-		}
-		file := pf.EnsureFile()
-		if file == nil {
-			continue
-		}
-		res := &resolve.Result{
-			RefsByID:      pf.RefsByID,
-			TypeRefsByID:  pf.TypeRefsByID,
-			RefIdents:     pf.RefIdents,
-			TypeRefIdents: pf.TypeRefIdents,
-			FileScope:     pf.FileScope,
-		}
-		l := &lowerer{
-			pkgName:      pkgName,
-			file:         file,
-			res:          res,
-			chk:          chk,
-			typeRefByPtr: typeRefByPtr,
-			refByPtr:     refByPtr,
-		}
-		fileMod, fileIssues := l.run()
-		if i == 0 {
-			mod.SpanV = fileMod.SpanV
-		}
-		mod.Decls = append(mod.Decls, fileMod.Decls...)
-		mod.Script = append(mod.Script, fileMod.Script...)
-		issues = append(issues, fileIssues...)
+	endMaps()
+	endLoop := beginIRPhase("ir.LowerPackage.fileLoop")
+	// Per-file lowering is independent — each lowerer allocates its own
+	// `bindingPatTypes` / `fieldTypeCache` / `native` / `issues` state,
+	// shares only read-only views of `chk`, `typeRefByPtr`, `refByPtr`,
+	// and writes to its own `*Module` that we concatenate in source order
+	// below. That makes the loop safe to fan out across worker goroutines.
+	// On the toolchain install-self build (118 files) this trades
+	// ~11.2s of serial CPU for parallel runs at GOMAXPROCS cap.
+	//
+	// Deterministic output order is preserved by writing into per-index
+	// slots in `results` and concatenating in package-file order, so
+	// downstream `ir.Monomorphize` / `Optimize` / `Validate` see the same
+	// decl order as before. Single-file packages (`len(pkg.Files) <= 1`)
+	// keep the serial path — the goroutine overhead would dominate.
+	results := make([]fileLowerResult, len(pkg.Files))
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 1 {
+		workers = 1
 	}
+	if workers > len(pkg.Files) {
+		workers = len(pkg.Files)
+	}
+	if workers <= 1 || len(pkg.Files) <= 1 {
+		for i, pf := range pkg.Files {
+			results[i] = lowerOneFile(pkgName, pf, chk, typeRefByPtr, refByPtr)
+		}
+	} else {
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, workers)
+		for i, pf := range pkg.Files {
+			i, pf := i, pf
+			wg.Add(1)
+			sem <- struct{}{}
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				results[i] = lowerOneFile(pkgName, pf, chk, typeRefByPtr, refByPtr)
+			}()
+		}
+		wg.Wait()
+	}
+	for i, r := range results {
+		if r.mod == nil {
+			continue
+		}
+		if i == 0 || mod.SpanV == (Span{}) {
+			mod.SpanV = r.mod.SpanV
+		}
+		mod.Decls = append(mod.Decls, r.mod.Decls...)
+		mod.Script = append(mod.Script, r.mod.Script...)
+		issues = append(issues, r.issues...)
+	}
+	endLoop()
 	return mod, issues
+}
+
+type fileLowerResult struct {
+	mod    *Module
+	issues []error
+}
+
+// lowerOneFile runs the per-file lowerer for one PackageFile and
+// returns its module + non-fatal issues. Pulled out of LowerPackage so
+// the parallel worker pool can call it without inlining a closure that
+// captures loop-iteration variables. Caller is responsible for
+// preserving order when merging results.
+func lowerOneFile(pkgName string, pf *resolve.PackageFile, chk *check.Result, typeRefByPtr map[*ast.NamedType]*resolve.Symbol, refByPtr map[*ast.Ident]*resolve.Symbol) fileLowerResult {
+	if pf == nil {
+		return fileLowerResult{}
+	}
+	file := pf.EnsureFile()
+	if file == nil {
+		return fileLowerResult{}
+	}
+	res := &resolve.Result{
+		RefsByID:      pf.RefsByID,
+		TypeRefsByID:  pf.TypeRefsByID,
+		RefIdents:     pf.RefIdents,
+		TypeRefIdents: pf.TypeRefIdents,
+		FileScope:     pf.FileScope,
+	}
+	l := &lowerer{
+		pkgName:      pkgName,
+		file:         file,
+		res:          res,
+		chk:          chk,
+		typeRefByPtr: typeRefByPtr,
+		refByPtr:     refByPtr,
+	}
+	mod, issues := l.run()
+	return fileLowerResult{mod: mod, issues: issues}
 }
 
 // lowerer holds per-file state for one Lower call.

--- a/internal/ir/phase_timing.go
+++ b/internal/ir/phase_timing.go
@@ -1,0 +1,34 @@
+package ir
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// beginIRPhase mirrors the `OSTY_BUILD_PHASE_TIMING=1` gate that
+// `internal/backend/phase_timing.go` and
+// `internal/resolve/phase_timing.go` use. The `ir` package can't
+// import `internal/backend` (backend imports ir), so the gate logic
+// is duplicated here. Output shape matches the others exactly so
+// the same grep pipeline catches every phase line.
+func beginIRPhase(name string) func() {
+	if !irPhaseTimingEnabled() {
+		return irPhaseTimingNoop
+	}
+	start := time.Now()
+	return func() {
+		d := time.Since(start)
+		fmt.Fprintf(os.Stderr, "phase-timing: %-32s %12s\n", name, d.Round(time.Millisecond))
+	}
+}
+
+func irPhaseTimingEnabled() bool {
+	switch os.Getenv("OSTY_BUILD_PHASE_TIMING") {
+	case "1", "true", "TRUE", "True", "yes", "YES", "on", "ON":
+		return true
+	}
+	return false
+}
+
+func irPhaseTimingNoop() {}


### PR DESCRIPTION
## Summary
The `LowerPackage` file loop was serial — 118 files × ~95ms each = **11.2s of pure CPU** on the install-self critical path (after [#1949](https://github.com/choiceoh/osty/pull/1949) landed). Each per-file lowerer is independent (per-call `bindingPatTypes` / `fieldTypeCache` / `native` / `issues` state, shared read-only views of `chk` / `typeRefByPtr` / `refByPtr`, and writes to its own `*Module`), so the loop fans out across `GOMAXPROCS` goroutines with a bounded semaphore.

Deterministic decl order is preserved: each worker writes into a pre-allocated `results[i]` slot, and the main goroutine concatenates slots in package-file order, so downstream `ir.Monomorphize` / `Optimize` / `Validate` see the same decl sequence as before. Packages with ≤1 file keep the serial path — the goroutine overhead would dominate.

## Measurement
Median of 3 runs, same env + same `OSTY_BUILD_PHASE_TIMING=1` instrumentation as [#1948](https://github.com/choiceoh/osty/pull/1948) / [#1949](https://github.com/choiceoh/osty/pull/1949):

| Phase | Before | After | Δ |
|---|---|---|---|
| ir.LowerPackage | 11.7s | **2.65s** | **-76%** |
| frontend.LowerIRPackage | 11.7s | 2.74s | -76% |
| frontend.LowerMIRPackage | 11.9s | 2.95s | -75% |
| **TOTAL real** | **74.8s** | **60.3s** | **-19%** |

Cumulative since baseline (83.3s) the install-self inner build is now **-28%** across [#1948](https://github.com/choiceoh/osty/pull/1948) + [#1949](https://github.com/choiceoh/osty/pull/1949) + this PR.

## Drive-by
- `internal/backend/entry.go::finalizeEntryIR` + `LowerEntryMIR` — per-step `BeginPhase` markers (ir.LowerPackage / ir.Monomorphize / ir.Optimize / ir.Validate / mir.Lower / mir.Optimize / mir.Validate) to confirm the parallelization closed the gap without shifting cost to a downstream stage. Same `OSTY_BUILD_PHASE_TIMING=1` env gate.
- `internal/ir/phase_timing.go` (new) — mirrors the gate used by `internal/backend/phase_timing.go` and `internal/resolve/phase_timing.go`. The `ir` package can't import `internal/backend` (backend imports ir), so the gate logic is duplicated. Same `phase-timing: <name> <duration>` shape.
- `internal/ir/lower.go::LowerPackage` — added two marker pairs (`.buildMaps` and `.fileLoop`) so the measurement that motivated this change stays reproducible.

## Test plan
- [x] `go test ./internal/ir -count=1` 통과
- [x] `just front` 통과 (parser / resolve / check / format)
- [x] `just prepush` 통과
- [x] e2e: 3-run install-self measurement before/after — consistent -19% TOTAL, -76% on the parallelized phase
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)