### PR TITLE
feat: A5-A11 annotation flags JSON-decode in mirJsonFunctionBuildCore

### DIFF
--- a/toolchain/mir_json.osty
+++ b/toolchain/mir_json.osty
@@ -1022,16 +1022,32 @@ fn mirJsonFunctionBuildCore(obj: List<MirJsonEntry>, params: List<Int>, locals: 
     let span = mirJsonSpanField(obj, 4020328, "span")?
     let returnLocal = mirJsonIntField(obj, 11161188, "returnLocal", 0)?
     let entry = mirJsonIntField(obj, 5034129, "entry", 0)?
-    let targetFeatures: List<String> = []
-    let noaliasParams: List<String> = []
     let exportSymbol = name
-    // A13 `#[pure]` → readnone. Go-side `internal/mirjson/json.go`
-    // emits `"pure": true` when `ir.FnDecl.Pure` is set; without this
-    // decode the production MIR-JSON path lost the flag and downstream
-    // emitters (`mir_generator.osty::mirEmitFnAttrsFromMir`,
-    // `lir_proto.osty::lirFnAttrsFromMir`) skipped readnone.
+    // A5–A13 annotation flags. Go-side `internal/mirjson/json.go`
+    // serializes every flag set on `ir.FnDecl`; this decoder threads
+    // each through to `MirFunction` so the downstream emitters
+    // `mir_generator.osty::mirEmitFnAttrsFromMir` (define-line attrs)
+    // and `lir_proto.osty::lirFnAttrsFromMir` / `lirNextLoopMD`
+    // (param attrs + loop metadata) see the same shape as the in-process
+    // pipeline. Prior to this batch only `pure` (A13) was decoded; the
+    // remaining flags silently dropped to defaults, leaving the LLVM
+    // emit code paths dead for production MIR-JSON inputs.
+    let inlineMode = mirJsonInlineMode(mirJsonIntField(obj, 10127682, "inlineMode", 0)?)
+    let hot = mirJsonBoolField(obj, 3012385, "hot", false)?
+    let cold = mirJsonBoolField(obj, 4019847, "cold", false)?
     let pure = mirJsonBoolField(obj, 4020706, "pure", false)?
-    Ok(MirFunction {name, params, returnType, returnLocal, locals, blocks, entry, isExternal: false, isIntrinsic: false, exported: false, exportSymbol, cAbi: false, span, vectorize: false, noVectorize: false, vectorizeWidth: 0, vectorizeScalable: false, vectorizePredicate: false, parallel: false, unroll: false, unrollCount: 0, inlineMode: MirInlineNone, hot: false, cold: false, targetFeatures, noaliasAll: false, noaliasParams, pure})
+    let vectorize = mirJsonBoolField(obj, 9110349, "vectorize", false)?
+    let noVectorize = mirJsonBoolField(obj, 11169689, "noVectorize", false)?
+    let vectorizeWidth = mirJsonIntField(obj, 14285181, "vectorizeWidth", 0)?
+    let vectorizeScalable = mirJsonBoolField(obj, 17432931, "vectorizeScalable", false)?
+    let vectorizePredicate = mirJsonBoolField(obj, 18503357, "vectorizePredicate", false)?
+    let parallel = mirJsonBoolField(obj, 8082271, "parallel", false)?
+    let unroll = mirJsonBoolField(obj, 6046941, "unroll", false)?
+    let unrollCount = mirJsonIntField(obj, 11168432, "unrollCount", 0)?
+    let noaliasAll = mirJsonBoolField(obj, 10127269, "noaliasAll", false)?
+    let targetFeatures = mirJsonStringList(mirJsonArrayField(obj, 14288238, "targetFeatures")?)?
+    let noaliasParams = mirJsonStringList(mirJsonArrayField(obj, 13238031, "noaliasParams")?)?
+    Ok(MirFunction {name, params, returnType, returnLocal, locals, blocks, entry, isExternal: false, isIntrinsic: false, exported: false, exportSymbol, cAbi: false, span, vectorize, noVectorize, vectorizeWidth, vectorizeScalable, vectorizePredicate, parallel, unroll, unrollCount, inlineMode, hot, cold, targetFeatures, noaliasAll, noaliasParams, pure})
 }
 
 fn mirJsonFunctionParamsField(obj: List<MirJsonEntry>, params: List<Int>) -> Result<Bool, String> {

--- a/toolchain/mir_json_test.osty
+++ b/toolchain/mir_json_test.osty
@@ -173,3 +173,255 @@ fn testMirJsonDecodeNonPureFunctionSkipsReadnone() {
     // readnone, masking a regression here.
     testing.assert(!strings.contains(ir, "@main() readnone"))
 }
+
+// A5–A11 round-trip — every annotation flag the Go-side
+// `internal/mirjson/json.go` serializes on `ir.FnDecl` must thread
+// through `mirJsonFunctionBuildCore` into `MirFunction` so the
+// downstream emitters (`mir_generator.osty::mirEmitFnAttrsFromMir`
+// for the `define`-line attrs, `lir_proto.osty::lirFnAttrsFromMir`
+// + `lirNextLoopMD` for param attrs and loop metadata) observe the
+// same shape as the in-process pipeline. Prior to this batch every
+// flag except `pure` (A13) dropped to its default, leaving the LLVM
+// emit code paths dead for production MIR-JSON inputs covering
+// `#[inline(...)]` (A8) / `#[hot]` + `#[cold]` (A9) /
+// `#[target_feature(...)]` (A10) / `#[noalias]` (A11) /
+// `#[vectorize(...)]` (A5) / `#[parallel]` (A6) / `#[unroll(...)]`
+// (A7).
+fn testMirJsonDecodeAllFnAnnotationFlagsRoundTrip() {
+    let moduleText = r"""
+{
+  "version": 1,
+  "packageName": "main",
+  "functions": [
+    {
+      "name": "main",
+      "returnType": {"kind": "prim", "display": "Int", "prim": "Int"},
+      "returnLocal": 0,
+      "locals": [
+        {"id": 0, "name": "ret", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "isReturn": true}
+      ],
+      "blocks": [
+        {
+          "id": 0,
+          "instrs": [
+            {
+              "kind": "assign",
+              "dest": {"local": 0},
+              "src": {
+                "kind": "use",
+                "op": {
+                  "kind": "const",
+                  "type": {"kind": "prim", "display": "Int", "prim": "Int"},
+                  "const": {"kind": "int", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "int": 0}
+                }
+              }
+            }
+          ],
+          "term": {"kind": "return"}
+        }
+      ],
+      "vectorize": true,
+      "vectorizeWidth": 8,
+      "vectorizeScalable": true,
+      "vectorizePredicate": true,
+      "parallel": true,
+      "unroll": true,
+      "unrollCount": 4,
+      "inlineMode": 2,
+      "hot": true,
+      "targetFeatures": ["avx512f", "avx512bw"],
+      "noaliasAll": true,
+      "noaliasParams": ["src", "dst"],
+      "pure": true
+    }
+  ]
+}
+"""
+    let m = mjDecodeModule(moduleText)
+    testing.assertEq(m.functions.len(), 1)
+    let fn_ = m.functions[0]
+    testing.assert(fn_.vectorize)
+    testing.assertEq(fn_.vectorizeWidth, 8)
+    testing.assert(fn_.vectorizeScalable)
+    testing.assert(fn_.vectorizePredicate)
+    testing.assert(fn_.parallel)
+    testing.assert(fn_.unroll)
+    testing.assertEq(fn_.unrollCount, 4)
+    testing.assert(fn_.inlineMode == MirInlineAlways)
+    testing.assert(fn_.hot)
+    testing.assert(!fn_.cold)
+    testing.assert(fn_.pure)
+    testing.assert(fn_.noaliasAll)
+    testing.assertEq(fn_.targetFeatures.len(), 2)
+    testing.assertEq(fn_.targetFeatures[0], "avx512f")
+    testing.assertEq(fn_.targetFeatures[1], "avx512bw")
+    testing.assertEq(fn_.noaliasParams.len(), 2)
+    testing.assertEq(fn_.noaliasParams[0], "src")
+    testing.assertEq(fn_.noaliasParams[1], "dst")
+}
+
+// Baseline default guard — every annotation absent from the JSON
+// must decode to the off / empty / `MirInlineNone` defaults the Go
+// `ir.FnDecl` zero-value carries. Guards against accidental
+// hardcoded-`true` regressions in `mirJsonFunctionBuildCore`'s
+// fallback values: if any field gets an inverted default, the
+// downstream LLVM emitter would stamp the attribute on every
+// function — including those without the corresponding source
+// annotation — silently miscompiling the program.
+fn testMirJsonDecodeFnAnnotationFlagsDefaults() {
+    let moduleText = r"""
+{
+  "version": 1,
+  "packageName": "main",
+  "functions": [
+    {
+      "name": "main",
+      "returnType": {"kind": "prim", "display": "Int", "prim": "Int"},
+      "returnLocal": 0,
+      "locals": [
+        {"id": 0, "name": "ret", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "isReturn": true}
+      ],
+      "blocks": [
+        {
+          "id": 0,
+          "instrs": [
+            {
+              "kind": "assign",
+              "dest": {"local": 0},
+              "src": {
+                "kind": "use",
+                "op": {
+                  "kind": "const",
+                  "type": {"kind": "prim", "display": "Int", "prim": "Int"},
+                  "const": {"kind": "int", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "int": 0}
+                }
+              }
+            }
+          ],
+          "term": {"kind": "return"}
+        }
+      ]
+    }
+  ]
+}
+"""
+    let m = mjDecodeModule(moduleText)
+    testing.assertEq(m.functions.len(), 1)
+    let fn_ = m.functions[0]
+    testing.assert(!fn_.vectorize)
+    testing.assert(!fn_.noVectorize)
+    testing.assertEq(fn_.vectorizeWidth, 0)
+    testing.assert(!fn_.vectorizeScalable)
+    testing.assert(!fn_.vectorizePredicate)
+    testing.assert(!fn_.parallel)
+    testing.assert(!fn_.unroll)
+    testing.assertEq(fn_.unrollCount, 0)
+    testing.assert(fn_.inlineMode == MirInlineNone)
+    testing.assert(!fn_.hot)
+    testing.assert(!fn_.cold)
+    testing.assert(!fn_.pure)
+    testing.assert(!fn_.noaliasAll)
+    testing.assertEq(fn_.targetFeatures.len(), 0)
+    testing.assertEq(fn_.noaliasParams.len(), 0)
+}
+
+// `#[cold]` round-trip — separate from the all-flags test because
+// `hot` and `cold` are mutually exclusive at the source level
+// (the resolver rejects both on the same function), so the LLVM
+// emitter would never see them both set. Verifies the cold path's
+// JSON wire ("cold": true) lands on `MirFunction.cold` without
+// also flipping `hot`.
+fn testMirJsonDecodeColdFunctionWithoutHot() {
+    let moduleText = r"""
+{
+  "version": 1,
+  "packageName": "main",
+  "functions": [
+    {
+      "name": "main",
+      "returnType": {"kind": "prim", "display": "Int", "prim": "Int"},
+      "returnLocal": 0,
+      "locals": [
+        {"id": 0, "name": "ret", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "isReturn": true}
+      ],
+      "blocks": [
+        {
+          "id": 0,
+          "instrs": [
+            {
+              "kind": "assign",
+              "dest": {"local": 0},
+              "src": {
+                "kind": "use",
+                "op": {
+                  "kind": "const",
+                  "type": {"kind": "prim", "display": "Int", "prim": "Int"},
+                  "const": {"kind": "int", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "int": 0}
+                }
+              }
+            }
+          ],
+          "term": {"kind": "return"}
+        }
+      ],
+      "cold": true
+    }
+  ]
+}
+"""
+    let m = mjDecodeModule(moduleText)
+    testing.assertEq(m.functions.len(), 1)
+    testing.assert(m.functions[0].cold)
+    testing.assert(!m.functions[0].hot)
+}
+
+// `#[no_vectorize]` round-trip — A5.2 baseline opts every function
+// into vectorize by default, so the explicit `noVectorize` opt-out
+// flag must survive JSON round-trip independently of the `vectorize`
+// flag (the two are not the same boolean inverted; both can be false
+// to mean "let the default policy decide"). Guards against the
+// decoder silently dropping the opt-out, which would re-vectorize a
+// loop the source explicitly asked to keep scalar.
+fn testMirJsonDecodeNoVectorizeFunction() {
+    let moduleText = r"""
+{
+  "version": 1,
+  "packageName": "main",
+  "functions": [
+    {
+      "name": "main",
+      "returnType": {"kind": "prim", "display": "Int", "prim": "Int"},
+      "returnLocal": 0,
+      "locals": [
+        {"id": 0, "name": "ret", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "isReturn": true}
+      ],
+      "blocks": [
+        {
+          "id": 0,
+          "instrs": [
+            {
+              "kind": "assign",
+              "dest": {"local": 0},
+              "src": {
+                "kind": "use",
+                "op": {
+                  "kind": "const",
+                  "type": {"kind": "prim", "display": "Int", "prim": "Int"},
+                  "const": {"kind": "int", "type": {"kind": "prim", "display": "Int", "prim": "Int"}, "int": 0}
+                }
+              }
+            }
+          ],
+          "term": {"kind": "return"}
+        }
+      ],
+      "noVectorize": true
+    }
+  ]
+}
+"""
+    let m = mjDecodeModule(moduleText)
+    testing.assertEq(m.functions.len(), 1)
+    testing.assert(m.functions[0].noVectorize)
+    testing.assert(!m.functions[0].vectorize)
+}


### PR DESCRIPTION
## Summary

PR #1946 의 A13 `#[pure]` JSON-decode landing 패턴을 잔여 9 annotation 그룹에 확장.

`toolchain/mir_json.osty::mirJsonFunctionBuildCore` 가 Go-side `internal/mirjson/json.go` 가 이미 직렬화하는 모든 `ir.FnDecl` annotation flag 를 decode:

- A5: `vectorize` / `noVectorize` / `vectorizeWidth` / `vectorizeScalable` / `vectorizePredicate`
- A6: `parallel`
- A7: `unroll` / `unrollCount`
- A8: `inlineMode` (`MirInlineMode` enum 으로 매핑)
- A9: `hot` / `cold`
- A10: `targetFeatures` (List<String>)
- A11: `noaliasAll` / `noaliasParams` (List<String>)

이전까지 `pure` (A13) 만 decode 되고 나머지 flag 는 `false` / `0` / 빈 list 로 hardcoded dropped 되어, `mir_generator.osty::mirEmitFnAttrsFromMir` (define-line attrs) 와 `lir_proto.osty::lirFnAttrsFromMir` + `lirNextLoopMD` (param attrs + loop metadata) 의 emit 코드 경로가 production MIR-JSON 입력에 대해 dead path 였음.

## Test plan

`toolchain/mir_json_test.osty` round-trip 회귀 4 종:

- [x] `testMirJsonDecodeAllFnAnnotationFlagsRoundTrip` — 모든 flag set → 각 `MirFunction` 필드가 source 값 보존 (List<String> 두 종 포함, length + 각 element 검증)
- [x] `testMirJsonDecodeFnAnnotationFlagsDefaults` — 모든 flag 부재 → Go zero-value 와 동일한 default (hardcoded `true` regression 방지)
- [x] `testMirJsonDecodeColdFunctionWithoutHot` — `cold` 단독 → `hot` flip 없음 (resolver 가 둘 다 reject 하므로 emitter 도 동시에 보는 일 없음)
- [x] `testMirJsonDecodeNoVectorizeFunction` — `noVectorize` 단독 → `vectorize` flip 없음 (둘은 boolean inverse 가 아니라 독립 flag)

KeyId 14 종 모두 toolchain 의 `mirJsonStringKeyIdFrom` hash 알고리즘으로 사전 계산해 commit 안에 인라인 — 기존 well-known keyId (`name=4019667`, `pure=4020706` 등) 와 동일 알고리즘으로 cross-check 완료.

`.bin/osty check toolchain/` 통과. `.bin/osty fmt --check` 통과.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2YbnUpRw682ooUP91JSsk)_