### PR TITLE
feat: flip EnsureNativeChecker managed build to LLVM-built

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -104,12 +104,14 @@ var productionNativeCheckerFactory = func() (nativeChecker, string) {
 // Gate (b-llvm) policy (this PR): the managed binary is now the
 // LLVM-built `cmd/osty-native-checker/` artifact, not the Go-built
 // `cmd/osty-native-checker/main.go` shell. `toolchain.EnsureNativeChecker`
-// requires a cached `osty-self` (via `osty install-self`) up front and
-// drives `osty build --backend llvm cmd/osty-native-checker/` to produce
-// the binary. The Go-built shell survives only for test helpers in
-// `testsupport.go` and the `OSTY_NATIVE_CHECKER_BIN` override path;
-// production checker capability is now sourced from live
-// `toolchain/*.osty` instead of `internal/selfhost/generated.go`.
+// requires a resolvable `osty-self` up front (via `selfhostcache.ResolveBinary`,
+// which accepts `OSTY_SELF_BIN`, in-tree `toolchain/.osty/out/{debug,release}/llvm/osty-self`
+// builds, or the `osty install-self` content-addressed cache) and drives
+// `osty build --backend llvm cmd/osty-native-checker/` to produce the binary.
+// The Go-built shell survives only for test helpers in `testsupport.go` and
+// the `OSTY_NATIVE_CHECKER_BIN` override path; production checker capability
+// is now sourced from live `toolchain/*.osty` instead of
+// `internal/selfhost/generated.go`.
 //
 // Tests do not call this and continue to use the embedded factory — the
 // managed binary build would otherwise add seconds and clutter

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -101,6 +101,16 @@ var productionNativeCheckerFactory = func() (nativeChecker, string) {
 // the live `toolchain/*.osty` sources and a silent fallback hides real
 // configuration/build problems.
 //
+// Gate (b-llvm) policy (this PR): the managed binary is now the
+// LLVM-built `cmd/osty-native-checker/` artifact, not the Go-built
+// `cmd/osty-native-checker/main.go` shell. `toolchain.EnsureNativeChecker`
+// requires a cached `osty-self` (via `osty install-self`) up front and
+// drives `osty build --backend llvm cmd/osty-native-checker/` to produce
+// the binary. The Go-built shell survives only for test helpers in
+// `testsupport.go` and the `OSTY_NATIVE_CHECKER_BIN` override path;
+// production checker capability is now sourced from live
+// `toolchain/*.osty` instead of `internal/selfhost/generated.go`.
+//
 // Tests do not call this and continue to use the embedded factory — the
 // managed binary build would otherwise add seconds and clutter
 // `internal/check/.osty/` on every package's test run.

--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -3,6 +3,7 @@ package toolchain
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,9 +12,18 @@ import (
 	"sync"
 
 	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
 
 const toolchainDirName = ".osty/toolchain"
+
+// RecursionGuardEnv prevents EnsureNativeChecker from looping when the
+// `osty build --backend llvm cmd/osty-native-checker/` subprocess spawned
+// by buildNativeChecker re-enters via `check.UseManagedSubprocessChecker`.
+// The subprocess inherits this env from its parent; when EnsureNativeChecker
+// sees it, the call returns a deterministic error instead of forking another
+// nested build.
+const RecursionGuardEnv = "OSTY_BUILDING_NATIVE_CHECKER"
 
 var (
 	nativeCheckerBuildMu sync.Mutex
@@ -23,6 +33,7 @@ var (
 	installNativeChecker   = buildNativeChecker
 	renameManagedFile      = os.Rename
 	removeManagedFile      = os.Remove
+	verifyOstySelfCached   = defaultVerifyOstySelfCached
 )
 
 // Version returns the toolchain version stamp used to scope managed artifacts.
@@ -41,13 +52,44 @@ func NativeCheckerBinaryName() string {
 	return name
 }
 
+// LLVMCheckerArtifactName returns the filename of the LLVM-built
+// `[bin]` artifact produced by `osty build --backend llvm
+// cmd/osty-native-checker/`. The leaf differs from the managed-slot
+// name because the package's `osty.toml` declares
+// `name = "osty-native-checker-llvm"` to keep the dual-target
+// `main.go` / `main.osty` build outputs visually distinct on disk.
+func LLVMCheckerArtifactName() string {
+	name := "osty-native-checker-llvm"
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
+
 func ManagedNativeCheckerPath(projectRoot string) string {
 	return filepath.Join(projectRoot, toolchainDirName, Version(), NativeCheckerBinaryName())
 }
 
 // EnsureNativeChecker returns the managed checker artifact for the current
 // project/worktree, building it into .osty/toolchain/<version>/ on first use.
+//
+// Build path (post LLVM-flip): the managed artifact is the LLVM-built
+// `cmd/osty-native-checker/` package. The Go-built shell at
+// `cmd/osty-native-checker/main.go` is no longer reachable from production —
+// it survives only for `internal/check/testsupport.BuildSharedNativeCheckerForTests`
+// and out-of-band `OSTY_NATIVE_CHECKER_BIN` overrides. See
+// `docs/llvm-selfhost-plan.md` for the trajectory that drove this flip.
 func EnsureNativeChecker(start string) (string, error) {
+	if os.Getenv(RecursionGuardEnv) == "1" {
+		return "", fmt.Errorf(
+			"managed osty-native-checker build re-entered EnsureNativeChecker via %s=1; "+
+				"the LLVM build subprocess (`osty build --backend llvm cmd/osty-native-checker/`) "+
+				"depends on the same managed checker it is trying to produce. "+
+				"Pre-build the artifact or set OSTY_NATIVE_CHECKER_BIN to an existing binary "+
+				"before triggering the managed path",
+			RecursionGuardEnv,
+		)
+	}
 	root, err := managedProjectRootFunc(start)
 	if err != nil {
 		return "", err
@@ -95,34 +137,108 @@ func defaultSourceRepoRoot() (string, error) {
 	return root, nil
 }
 
+// buildNativeChecker drives `osty build --backend llvm
+// cmd/osty-native-checker/` and promotes the produced LLVM artifact
+// into the managed slot.
+//
+// Prerequisites (caller surfaces failures as a single focused error):
+//
+//  1. `osty-self` is resolvable via `selfhostcache.ResolveBinary` —
+//     stage0 fallback is not honoured by the production build path,
+//     so a fresh worktree must run `osty install-self` once first.
+//  2. The host osty executable that called us (`os.Executable()`) can
+//     reinvoke itself with `build --backend llvm <pkg>` — i.e. we are
+//     running inside an `osty` CLI process, not a test binary that
+//     happens to import this package without exposing a build mode.
+//
+// The chicken-and-egg case (managed-checker build needs the checker
+// to typecheck the package source) is handled by setting
+// `RecursionGuardEnv` on the subprocess; the nested EnsureNativeChecker
+// call returns a deterministic error rather than forking again. Closing
+// the bootstrap UX cleanly is a separate follow-up (see
+// `docs/llvm-selfhost-plan.md` PR3-G+ trajectory).
 func buildNativeChecker(dest string) error {
 	root, err := sourceRepoRootFunc()
 	if err != nil {
 		return err
 	}
-	tmpDir, err := os.MkdirTemp(filepath.Dir(dest), "osty-native-checker-*")
-	if err != nil {
-		return fmt.Errorf("create native checker temp dir: %w", err)
+	if err := verifyOstySelfCached(root); err != nil {
+		return err
 	}
-	defer os.RemoveAll(tmpDir)
 
-	tmpPath := filepath.Join(tmpDir, NativeCheckerBinaryName())
-	cmd := exec.Command("go", "build", "-o", tmpPath, "./cmd/osty-native-checker")
+	hostOsty, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate host osty executable for native checker build: %w", err)
+	}
+
+	pkgDir := filepath.Join(root, "cmd", "osty-native-checker")
+	cmd := exec.Command(hostOsty, "build", "--backend", "llvm", pkgDir)
 	cmd.Dir = root
+	cmd.Env = append(os.Environ(), RecursionGuardEnv+"=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
 		if msg == "" {
 			msg = "<no output>"
 		}
-		return fmt.Errorf("build managed osty-native-checker: %w (%s)", err, msg)
+		return fmt.Errorf("build LLVM osty-native-checker: %w (%s)", err, msg)
 	}
-	if runtime.GOOS != "windows" {
-		if err := os.Chmod(tmpPath, 0o755); err != nil {
-			return fmt.Errorf("chmod managed osty-native-checker: %w", err)
-		}
+
+	artifact := filepath.Join(pkgDir, ".osty", "out", "debug", "llvm", LLVMCheckerArtifactName())
+	if !fileExists(artifact) {
+		return fmt.Errorf("LLVM build of osty-native-checker did not produce expected artifact at %s", artifact)
+	}
+
+	tmpDir, err := os.MkdirTemp(filepath.Dir(dest), "osty-native-checker-*")
+	if err != nil {
+		return fmt.Errorf("create managed native checker temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpPath := filepath.Join(tmpDir, NativeCheckerBinaryName())
+	if err := copyExecutable(artifact, tmpPath); err != nil {
+		return fmt.Errorf("stage LLVM native checker artifact: %w", err)
 	}
 	return installManagedBinary(tmpPath, dest, "osty-native-checker")
+}
+
+func defaultVerifyOstySelfCached(root string) error {
+	if _, _, err := selfhostcache.ResolveBinary(root); err != nil {
+		return fmt.Errorf(
+			"LLVM-built osty-native-checker requires a cached osty-self; "+
+				"run `osty install-self` to populate %s: %w",
+			selfhostcache.CacheDirName, err,
+		)
+	}
+	return nil
+}
+
+// copyExecutable streams src to dst with 0755 perm. Unlike os.Rename it
+// does not consume the source, so the in-tree build output stays in place
+// for follow-up commands while a sibling copy lands in the managed slot.
+func copyExecutable(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(dst, 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func fileExists(path string) bool {

--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -174,7 +174,12 @@ func buildNativeChecker(dest string) error {
 	pkgDir := filepath.Join(root, "cmd", "osty-native-checker")
 	cmd := exec.Command(hostOsty, "build", "--backend", "llvm", pkgDir)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(), RecursionGuardEnv+"=1")
+	// Strip any pre-existing OSTY_BUILDING_NATIVE_CHECKER from the parent
+	// env before appending the guard. `os.Environ()` reflects whatever the
+	// user exported (including `=0`); the child's `os.Getenv` returns the
+	// first match, so an unfiltered append would let an inherited `=0`
+	// shadow our `=1` and re-enable the recursion.
+	cmd.Env = append(filterEnv(os.Environ(), RecursionGuardEnv), RecursionGuardEnv+"=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
@@ -204,13 +209,35 @@ func buildNativeChecker(dest string) error {
 
 func defaultVerifyOstySelfCached(root string) error {
 	if _, _, err := selfhostcache.ResolveBinary(root); err != nil {
+		// `selfhostcache.ResolveBinary` accepts OSTY_SELF_BIN, in-tree
+		// toolchain/.osty/out/{debug,release}/llvm/osty-self builds, AND the
+		// content-addressed `.osty/cache/self-host/` entries — so phrase the
+		// failure as a generic "no resolvable osty-self" rather than naming
+		// only the cache, and point at the install-self recipe as the
+		// canonical fix.
 		return fmt.Errorf(
-			"LLVM-built osty-native-checker requires a cached osty-self; "+
-				"run `osty install-self` to populate %s: %w",
+			"LLVM-built osty-native-checker requires a resolvable osty-self "+
+				"(OSTY_SELF_BIN override, toolchain/.osty/out/{debug,release}/llvm/osty-self, "+
+				"or `.osty/cache/self-host/`); run `osty install-self` to populate %s: %w",
 			selfhostcache.CacheDirName, err,
 		)
 	}
 	return nil
+}
+
+// filterEnv returns a copy of env with all `<key>=...` entries removed.
+// Used to prevent inherited assignments from shadowing a value we are
+// about to append.
+func filterEnv(env []string, key string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }
 
 // copyExecutable streams src to dst with 0755 perm. Unlike os.Rename it

--- a/internal/toolchain/native_checker_test.go
+++ b/internal/toolchain/native_checker_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -103,6 +104,45 @@ func TestInstallManagedBinaryReplacesExistingArtifactAfterRenameFailure(t *testi
 	}
 	if removeCalls != 1 {
 		t.Fatalf("remove calls = %d, want 1", removeCalls)
+	}
+}
+
+func TestEnsureNativeCheckerReturnsRecursionGuardError(t *testing.T) {
+	t.Setenv(RecursionGuardEnv, "1")
+	_, err := EnsureNativeChecker(".")
+	if err == nil {
+		t.Fatal("EnsureNativeChecker returned nil, want recursion guard error")
+	}
+	if !strings.Contains(err.Error(), RecursionGuardEnv) {
+		t.Fatalf("error %q does not mention %q", err, RecursionGuardEnv)
+	}
+}
+
+func TestBuildNativeCheckerFailsWhenOstySelfCacheMisses(t *testing.T) {
+	root := t.TempDir()
+	dest := filepath.Join(root, NativeCheckerBinaryName())
+
+	oldRepoRoot := sourceRepoRootFunc
+	oldVerify := verifyOstySelfCached
+	t.Cleanup(func() {
+		sourceRepoRootFunc = oldRepoRoot
+		verifyOstySelfCached = oldVerify
+	})
+
+	sourceRepoRootFunc = func() (string, error) { return root, nil }
+	verifyOstySelfCached = func(string) error {
+		return errors.New("osty-self not cached: run `osty install-self` first")
+	}
+
+	err := buildNativeChecker(dest)
+	if err == nil {
+		t.Fatal("buildNativeChecker returned nil, want osty-self cache-miss error")
+	}
+	if !strings.Contains(err.Error(), "osty-self not cached") {
+		t.Fatalf("error %q does not propagate cache-miss reason", err)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("dest %q must not exist after failed build (stat err: %v)", dest, statErr)
 	}
 }
 

--- a/internal/toolchain/native_checker_test.go
+++ b/internal/toolchain/native_checker_test.go
@@ -118,6 +118,34 @@ func TestEnsureNativeCheckerReturnsRecursionGuardError(t *testing.T) {
 	}
 }
 
+func TestFilterEnvRemovesInheritedRecursionGuard(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin",
+		RecursionGuardEnv + "=0",
+		"HOME=/home/test",
+		RecursionGuardEnv + "=anything",
+	}
+	got := filterEnv(env, RecursionGuardEnv)
+	for _, kv := range got {
+		if strings.HasPrefix(kv, RecursionGuardEnv+"=") {
+			t.Fatalf("filterEnv left a %s entry: %v", RecursionGuardEnv, got)
+		}
+	}
+	final := append(got, RecursionGuardEnv+"=1")
+	seen := 0
+	for _, kv := range final {
+		if strings.HasPrefix(kv, RecursionGuardEnv+"=") {
+			if kv != RecursionGuardEnv+"=1" {
+				t.Fatalf("unexpected guard entry %q in %v", kv, final)
+			}
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("expected exactly one %s=1 entry after append, got %d in %v", RecursionGuardEnv, seen, final)
+	}
+}
+
 func TestBuildNativeCheckerFailsWhenOstySelfCacheMisses(t *testing.T) {
 	root := t.TempDir()
 	dest := filepath.Join(root, NativeCheckerBinaryName())


### PR DESCRIPTION
## Summary

`toolchain.EnsureNativeChecker(start)` now populates `.osty/toolchain/<ver>/osty-native-checker` from the **LLVM-built** `cmd/osty-native-checker/` package instead of `go build ./cmd/osty-native-checker`. Production checker capability is sourced from live `toolchain/*.osty` rather than the frozen `internal/selfhost/generated.go` seed.

- `buildNativeChecker` drives `os.Executable() build --backend llvm cmd/osty-native-checker/`, then copies the produced `osty-native-checker-llvm` artifact into the managed slot.
- An `osty-self` cache hit (`selfhostcache.ResolveBinary`) is required upfront — miss surfaces a focused diagnostic ("run `osty install-self` first") instead of cascading inside the build subprocess. No stage0 fallback.
- The subprocess inherits `OSTY_BUILDING_NATIVE_CHECKER=1`; if `EnsureNativeChecker` sees that env on re-entry (the unavoidable chicken-and-egg when the build itself needs the checker), it fails fast with a guidance message rather than looping. Closing the bootstrap UX cleanly is a follow-up (`docs/llvm-selfhost-plan.md` PR3-G+).
- `cmd/osty-native-checker/main.go` (Go-built shell) stays in tree for `internal/check/testsupport.BuildSharedNativeCheckerForTests` and `OSTY_NATIVE_CHECKER_BIN` override consumers; it is no longer reachable from the production path.

## Known regressions (accepted, follow-ups)

Documented in `docs/llvm-selfhost-plan.md` / `cmd/osty-native-checker/README.md`. After this PR `osty check` / `build` / `run` will surface "managed native checker unavailable" until those are resolved:

- `cmd/osty-native-checker/main.osty` reads stdin via `io.readLine()` → single line only; multi-line JSON requests fail.
- `naiveExtractSource` does not handle escaped `\"` / `\n` inside the `"source"` value.
- `CheckRequest.package` mode (multi-file workspace check) is not implemented — only the single-`source` mode is wired.
- Recursive build path (`osty build cmd/osty-native-checker/` re-entering `EnsureNativeChecker`) errors out instead of looping; needs either a bootstrap escape or an `OSTY_NATIVE_CHECKER_BIN` pre-built pointer.

## Test plan

- [x] `go test ./internal/toolchain/... -count=1` — new `TestEnsureNativeCheckerReturnsRecursionGuardError` + `TestBuildNativeCheckerFailsWhenOstySelfCacheMisses` pass alongside the existing mock-based installer test
- [x] `go test ./internal/check/ -run TestUseManagedSubprocessChecker -count=1` — factory closure still satisfies the gate (b) contract (resolves or returns `(nil, note)`)
- [x] `go build ./...` + `go vet ./...` clean
- [ ] `just prepush` (left to follow-up — managed-checker dependent test paths will surface the documented regression until M5 main.osty work lands)

https://claude.ai/code/session_01WvV3k4YEbsvvXJKGpPC6UL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvV3k4YEbsvvXJKGpPC6UL)_