### PR TITLE
refactor: drop deprecated FrontendRun.File() + AstbridgeLowerCount counter

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -19,8 +19,8 @@
   `internal/selfhost/generated.go`는 재생성 대상이 아니라 frozen seed다.
 - native checker bundle은 `internal/selfhost/bundle.ToolchainCheckerFiles()`에
   고정되어 있고, `internal/selfhost/ast_lower.osty`를 포함하지 않는다. 해당
-  파일은 `FrontendRun.File` / `Parse` / `EnsureFile` 기반 legacy public-AST
-  소비자용 호환 어댑터로만 남아 있다.
+  파일은 `selfhost.LowerPublicFileFromRun` / `Parse` / `EnsureFile` 기반
+  legacy public-AST 소비자용 호환 어댑터로만 남아 있다.
 - `osty check`, `osty typecheck`, `osty resolve`의 happy path는 self-host arena
   구조체를 직접 소비한다. 현재 기준 `just front`, `just spec`,
   `just verify-selfhost`, `go run ./cmd/osty check toolchain`은 통과한다.
@@ -765,7 +765,7 @@ astbridge는 한 방에 제거하지 않고 `*ast.File` 소비자들이 AstArena
 
 ### CLI 재배선 진척 (2026-04)
 
-CLI 재배선의 resolve + check/typecheck 축은 **단일 파일 + 단일 패키지 + workspace** happy path 에서 완료됐다. `--legacy` check/typecheck escape hatch 는 제거됐고, `--native` 는 no-op 으로만 남았다. in-process 회귀 테스트는 native/default 경로가 `astLowerPublicFile` 호출을 트리거하지 않는지 `selfhost.AstbridgeLowerCount` 로 pin 한다.
+CLI 재배선의 resolve + check/typecheck 축은 **단일 파일 + 단일 패키지 + workspace** happy path 에서 완료됐다. `--legacy` check/typecheck escape hatch 는 제거됐고, `--native` 는 no-op 으로만 남았다. `FrontendRun.File()` 가 제거되면서 native/default 경로가 astbridge 를 우회한다는 사실은 컴파일 타임 구조적 (메서드 부재) 으로 강제된다 — 이전의 `selfhost.AstbridgeLowerCount` 런타임 카운터는 함께 제거됐다.
 
 | CLI 경로                            | Warm astbridge bumps | 회귀 테스트                                      |
 | ----------------------------------- | -------------------- | ------------------------------------------------ |
@@ -788,7 +788,7 @@ CLI 재배선의 resolve + check/typecheck 축은 **단일 파일 + 단일 패�
 - `selfhost.CheckDiagnosticsAsDiag(src, records) []*diag.Diagnostic` — 네이티브 `CheckDiagnosticRecord`를 `*diag.Diagnostic`으로 변환하는 공용 헬퍼 (PR #631).
 - `resolve.LoadPackageForNative` / `PackageFile.Run` / `EnsureFile` — loader를 lazy하게 만들어 native 경로는 0 bump, fallback 경로는 필요 시에만 lowering (PR #621 #628).
 - `selfhostIntrinsicBodyDiagnosticsFromArena` — `#[intrinsic]` 게이트를 AstArena 기반으로 재작성 (PR #623 #626), `selfhostAppendIntrinsicBodyGateForSource` / `...ForPackage` 둘 다 arena walker 사용.
-- `selfhost.AstbridgeLowerCount()` / `ResetAstbridgeLowerCount()` — `FrontendRun.File()` 단일 진입점을 계수하는 글로벌 카운터 (PR #623).
+- ~~`selfhost.AstbridgeLowerCount()` / `ResetAstbridgeLowerCount()` — `FrontendRun.File()` 단일 진입점을 계수하는 글로벌 카운터 (PR #623).~~ `FrontendRun.File()` 가 제거되면서 counter 인프라도 함께 폐기됐다. astbridge 우회는 이제 메서드 부재로 구조적 강제.
 
 **남아있는 작업**:
 

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -767,19 +767,19 @@ astbridge는 한 방에 제거하지 않고 `*ast.File` 소비자들이 AstArena
 
 CLI 재배선의 resolve + check/typecheck 축은 **단일 파일 + 단일 패키지 + workspace** happy path 에서 완료됐다. `--legacy` check/typecheck escape hatch 는 제거됐고, `--native` 는 no-op 으로만 남았다. `FrontendRun.File()` 가 제거되면서 native/default 경로가 astbridge 를 우회한다는 사실은 컴파일 타임 구조적 (메서드 부재) 으로 강제된다 — 이전의 `selfhost.AstbridgeLowerCount` 런타임 카운터는 함께 제거됐다.
 
-| CLI 경로                            | Warm astbridge bumps | 회귀 테스트                                      |
-| ----------------------------------- | -------------------- | ------------------------------------------------ |
-| `osty resolve FILE` (기본 native)   | 0                    | `TestRunResolveFileHappyPathIsAstbridgeFree`     |
-| `osty resolve DIR` (기본 native)    | 0                    | `TestRunResolvePackageHappyPathIsAstbridgeFree`  |
-| `osty check --native FILE`          | 0                    | `TestRunCheckFileNativeIsAstbridgeFree`          |
-| `osty check --native DIR`           | 0                    | `TestRunCheckPackageNativeIsAstbridgeFree`       |
-| `osty check --native WORKSPACE`     | 0                    | `TestRunCheckWorkspaceNativeIsAstbridgeFree`     |
-| `osty check FILE` (default)         | 0                    | `TestRunCheckFileDefaultPathIsAstbridgeFree`     |
-| `osty typecheck --native FILE`      | 0                    | `TestRunTypecheckFileNativeIsAstbridgeFree`      |
-| `osty typecheck --native DIR`       | 0                    | `TestRunTypecheckPackageNativeIsAstbridgeFree`   |
-| `osty typecheck --native WORKSPACE` | 0                    | `TestRunTypecheckWorkspaceNativeIsAstbridgeFree` |
+| CLI 경로                            | Happy-path 회귀 테스트                               |
+| ----------------------------------- | ---------------------------------------------------- |
+| `osty resolve FILE` (기본 native)   | `TestRunResolveFileHappyPath`                        |
+| `osty resolve DIR` (기본 native)    | `TestRunResolvePackageHappyPath`                     |
+| `osty check --native FILE`          | `TestRunCheckFileNativeDumpTelemetry`                |
+| `osty check --native DIR`           | `TestRunCheckPackageNativeHappyPath`                 |
+| `osty check --native WORKSPACE`     | `TestRunCheckWorkspaceNativeHappyPath`               |
+| `osty check FILE` (default)         | `TestRunCheckFileDefaultPathHappyPath`               |
+| `osty typecheck --native FILE`      | `TestRunTypecheckFileNativeDumpTelemetry`            |
+| `osty typecheck --native DIR`       | `TestRunTypecheckPackageNativeHappyPath`             |
+| `osty typecheck --native WORKSPACE` | `TestRunTypecheckWorkspaceNativeHappyPath`           |
 
-이 회귀 넷은 네이티브 경로 비용 누출을 잡는다. 예: fallback이 `EnsureFiles`를 부당하게 발동해 astbridge bump 가 생기면 즉시 실패한다.
+이 smoke 셋은 네이티브 CLI 경로의 exit-zero / 출력 기대치를 잡는다. astbridge 우회는 더 이상 런타임 카운터가 아니라 `FrontendRun.File()` 부재로 구조적으로 강제된다 — `LowerPublicFileFromRun` 만이 명시적 진입점이다.
 
 **인프라 작업**:
 

--- a/SELFHOST_PORT_MATRIX.md
+++ b/SELFHOST_PORT_MATRIX.md
@@ -179,12 +179,16 @@ Go-native `runCheckFileLegacy` / `runCheckPackageLegacy` /
 - `osty lint DIR` / workspace lint 도 arena-first loader 뒤에 Go resolver +
   linter 를 태운다. lint identity 모델 포팅 전까지 astbridge 제거 대상이다.
 
-회귀 테스트:
+회귀 테스트 (모두 happy-path smoke; astbridge 우회는 이제 `FrontendRun.File()`
+부재로 컴파일 타임 강제):
 - `TestCheckCLIDefaultPathExitsZero` — `osty check FILE` 기본 경로 exit 0
-- `TestRunCheckFileDefaultPathIsAstbridgeFree` — 기본 check 경로 astbridge 0
-- `TestRunResolve{File,Package}HappyPathIsAstbridgeFree` +
-  `TestRun{Check,Typecheck}{File,Package,Workspace}NativeIsAstbridgeFree`
-  — resolve/check/typecheck native/default 경로 astbridge 0
+- `TestRunCheckFileDefaultPathHappyPath` — 기본 check 경로 in-process smoke
+- `TestRunResolve{File,Package}HappyPath` +
+  `TestRunCheck{Package,Workspace}NativeHappyPath` +
+  `TestRunCheckFileNativeDumpTelemetry` +
+  `TestRunTypecheck{Package,Workspace}NativeHappyPath` +
+  `TestRunTypecheckFileNativeDumpTelemetry`
+  — resolve/check/typecheck native/default 경로 exit-zero + 텔레메트리 헤더
 - ~~`TestGoGenerateSelfhostLeavesGeneratedArtifactsClean`~~ — **삭제됨
   (2026-04-23, PR #854)**. Osty→Go bootstrap transpiler 가 retire 되면서
   `go generate ./internal/selfhost` regen 파이프라인 자체가 사라졌고,

--- a/cmd/osty/check_native_test.go
+++ b/cmd/osty/check_native_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/osty/osty/internal/selfhost"
 )
 
 // TestCheckCLINativeCleanSourceExitsZero is the subprocess-level smoke
@@ -107,7 +105,6 @@ fn main() {
 	os.Stderr = werr
 	t.Cleanup(func() { os.Stderr = origStderr })
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runCheckFileNative(path, src, formatter, flags)
 	_ = werr.Close()
 	stderrBytes, err := io.ReadAll(rerr)
@@ -118,9 +115,6 @@ fn main() {
 
 	if exit != 0 {
 		t.Fatalf("runCheckFileNative exit = %d, want 0\nstderr:\n%s", exit, stderr)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after dump-native-diags native check = %d, want 0", got)
 	}
 	if !strings.Contains(stderr, "native checker telemetry: "+path) {
 		t.Fatalf("stderr missing telemetry header:\n%s", stderr)
@@ -248,12 +242,10 @@ fn main() {
 	}
 }
 
-// TestRunCheckPackageNativeIsAstbridgeFree is the DIR in-process
-// counter test. LoadPackageForNative + CheckPackageStructured +
-// nativePackageCheckDiags + CheckDiagnosticsAsDiag must all leave
-// AstbridgeLowerCount at zero for a clean multi-file package. Pairs
-// with TestLoadPackageForNativeMultiFileIsAstbridgeFree (which only
-// covered the resolve side).
+// TestRunCheckPackageNativeIsAstbridgeFree exercises the DIR check
+// path end-to-end (LoadPackageForNative + CheckPackageStructured +
+// nativePackageCheckDiags + CheckDiagnosticsAsDiag) on a clean
+// multi-file package and asserts exit 0.
 func TestRunCheckPackageNativeIsAstbridgeFree(t *testing.T) {
 	dir := t.TempDir()
 	aPath := filepath.Join(dir, "a.osty")
@@ -290,7 +282,6 @@ func TestRunCheckPackageNativeIsAstbridgeFree(t *testing.T) {
 	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
 	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runCheckPackageNative(dir, cliFlags{noColor: true})
 	_ = wout.Close()
 	_ = werr.Close()
@@ -299,9 +290,6 @@ func TestRunCheckPackageNativeIsAstbridgeFree(t *testing.T) {
 
 	if exit != 0 {
 		t.Fatalf("runCheckPackageNative exit = %d, want 0", exit)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after runCheckPackageNative = %d, want 0 (DIR path regressed into *ast.File detour)", got)
 	}
 }
 
@@ -348,7 +336,6 @@ fn main() {
 	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
 	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runCheckWorkspaceNative(dir, cliFlags{noColor: true})
 	_ = wout.Close()
 	_ = werr.Close()
@@ -357,9 +344,6 @@ fn main() {
 
 	if exit != 0 {
 		t.Fatalf("runCheckWorkspaceNative exit = %d, want 0", exit)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after runCheckWorkspaceNative = %d, want 0", got)
 	}
 }
 
@@ -491,7 +475,6 @@ func TestRunCheckFileNativeIsAstbridgeFree(t *testing.T) {
 	go func() { _, _ = io.Copy(io.Discard, r); drained <- struct{}{} }()
 	go func() { _, _ = io.Copy(io.Discard, re); drained <- struct{}{} }()
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runCheckFileNative(path, src, formatter, flags)
 	_ = w.Close()
 	_ = we.Close()
@@ -500,9 +483,6 @@ func TestRunCheckFileNativeIsAstbridgeFree(t *testing.T) {
 
 	if exit != 0 {
 		t.Fatalf("runCheckFileNative exit = %d, want 0", exit)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after runCheckFileNative = %d, want 0 (--native CLI path regressed into a *ast.File detour)", got)
 	}
 }
 
@@ -570,7 +550,6 @@ func TestRunCheckFileDefaultPathIsAstbridgeFree(t *testing.T) {
 	go func() { _, _ = io.Copy(io.Discard, r); drained <- struct{}{} }()
 	go func() { _, _ = io.Copy(io.Discard, re); drained <- struct{}{} }()
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runCheckFileNative(path, src, formatter, flags)
 	_ = w.Close()
 	_ = we.Close()
@@ -579,8 +558,5 @@ func TestRunCheckFileDefaultPathIsAstbridgeFree(t *testing.T) {
 
 	if exit != 0 {
 		t.Fatalf("runCheckFileNative (default) exit = %d, want 0", exit)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after default runCheckFileNative = %d, want 0", got)
 	}
 }

--- a/cmd/osty/check_native_test.go
+++ b/cmd/osty/check_native_test.go
@@ -242,11 +242,11 @@ fn main() {
 	}
 }
 
-// TestRunCheckPackageNativeIsAstbridgeFree exercises the DIR check
+// TestRunCheckPackageNativeHappyPath exercises the DIR check
 // path end-to-end (LoadPackageForNative + CheckPackageStructured +
 // nativePackageCheckDiags + CheckDiagnosticsAsDiag) on a clean
 // multi-file package and asserts exit 0.
-func TestRunCheckPackageNativeIsAstbridgeFree(t *testing.T) {
+func TestRunCheckPackageNativeHappyPath(t *testing.T) {
 	dir := t.TempDir()
 	aPath := filepath.Join(dir, "a.osty")
 	bPath := filepath.Join(dir, "b.osty")
@@ -293,7 +293,7 @@ func TestRunCheckPackageNativeIsAstbridgeFree(t *testing.T) {
 	}
 }
 
-func TestRunCheckWorkspaceNativeIsAstbridgeFree(t *testing.T) {
+func TestRunCheckWorkspaceNativeHappyPath(t *testing.T) {
 	dir := t.TempDir()
 	depDir := filepath.Join(dir, "dep")
 	appDir := filepath.Join(dir, "app")
@@ -436,14 +436,10 @@ fn main() {
 	}
 }
 
-// TestRunCheckFileNativeIsAstbridgeFree is the in-process counter
-// test analog of TestRunResolveFileHappyPathIsAstbridgeFree. Proves
-// the --native CLI path produces zero astLowerPublicFile calls
-// end-to-end, including through CheckStructuredFromRun and the
-// CheckDiagnosticsAsDiag converter. Stdout redirected to discard so
-// printDiags output doesn't pollute test logs; the counter assertion
-// is the actual invariant.
-func TestRunCheckFileNativeIsAstbridgeFree(t *testing.T) {
+// TestRunCheckFileNativeDumpTelemetry exercises the --native CLI path
+// end-to-end (CheckStructuredFromRun + CheckDiagnosticsAsDiag) and
+// asserts the dump-native-diags telemetry header lands on stderr.
+func TestRunCheckFileNativeDumpTelemetry(t *testing.T) {
 	src := []byte(`fn main() {
     let x = 1
     let y = x + 2
@@ -487,7 +483,7 @@ func TestRunCheckFileNativeIsAstbridgeFree(t *testing.T) {
 }
 
 // TestCheckCLIDefaultPathUsesSelfhostArena is the production-default
-// companion to TestRunCheckFileNativeIsAstbridgeFree: after the
+// companion to TestRunCheckFileNativeDumpTelemetry: after the
 // 1c.1 flip (SELFHOST_PORT_MATRIX.md), `osty check FILE` with no
 // flag at all routes through the self-host arena pipeline the same
 // way `--native` does. Run the subprocess CLI so the default
@@ -514,11 +510,10 @@ func TestCheckCLIDefaultPathExitsZero(t *testing.T) {
 	}
 }
 
-// TestRunCheckFileDefaultPathIsAstbridgeFree is the in-process
-// counter assertion for the default flip. runCheckFileNative is the
-// production happy path for single-file check; confirm zero astbridge
-// lowerings end-to-end.
-func TestRunCheckFileDefaultPathIsAstbridgeFree(t *testing.T) {
+// TestRunCheckFileDefaultPathHappyPath exercises the production
+// default-path single-file check (runCheckFileNative) and asserts
+// exit 0 on clean input.
+func TestRunCheckFileDefaultPathHappyPath(t *testing.T) {
 	src := []byte(`fn main() {
     let x = 1
     let y = x + 2

--- a/cmd/osty/lint_native_test.go
+++ b/cmd/osty/lint_native_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/osty/osty/internal/lint"
 	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/selfhost"
 )
 
 func TestRunLintFileIsAstbridgeFree(t *testing.T) {
@@ -25,15 +24,11 @@ func TestRunLintFileIsAstbridgeFree(t *testing.T) {
 	formatter := newFormatter(path, src, flags)
 
 	restore := redirectStdoutStderr(t)
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runLintFile(path, src, formatter, flags, lint.Config{}, false)
 	restore()
 
 	if exit != 0 {
 		t.Fatalf("runLintFile exit = %d, want 0", exit)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after runLintFile = %d, want 0", got)
 	}
 }
 
@@ -55,7 +50,6 @@ func TestLintPackageNativeDiagnosticsIsAstbridgeFree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadPackageForNative: %v", err)
 	}
-	selfhost.ResetAstbridgeLowerCount()
 	frontendDiags, err := lintNativePackageDiagnostics(pkg, nil)
 	if err != nil {
 		t.Fatalf("lintNativePackageDiagnostics: %v", err)
@@ -63,9 +57,6 @@ func TestLintPackageNativeDiagnosticsIsAstbridgeFree(t *testing.T) {
 	lintDiags := lint.Package(pkg).Diags
 	if hasError(append(frontendDiags, lintDiags...)) {
 		t.Fatalf("clean package produced diagnostics: frontend=%#v lint=%#v", frontendDiags, lintDiags)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after native package lint path = %d, want 0", got)
 	}
 }
 

--- a/cmd/osty/lint_native_test.go
+++ b/cmd/osty/lint_native_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/osty/osty/internal/resolve"
 )
 
-func TestRunLintFileIsAstbridgeFree(t *testing.T) {
+func TestRunLintFileHappyPath(t *testing.T) {
 	src := []byte(`fn main() {
     let x = 1
     x
@@ -32,7 +32,7 @@ func TestRunLintFileIsAstbridgeFree(t *testing.T) {
 	}
 }
 
-func TestLintPackageNativeDiagnosticsIsAstbridgeFree(t *testing.T) {
+func TestLintPackageNativeDiagnosticsCleanPackage(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.osty"), []byte(`pub fn helper() -> Int { 1 }
 `), 0o644); err != nil {

--- a/cmd/osty/native_check.go
+++ b/cmd/osty/native_check.go
@@ -361,11 +361,9 @@ func loadNativeWorkspace(dir, mode string, flags cliFlags) (*resolve.Workspace, 
 
 // nativeLazyStdlibProvider defers stdlib.LoadCached() until a `use
 // std.*` import actually needs resolving. The eager alternative
-// (assigning stdlib.LoadCached() directly) triggers astbridge
-// lowering at workspace setup time, which violates the
-// astbridge-free invariant pinned by
-// TestRunCheckPackageNativeIsAstbridgeFree on packages that import
-// no stdlib.
+// (assigning stdlib.LoadCached() directly) would force stdlib
+// lowering at workspace setup time even for packages that import
+// no stdlib — defer it until a use site demands it.
 type nativeLazyStdlibProvider struct{}
 
 func (nativeLazyStdlibProvider) LookupPackage(dotPath string) *resolve.Package {

--- a/cmd/osty/resolve_native_test.go
+++ b/cmd/osty/resolve_native_test.go
@@ -6,21 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/osty/osty/internal/selfhost"
 )
 
-// TestRunResolveFileHappyPathIsAstbridgeFree pins the end-to-end CLI
-// invariant: the extracted runResolveFile body that powers `osty
-// resolve FILE` must not trigger a single astLowerPublicFile call on
-// clean input. This catches CLI-layer regressions that the library
-// primitive tests (ResolveStructuredFromRun, LoadPackageForNative)
-// cannot see on their own — any accidentally-added run.File() inside
-// the subcommand body would fail this test.
-//
-// Stdout is redirected to discard so the subcommand's normal ref/diag
-// rendering doesn't pollute go test output; the counter assertion is
-// the actual invariant under test.
 func TestRunResolveFileHappyPathIsAstbridgeFree(t *testing.T) {
 	src := []byte(`fn helper(x: Int) -> Int {
     x
@@ -51,7 +38,6 @@ fn main() {
 		_, _ = io.Copy(io.Discard, r)
 	}()
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runResolveFile(path, src, formatter, flags)
 	_ = w.Close()
 	<-drained
@@ -59,24 +45,8 @@ fn main() {
 	if exit != 0 {
 		t.Fatalf("runResolveFile exit = %d, want 0", exit)
 	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after runResolveFile happy path = %d, want 0 (any non-zero means the CLI body regressed into a *ast.File detour)", got)
-	}
 }
 
-// TestRunResolvePackageHappyPathIsAstbridgeFree is the DIR sibling of
-// TestRunResolveFileHappyPathIsAstbridgeFree. A two-file clean
-// package should round-trip through runResolvePackageInner with zero
-// astbridge lowerings — LoadPackageForNative gives us FrontendRuns
-// per file, native diagnostics + native rows don't need *ast.File,
-// and the EnsureFiles fallback should never fire on this input
-// (native rows are always available for resolvable refs).
-//
-// Any non-zero count means the DIR CLI body regressed: either a
-// fallback triggered unnecessarily (ensureGoResolve ran when it
-// shouldn't), or a new call site leaked run.File() in. Pairs with
-// the library-level TestLoadPackageForNativeMultiFileIsAstbridgeFree
-// to cover the entire stack from loader to printer.
 func TestRunResolvePackageHappyPathIsAstbridgeFree(t *testing.T) {
 	dir := t.TempDir()
 	aPath := filepath.Join(dir, "a.osty")
@@ -112,7 +82,6 @@ func TestRunResolvePackageHappyPathIsAstbridgeFree(t *testing.T) {
 	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
 	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runResolvePackageInner(dir, cliFlags{noColor: true})
 	_ = wout.Close()
 	_ = werr.Close()
@@ -121,9 +90,6 @@ func TestRunResolvePackageHappyPathIsAstbridgeFree(t *testing.T) {
 
 	if exit != 0 {
 		t.Fatalf("runResolvePackageInner exit = %d, want 0", exit)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after runResolvePackageInner = %d, want 0 (DIR resolve CLI body regressed into a *ast.File fallback)", got)
 	}
 }
 

--- a/cmd/osty/resolve_native_test.go
+++ b/cmd/osty/resolve_native_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestRunResolveFileHappyPathIsAstbridgeFree(t *testing.T) {
+func TestRunResolveFileHappyPath(t *testing.T) {
 	src := []byte(`fn helper(x: Int) -> Int {
     x
 }
@@ -47,7 +47,7 @@ fn main() {
 	}
 }
 
-func TestRunResolvePackageHappyPathIsAstbridgeFree(t *testing.T) {
+func TestRunResolvePackageHappyPath(t *testing.T) {
 	dir := t.TempDir()
 	aPath := filepath.Join(dir, "a.osty")
 	bPath := filepath.Join(dir, "b.osty")

--- a/cmd/osty/typecheck_native_test.go
+++ b/cmd/osty/typecheck_native_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/osty/osty/internal/selfhost"
 )
 
 // TestTypecheckCLINativeCleanSourcePrintsTypes confirms `osty
@@ -114,7 +112,6 @@ fn main() {
 	os.Stderr = werr
 	t.Cleanup(func() { os.Stderr = origStderr })
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runTypecheckFileNative(path, src, formatter, flags)
 	_ = wout.Close()
 	_ = werr.Close()
@@ -131,9 +128,6 @@ fn main() {
 
 	if exit != 0 {
 		t.Fatalf("runTypecheckFileNative exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exit, stdout, stderr)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after dump-native-diags native typecheck = %d, want 0", got)
 	}
 	if !strings.Contains(stderr, "native checker telemetry: "+path) {
 		t.Fatalf("stderr missing telemetry header:\n%s", stderr)
@@ -240,11 +234,10 @@ fn main() {
 	}
 }
 
-// TestRunTypecheckPackageNativeIsAstbridgeFree is the DIR in-process
-// counter test: runTypecheckPackageNative's full pipeline
-// (LoadPackageForNative → CheckPackageStructured →
-// nativePackageCheckDiags → printNativePackageTypes) must produce
-// AstbridgeLowerCount == 0.
+// TestRunTypecheckPackageNativeIsAstbridgeFree exercises the DIR
+// typecheck path end-to-end (LoadPackageForNative →
+// CheckPackageStructured → nativePackageCheckDiags →
+// printNativePackageTypes) on a clean two-file package.
 func TestRunTypecheckPackageNativeIsAstbridgeFree(t *testing.T) {
 	dir := t.TempDir()
 	aPath := filepath.Join(dir, "a.osty")
@@ -281,7 +274,6 @@ func TestRunTypecheckPackageNativeIsAstbridgeFree(t *testing.T) {
 	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
 	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runTypecheckPackageNative(dir, cliFlags{noColor: true})
 	_ = wout.Close()
 	_ = werr.Close()
@@ -290,9 +282,6 @@ func TestRunTypecheckPackageNativeIsAstbridgeFree(t *testing.T) {
 
 	if exit != 0 {
 		t.Fatalf("runTypecheckPackageNative exit = %d, want 0", exit)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after runTypecheckPackageNative = %d, want 0", got)
 	}
 }
 
@@ -339,7 +328,6 @@ fn main() {
 	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
 	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runTypecheckWorkspaceNative(dir, cliFlags{noColor: true})
 	_ = wout.Close()
 	_ = werr.Close()
@@ -349,16 +337,11 @@ fn main() {
 	if exit != 0 {
 		t.Fatalf("runTypecheckWorkspaceNative exit = %d, want 0", exit)
 	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after runTypecheckWorkspaceNative = %d, want 0", got)
-	}
 }
 
-// TestRunTypecheckFileNativeIsAstbridgeFree is the in-process counter
-// test. Verifies the typecheck --native CLI body leaves
-// AstbridgeLowerCount at zero — including the type dump (which
-// iterates TypedNodes, not AST nodes, and should not trigger any
-// *ast.File lowering).
+// TestRunTypecheckFileNativeIsAstbridgeFree exercises the typecheck
+// --native CLI body end-to-end including the type dump (which iterates
+// TypedNodes, not AST nodes) and asserts exit 0.
 func TestRunTypecheckFileNativeIsAstbridgeFree(t *testing.T) {
 	src := []byte(`fn main() {
     let x = 1
@@ -393,7 +376,6 @@ func TestRunTypecheckFileNativeIsAstbridgeFree(t *testing.T) {
 	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
 	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
 
-	selfhost.ResetAstbridgeLowerCount()
 	exit := runTypecheckFileNative(path, src, formatter, flags)
 	_ = wout.Close()
 	_ = werr.Close()
@@ -402,8 +384,5 @@ func TestRunTypecheckFileNativeIsAstbridgeFree(t *testing.T) {
 
 	if exit != 0 {
 		t.Fatalf("runTypecheckFileNative exit = %d, want 0", exit)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after runTypecheckFileNative = %d, want 0 (typecheck --native regressed into *ast.File detour)", got)
 	}
 }

--- a/cmd/osty/typecheck_native_test.go
+++ b/cmd/osty/typecheck_native_test.go
@@ -234,11 +234,11 @@ fn main() {
 	}
 }
 
-// TestRunTypecheckPackageNativeIsAstbridgeFree exercises the DIR
+// TestRunTypecheckPackageNativeHappyPath exercises the DIR
 // typecheck path end-to-end (LoadPackageForNative →
 // CheckPackageStructured → nativePackageCheckDiags →
 // printNativePackageTypes) on a clean two-file package.
-func TestRunTypecheckPackageNativeIsAstbridgeFree(t *testing.T) {
+func TestRunTypecheckPackageNativeHappyPath(t *testing.T) {
 	dir := t.TempDir()
 	aPath := filepath.Join(dir, "a.osty")
 	bPath := filepath.Join(dir, "b.osty")
@@ -285,7 +285,7 @@ func TestRunTypecheckPackageNativeIsAstbridgeFree(t *testing.T) {
 	}
 }
 
-func TestRunTypecheckWorkspaceNativeIsAstbridgeFree(t *testing.T) {
+func TestRunTypecheckWorkspaceNativeHappyPath(t *testing.T) {
 	dir := t.TempDir()
 	depDir := filepath.Join(dir, "dep")
 	appDir := filepath.Join(dir, "app")
@@ -339,10 +339,11 @@ fn main() {
 	}
 }
 
-// TestRunTypecheckFileNativeIsAstbridgeFree exercises the typecheck
-// --native CLI body end-to-end including the type dump (which iterates
-// TypedNodes, not AST nodes) and asserts exit 0.
-func TestRunTypecheckFileNativeIsAstbridgeFree(t *testing.T) {
+// TestRunTypecheckFileNativeDumpTelemetry exercises the typecheck
+// --native CLI body end-to-end (including the type dump which iterates
+// TypedNodes) and asserts the dump-native-diags telemetry header
+// lands on stderr.
+func TestRunTypecheckFileNativeDumpTelemetry(t *testing.T) {
 	src := []byte(`fn main() {
     let x = 1
     let y = x + 2

--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -6,8 +6,8 @@
 
 `internal/selfhost/ast_lower.osty` is no longer a checker-bundle input. It
 remains only as the public-AST compatibility adapter for legacy Go callers that
-still request `*ast.File` through `FrontendRun.File`, `Parse`, or
-`PackageFile.EnsureFile`. The native checker input set is pinned in
+still request `*ast.File` through `selfhost.LowerPublicFileFromRun`, `Parse`,
+or `PackageFile.EnsureFile`. The native checker input set is pinned in
 `internal/selfhost/bundle.ToolchainCheckerFiles()` and rejects bootstrap-only
 host adapters, including `use runtime.cihost`.
 
@@ -170,7 +170,7 @@ Current-tree observations from the code re-audit:
 | Layer | Where | What blocks |
 |---|---|---|
 | CLI wiring | universal LLVM entry wedge | **resolved** — hello-world `osty gen --backend=llvm` exits 0 and writes `.ll` output |
-| Bootstrap boundary | merged whole-toolchain probe / checker bundle | the current toolchain host adapter is `toolchain/ci.osty` with `use runtime.cihost as host`. `toolchain/ast_lower.osty` (dead duplicate of `internal/selfhost/ast_lower.osty`, 1672 LOC) was deleted 2026-04-22, and `internal/selfhost/ast_lower.osty` is now deliberately outside `ToolchainCheckerFiles()` as a legacy public-AST adapter for `FrontendRun.File` / `Parse` / `EnsureFile` consumers. `toolchain/docgen.osty` + `toolchain/manifest_validation.osty` were ported from `use go "strings"` to `use std.strings as strings` on the same day. |
+| Bootstrap boundary | merged whole-toolchain probe / checker bundle | the current toolchain host adapter is `toolchain/ci.osty` with `use runtime.cihost as host`. `toolchain/ast_lower.osty` (dead duplicate of `internal/selfhost/ast_lower.osty`, 1672 LOC) was deleted 2026-04-22, and `internal/selfhost/ast_lower.osty` is now deliberately outside `ToolchainCheckerFiles()` as a legacy public-AST adapter for `selfhost.LowerPublicFileFromRun` / `Parse` / `EnsureFile` consumers. `toolchain/docgen.osty` + `toolchain/manifest_validation.osty` were ported from `use go "strings"` to `use std.strings as strings` on the same day. |
 | Native backend surface | merged native-only probe | the old AST merged probe is info-only; the authoritative current gate is `TestNativeToolchainMergedMIRPipelineIsClean`, which mirrors production MIR-first dispatch without a legacy backend retry. Bootstrap-only sources are filtered by FFI stanza (`use runtime.cihost`, `use runtime.golegacy.*`, or `use go "..."`). Historical 2026-04-21 notes about `TestNativeToolchainMergedIsClean` describe the retired AST gate, not the current pass/fail surface. |
 | Public runtime scheduler | `osty_rt_*` task/thread/select | `#496` complete. Select-send arm landed as typed entry points `osty_rt_select_send_{i64,i1,f64,ptr,bytes_v1}` (scalar packing into channel ring slot, bytes via GC-managed copy). The public LLVM runtime now has zero `osty_sched_unimplemented` call sites — concurrency spec §8 (taskGroup / spawn / join / cancel / chan / select / parallel / race / collectAll) is fully covered. See RUNTIME_SCHEDULER.md |
 | MIR Osty port | `toolchain/mir.osty` | `#503` — MIR core (intrinsic kinds, printer, operand/instr shapes) now has an Osty-native mirror in `toolchain/mir.osty`; Go remains authoritative while the Osty side participates in the spec corpus |

--- a/internal/check/selfhost_run_test.go
+++ b/internal/check/selfhost_run_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/osty/osty/internal/parser"
-	"github.com/osty/osty/internal/selfhost"
 )
 
 func TestSelfhostRunStaysOffPublicASTCompatibility(t *testing.T) {
@@ -14,11 +13,7 @@ func TestSelfhostRunStaysOffPublicASTCompatibility(t *testing.T) {
 		t.Fatal("ParseRun returned nil")
 	}
 
-	selfhost.ResetAstbridgeLowerCount()
 	result := SelfhostRun(run, Opts{Source: src})
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("SelfhostRun astbridge count = %d, want 0", got)
-	}
 	if result == nil || result.NativeCheckResult == nil {
 		t.Fatalf("SelfhostRun result = %#v, want structured native check result", result)
 	}

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/selfhost"
 )
 
 func TestSourceDoesNotMaterializePublicAST(t *testing.T) {
@@ -15,7 +14,6 @@ x
 }
 `)
 
-	selfhost.ResetAstbridgeLowerCount()
 	out, diags, err := Source(src)
 	if err != nil {
 		t.Fatalf("Source: %v", err)
@@ -27,9 +25,6 @@ x
 	}
 	if len(out) == 0 {
 		t.Fatal("Source returned empty formatted output")
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("Source astbridge count = %d, want 0", got)
 	}
 }
 

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 )
 
-func TestSourceDoesNotMaterializePublicAST(t *testing.T) {
+func TestSourceFormatsCleanSource(t *testing.T) {
 	src := []byte(`fn main() {
 let x = 1
 x

--- a/internal/lsp/server_native_test.go
+++ b/internal/lsp/server_native_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/selfhost"
 )
 
 func TestAnalyzePackageContainingUsesNativeCompatibilityPath(t *testing.T) {
@@ -25,16 +24,9 @@ func TestAnalyzePackageContainingUsesNativeCompatibilityPath(t *testing.T) {
 	src := []byte("pub fn fresh() {}\n")
 	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
 
-	selfhost.ResetAstbridgeLowerCount()
 	a := s.analyzePackageContaining(path, src)
 	if a == nil {
 		t.Fatal("analyzePackageContaining returned nil")
-	}
-	// The engine-based package path may still materialize public ASTs for
-	// compatibility consumers, but parser.ParseDetailed must use the explicit
-	// adapter rather than FrontendRun.File's legacy astbridge entry point.
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after package analyze = %d, want 0", got)
 	}
 	if len(a.packages) != 1 {
 		t.Fatalf("packages = %d, want 1", len(a.packages))
@@ -58,13 +50,9 @@ func TestAnalyzePackageDiagnosticsUseNativeResolveResult(t *testing.T) {
 	src := []byte("fn main() { missing() }\n")
 	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
 
-	selfhost.ResetAstbridgeLowerCount()
 	a := s.analyzePackageContaining(path, src)
 	if a == nil {
 		t.Fatal("analyzePackageContaining returned nil")
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after package diagnostics = %d, want 0", got)
 	}
 	var sawUndefined bool
 	for _, d := range a.diags {
@@ -94,13 +82,9 @@ func TestAnalyzePackageIdentIndexUsesNativeStructuredResult(t *testing.T) {
 	src := []byte("fn main() { helper() }\n")
 	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
 
-	selfhost.ResetAstbridgeLowerCount()
 	a := s.analyzePackageContaining(path, src)
 	if a == nil {
 		t.Fatal("analyzePackageContaining returned nil")
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after package ident index = %d, want 0", got)
 	}
 	helperOff := bytes.Index(src, []byte("helper"))
 	if helperOff < 0 {
@@ -115,15 +99,9 @@ func TestAnalyzeSingleFileUsesNativeCompatibilityPath(t *testing.T) {
 	src := []byte("pub fn fresh() {}\n")
 	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
 
-	selfhost.ResetAstbridgeLowerCount()
 	a := s.analyzeSingleFileViaEngine("untitled:NativeCompat.osty", src)
 	if a == nil {
 		t.Fatal("analyzeSingleFileViaEngine returned nil")
-	}
-	// The public-AST compatibility surface stays explicit; no LSP single-file
-	// analysis path should call FrontendRun.File.
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after single-file analyze = %d, want 0", got)
 	}
 	if got := lspFirstFnName(a.file); got != "fresh" {
 		t.Fatalf("first function = %q, want %q", got, "fresh")
@@ -153,15 +131,9 @@ func TestAnalyzeWorkspaceUsesNativeCompatibilityPath(t *testing.T) {
 	src := []byte("pub fn fresh() {}\n")
 	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
 
-	selfhost.ResetAstbridgeLowerCount()
 	a := s.analyzePackageContaining(path, src)
 	if a == nil {
 		t.Fatal("analyzePackageContaining returned nil")
-	}
-	// Workspace analysis can still expose public ASTs to compatibility
-	// consumers, but it must not use FrontendRun.File as the authority path.
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after workspace analyze = %d, want 0", got)
 	}
 	if len(a.packages) != 2 {
 		t.Fatalf("packages = %d, want 2", len(a.packages))

--- a/internal/parser/frontend_authority_test.go
+++ b/internal/parser/frontend_authority_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/osty/osty/internal/ast"
-	"github.com/osty/osty/internal/selfhost"
 )
 
 func requireNoParseDiagnostics(t *testing.T, result Result) {
@@ -333,7 +332,6 @@ func TestParseDetailedKeepsFrontendRunAndUsesExplicitPublicCompatibility(t *test
 }
 `)
 
-	selfhost.ResetAstbridgeLowerCount()
 	result := ParseDetailed(src)
 	requireNoParseDiagnostics(t, result)
 	if result.Run == nil {
@@ -341,9 +339,6 @@ func TestParseDetailedKeepsFrontendRunAndUsesExplicitPublicCompatibility(t *test
 	}
 	if result.File == nil {
 		t.Fatal("ParseDetailed File = nil, want public compatibility AST")
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("ParseDetailed astbridge count = %d, want 0", got)
 	}
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -37,8 +37,8 @@ func Parse(src []byte) (*ast.File, []error) {
 // semantic AST plus parser-level compatibility provenance. Compatibility
 // helper syntax is canonicalized in the parser core; this facade only records
 // source alias provenance that remains useful at legacy boundaries. The public
-// AST is produced through the explicit compatibility adapter so ParseDetailed
-// does not exercise FrontendRun.File's legacy astbridge entry point.
+// AST is produced through the explicit compatibility adapter
+// (selfhost.LowerPublicFileFromRun).
 func ParseDetailed(src []byte) Result {
 	pipeline := newParsePipeline(src)
 	run := pipeline.parseRun()
@@ -70,9 +70,8 @@ func ParseDiagnostics(src []byte) (*ast.File, []*diag.Diagnostic) {
 // FrontendRun without lowering the result to the public *ast.File semantic AST.
 // Callers that only need the Osty-native parser arena (native resolver, native
 // checker, native llvmgen) should use this entry point so astbridge-based
-// public lowering is not triggered. Calling run.File() afterwards remains valid
-// if the *ast.File is eventually needed; it is computed lazily from the
-// semantic arena on first access.
+// public lowering is not triggered. Pass the run to
+// selfhost.LowerPublicFileFromRun if the *ast.File is eventually needed.
 func ParseRun(src []byte) *selfhost.FrontendRun {
 	return selfhost.Run(src)
 }

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lint"
 	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
 )
@@ -412,13 +411,9 @@ func TestIdentIndexUpdatesWithSymbols(t *testing.T) {
 	src := "pub fn foo() -> Int { 1 }\nfn main() { foo() }\n"
 	path := seedFile(eng, "/tmp/pkg_ii", "main.osty", src)
 
-	selfhost.ResetAstbridgeLowerCount()
 	idx := eng.Queries.IdentIndex.Get(eng.DB, path)
 	if idx == nil {
 		t.Fatal("IdentIndex returned nil")
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("IdentIndex touched astbridge = %d, want 0", got)
 	}
 	callOff := strings.LastIndex(src, "foo")
 	if callOff < 0 {
@@ -446,11 +441,7 @@ func TestResolveDiagnosticsUseNativeStructuredResult(t *testing.T) {
 
 	path := seedFile(eng, "/tmp/pkg_resolve_diags", "main.osty", "fn main() { missing() }\n")
 
-	selfhost.ResetAstbridgeLowerCount()
 	diags := eng.Queries.ResolveDiagnostics.Get(eng.DB, path)
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("ResolveDiagnostics touched astbridge = %d, want 0", got)
-	}
 	var sawUndefined bool
 	for _, d := range diags {
 		if d != nil && d.Code == diag.CodeUndefinedName {

--- a/internal/resolve/public_compat_test.go
+++ b/internal/resolve/public_compat_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/osty/osty/internal/parser"
 )
 
-func TestMaterializePublicCompatibilityKeepsNativePackageAstbridgeFree(t *testing.T) {
+func TestMaterializePublicCompatibilityIsLazyAndIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	aPath := filepath.Join(dir, "a.osty")
 	bPath := filepath.Join(dir, "b.osty")

--- a/internal/resolve/public_compat_test.go
+++ b/internal/resolve/public_compat_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
-	"github.com/osty/osty/internal/selfhost"
 )
 
 func TestMaterializePublicCompatibilityKeepsNativePackageAstbridgeFree(t *testing.T) {
@@ -28,14 +27,9 @@ func TestMaterializePublicCompatibilityKeepsNativePackageAstbridgeFree(t *testin
 		t.Fatal(err)
 	}
 
-	selfhost.ResetAstbridgeLowerCount()
-
 	pkg, err := LoadPackageForNative(dir)
 	if err != nil {
 		t.Fatalf("LoadPackageForNative: %v", err)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("after LoadPackageForNative: astbridge count = %d, want 0", got)
 	}
 	for _, pf := range pkg.Files {
 		if pf.Run == nil {
@@ -71,14 +65,8 @@ func TestMaterializePublicCompatibilityKeepsNativePackageAstbridgeFree(t *testin
 	if got := idx[helperOff]; got != "function" {
 		t.Fatalf("NativeIdentKindIndex[%d] = %q, want function (idx=%#v)", helperOff, got, idx)
 	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("after native package queries: astbridge count = %d, want 0", got)
-	}
 
 	pkg.MaterializePublicCompatibility()
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("after MaterializePublicCompatibility: astbridge count = %d, want 0", got)
-	}
 	for _, pf := range pkg.Files {
 		if pf.File == nil {
 			t.Fatalf("MaterializePublicCompatibility left File nil for %s", pf.Path)
@@ -86,9 +74,6 @@ func TestMaterializePublicCompatibilityKeepsNativePackageAstbridgeFree(t *testin
 	}
 
 	pkg.MaterializePublicCompatibility()
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("second MaterializePublicCompatibility: astbridge count = %d, want 0", got)
-	}
 }
 
 func TestWorkspaceLoadPackageNativeDiscoversDepsWithoutPublicAST(t *testing.T) {
@@ -110,8 +95,6 @@ fn main() {
 		t.Fatal(err)
 	}
 
-	selfhost.ResetAstbridgeLowerCount()
-
 	ws, err := NewWorkspace(root)
 	if err != nil {
 		t.Fatalf("NewWorkspace: %v", err)
@@ -131,9 +114,6 @@ fn main() {
 				t.Fatalf("package %q file %s materialized public AST during native workspace load", key, pf.Path)
 			}
 		}
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("after workspace LoadPackageNative: astbridge count = %d, want 0", got)
 	}
 }
 

--- a/internal/resolve/semanticdb_test.go
+++ b/internal/resolve/semanticdb_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestNativeSemanticDBKeepsResolveFactsAstbridgeFree(t *testing.T) {
+func TestNativeSemanticDBPopulatesResolveFacts(t *testing.T) {
 	dir := t.TempDir()
 	helperPath := filepath.Join(dir, "helper.osty")
 	mainPath := filepath.Join(dir, "main.osty")

--- a/internal/resolve/semanticdb_test.go
+++ b/internal/resolve/semanticdb_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/osty/osty/internal/selfhost"
 )
 
 func TestNativeSemanticDBKeepsResolveFactsAstbridgeFree(t *testing.T) {
@@ -26,7 +24,6 @@ func TestNativeSemanticDBKeepsResolveFactsAstbridgeFree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	selfhost.ResetAstbridgeLowerCount()
 	pkg, err := LoadPackageForNative(dir)
 	if err != nil {
 		t.Fatalf("LoadPackageForNative: %v", err)
@@ -37,9 +34,6 @@ func TestNativeSemanticDBKeepsResolveFactsAstbridgeFree(t *testing.T) {
 	}
 	if db == nil {
 		t.Fatal("NativeSemanticDB returned nil")
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("NativeSemanticDB astbridge count = %d, want 0", got)
 	}
 	if db.PackageID == "" {
 		t.Fatal("SemanticDB PackageID is empty")

--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -27,9 +27,11 @@ Authority rule:
 - Production front-end paths must treat `FrontendRun` / arena / structured
   results as the source of truth. Public `*ast.File` values are compatibility
   output only.
-- `FrontendRun.File()` is deprecated for production code. If a legacy consumer
-  still needs public AST shape, use `LowerPublicFileFromRun()` at that explicit
-  boundary so the compatibility hop is visible and searchable.
+- If a legacy consumer still needs public AST shape, use
+  `LowerPublicFileFromRun()` at that explicit boundary so the compatibility hop
+  is visible and searchable. The previous lazy `FrontendRun.File()` accessor
+  was removed; structural enforcement (no method to call) replaces the prior
+  runtime counter.
 - Package-level code should keep `PackageFile.Run` / structured results where
   possible. If a legacy package consumer still needs `PackageFile.File`, call
   `MaterializePublicCompatibility()` at that boundary rather than hiding the

--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -1,38 +1,11 @@
 package selfhost
 
 import (
-	"sync/atomic"
 	"unicode/utf8"
 
-	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/token"
 )
-
-// astbridgeLowerCount records every time a FrontendRun materializes
-// the *ast.File via the astbridge-based astLowerPublicFile adapter.
-// It is the single source of truth for "did this code path touch the
-// runtime.golegacy.astbridge bootstrap bridge?" — tests use it to pin
-// astbridge-free code paths (e.g., the native resolve wedge) and to
-// detect regressions when a would-be-native path silently falls back
-// to the Go AST. Counter is package-global because FrontendRun.File()
-// is the only astbridge entry point for the resolve/check/llvmgen
-// callers. See ResolveStructuredFromRun / cmd/osty case "resolve" for
-// the intended zero-bump usage.
-var astbridgeLowerCount int64
-
-// AstbridgeLowerCount returns the total number of astbridge-based
-// *ast.File lowerings performed since process start (or since the
-// last ResetAstbridgeLowerCount call).
-func AstbridgeLowerCount() int64 {
-	return atomic.LoadInt64(&astbridgeLowerCount)
-}
-
-// ResetAstbridgeLowerCount zeros the counter. Intended for tests that
-// want to measure astbridge activity over a specific code window.
-func ResetAstbridgeLowerCount() {
-	atomic.StoreInt64(&astbridgeLowerCount, 0)
-}
 
 // Lex runs the bootstrapped pure-Osty lexer and adapts its stream to the
 // compiler's public token surface.
@@ -46,8 +19,8 @@ func Lex(src []byte) ([]token.Token, []*diag.Diagnostic, []token.Comment) {
 
 // FrontendRun is one complete self-hosted front-end pass over a source file.
 // It owns the shared lex stream, parser arena, public token adaptation,
-// lowered AST, and diagnostic adaptation so callers do not accidentally
-// re-run the front end.
+// and diagnostic adaptation so callers do not accidentally re-run the
+// front end. Use LowerPublicFileFromRun when a public *ast.File is needed.
 type FrontendRun struct {
 	text     string
 	rt       runeTable
@@ -56,7 +29,6 @@ type FrontendRun struct {
 	parser   *OstyParser
 	toks     []token.Token
 	comments []token.Comment
-	file     *ast.File
 	semantic *AstFile
 	lexDiags []*diag.Diagnostic
 	diags    []*diag.Diagnostic
@@ -151,29 +123,6 @@ func (r *FrontendRun) Tokens() []token.Token {
 func (r *FrontendRun) Comments() []token.Comment {
 	r.ensureLexAdapted()
 	return r.comments
-}
-
-// File returns the public semantic AST for this front-end pass.
-//
-// First call materializes the *ast.File from the already-lowered semantic
-// arena via astLowerPublicFile. Subsequent calls return the cached result
-// without touching astbridge again, so each FrontendRun contributes at most one
-// lowering to AstbridgeLowerCount regardless of how many callers poke it.
-//
-// Deprecated: production front-end paths should keep FrontendRun / arena /
-// structured results as the source of truth. Use LowerPublicFileFromRun only at
-// explicit public-AST compatibility boundaries.
-func (r *FrontendRun) File() *ast.File {
-	if r.file != nil {
-		return r.file
-	}
-	atomic.AddInt64(&astbridgeLowerCount, 1)
-	arena := r.parser.arena
-	if semantic := r.semanticAstFile(); semantic != nil && semantic.arena != nil {
-		arena = semantic.arena
-	}
-	r.file = lowerPublicFileFromArena(arena, r.Tokens())
-	return r.file
 }
 
 // astFile wraps the parser arena in the self-host AstFile handle without

--- a/internal/selfhost/ast_lower.osty
+++ b/internal/selfhost/ast_lower.osty
@@ -2,9 +2,8 @@
 //
 // Core selfhost consumers should stay arena-native and use FrontendRun /
 // AstArena APIs directly. This file is intentionally isolated behind
-// FrontendRun.File and LowerPublicFileFromRun for legacy callers that still
-// need *ast.File while the checker/resolver/LLVM paths migrate away from the
-// Go astbridge surface.
+// LowerPublicFileFromRun for legacy callers that still need *ast.File while
+// the checker/resolver/LLVM paths migrate away from the Go astbridge surface.
 use go "github.com/osty/osty/internal/selfhost/astbridge" as astbridge {
     struct File {}
     struct Decl {}

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -369,51 +369,24 @@ func TestRunDiagnosticsAllowDiscardInForInHead(t *testing.T) {
 	}
 }
 
-// TestCheckStructuredFromRunIsAstbridgeFree pins the PR8 wedge:
+// TestCheckStructuredFromRunSmoke exercises the PR8 wedge:
 // CheckStructuredFromRun runs the native checker plus the
-// intrinsic-body gate entirely off the FrontendRun's AstArena, so the
-// astbridge *ast.File lowering is never invoked. The only bump path
-// is run.File() on explicit demand.
-func TestCheckStructuredFromRunIsAstbridgeFree(t *testing.T) {
+// intrinsic-body gate entirely off the FrontendRun's AstArena.
+func TestCheckStructuredFromRunSmoke(t *testing.T) {
 	src := []byte(`fn main() {
     let x = 1
     let y = x + 2
     y
 }
 `)
-	ResetAstbridgeLowerCount()
-
 	run := Run(src)
-	if got := AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("Run alone: AstbridgeLowerCount = %d, want 0", got)
-	}
-
 	_ = CheckStructuredFromRun(run)
-	if got := AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("after CheckStructuredFromRun: AstbridgeLowerCount = %d, want 0 (arena-direct check + arena-direct gate must not touch astbridge)", got)
-	}
-
 	_ = CheckStructuredFromRun(run)
-	if got := AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("second CheckStructuredFromRun on same run: AstbridgeLowerCount = %d, want 0", got)
-	}
-
-	// Explicit run.File() still works and is the only way to bump the
-	// counter — proves the counter wiring isn't accidentally short-
-	// circuited by the earlier CheckStructuredFromRun calls.
-	if f := run.File(); f == nil {
-		t.Fatalf("run.File() returned nil")
-	}
-	if got := AstbridgeLowerCount(); got != 1 {
-		t.Fatalf("after explicit run.File(): AstbridgeLowerCount = %d, want 1", got)
-	}
 }
 
-// TestCheckSourceStructuredIsAstbridgeFree extends the zero-astbridge
-// guarantee to CheckSourceStructured: the full source-based check path
-// runs the generated checker and its internal gates without triggering
-// astLowerPublicFile.
-func TestCheckSourceStructuredIsAstbridgeFree(t *testing.T) {
+// TestCheckSourceStructuredSmoke covers the full source-based check
+// path through the generated checker and its internal gates.
+func TestCheckSourceStructuredSmoke(t *testing.T) {
 	src := []byte(`#[intrinsic]
 fn bad() -> Int {
     42
@@ -425,17 +398,8 @@ fn main() {
     y
 }
 `)
-	ResetAstbridgeLowerCount()
-
 	_ = CheckSourceStructured(src)
-	if got := AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("CheckSourceStructured: AstbridgeLowerCount = %d, want 0 (arena gate must not touch astbridge)", got)
-	}
-
 	_ = CheckSourceStructured(src)
-	if got := AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("second CheckSourceStructured: AstbridgeLowerCount = %d, want 0", got)
-	}
 }
 
 func TestCheckFromSourceMatchesRunDiagnosticsAndStructuredResult(t *testing.T) {
@@ -467,16 +431,12 @@ func TestCheckFromSourceMatchesRunDiagnosticsAndStructuredResult(t *testing.T) {
 			wantDiags := run.Diagnostics()
 			wantResult := CheckStructuredFromRun(run)
 
-			ResetAstbridgeLowerCount()
 			gotDiags, gotResult := CheckFromSource(tc.src)
 			if !reflect.DeepEqual(wantDiags, gotDiags) {
 				t.Fatalf("CheckFromSource parse diagnostics diverge\nwant=%#v\ngot=%#v", wantDiags, gotDiags)
 			}
 			if !reflect.DeepEqual(wantResult, gotResult) {
 				t.Fatalf("CheckFromSource result diverges\nwant=%#v\ngot=%#v", wantResult, gotResult)
-			}
-			if got := AstbridgeLowerCount(); got != 0 {
-				t.Fatalf("CheckFromSource: AstbridgeLowerCount = %d, want 0", got)
 			}
 		})
 	}
@@ -505,14 +465,9 @@ fn main() {
 		},
 	}
 
-	ResetAstbridgeLowerCount()
-
 	result, err := CheckPackageStructured(input)
 	if err != nil {
 		t.Fatalf("CheckPackageStructured: %v", err)
-	}
-	if got := AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("CheckPackageStructured: AstbridgeLowerCount = %d, want 0", got)
 	}
 
 	// Sanity: the intrinsic violation in b.osty surfaces as a

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -442,11 +442,11 @@ func TestCheckFromSourceMatchesRunDiagnosticsAndStructuredResult(t *testing.T) {
 	}
 }
 
-// TestCheckPackageStructuredIsAstbridgeFree is the multi-file analogue.
-// The package adapter merges parser arenas and lets the generated checker
-// run its internal gates, so no *ast.File lowering happens even with the
-// Direct-path input.
-func TestCheckPackageStructuredIsAstbridgeFree(t *testing.T) {
+// TestCheckPackageStructuredSurfacesIntrinsicGate is the multi-file
+// analogue: the package adapter merges parser arenas and lets the
+// generated checker run its internal gates; an `#[intrinsic]`
+// violation in one of the files must surface as E0773.
+func TestCheckPackageStructuredSurfacesIntrinsicGate(t *testing.T) {
 	aSrc := []byte(`pub fn helper() -> Int { 1 }
 `)
 	bSrc := []byte(`#[intrinsic]

--- a/internal/selfhost/check_diag_convert_test.go
+++ b/internal/selfhost/check_diag_convert_test.go
@@ -92,11 +92,7 @@ fn bad() -> Int { 42 }
 `)
 	checked := selfhost.CheckSourceStructured(src)
 
-	selfhost.ResetAstbridgeLowerCount()
 	diags := selfhost.CheckDiagnosticsAsDiag(src, checked.Diagnostics)
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("CheckDiagnosticsAsDiag: AstbridgeLowerCount = %d, want 0", got)
-	}
 	if len(diags) == 0 {
 		t.Fatalf("expected at least one converted diagnostic")
 	}

--- a/internal/selfhost/check_diag_convert_test.go
+++ b/internal/selfhost/check_diag_convert_test.go
@@ -80,13 +80,11 @@ func TestCheckDiagnosticsAsDiagDropsEmptyRecords(t *testing.T) {
 	}
 }
 
-// TestCheckDiagnosticsAsDiagIsAstbridgeFree pins the invariant that
-// record-to-diagnostic conversion — purely byte-offset → line/column
-// math plus struct shaping — never walks into astbridge. Combined
-// with the existing CheckSourceStructured / CheckStructuredFromRun
-// astbridge-free guarantees, this proves a future native CLI path
-// (parse → check → convert → print) stays at count == 0.
-func TestCheckDiagnosticsAsDiagIsAstbridgeFree(t *testing.T) {
+// TestCheckDiagnosticsAsDiagConvertsDiagnostics exercises the
+// `CheckDiagnosticRecord` → `*diag.Diagnostic` converter end-to-end
+// and asserts at least one diagnostic surfaces when the source has
+// a real violation.
+func TestCheckDiagnosticsAsDiagConvertsDiagnostics(t *testing.T) {
 	src := []byte(`#[intrinsic]
 fn bad() -> Int { 42 }
 `)

--- a/internal/selfhost/frontend_authority_test.go
+++ b/internal/selfhost/frontend_authority_test.go
@@ -9,47 +9,7 @@ import (
 	"testing"
 )
 
-var frontendRunFileCallRE = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*(?:[Rr]un)\.File\(\)`)
 var structuredSelfhostAliasRE = regexp.MustCompile(`selfhost\.(PackageCheckInput|PackageCheckFile|PackageCheckImport|CheckResult|CheckedNode|CheckDiagnosticRecord|ResolveResult|ResolvedRef|ResolvedSymbol|ResolvedTypeRef|PackageResolveInput|PackageResolveFile|CfgEnv)\b`)
-
-func TestProductionFrontendPathsDoNotCallFrontendRunFile(t *testing.T) {
-	root := repoRootForAuthorityTest(t)
-	for _, dir := range []string{"cmd", "internal"} {
-		scanDir := filepath.Join(root, dir)
-		err := filepath.WalkDir(scanDir, func(path string, entry os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if entry.IsDir() {
-				switch entry.Name() {
-				case ".git", ".osty", ".direnv":
-					return filepath.SkipDir
-				}
-				return nil
-			}
-			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-				return nil
-			}
-			data, err := os.ReadFile(path)
-			if err != nil {
-				return err
-			}
-			for i, line := range strings.Split(string(data), "\n") {
-				if strings.HasPrefix(strings.TrimSpace(line), "//") {
-					continue
-				}
-				if frontendRunFileCallRE.MatchString(line) {
-					rel, _ := filepath.Rel(root, path)
-					t.Fatalf("%s:%d calls FrontendRun.File(); use FrontendRun/arena/structured results, or LowerPublicFileFromRun at an explicit compatibility boundary", rel, i+1)
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatalf("scan %s: %v", dir, err)
-		}
-	}
-}
 
 func TestNativeConsumersImportStructuredAPITypesDirectly(t *testing.T) {
 	root := repoRootForAuthorityTest(t)

--- a/internal/selfhost/parse_contract_test.go
+++ b/internal/selfhost/parse_contract_test.go
@@ -167,10 +167,4 @@ func TestLowerPublicFileUsesSelfhostStableNodeIDs(t *testing.T) {
 	if got, want := stmt.Value.(*ast.CallExpr).ID, ast.NodeID(callIdx+2); got != want {
 		t.Fatalf("call ID = %d, want selfhost arena stable ID %d", got, want)
 	}
-
-	fromRunFile := run.File()
-	fromRunFn := fromRunFile.Decls[0].(*ast.FnDecl)
-	if fromRunFn.ID != fn.ID {
-		t.Fatalf("run.File fn ID = %d, want same stable ID %d", fromRunFn.ID, fn.ID)
-	}
 }

--- a/internal/selfhost/parse_cst_contract_test.go
+++ b/internal/selfhost/parse_cst_contract_test.go
@@ -24,16 +24,12 @@ func TestParseCSTLosslessOnMalformedSource(t *testing.T) {
 
 func TestParseCSTUsesSelfhostArenaEntitySpans(t *testing.T) {
 	src := []byte("use std::{fs, io as io}\nfn main() {\n    let items = [1]\n    let count = len(items)\n}\n")
-	ResetAstbridgeLowerCount()
 	tree, diags := ParseCST(src)
 	if len(diags) != 0 {
 		t.Fatalf("ParseCST diagnostics = %#v, want none", diags)
 	}
 	if tree == nil {
 		t.Fatal("ParseCST returned nil tree")
-	}
-	if got := AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("ParseCST FrontendRun.File count = %d, want 0", got)
 	}
 	if got := countCSTKind(tree, cst.GkUseDecl); got != 2 {
 		t.Fatalf("CST grouped use decl count = %d, want 2", got)

--- a/internal/selfhost/parse_stable_alias_test.go
+++ b/internal/selfhost/parse_stable_alias_test.go
@@ -5,13 +5,9 @@ import "testing"
 func TestParseStableAliasesDirectly(t *testing.T) {
 	src := []byte("import std.testing as t\nfunc main() {\n    while false {\n        break\n    }\n}\n")
 
-	ResetAstbridgeLowerCount()
 	file, diags := Parse(src)
 	if len(diags) > 0 {
 		t.Fatalf("Parse returned %d diagnostics: %v", len(diags), diags[0])
-	}
-	if got := AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("Parse astbridge count = %d, want 0", got)
 	}
 	if file == nil || len(file.Uses) != 1 || len(file.Decls) != 1 {
 		t.Fatalf("parsed file = %#v, want one use and one decl", file)

--- a/internal/selfhost/public_file_adapter.go
+++ b/internal/selfhost/public_file_adapter.go
@@ -9,6 +9,11 @@ import (
 // *ast.File surface. Use this explicit compatibility API only where host-side
 // AST inspection is still required while the caller remains on the native
 // parser path.
+//
+// The result is not cached. Each call walks the semantic arena, allocates a
+// new *ast.File, and re-runs assignPublicStableIDs / ast.AssignIDs. Callers
+// that need the *ast.File more than once for the same run should retain the
+// returned value rather than calling this helper repeatedly.
 func LowerPublicFileFromRun(run *FrontendRun) *ast.File {
 	if run == nil || run.parser == nil {
 		return nil

--- a/internal/selfhost/public_file_adapter.go
+++ b/internal/selfhost/public_file_adapter.go
@@ -6,9 +6,9 @@ import (
 )
 
 // LowerPublicFileFromRun lowers a FrontendRun's semantic arena to the public
-// *ast.File surface without bumping AstbridgeLowerCount. Use this explicit
-// compatibility API only where host-side AST inspection is still required while
-// the caller remains on the native parser path.
+// *ast.File surface. Use this explicit compatibility API only where host-side
+// AST inspection is still required while the caller remains on the native
+// parser path.
 func LowerPublicFileFromRun(run *FrontendRun) *ast.File {
 	if run == nil || run.parser == nil {
 		return nil

--- a/internal/selfhost/resolve_adapter_test.go
+++ b/internal/selfhost/resolve_adapter_test.go
@@ -363,17 +363,10 @@ use std.fs as strings
 	}
 }
 
-// TestResolveStructuredFromRunIsAstbridgeFree pins the core wedge
-// promise: calling Run + Diagnostics + ResolveStructuredFromRun on a
-// clean single-file source must not trigger astLowerPublicFile, i.e.
-// AstbridgeLowerCount stays at zero. The same test then calls
-// run.File() and verifies the counter bumps exactly once, confirming
-// that astbridge is still reachable for fallbacks (for example the
-// --show-scopes path in `osty resolve`) and that the counter is wired
-// to the right site. This is the regression net for future wedges:
-// any new native path that accidentally re-introduces an *ast.File
-// detour will bump the counter and fail this test.
-func TestResolveStructuredFromRunIsAstbridgeFree(t *testing.T) {
+// TestResolveStructuredFromRunSmoke exercises the core wedge:
+// Run + Diagnostics + ResolveStructuredFromRun on a clean single-file
+// source completes without diagnostics.
+func TestResolveStructuredFromRunSmoke(t *testing.T) {
 	src := []byte(`fn helper(x: Int) -> Int {
     x
 }
@@ -382,29 +375,12 @@ fn main() {
     let value = helper(1)
 }
 `)
-	selfhost.ResetAstbridgeLowerCount()
-
 	run := selfhost.Run(src)
 	_ = run.Diagnostics()
 	resolved := selfhost.ResolveStructuredFromRun(run)
 
 	if resolved.Summary.Diagnostics != 0 {
 		t.Fatalf("clean source produced diagnostics: %#v", resolved.Diagnostics)
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 0 {
-		t.Fatalf("AstbridgeLowerCount after Run + Diagnostics + ResolveStructuredFromRun = %d, want 0 (the arena path must not touch astbridge)", got)
-	}
-
-	if file := run.File(); file == nil {
-		t.Fatalf("run.File() returned nil")
-	}
-	if got := selfhost.AstbridgeLowerCount(); got != 1 {
-		t.Fatalf("AstbridgeLowerCount after run.File() = %d, want 1 (counter should be wired to the sole astbridge entry point)", got)
-	}
-
-	_ = run.File()
-	if got := selfhost.AstbridgeLowerCount(); got != 1 {
-		t.Fatalf("AstbridgeLowerCount after cached run.File() = %d, want 1 (re-calling File() should not re-lower)", got)
 	}
 }
 
@@ -500,16 +476,12 @@ fn main() {
 			wantDiags := run.Diagnostics()
 			wantResult := selfhost.ResolveStructuredFromRunForPath(run, tc.path)
 
-			selfhost.ResetAstbridgeLowerCount()
 			gotDiags, gotResult := selfhost.ResolveFromSource(tc.src, tc.path)
 			if !reflect.DeepEqual(wantDiags, gotDiags) {
 				t.Fatalf("ResolveFromSource parse diagnostics diverge\nwant=%#v\ngot=%#v", wantDiags, gotDiags)
 			}
 			if !reflect.DeepEqual(wantResult, gotResult) {
 				t.Fatalf("ResolveFromSource result diverges\nwant=%#v\ngot=%#v", wantResult, gotResult)
-			}
-			if got := selfhost.AstbridgeLowerCount(); got != 0 {
-				t.Fatalf("ResolveFromSource: AstbridgeLowerCount = %d, want 0", got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Removes the long-tail Go legacy surface around `FrontendRun.File()`:

- The deprecated `FrontendRun.File()` accessor (only callers were tests verifying its existence).
- The `astbridgeLowerCount` global counter and its `AstbridgeLowerCount` / `ResetAstbridgeLowerCount` exports, which existed solely to police accidental `.File()` calls from production code.
- The source-scanning `TestProductionFrontendPathsDoNotCallFrontendRunFile` authority test, vacuous once the method is gone.
- Counter-assertion blocks and `.File()` exercise blocks across 17 test files.
- Stale doc references in `LLVM_MIGRATION_PLAN.md`, `docs/toolchain_llvm_status.md`, `internal/selfhost/README.md`, and `internal/selfhost/ast_lower.osty`.

Now **structural enforcement replaces runtime sentinels**: accidentally re-introducing an astbridge detour is a compile error (no method exists), not a counter assertion failure.

Net change: **25 files, +44 / -392 LOC**.

## Background

Production paths have used `selfhost.LowerPublicFileFromRun` (the explicit, counter-free entry point) since the wedge work landed. The deprecated `.File()` shim was retained as a runtime-policed safety net. Per `SELFHOST_PORT_MATRIX.md`, this is exactly the kind of long-tail Go legacy that should retire.

Confirmed before edits:
- Zero non-test, non-comment callers of `FrontendRun.File()` anywhere in `cmd/` or `internal/`.
- The authority test (`frontend_authority_test.go::TestProductionFrontendPathsDoNotCallFrontendRunFile`) already enforced that.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test -count=1 -short` passes on all touched packages: `internal/selfhost`, `internal/parser`, `internal/resolve`, `internal/format`, `internal/check`, `internal/query/osty`, `internal/lsp`, `cmd/osty`.
- [ ] CI green.

https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ)_