### PR TITLE
perf: parallelize selfhost package parse, combine bridge walks (install-self -30%)

### DIFF
--- a/internal/resolve/resolve_bridge.go
+++ b/internal/resolve/resolve_bridge.go
@@ -27,18 +27,36 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 	}
 	semanticDB := pkg.nativeResolve.db
 
+	// Build a `path → nativeResolveFileInfo` map once so the
+	// per-iteration lookups in this function (defineTopLevelSymbols,
+	// processFile) skip the `nativeResolveFileInfoFor` linear scan over
+	// `files`. The slice is still threaded into the bridge functions
+	// because the per-ref findOrCreateSymbol path needs target-file
+	// lookups too, but the dominant cost there is the reflect-based
+	// walks; this map shaves the per-file constant.
+	filesByPath := make(map[string]nativeResolveFileInfo, len(files))
+	for _, f := range files {
+		filesByPath[f.path] = f
+	}
+
 	pkgScope := NewScope(prelude, "package:"+pkg.Name)
 	diags := nativeParseDiagnostics(pkg)
 	endDecl := beginResolvePhase("resolve.native.declIndexes")
 	declIndexes := make(map[string]map[int]ast.Node, len(pkg.Files))
+	// Pre-bucket result.Symbols by sym.File so per-file
+	// defineTopLevelSymbols iterates only its own symbols rather than
+	// the whole slice with a `sym.File != fi.path` filter for every
+	// file. Same O(N×M) → O(total) shape as the ref / typeRef bucket
+	// below.
+	symbolsByFile := groupSymbolsByFile(result.Symbols)
 	for _, pf := range pkg.Files {
 		if pf.File == nil || len(pf.Source) == 0 && len(pf.CanonicalSource) == 0 {
 			continue
 		}
-		fi := nativeResolveFileInfoFor(files, pf.Path)
+		fi := filesByPath[pf.Path]
 		declIdx := buildDeclIndex(pf.File)
 		declIndexes[pf.Path] = declIdx
-		defineTopLevelSymbols(pkgScope, result.Symbols, fi, declIdx)
+		defineTopLevelSymbolsForFile(pkgScope, symbolsByFile, fi, declIdx)
 	}
 	endDecl()
 
@@ -80,9 +98,8 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 		bridgeFiles = append(bridgeFiles, pf)
 	}
 	processFile := func(pf *PackageFile) {
-		fi := nativeResolveFileInfoFor(files, pf.Path)
-		identIdx := buildIdentIndex(pf.File)
-		typeIdx := buildNamedTypeIndex(pf.File)
+		fi := filesByPath[pf.Path]
+		identIdx, typeIdx := buildIdentAndNamedTypeIndex(pf.File)
 		fileScope := NewScope(pkgScope, "file:"+pf.Path)
 
 		refsForFile := refsByFile[pf.Path]
@@ -101,7 +118,7 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 		// missing slot is unreachable, and a shared-map write here
 		// would race with the workers.
 		refsByID, refIdents := bridgeRefsForFile(refsForFile, symByTarget, files, fi, identIdx, declIndexes, fileScope)
-		refsByID, refIdents = supplementUseAliasRefs(pf.File, fileScope, refsByID, refIdents)
+		refsByID, refIdents = supplementUseAliasRefsFromIndex(pf.File, fileScope, identIdx, refsByID, refIdents)
 		pf.RefsByID = refsByID
 		pf.RefIdents = refIdents
 
@@ -173,6 +190,29 @@ func groupTypeRefsByFile(refs []api.ResolvedTypeRef) (map[string][]api.ResolvedT
 		byFile[ref.File] = append(byFile[ref.File], ref)
 	}
 	return byFile, shared
+}
+
+// groupSymbolsByFile partitions selfhost-emitted symbols by their owning
+// file path so `defineTopLevelSymbolsForFile` can iterate only the
+// per-file slice instead of the whole `result.Symbols` slice (with a
+// `sym.File != fi.path` filter) once per file. Symbols whose `File` is
+// empty land in the shared bucket so they are visited from every
+// file — preserving the old wildcard semantics in
+// `defineTopLevelSymbols`.
+func groupSymbolsByFile(symbols []api.ResolvedSymbol) map[string][]api.ResolvedSymbol {
+	byFile := make(map[string][]api.ResolvedSymbol, 16)
+	var shared []api.ResolvedSymbol
+	for _, sym := range symbols {
+		if sym.File == "" {
+			shared = append(shared, sym)
+			continue
+		}
+		byFile[sym.File] = append(byFile[sym.File], sym)
+	}
+	if len(shared) > 0 {
+		byFile[""] = shared
+	}
+	return byFile
 }
 
 func nativeParseDiagnostics(pkg *Package) []*diag.Diagnostic {
@@ -303,6 +343,27 @@ func buildNamedTypeIndex(file *ast.File) map[int]*ast.NamedType {
 		}
 	})
 	return idx
+}
+
+// buildIdentAndNamedTypeIndex is the combined `buildIdentIndex` +
+// `buildNamedTypeIndex` walker. The reflect-based AST traversal is the
+// dominant cost in the per-file bridge loop (~19s wall on the
+// install-self toolchain build), and the two separate walks duplicate
+// every traversal step. Combining them halves the walker overhead while
+// keeping the per-index map shape identical.
+func buildIdentAndNamedTypeIndex(file *ast.File) (map[int]*ast.Ident, map[int]*ast.NamedType) {
+	identIdx := make(map[int]*ast.Ident, 64)
+	typeIdx := make(map[int]*ast.NamedType, 32)
+	walkReflect(reflect.ValueOf(file), func(id *ast.Ident) {
+		if id.ID != 0 {
+			identIdx[id.PosV.Offset] = id
+		}
+	}, func(nt *ast.NamedType) {
+		if nt.ID != 0 {
+			typeIdx[nt.PosV.Offset] = nt
+		}
+	})
+	return identIdx, typeIdx
 }
 
 func buildDeclIndex(file *ast.File) map[int]ast.Node {
@@ -725,6 +786,56 @@ func supplementUseAliasRefs(
 	return refsByID, refIdents
 }
 
+// supplementUseAliasRefsFromIndex is the identIdx-driven variant of
+// `supplementUseAliasRefs`. The caller has already walked the file once
+// to build `identIdx`, so we reuse that map instead of paying for a
+// third reflect-walk per file. Behaviour matches the walk-based path:
+// every non-zero-ID ident in the file is considered, and unresolved
+// idents that match a `use`-decl alias are bridged to the alias's
+// fileScope symbol.
+func supplementUseAliasRefsFromIndex(
+	file *ast.File,
+	fileScope *Scope,
+	identIdx map[int]*ast.Ident,
+	refsByID map[ast.NodeID]*Symbol,
+	refIdents []*ast.Ident,
+) (map[ast.NodeID]*Symbol, []*ast.Ident) {
+	if file == nil || fileScope == nil {
+		return refsByID, refIdents
+	}
+	aliases := map[string]*Symbol{}
+	for _, u := range file.Uses {
+		name := nativeUseAlias(u)
+		if name == "" {
+			continue
+		}
+		if sym := fileScope.LookupLocal(name); sym != nil {
+			aliases[name] = sym
+		}
+	}
+	if len(aliases) == 0 {
+		return refsByID, refIdents
+	}
+	if refsByID == nil {
+		refsByID = map[ast.NodeID]*Symbol{}
+	}
+	for _, id := range identIdx {
+		if id == nil || id.ID == 0 {
+			continue
+		}
+		if _, exists := refsByID[id.ID]; exists {
+			continue
+		}
+		sym := aliases[id.Name]
+		if sym == nil {
+			continue
+		}
+		refsByID[id.ID] = sym
+		refIdents = append(refIdents, id)
+	}
+	return refsByID, refIdents
+}
+
 func bridgeTypeRefs(
 	typeRefs []api.ResolvedTypeRef,
 	symbols []api.ResolvedSymbol,
@@ -954,6 +1065,24 @@ func findNearestDecl(declIdx map[int]ast.Node, targetOff int) ast.Node {
 }
 
 // --- Symbol construction from native symbols ---
+
+// defineTopLevelSymbolsForFile is the pre-bucketed counterpart of
+// `defineTopLevelSymbols`. The caller has already partitioned the
+// selfhost-emitted Symbols slice by sym.File via `groupSymbolsByFile`,
+// so the per-file loop iterates only its own bucket plus the shared
+// (`File==""`) bucket — eliminating the `sym.File != fi.path` rescan
+// every previous file paid for the whole slice.
+func defineTopLevelSymbolsForFile(
+	scope *Scope,
+	symbolsByFile map[string][]api.ResolvedSymbol,
+	fi nativeResolveFileInfo,
+	declIdx map[int]ast.Node,
+) {
+	defineTopLevelSymbols(scope, symbolsByFile[fi.path], fi, declIdx)
+	if shared, ok := symbolsByFile[""]; ok && fi.path != "" {
+		defineTopLevelSymbols(scope, shared, fi, declIdx)
+	}
+}
 
 func defineTopLevelSymbols(
 	scope *Scope,

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -194,6 +194,21 @@ func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPacka
 				sem <- struct{}{}
 				i := i
 				go func() {
+					// Convert any panic inside the selfhost lexer /
+					// parser into a parsedFile.err so the serial
+					// merge consumer surfaces it as a normal package
+					// adapter error. The caller's `defer
+					// recoverCheckResult` (CheckPackageStructured)
+					// or InspectPackageStructured recover is on the
+					// host goroutine and cannot reach panics raised
+					// here — recover does not cross goroutine
+					// boundaries.
+					defer func() {
+						if r := recover(); r != nil {
+							parsedSlots[i] = parsedFile{err: fmt.Errorf("selfhost package adapter: parse panic: %v", r)}
+							close(done[i])
+						}
+					}()
 					parsedSlots[i] = parseOne(files[i])
 					close(done[i])
 				}()

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -179,19 +179,46 @@ func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPacka
 		// released by the merge consumer after the slot is drained,
 		// so a slow parse (mir_generator.osty is 23k lines) cannot
 		// open the floodgates for the rest of the package.
+		//
+		// `cancelCh` lets the consumer fail fast on the first parse
+		// error without paying the worst-case "wait for every parse
+		// in flight" tail latency. The producer skips queueing new
+		// work past the cancellation point, and any unstarted worker
+		// short-circuits past `parseOne` and releases its sem slot
+		// itself; consumer drain reads sem non-blocking so it
+		// doesn't matter who released it.
 		parsedSlots := make([]parsedFile, len(files))
 		done := make([]chan struct{}, len(files))
 		for i := range done {
 			done[i] = make(chan struct{})
 		}
 		sem := make(chan struct{}, workers)
+		cancelCh := make(chan struct{})
+		cancelled := false
+		cancel := func() {
+			if !cancelled {
+				cancelled = true
+				close(cancelCh)
+			}
+		}
 		go func() {
 			for i := range files {
 				if len(files[i].Source) == 0 {
 					close(done[i])
 					continue
 				}
-				sem <- struct{}{}
+				select {
+				case sem <- struct{}{}:
+				case <-cancelCh:
+					// Cancelled while waiting for a sem slot —
+					// close remaining done channels so the consumer
+					// drain returns immediately.
+					close(done[i])
+					for j := i + 1; j < len(files); j++ {
+						close(done[j])
+					}
+					return
+				}
 				i := i
 				go func() {
 					// Convert any panic inside the selfhost lexer /
@@ -209,28 +236,47 @@ func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPacka
 							close(done[i])
 						}
 					}()
+					// Skip expensive parse work when an earlier file
+					// already errored. Release the sem slot we
+					// acquired so the consumer's non-blocking drain
+					// doesn't double-pull.
+					select {
+					case <-cancelCh:
+						<-sem
+						close(done[i])
+						return
+					default:
+					}
 					parsedSlots[i] = parseOne(files[i])
 					close(done[i])
 				}()
 			}
 		}()
+		releaseSem := func(idx int) {
+			if len(files[idx].Source) == 0 {
+				return
+			}
+			select {
+			case <-sem:
+			default:
+			}
+		}
 		for i, file := range files {
 			<-done[i]
 			p := parsedSlots[i]
 			parsedSlots[i] = parsedFile{}
-			if len(file.Source) != 0 {
-				<-sem
-			}
+			releaseSem(i)
 			if p.err != nil {
-				// Drain remaining done channels so producer goroutines
-				// can exit cleanly; we already abort the package, so
-				// the leftover ASTs will be GC'd along with the slot
-				// slice once this function returns.
+				cancel()
+				// Drain remaining done channels so producer + worker
+				// goroutines exit cleanly. Cancellation makes this
+				// fast: unstarted workers short-circuit, the
+				// producer abandons the queue, and only the parses
+				// already past their cancel check still run to
+				// completion.
 				for j := i + 1; j < len(files); j++ {
 					<-done[j]
-					if len(files[j].Source) != 0 {
-						<-sem
-					}
+					releaseSem(j)
 				}
 				return nil, nil, p.err
 			}

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -3,6 +3,7 @@ package selfhost
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"strings"
 
 	"github.com/osty/osty/internal/selfhost/api"
@@ -92,20 +93,58 @@ type selfhostPackageTokenLayout struct {
 func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPackageTokenLayout, error) {
 	arena := emptyAstArena()
 	layout := &selfhostPackageTokenLayout{}
-	haveFile := false
-	for _, file := range files {
+
+	// Per-file lex + parse + semantic clone are independent; the
+	// `ostyTagType` and `frontPositionCache` package globals they touch
+	// are mutex-protected, so concurrent invocation is safe. Fan out
+	// across GOMAXPROCS while the deterministic arena/layout merge
+	// stays strictly serial below — the merge depends on cumulative
+	// `tokenBase` / `fileIdx` from prior iterations.
+	//
+	// Memory note: a naive "spawn all parsers, then merge" model holds
+	// every parsed AST live at once (200 files × multi-MB toolchain
+	// sources easily exceeds 16 GB). The pipeline below caps in-flight
+	// parses to `workers` by holding each parser's semaphore slot until
+	// the merge consumer drains it — `parsedSlot` is cleared right
+	// after merging file i so the GC can reclaim the AST before the
+	// next file's parse fills its slot.
+	//
+	// Toolchain-scale install-self builds (200 files) used to spend
+	// ~9.4s here serially; the bounded-parallel fan-out cuts that to
+	// GOMAXPROCS-divided wall-time while keeping peak memory
+	// proportional to GOMAXPROCS, not file count.
+	type parsedFile struct {
+		lexed  *OstyLexedSource
+		parsed *AstFile
+		err    error
+	}
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > len(files) {
+		workers = len(files)
+	}
+
+	parseOne := func(file PackageCheckFile) parsedFile {
 		if len(file.Source) == 0 {
-			continue
+			return parsedFile{}
 		}
 		lexed := ostyLexSource(string(file.Source))
-		parsed := astParseLexedSource(lexed)
-		if parsed == nil || parsed.arena == nil {
-			return nil, nil, fmt.Errorf("selfhost package adapter: parse produced no AST")
+		ast := astParseLexedSource(lexed)
+		if ast == nil || ast.arena == nil {
+			return parsedFile{err: fmt.Errorf("selfhost package adapter: parse produced no AST")}
 		}
-		if len(parsed.arena.errors) > 0 {
-			return nil, nil, fmt.Errorf("selfhost package adapter: parse errors: %s", astFormatErrors(parsed))
+		if len(ast.arena.errors) > 0 {
+			return parsedFile{err: fmt.Errorf("selfhost package adapter: parse errors: %s", astFormatErrors(ast))}
 		}
-		parsed = selfhostSemanticAstFile(parsed)
+		return parsedFile{lexed: lexed, parsed: selfhostSemanticAstFile(ast)}
+	}
+
+	mergeOne := func(p parsedFile, file PackageCheckFile) {
+		if p.parsed == nil {
+			return
+		}
 		tokenBase := len(layout.starts)
 		fileIdx := -1
 		displayName := file.Path
@@ -117,9 +156,74 @@ func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPacka
 			layout.files = append(layout.files, displayName)
 			layout.fileIDs = append(layout.fileIDs, file.SourceFileID)
 		}
-		selfhostAppendTokenLayout(layout, lexed, file.Base, fileIdx)
-		selfhostMergeAstArena(arena, parsed.arena, tokenBase)
-		haveFile = true
+		selfhostAppendTokenLayout(layout, p.lexed, file.Base, fileIdx)
+		selfhostMergeAstArena(arena, p.parsed.arena, tokenBase)
+	}
+
+	haveFile := false
+	if workers <= 1 || len(files) <= 1 {
+		for _, file := range files {
+			p := parseOne(file)
+			if p.err != nil {
+				return nil, nil, p.err
+			}
+			if p.parsed != nil {
+				haveFile = true
+				mergeOne(p, file)
+			}
+		}
+	} else {
+		// Bounded-parallel pipeline: per-file done channels gate the
+		// merge in input order while a `workers`-deep semaphore caps
+		// the number of parsers in flight. Each parser's sem slot is
+		// released by the merge consumer after the slot is drained,
+		// so a slow parse (mir_generator.osty is 23k lines) cannot
+		// open the floodgates for the rest of the package.
+		parsedSlots := make([]parsedFile, len(files))
+		done := make([]chan struct{}, len(files))
+		for i := range done {
+			done[i] = make(chan struct{})
+		}
+		sem := make(chan struct{}, workers)
+		go func() {
+			for i := range files {
+				if len(files[i].Source) == 0 {
+					close(done[i])
+					continue
+				}
+				sem <- struct{}{}
+				i := i
+				go func() {
+					parsedSlots[i] = parseOne(files[i])
+					close(done[i])
+				}()
+			}
+		}()
+		for i, file := range files {
+			<-done[i]
+			p := parsedSlots[i]
+			parsedSlots[i] = parsedFile{}
+			if len(file.Source) != 0 {
+				<-sem
+			}
+			if p.err != nil {
+				// Drain remaining done channels so producer goroutines
+				// can exit cleanly; we already abort the package, so
+				// the leftover ASTs will be GC'd along with the slot
+				// slice once this function returns.
+				for j := i + 1; j < len(files); j++ {
+					<-done[j]
+					if len(files[j].Source) != 0 {
+						<-sem
+					}
+				}
+				return nil, nil, p.err
+			}
+			if p.parsed != nil {
+				haveFile = true
+				mergeOne(p, file)
+			}
+		}
 	}
 	if !haveFile {
 		return nil, layout, nil


### PR DESCRIPTION
## Summary

Two complementary optimizations on the `osty install-self` bootstrap critical path that together drop `install-self.build-via-stage0` from ~162s to ~111s (-30%) on the toolchain build.

### 1. Bounded-parallel self-host package parse

`selfhost.selfhostBuildPackageAst` now lex+parse+semanticizes per-file work concurrently across `GOMAXPROCS` workers, with a strictly serial arena/layout merge after each file completes (the merge depends on cumulative `tokenBase`/`fileIdx`).

A naive "spawn all 200, then merge" version OOM-killed the 16 GB bootstrap because every parsed AST stayed live until the merge ran. The pipeline shipped here caps in-flight ASTs to `workers` via a per-file `done` channel + `workers`-deep semaphore: each parser's sem slot is held until the merge consumer drains the slot, so `mir_generator.osty` (23k lines) can't open the floodgates for the rest of the package.

This phase also runs on every `osty check`/`osty pipeline` invocation, so the parallel pipeline benefits `frontend.CheckWorkspace` too (it routes through `CheckPackageStructured` → `selfhostBuildPackageAst`).

### 2. resolve-bridge constant-factor cleanups

`internal/resolve/resolvePackageViaNative`:

- Builds a `path → nativeResolveFileInfo` map once for the per-file lookups in `defineTopLevelSymbols` / `processFile` (was linear-scanning `files` each call).
- Pre-buckets `result.Symbols` by file via `groupSymbolsByFile` so each file's `defineTopLevelSymbolsForFile` iterates only its own bucket instead of re-filtering the whole slice (O(N×M) → O(total)).
- Combines `buildIdentIndex` + `buildNamedTypeIndex` into a single `buildIdentAndNamedTypeIndex` reflect walk — the reflect-based AST traversal was paying every per-node step twice.
- Reuses the just-built `identIdx` in `supplementUseAliasRefsFromIndex` instead of doing a third reflect walk per file.

The hot `bridgeRefsForFile` / `findOrCreateSymbol` signatures stay slice-based (no API churn), so test entry points (`bridgeRefs`, `bridgeTypeRefs`) and the per-ref target-file lookups are unaffected.

## Measurements (toolchain `install-self`)

`install-self.build-via-stage0` wall-clock:

| | baseline | optimized | Δ |
|---|---|---|---|
| **total** | **162s** | **111s** | **-31%** |

Per-phase deltas:

| phase | baseline | optimized | Δ |
|---|---|---|---|
| selfhost.buildPackageAst | 9.4s | 3.7s | -61% |
| resolve.native.artifacts | 24.4s | 17.4s | -29% |
| frontend.ResolveWorkspace | 49.4s | 41.1s | -17% |
| frontend.CheckWorkspace | 8.3s | 2.0s | -76% |
| ir.LowerPackage.fileLoop | 14.9s | 11.7s | -21% |
| resolve.native.bridgeLoop | 19.1s | 18.3s | -4% |

The `CheckWorkspace` and `LowerPackage.fileLoop` deltas are partly downstream of the parallel parser (the checker subprocess runs the same path; the IR loop was already parallel but benefits from the lower memory pressure).

Run on a 4-core/16 GB host. The pre-existing `std.crypto.sha256` link error is the same final state as `main` — these changes shave time off the path up to that point; they do not alter the link step.

## Test plan

- [x] `go test ./internal/selfhost ./internal/resolve ./internal/check ./internal/ir ./internal/parser ./internal/format` (all pass)
- [x] `go test ./internal/lsp ./internal/query/... ./internal/mir ./internal/backend/stage0` (all pass)
- [x] `go test ./cmd/osty` (passes)
- [x] `go test ./internal/backend` — `TestStage0RealMIRBaseline` failures are pre-existing on main (verified via `git stash`)
- [x] `osty install-self` runs end-to-end and reaches the same final link state as `main`, in 31% less wall time
- [x] Memory bounded — no OOM on the 16 GB host
- [x] Frontend test corpus (`internal/check`, `internal/parser`, `internal/format` with `-short`)

https://claude.ai/code/session_01FVMnNRRNFpGbAeBnGzvVLv

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVMnNRRNFpGbAeBnGzvVLv)_