### PR TITLE
perf: selfhostAssignResolveIDs -81% (ResolveWorkspace -16%, toolchain build -5%)

### DIFF
--- a/internal/selfhost/phase_timing.go
+++ b/internal/selfhost/phase_timing.go
@@ -1,0 +1,36 @@
+package selfhost
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// beginSelfhostPhase mirrors the `OSTY_BUILD_PHASE_TIMING=1` gate used
+// by `internal/backend/phase_timing.go`,
+// `internal/resolve/phase_timing.go`, and
+// `internal/ir/phase_timing.go`. The `selfhost` package sits at the
+// bottom of the import graph (none of the others import it) so the
+// gate logic is duplicated to avoid forcing a cycle. Output shape
+// matches the others exactly so the same grep pipeline catches every
+// phase line.
+func beginSelfhostPhase(name string) func() {
+	if !selfhostPhaseTimingEnabled() {
+		return selfhostPhaseTimingNoop
+	}
+	start := time.Now()
+	return func() {
+		d := time.Since(start)
+		fmt.Fprintf(os.Stderr, "phase-timing: %-32s %12s\n", name, d.Round(time.Millisecond))
+	}
+}
+
+func selfhostPhaseTimingEnabled() bool {
+	switch os.Getenv("OSTY_BUILD_PHASE_TIMING") {
+	case "1", "true", "TRUE", "True", "yes", "YES", "on", "ON":
+		return true
+	}
+	return false
+}
+
+func selfhostPhaseTimingNoop() {}

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -4,13 +4,27 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
+	"runtime"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/spanid"
 )
+
+// resolveIDHashPool pools sha256 hashers so each call to
+// stableResolveID can reuse one instead of allocating fresh
+// internal state per call. selfhostAssignResolveIDs makes 4–9 ID
+// computations per symbol / ref / typeRef on the install-self toolchain
+// build, so the per-call hasher allocation was a measurable share of
+// the 2.7s ID-assignment phase.
+var resolveIDHashPool = sync.Pool{
+	New: func() any { return sha256.New() },
+}
 
 // Resolve-side types re-exported from internal/selfhost/api for compatibility.
 // New consumers should import internal/selfhost/api directly.
@@ -255,26 +269,41 @@ func ResolveStructuredFromRunForPath(run *FrontendRun, path string) ResolveResul
 // filtering activates when input.Cfg is non-nil.
 func ResolvePackageStructured(input PackageResolveInput) (ResolveResult, error) {
 	cfg := cfgEnvToSelf(input.Cfg)
+	endBuild := beginSelfhostPhase("selfhost.buildPackageAst")
 	file, layout, err := selfhostBuildPackageAst(input.Files)
+	endBuild()
 	if err != nil {
 		return ResolveResult{}, err
 	}
 	if file == nil {
 		return ResolveResult{}, nil
 	}
+	endResolve := beginSelfhostPhase("selfhost.selfResolveAst")
+	resolveOut := selfResolveAstFileWithCfg(file, cfg)
+	endResolve()
+	endAdapt := beginSelfhostPhase("selfhost.adaptResolveResult")
 	result := adaptResolveResult(
-		selfResolveAstFileWithCfg(file, cfg),
+		resolveOut,
 		file,
 		func(start, end int) (int, int) {
 			return checkNodeOffsetsWithTokenLayout(layout, start, end)
 		},
 	)
+	endAdapt()
+	endImports := beginSelfhostPhase("selfhost.applyImportSurfaces")
 	selfhostApplyResolveImportSurfaces(&result, file, input.Imports, func(start, end int) (int, int) {
 		return checkNodeOffsetsWithTokenLayout(layout, start, end)
 	})
+	endImports()
+	endAnnotate := beginSelfhostPhase("selfhost.annotateFiles")
 	selfhostAnnotateResolveFiles(&result, input.Files)
+	endAnnotate()
+	endFilter := beginSelfhostPhase("selfhost.filterDupUseDiag")
 	selfhostFilterCrossFileDuplicateUseDiagnostics(&result, file, layout)
+	endFilter()
+	endIDs := beginSelfhostPhase("selfhost.assignResolveIDs")
 	selfhostAssignResolveIDs(&result, selfhostResolvePackageKey(input))
+	endIDs()
 	return result, nil
 }
 
@@ -661,53 +690,124 @@ func selfhostAssignResolveIDs(result *ResolveResult, packageKey string) {
 	}
 	packageID := stableResolveID("package", packageKey)
 	result.PackageID = packageID
-	byTarget := map[string]string{}
+
+	// Symbol pass is serial because the Refs / TypeRefs passes below
+	// look up TargetSymbolID through `byTarget` keyed by the symbol's
+	// (file, node, start, end). Build that map once, then fan the
+	// downstream passes out across workers.
+	byTarget := make(map[string]string, len(result.Symbols))
 	for i := range result.Symbols {
 		sym := &result.Symbols[i]
 		sym.PackageID = packageID
-		sym.DeclID = stableResolveID("decl", packageKey, sym.File, sym.Kind, sym.Name, fmt.Sprint(sym.Node), fmt.Sprint(sym.Start), fmt.Sprint(sym.End))
-		sym.ID = stableResolveID("symbol", packageKey, sym.File, sym.Kind, sym.Name, fmt.Sprint(sym.Node), fmt.Sprint(sym.Start), fmt.Sprint(sym.End), fmt.Sprint(sym.Public))
+		sym.DeclID = stableResolveID("decl", packageKey, sym.File, sym.Kind, sym.Name, itoa(sym.Node), itoa(sym.Start), itoa(sym.End))
+		sym.ID = stableResolveID("symbol", packageKey, sym.File, sym.Kind, sym.Name, itoa(sym.Node), itoa(sym.Start), itoa(sym.End), strconv.FormatBool(sym.Public))
 		byTarget[resolveTargetKey(sym.File, sym.Node, sym.Start, sym.End)] = sym.ID
 	}
-	for i := range result.Refs {
+
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 1 {
+		workers = 1
+	}
+
+	// Refs pass — each ref reads byTarget (read-only after symbol pass)
+	// and writes only to its own slot.
+	parallelAssignIDs(len(result.Refs), workers, func(i int) {
 		ref := &result.Refs[i]
 		ref.PackageID = packageID
-		ref.BindingID = stableResolveID("binding", packageKey, ref.File, ref.Name, fmt.Sprint(ref.Node), fmt.Sprint(ref.Start), fmt.Sprint(ref.End))
-		ref.ID = stableResolveID("ref", packageKey, ref.File, ref.Name, fmt.Sprint(ref.Node), fmt.Sprint(ref.Start), fmt.Sprint(ref.End), fmt.Sprint(ref.TargetNode), fmt.Sprint(ref.TargetStart), fmt.Sprint(ref.TargetEnd), ref.TargetFile)
+		ref.BindingID = stableResolveID("binding", packageKey, ref.File, ref.Name, itoa(ref.Node), itoa(ref.Start), itoa(ref.End))
+		ref.ID = stableResolveID("ref", packageKey, ref.File, ref.Name, itoa(ref.Node), itoa(ref.Start), itoa(ref.End), itoa(ref.TargetNode), itoa(ref.TargetStart), itoa(ref.TargetEnd), ref.TargetFile)
 		if id := byTarget[resolveTargetKey(ref.TargetFile, ref.TargetNode, ref.TargetStart, ref.TargetEnd)]; id != "" {
 			ref.TargetSymbolID = id
 		} else if ref.TargetNode >= 0 {
-			ref.TargetSymbolID = stableResolveID("symbol-target", packageKey, ref.TargetFile, ref.Name, fmt.Sprint(ref.TargetNode), fmt.Sprint(ref.TargetStart), fmt.Sprint(ref.TargetEnd))
+			ref.TargetSymbolID = stableResolveID("symbol-target", packageKey, ref.TargetFile, ref.Name, itoa(ref.TargetNode), itoa(ref.TargetStart), itoa(ref.TargetEnd))
 		}
-	}
-	for i := range result.TypeRefs {
+	})
+
+	// TypeRefs pass — same shape as Refs.
+	parallelAssignIDs(len(result.TypeRefs), workers, func(i int) {
 		ref := &result.TypeRefs[i]
 		ref.PackageID = packageID
-		ref.ID = stableResolveID("type-ref", packageKey, ref.File, ref.Name, fmt.Sprint(ref.Node), fmt.Sprint(ref.Start), fmt.Sprint(ref.End), fmt.Sprint(ref.TargetNode), fmt.Sprint(ref.TargetStart), fmt.Sprint(ref.TargetEnd), ref.TargetFile)
+		ref.ID = stableResolveID("type-ref", packageKey, ref.File, ref.Name, itoa(ref.Node), itoa(ref.Start), itoa(ref.End), itoa(ref.TargetNode), itoa(ref.TargetStart), itoa(ref.TargetEnd), ref.TargetFile)
 		if id := byTarget[resolveTargetKey(ref.TargetFile, ref.TargetNode, ref.TargetStart, ref.TargetEnd)]; id != "" {
 			ref.TargetSymbolID = id
 		} else if ref.TargetNode >= 0 {
-			ref.TargetSymbolID = stableResolveID("symbol-target", packageKey, ref.TargetFile, ref.Name, fmt.Sprint(ref.TargetNode), fmt.Sprint(ref.TargetStart), fmt.Sprint(ref.TargetEnd))
+			ref.TargetSymbolID = stableResolveID("symbol-target", packageKey, ref.TargetFile, ref.Name, itoa(ref.TargetNode), itoa(ref.TargetStart), itoa(ref.TargetEnd))
 		}
-	}
-	for i := range result.Diagnostics {
+	})
+
+	// Diagnostics pass — independent of the others.
+	parallelAssignIDs(len(result.Diagnostics), workers, func(i int) {
 		d := &result.Diagnostics[i]
 		d.PackageID = packageID
-		d.ID = stableResolveID("diagnostic", packageKey, d.File, d.Code, d.Name, fmt.Sprint(d.Node), fmt.Sprint(d.Start), fmt.Sprint(d.End), d.Message)
-	}
+		d.ID = stableResolveID("diagnostic", packageKey, d.File, d.Code, d.Name, itoa(d.Node), itoa(d.Start), itoa(d.End), d.Message)
+	})
 }
 
+// parallelAssignIDs invokes fn(i) for every i in [0, n) using a worker
+// pool of size `workers`. The serial path runs for small n / single
+// worker to avoid goroutine startup overhead.
+func parallelAssignIDs(n, workers int, fn func(i int)) {
+	if n == 0 {
+		return
+	}
+	if workers <= 1 || n < 64 {
+		for i := 0; i < n; i++ {
+			fn(i)
+		}
+		return
+	}
+	chunk := (n + workers - 1) / workers
+	var wg sync.WaitGroup
+	for start := 0; start < n; start += chunk {
+		end := start + chunk
+		if end > n {
+			end = n
+		}
+		wg.Add(1)
+		go func(lo, hi int) {
+			defer wg.Done()
+			for i := lo; i < hi; i++ {
+				fn(i)
+			}
+		}(start, end)
+	}
+	wg.Wait()
+}
+
+// itoa is a small wrapper around strconv.Itoa kept local so the
+// hot-path call sites in selfhostAssignResolveIDs read tightly.
+// Replaces the previous `fmt.Sprint(intValue)` calls which went
+// through reflection and allocated multiple times per call.
+func itoa(n int) string { return strconv.Itoa(n) }
+
 func resolveTargetKey(file string, node, start, end int) string {
-	return file + "\x00" + fmt.Sprint(node) + "\x00" + fmt.Sprint(start) + "\x00" + fmt.Sprint(end)
+	// Pre-sized builder avoids the multi-step allocations of
+	// `file + "\x00" + fmt.Sprint(...) + ...`. itoa + Builder cuts
+	// per-call cost ~5x measured against the previous fmt.Sprint
+	// concat path on the install-self toolchain build.
+	var b strings.Builder
+	b.Grow(len(file) + 32)
+	b.WriteString(file)
+	b.WriteByte(0)
+	b.WriteString(itoa(node))
+	b.WriteByte(0)
+	b.WriteString(itoa(start))
+	b.WriteByte(0)
+	b.WriteString(itoa(end))
+	return b.String()
 }
 
 func stableResolveID(parts ...string) string {
-	h := sha256.New()
+	h := resolveIDHashPool.Get().(hash.Hash)
+	h.Reset()
 	for _, part := range parts {
 		_, _ = h.Write([]byte(part))
 		_, _ = h.Write([]byte{0})
 	}
-	return hex.EncodeToString(h.Sum(nil))
+	sum := h.Sum(nil)
+	out := hex.EncodeToString(sum)
+	resolveIDHashPool.Put(h)
+	return out
 }
 
 func selfhostResolveNodeOffsets(file *AstFile, node int, offsets func(start, end int) (int, int)) (int, int) {


### PR DESCRIPTION
## Summary
`selfhostAssignResolveIDs` runs 4–9 ID computations per symbol / ref / typeRef / diagnostic on the install-self toolchain build. Each `stableResolveID` call allocated a fresh sha256 hasher, and every int field went through `fmt.Sprint(int)` (reflection-based, multi-allocation). Tens of thousands of symbols on a 122k-LOC package → 2.7s, ~36% of `resolve.native.artifacts`.

**Three stacking wins:**
1. `fmt.Sprint(int)` → `strconv.Itoa(int)` (and `fmt.Sprint(bool)` → `strconv.FormatBool`). Reflection + multi-step formatting → single constant-time conversion.
2. `sha256.New()` per call → `sync.Pool` of hashers reused via `Reset()`.
3. Refs / TypeRefs / Diagnostics loops fan out across `GOMAXPROCS` workers (chunked, serial fallback when `n < 64`). Symbol loop stays serial — it populates the `byTarget` map; once built, downstream reads are concurrent-safe.

`resolveTargetKey` also moves off `file + "\x00" + fmt.Sprint(...) + ...` concat onto a pre-sized `strings.Builder` + `itoa`, cutting per-call cost ~5x.

## Measurement (median of 3)

| Phase | Before | After | Δ |
|---|---|---|---|
| selfhost.assignResolveIDs | 2.68s | **0.52s** | **-81%** |
| resolve.native.artifacts | 7.34s | **5.07s** | **-31%** |
| frontend.ResolveWorkspace | 13.6s | **11.4s** | **-16%** |
| **TOTAL real** | **56.6s** | **53.9s** | **-5%** |

Cumulative since baseline (83.3s → 53.9s) the install-self inner build is now **-35%** across [#1948](https://github.com/choiceoh/osty/pull/1948) + [#1949](https://github.com/choiceoh/osty/pull/1949) + [#1950](https://github.com/choiceoh/osty/pull/1950) + [#1951](https://github.com/choiceoh/osty/pull/1951) + this PR.

## Drive-by
- `internal/selfhost/phase_timing.go` (new) — mirrors the env gate used by the other phase_timing helpers. selfhost sits at the bottom of the import graph; none of the other phase_timing-using packages import it. Surfaced sub-phases: buildPackageAst / selfResolveAst / adaptResolveResult / applyImportSurfaces / annotateFiles / filterDupUseDiag / assignResolveIDs.
- The exposed sub-phase markers identify `selfhost.selfResolveAst` (3.3s, the Osty-language resolver core / frozen seed) as the next dominant phase — that's harder to attack at the Go layer.

## Test plan
- [x] `go test ./internal/selfhost -count=1` 통과
- [x] `just front` 통과 (parser / resolve / check / format)
- [x] `just prepush` 통과
- [x] e2e: 3-run install-self measurement before/after — consistent -81% on assignResolveIDs, -5% TOTAL
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)