### PR TITLE
perf: skip tryExternal LLVM subprocess under --bootstrap-stage0 (toolchain build -41%)

### DIFF
--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -528,11 +528,22 @@ func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyqu
 	features := resolvedFeatures(resolved)
 	linkLibraries := resolvedLinkLibraries(resolved)
 
-	if backendID == backend.NameLLVM {
+	if backendID == backend.NameLLVM && !bootstrapStage0 {
 		// Cross-package dependency objects: built once per dep (when
 		// OSTY_CROSS_PKG_LINK is truthy), passed as ExtraObjects to the
 		// link step. Otherwise nil — the default matches the pre–PR-G2
 		// baseline. See cmd/osty/cross_pkg_deps.go and ARCHITECTURE.md.
+		//
+		// Skip the native-owned external path entirely under
+		// `--bootstrap-stage0`. The caller is install-self's source
+		// bootstrap which already knows `osty-self` is unavailable;
+		// invoking `nativellvmgen.TryPackage` here re-parses + re-
+		// resolves the entire package in a subprocess that is
+		// guaranteed to decline, then falls through to the in-process
+		// `Emit.Get` path anyway. Measured at 22.2s of pure waste on
+		// the install-self toolchain build before this gate. The non-
+		// bootstrap path keeps the original dispatch: cached
+		// `osty-self` makes the subprocess the production fast lane.
 		var extraObjects []string
 		if emitMode == backend.EmitBinary {
 			extraObjects = buildCrossPkgDepObjects(context.Background(), root, m, eng, lower, resolved, feats, layout)


### PR DESCRIPTION
## Summary
`osty build --bootstrap-stage0` is install-self's source bootstrap path — it runs only when `osty-self` is unavailable (no selfhostcache hit, no registry, no `OSTY_SELF_BIN`). In that state the external native-owned LLVM IR path (`tryExternalPackageLLVMArtifacts` → `nativellvmgen.TryPackage`) forks the osty-native-llvmgen subprocess which in turn forks osty-native-lirproto which in turn forks osty-self. None of that chain can succeed without a working osty-self, so it always declines and the parent falls through to the in-process `Emit.Get` path.

Before this gate the subprocess chain re-parsed + re-resolved the entire 122k-LOC toolchain inside the failed fork before declining — **22.2s of pure waste per install-self build** measured with the just-shipped `OSTY_BUILD_PHASE_TIMING=1` instrumentation. Gating on `!bootstrapStage0` skips the subprocess attempt entirely and goes straight to the in-process emit path.

## Measurement (median of 3)

| Phase | Before | After | Δ |
|---|---|---|---|
| cmd.osty.emit.tryExternal | 22.25s | **0** | **-100%** |
| cmd.osty.emit.queryEmitGet | 4.07s | 3.94s | ~0 |
| cmd.osty.buildPackage.emitAndBuild | 26.32s | **3.94s** | **-85%** |
| **TOTAL real** | **54.3s** | **31.9s** | **-41%** |

Cumulative since baseline (83.3s → 31.9s) the install-self inner build is now **-62%** across [#1948](https://github.com/choiceoh/osty/pull/1948) + [#1949](https://github.com/choiceoh/osty/pull/1949) + [#1950](https://github.com/choiceoh/osty/pull/1950) + [#1951](https://github.com/choiceoh/osty/pull/1951) + [#1952](https://github.com/choiceoh/osty/pull/1952) + this PR.

## Safety
The non-bootstrap path keeps the original dispatch: with a cached `osty-self` the subprocess IS the production fast lane (lets the Osty-owned LLVM IR pipeline take over), so the gate fires only for the source bootstrap critical path where we already know it must fail. Production `osty build` over user projects is unaffected.

## Test plan
- [x] `go test ./cmd/osty -count=1 -short` 통과
- [x] `just front` 통과
- [x] `just prepush` 통과
- [x] e2e: 3-run install-self before/after — consistent -41% TOTAL, -100% on the skipped phase
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)