### PR TITLE
refactor: remove --engine, --native no-op, and dead LegacyCachePath cluster

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,10 +116,9 @@ pipeline** by default: `parser.ParseRun` produces a selfhost `FrontendRun`
 (no astbridge lowering), then `selfhost.CheckStructuredFromRun` runs the
 Osty-native resolver + checker in one pass, emitting structured records
 that `selfhost.CheckDiagnosticsAsDiag` lifts into the CLI's `diag.Diagnostic`
-shape. The old Go-hosted `--legacy` check/typecheck escape hatch and
-`check.File` entrypoint have been removed; `--native` remains accepted only as
-a backwards-compatible no-op (the global `-native` flag defaults to `true`, and
-`cliFlags.native` is no longer consulted to pick a checker backend). `osty resolve` is also self-host-first. Package
+shape. The Go-hosted `--legacy` check/typecheck escape hatch, the `check.File`
+entrypoint, and the no-op `--native` flag have all been removed; the self-host
+pipeline is the only path. `osty resolve` is also self-host-first. Package
 and workspace loaders for `pipeline`, `build`, `run`, `doc`, `lsp`, and
 `cihost` use arena-first `FrontendRun` parsing. Some compatibility wrappers
 still call `EnsureFiles` / `MaterializeCanonicalSources` to hand downstream

--- a/LLVM_ARTIFACT_LAYOUT.md
+++ b/LLVM_ARTIFACT_LAYOUT.md
@@ -15,7 +15,7 @@ Phase 6 이전 구현은 Go backend 단일 경로를 전제로 했다.
 | `osty build` generated Go | `<root>/.osty/out/<profile>[-<target>]/main.go` | `profile.OutputDir`, `cmd/osty/build.go` |
 | `osty build` binary | `<root>/.osty/out/<profile>[-<target>]/<bin>[-<target>]` | `cmd/osty/build.go` |
 | `osty run` generated Go | `<root>/.osty/out/<profile>[-<target>]/main.go` | `cmd/osty/run.go` |
-| build fingerprint | `<root>/.osty/cache/<profile>[-<target>].json` | `profile.LegacyCachePath` |
+| build fingerprint (legacy, pre-backend-aware) | `<root>/.osty/cache/<profile>[-<target>].json` | retired (was `profile.LegacyCachePath`) |
 | `osty test` generated harness | `$TMPDIR/osty-test-<pkg-hash>/main.go`, `harness.go` | `cmd/osty/test.go` |
 | `osty test` cached binary | `$TMPDIR/osty-test-<pkg-hash>/osty-test-bin-<hash>` | `cmd/osty/test.go` |
 | publish tarball | `<root>/.osty/publish/<name>-<version>.tgz` | `cmd/osty/publish.go` |
@@ -116,8 +116,9 @@ During the migration, the existing cache path:
 ```
 
 may remain on disk as a stale legacy Go backend fingerprint. Migrated builds
-write and read the backend-aware path only; `ReadLegacyFingerprint` exists for
-diagnostics, not for freshness decisions.
+write and read the backend-aware path only; the helpers that targeted the
+legacy fingerprint (`profile.LegacyCachePath`, `profile.ReadLegacyFingerprint`,
+`backend.Layout.LegacyCachePath`) were retired once no caller remained.
 
 Fingerprint fields should include:
 

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -765,19 +765,18 @@ astbridge는 한 방에 제거하지 않고 `*ast.File` 소비자들이 AstArena
 
 ### CLI 재배선 진척 (2026-04)
 
-CLI 재배선의 resolve + check/typecheck 축은 **단일 파일 + 단일 패키지 + workspace** happy path 에서 완료됐다. `--legacy` check/typecheck escape hatch 는 제거됐고, `--native` 는 no-op 으로만 남았다. `FrontendRun.File()` 가 제거되면서 native/default 경로가 astbridge 를 우회한다는 사실은 컴파일 타임 구조적 (메서드 부재) 으로 강제된다 — 이전의 `selfhost.AstbridgeLowerCount` 런타임 카운터는 함께 제거됐다.
+CLI 재배선의 resolve + check/typecheck 축은 **단일 파일 + 단일 패키지 + workspace** happy path 에서 완료됐다. `--legacy` check/typecheck escape hatch 와 no-op `--native` 플래그 둘 다 제거됐다 — self-host arena pipeline 이 유일한 경로다. `FrontendRun.File()` 가 제거되면서 native/default 경로가 astbridge 를 우회한다는 사실은 컴파일 타임 구조적 (메서드 부재) 으로 강제된다 — 이전의 `selfhost.AstbridgeLowerCount` 런타임 카운터는 함께 제거됐다.
 
-| CLI 경로                            | Happy-path 회귀 테스트                               |
-| ----------------------------------- | ---------------------------------------------------- |
-| `osty resolve FILE` (기본 native)   | `TestRunResolveFileHappyPath`                        |
-| `osty resolve DIR` (기본 native)    | `TestRunResolvePackageHappyPath`                     |
-| `osty check --native FILE`          | `TestRunCheckFileNativeDumpTelemetry`                |
-| `osty check --native DIR`           | `TestRunCheckPackageNativeHappyPath`                 |
-| `osty check --native WORKSPACE`     | `TestRunCheckWorkspaceNativeHappyPath`               |
-| `osty check FILE` (default)         | `TestRunCheckFileDefaultPathHappyPath`               |
-| `osty typecheck --native FILE`      | `TestRunTypecheckFileNativeDumpTelemetry`            |
-| `osty typecheck --native DIR`       | `TestRunTypecheckPackageNativeHappyPath`             |
-| `osty typecheck --native WORKSPACE` | `TestRunTypecheckWorkspaceNativeHappyPath`           |
+| CLI 경로                  | Happy-path 회귀 테스트                            |
+| ------------------------- | ------------------------------------------------- |
+| `osty resolve FILE`       | `TestRunResolveFileHappyPath`                     |
+| `osty resolve DIR`        | `TestRunResolvePackageHappyPath`                  |
+| `osty check FILE`         | `TestRunCheckFileDefaultPathHappyPath` + `TestRunCheckFileNativeDumpTelemetry` |
+| `osty check DIR`          | `TestRunCheckPackageNativeHappyPath`              |
+| `osty check WORKSPACE`    | `TestRunCheckWorkspaceNativeHappyPath`            |
+| `osty typecheck FILE`     | `TestRunTypecheckFileNativeDumpTelemetry`         |
+| `osty typecheck DIR`      | `TestRunTypecheckPackageNativeHappyPath`          |
+| `osty typecheck WORKSPACE` | `TestRunTypecheckWorkspaceNativeHappyPath`       |
 
 이 smoke 셋은 네이티브 CLI 경로의 exit-zero / 출력 기대치를 잡는다. astbridge 우회는 더 이상 런타임 카운터가 아니라 `FrontendRun.File()` 부재로 구조적으로 강제된다 — `LowerPublicFileFromRun` 만이 명시적 진입점이다.
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ coverage gate rather than front-end type-check drift.
 Code-level re-audit on 2026-04-28: the tree is not yet "fully self-hosted"
 end-to-end, but the front-end CLI path is ahead of several older documents.
 `osty check`, `osty typecheck`, and `osty resolve` now run the self-host arena
-path by default, and the Go-hosted `--legacy` check/typecheck escape hatch has
-been removed. `--native` is still accepted only as a backwards-compatible no-op.
+path by default. The Go-hosted `--legacy` check/typecheck escape hatch and the
+no-op `--native` flag have both been removed; the self-host arena pipeline is
+the only path.
 `internal/check` routes package checks through the native checker subprocess:
 the CLI installs `check.UseManagedSubprocessChecker` at startup, which lazily
 builds or reuses `.osty/toolchain/<ver>/osty-native-checker` via
@@ -422,7 +423,7 @@ osty check FILE|DIR    # lex + parse + resolve + type-check (diagnostics only)
                        # inference rule applied (see LANG_SPEC_v0.5/02a-type-inference.md)
 osty typecheck FILE    # same as check, plus a per-expression type dump
 osty lint FILE|DIR     # style + correctness warnings (L0xxx codes)
-osty fmt FILE          # airepair + format to canonical style (see --check, --write, --engine)
+osty fmt FILE          # airepair + format to canonical style (see --check, --write)
 osty airepair FILE     # auto-fix common AI-authored syntax/idiom slips (legacy alias: repair)
 osty airepair triage DIR
 osty airepair learn DIR
@@ -469,10 +470,6 @@ default, so AI-authored syntax slips are normalized in one command.
 - `--airepair` — enable the default automatic AI repair pass
 - `--no-airepair` — disable the default automatic AI repair pass
   Legacy aliases: `--repair`, `--no-repair`
-- `--engine go|osty` — choose the formatter engine. `go` is the default
-  AST formatter; `osty` is a compatibility entry point that now shares the
-  same AST-backed formatting contract instead of maintaining a separate
-  token-heuristic printer.
 
 `airepair`-specific flags (after the subcommand):
 

--- a/SELFHOST_PORT_MATRIX.md
+++ b/SELFHOST_PORT_MATRIX.md
@@ -13,8 +13,8 @@ Go → Osty 셀프호스팅 포팅 현황 매트릭스. 리졸버 / 체커 잔�
 > fallback 제거 + managed subprocess flip 이 누적.
 > 이전 2026-04-24 스냅샷 이후 80 커밋이 들어왔고, 그 위에 Phase 0 (MirSwitchCase
 > rename + typeRepr migration + scopeFor O(N²) → sorted-binsearch+memoize) 가
-> 추가됐다. 코드 실측 기준: `--legacy` check/typecheck escape hatch 는
-> 제거됐고, `--native` 는 backwards-compat no-op 이다. `just front`,
+> 추가됐다. 코드 실측 기준: `--legacy` check/typecheck escape hatch 와
+> no-op `--native` 플래그 둘 다 제거됐다. `just front`,
 > `just verify-selfhost`, CLI astbridge-free 회귀 테스트는 통과. **`osty check
 > toolchain` smoke 는 EXIT=0 으로 복구됐다** (Phase 0 a/b 커밋 후). MIR-merged
 > probe 4 종 중 `TestProbeWholeToolchainMerged` / `TestProbeNativeToolchainMerged`
@@ -167,8 +167,7 @@ adapter 통합) 은 2026-05-16 착륙 — **Go-side LSP 의 algorithmic pointer-
 (`ParseRun → CheckStructuredFromRun → CheckDiagnosticsAsDiag`) 로 전환되었다.
 Go-native `runCheckFileLegacy` / `runCheckPackageLegacy` /
 `runTypecheckFileLegacy` 경로와 `cliFlags.legacy` 는 삭제됐다. 역사적인
-`--native` 플래그는 현재도 backwards compat 로 수락되지만 선택지는 바꾸지 않는다
-(no-op).
+`--native` no-op 플래그도 함께 제거됐다.
 
 영향 범위:
 - `osty check FILE` / `osty check DIR` → self-host default
@@ -271,8 +270,8 @@ Go-native `runCheckFileLegacy` / `runCheckPackageLegacy` /
     `runLintFile` / `runLintPackageLegacy` → `runLintPackage` 리네임 +
     `cmd/osty/check_legacy_baseline_test.go` / `lint_legacy_baseline_test.go`
     test file 전체 삭제 + 관련 legacy 가드 test 2 종 (`TestCheckCLILegacyOptOutStillWorks` /
-    `TestTypecheckCLILegacyPackageRejected`) 삭제. `--native` 는 backwards-compat
-    no-op 으로 수락. `check.File` 잔여 호출자는 0.
+    `TestTypecheckCLILegacyPackageRejected`) 삭제. `--native` no-op 플래그도
+    함께 제거됨. `check.File` 잔여 호출자는 0.
 
 각 phase 의 끝에 `just full` + 매뉴얼 `osty check toolchain` smoke 로
 regression 없음을 확인하고 이 문서의 ⏳ → ✅ 전환. **2026-04-26 시점에는

--- a/cmd/osty/check_native_test.go
+++ b/cmd/osty/check_native_test.go
@@ -24,7 +24,7 @@ func TestCheckCLINativeCleanSourceExitsZero(t *testing.T) {
 `), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	got := runOstyCLI(t, "check", "--native", path)
+	got := runOstyCLI(t, "check", path)
 	if got.exit != 0 {
 		t.Fatalf("osty check --native exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -46,7 +46,7 @@ fn bad() -> Int {
 `), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	got := runOstyCLI(t, "check", "--native", path)
+	got := runOstyCLI(t, "check", path)
 	if got.exit != 1 {
 		t.Fatalf("osty check --native exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -71,7 +71,7 @@ func TestCheckCLINativeInspectFlagUsesSelfhost(t *testing.T) {
 `), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	got := runOstyCLI(t, "--inspect", "check", "--native", path)
+	got := runOstyCLI(t, "--inspect", "check", path)
 	if got.exit != 0 {
 		t.Fatalf("exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -144,7 +144,7 @@ func TestCheckCLINativePackageCleanSourceExitsZero(t *testing.T) {
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := runOstyCLI(t, "check", "--native", dir)
+	got := runOstyCLI(t, "check", dir)
 	if got.exit != 0 {
 		t.Fatalf("osty check --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -165,7 +165,7 @@ fn main() {
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := runOstyCLI(t, "check", "--native", dir)
+	got := runOstyCLI(t, "check", dir)
 	if got.exit != 0 {
 		t.Fatalf("osty check --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -193,7 +193,7 @@ fn bad() -> Int {
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := runOstyCLI(t, "check", "--native", dir)
+	got := runOstyCLI(t, "check", dir)
 	if got.exit != 1 {
 		t.Fatalf("exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -233,7 +233,7 @@ fn main() {
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := runOstyCLI(t, "check", "--native", dir)
+	got := runOstyCLI(t, "check", dir)
 	if got.exit != 0 {
 		t.Fatalf("osty check --native WORKSPACE exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}

--- a/cmd/osty/check_native_test.go
+++ b/cmd/osty/check_native_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestCheckCLINativeCleanSourceExitsZero is the subprocess-level smoke
-// test: `osty check --native FILE` on well-typed input succeeds with
+// test: `osty check FILE` on well-typed input succeeds with
 // exit 0 and produces no error output. Validates end-to-end
 // invocation (flag parsing, dispatch, conversion, exit code) without
 // depending on the in-process counter.
@@ -26,7 +26,7 @@ func TestCheckCLINativeCleanSourceExitsZero(t *testing.T) {
 	}
 	got := runOstyCLI(t, "check", path)
 	if got.exit != 0 {
-		t.Fatalf("osty check --native exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty check exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if strings.Contains(got.stderr, "error[") {
 		t.Fatalf("stderr contained error output on clean source:\n%s", got.stderr)
@@ -48,7 +48,7 @@ fn bad() -> Int {
 	}
 	got := runOstyCLI(t, "check", path)
 	if got.exit != 1 {
-		t.Fatalf("osty check --native exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty check exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if !strings.Contains(got.stderr, "error[E0773]") {
 		t.Fatalf("stderr missing E0773:\n%s", got.stderr)
@@ -126,7 +126,7 @@ fn main() {
 
 // TestCheckCLINativePackageCleanSourceExitsZero is the DIR sibling
 // of the single-file happy-path test. A two-file package (no cross-
-// file references) should pass `osty check --native DIR` with exit
+// file references) should pass `osty check DIR` with exit
 // 0 and no stderr error output.
 func TestCheckCLINativePackageCleanSourceExitsZero(t *testing.T) {
 	dir := t.TempDir()
@@ -146,7 +146,7 @@ func TestCheckCLINativePackageCleanSourceExitsZero(t *testing.T) {
 	}
 	got := runOstyCLI(t, "check", dir)
 	if got.exit != 0 {
-		t.Fatalf("osty check --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty check DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if strings.Contains(got.stderr, "error[") {
 		t.Fatalf("stderr contained error output on clean package:\n%s", got.stderr)
@@ -167,7 +167,7 @@ fn main() {
 	}
 	got := runOstyCLI(t, "check", dir)
 	if got.exit != 0 {
-		t.Fatalf("osty check --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty check DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if strings.Contains(got.stderr, "error[E0703]") {
 		t.Fatalf("stderr retained missing-method E0703 for std.strings surface:\n%s", got.stderr)
@@ -235,7 +235,7 @@ fn main() {
 	}
 	got := runOstyCLI(t, "check", dir)
 	if got.exit != 0 {
-		t.Fatalf("osty check --native WORKSPACE exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty check WORKSPACE exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if strings.Contains(got.stderr, "error[") {
 		t.Fatalf("stderr contained error output on clean workspace:\n%s", got.stderr)
@@ -436,9 +436,9 @@ fn main() {
 	}
 }
 
-// TestRunCheckFileNativeDumpTelemetry exercises the --native CLI path
-// end-to-end (CheckStructuredFromRun + CheckDiagnosticsAsDiag) and
-// asserts the dump-native-diags telemetry header lands on stderr.
+// TestRunCheckFileNativeDumpTelemetry exercises the native check CLI
+// path end-to-end (CheckStructuredFromRun + CheckDiagnosticsAsDiag)
+// and asserts the dump-native-diags telemetry header lands on stderr.
 func TestRunCheckFileNativeDumpTelemetry(t *testing.T) {
 	src := []byte(`fn main() {
     let x = 1
@@ -484,11 +484,10 @@ func TestRunCheckFileNativeDumpTelemetry(t *testing.T) {
 
 // TestCheckCLIDefaultPathUsesSelfhostArena is the production-default
 // companion to TestRunCheckFileNativeDumpTelemetry: after the
-// 1c.1 flip (SELFHOST_PORT_MATRIX.md), `osty check FILE` with no
-// flag at all routes through the self-host arena pipeline the same
-// way `--native` does. Run the subprocess CLI so the default
-// actually goes through clicmd.ParseArgs dispatch, then verify exit 0 on
-// a well-typed input. Phase 1c.5 retired the Go-hosted escape
+// 1c.1 flip (SELFHOST_PORT_MATRIX.md), `osty check FILE` routes
+// through the self-host arena pipeline. Run the subprocess CLI so
+// dispatch actually goes through clicmd.ParseArgs, then verify exit 0
+// on a well-typed input. Phase 1c.5 retired the Go-hosted escape
 // hatch — the self-host path is the only path now.
 func TestCheckCLIDefaultPathExitsZero(t *testing.T) {
 	dir := t.TempDir()

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -353,19 +353,6 @@ func main() {
 			runCi(rest, flags)
 			return
 		}
-		// `--native` is accepted after the subcommand as a backwards-
-		// compat no-op; the self-host pipeline is the only path since
-		// Phase 1c.5 retired `--legacy`. Strip it so the downstream
-		// file-required check and subcommand dispatch see positional-
-		// only input.
-		if rest, present := takeBoolFlag(args[1:], "--native"); present {
-			args = append([]string{"check"}, rest...)
-		}
-	}
-	if cmd == "typecheck" {
-		if rest, present := takeBoolFlag(args[1:], "--native"); present {
-			args = append([]string{"typecheck"}, rest...)
-		}
 	}
 	// explain looks up a diagnostic or lint code and prints its doc.
 	// Handled before the generic "file required" check because it
@@ -1414,9 +1401,6 @@ func runFmt(args []string) {
 	}
 	var checkMode, writeMode, noAIRepair bool
 	repairMode := true
-	// Accepted but ignored — historical alias for the formatter engine
-	// selector. There is now only one engine (the self-host formatter).
-	var engineUnused string
 	fs.BoolVar(&checkMode, "check", false, "exit 1 if FILE is not already formatted")
 	fs.BoolVar(&checkMode, "c", false, "alias for --check")
 	fs.BoolVar(&writeMode, "write", false, "overwrite FILE in place")
@@ -1425,9 +1409,7 @@ func runFmt(args []string) {
 	fs.BoolVar(&repairMode, "repair", true, "alias for --airepair")
 	fs.BoolVar(&noAIRepair, "no-airepair", false, "disable automatic AI repair before formatting")
 	fs.BoolVar(&noAIRepair, "no-repair", false, "alias for --no-airepair")
-	fs.StringVar(&engineUnused, "engine", "", "deprecated; the only engine is the self-host formatter")
 	_ = fs.Parse(args)
-	_ = engineUnused
 	if noAIRepair {
 		repairMode = false
 	}

--- a/cmd/osty/typecheck_native_test.go
+++ b/cmd/osty/typecheck_native_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestTypecheckCLINativeCleanSourcePrintsTypes confirms `osty
-// typecheck --native FILE` on clean input exits 0 AND emits at least
+// typecheck FILE` on clean input exits 0 AND emits at least
 // one `line:col-line:col\tType` row per printNativeTypes. The exact
 // node set depends on the native checker's recording, so we only
 // assert the presence of the `Int` type for the scalar bindings
@@ -27,7 +27,7 @@ func TestTypecheckCLINativeCleanSourcePrintsTypes(t *testing.T) {
 	}
 	got := runOstyCLI(t, "typecheck", path)
 	if got.exit != 0 {
-		t.Fatalf("osty typecheck --native exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty typecheck exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if strings.Contains(got.stderr, "error[") {
 		t.Fatalf("stderr contained error output on clean source:\n%s", got.stderr)
@@ -39,7 +39,7 @@ func TestTypecheckCLINativeCleanSourcePrintsTypes(t *testing.T) {
 
 // TestTypecheckCLINativeSurfacesTypeError pins that a clear type
 // mismatch (Int binding initialized with String) still surfaces a
-// typed-check diagnostic on stderr under --native.
+// typed-check diagnostic on stderr.
 func TestTypecheckCLINativeSurfacesTypeError(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.osty")
@@ -51,7 +51,7 @@ func TestTypecheckCLINativeSurfacesTypeError(t *testing.T) {
 	}
 	got := runOstyCLI(t, "typecheck", path)
 	if got.exit != 1 {
-		t.Fatalf("osty typecheck --native exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty typecheck exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if !strings.Contains(got.stderr, "error[") {
 		t.Fatalf("stderr missing error[ prefix:\n%s", got.stderr)
@@ -162,7 +162,7 @@ func TestTypecheckCLINativePackageCleanSourcePrintsPerFileTypes(t *testing.T) {
 	}
 	got := runOstyCLI(t, "typecheck", dir)
 	if got.exit != 0 {
-		t.Fatalf("osty typecheck --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty typecheck DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if !strings.Contains(got.stdout, "# "+bPath) {
 		t.Fatalf("stdout missing `# %s` header:\n%s", bPath, got.stdout)
@@ -188,7 +188,7 @@ fn main() {
 	}
 	got := runOstyCLI(t, "typecheck", dir)
 	if got.exit != 0 {
-		t.Fatalf("osty typecheck --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty typecheck DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if strings.Contains(got.stderr, "error[E0703]") {
 		t.Fatalf("stderr retained missing-method E0703 for std.strings surface:\n%s", got.stderr)
@@ -224,7 +224,7 @@ fn main() {
 	}
 	got := runOstyCLI(t, "typecheck", dir)
 	if got.exit != 0 {
-		t.Fatalf("osty typecheck --native WORKSPACE exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("osty typecheck WORKSPACE exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 	if !strings.Contains(got.stdout, "# "+appPath) {
 		t.Fatalf("stdout missing `# %s` header:\n%s", appPath, got.stdout)
@@ -339,10 +339,10 @@ fn main() {
 	}
 }
 
-// TestRunTypecheckFileNativeDumpTelemetry exercises the typecheck
-// --native CLI body end-to-end (including the type dump which iterates
-// TypedNodes) and asserts the dump-native-diags telemetry header
-// lands on stderr.
+// TestRunTypecheckFileNativeDumpTelemetry exercises the native
+// typecheck CLI body end-to-end (including the type dump which
+// iterates TypedNodes) and asserts the dump-native-diags telemetry
+// header lands on stderr.
 func TestRunTypecheckFileNativeDumpTelemetry(t *testing.T) {
 	src := []byte(`fn main() {
     let x = 1

--- a/cmd/osty/typecheck_native_test.go
+++ b/cmd/osty/typecheck_native_test.go
@@ -25,7 +25,7 @@ func TestTypecheckCLINativeCleanSourcePrintsTypes(t *testing.T) {
 `), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	got := runOstyCLI(t, "typecheck", "--native", path)
+	got := runOstyCLI(t, "typecheck", path)
 	if got.exit != 0 {
 		t.Fatalf("osty typecheck --native exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -49,7 +49,7 @@ func TestTypecheckCLINativeSurfacesTypeError(t *testing.T) {
 `), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	got := runOstyCLI(t, "typecheck", "--native", path)
+	got := runOstyCLI(t, "typecheck", path)
 	if got.exit != 1 {
 		t.Fatalf("osty typecheck --native exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -71,7 +71,7 @@ func TestTypecheckCLINativeInspectFlagUsesSelfhost(t *testing.T) {
 `), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	got := runOstyCLI(t, "--inspect", "typecheck", "--native", path)
+	got := runOstyCLI(t, "--inspect", "typecheck", path)
 	if got.exit != 0 {
 		t.Fatalf("exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -160,7 +160,7 @@ func TestTypecheckCLINativePackageCleanSourcePrintsPerFileTypes(t *testing.T) {
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := runOstyCLI(t, "typecheck", "--native", dir)
+	got := runOstyCLI(t, "typecheck", dir)
 	if got.exit != 0 {
 		t.Fatalf("osty typecheck --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -186,7 +186,7 @@ fn main() {
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := runOstyCLI(t, "typecheck", "--native", dir)
+	got := runOstyCLI(t, "typecheck", dir)
 	if got.exit != 0 {
 		t.Fatalf("osty typecheck --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
@@ -222,7 +222,7 @@ fn main() {
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := runOstyCLI(t, "typecheck", "--native", dir)
+	got := runOstyCLI(t, "typecheck", dir)
 	if got.exit != 0 {
 		t.Fatalf("osty typecheck --native WORKSPACE exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}

--- a/internal/backend/layout.go
+++ b/internal/backend/layout.go
@@ -41,12 +41,6 @@ func (l Layout) CachePath(n Name) string {
 	return filepath.Join(l.CacheRoot(), n.String()+".json")
 }
 
-// LegacyCachePath returns the pre-backend-aware fingerprint path. It exists so
-// the migration can read or retire old cache files deliberately.
-func (l Layout) LegacyCachePath() string {
-	return profile.LegacyCachePath(l.Root, l.Profile, l.Target)
-}
-
 // Artifacts is the conventional set of paths a backend may write. Not every
 // field is populated by every backend or emit mode.
 type Artifacts struct {

--- a/internal/profile/cache.go
+++ b/internal/profile/cache.go
@@ -58,13 +58,6 @@ func CachePath(root, profile, triple string) string {
 	return BackendCachePath(root, profile, triple, defaultCacheBackend)
 }
 
-// LegacyCachePath returns the pre-backend-aware fingerprint JSON file. New
-// builds do not write this path; it remains here so migration code and layout
-// tests can identify stale records deliberately.
-func LegacyCachePath(root, profile, triple string) string {
-	return filepath.Join(root, CacheDirName, ArtifactKey(profile, triple)+".json")
-}
-
 // Fingerprint is the on-disk record describing one build. Sources
 // maps the project-relative .osty file path to its sha256 content
 // hash; ToolVersion records the toolchain stamp so a binary upgrade
@@ -266,20 +259,6 @@ func ReadFingerprintForBackend(root, profile, triple, backend string) (*Fingerpr
 		f.Backend = backend
 	}
 	return f, nil
-}
-
-// ReadLegacyFingerprint loads the old <key>.json cache path. Build does not
-// use this for freshness decisions; it exists for cache migration diagnostics.
-func ReadLegacyFingerprint(root, profile, triple string) (*Fingerprint, error) {
-	path := LegacyCachePath(root, profile, triple)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return parseFingerprint(path, data)
 }
 
 // parseFingerprint decodes one cache JSON record and annotates corrupt-cache

--- a/internal/selfhost/format_adapter.go
+++ b/internal/selfhost/format_adapter.go
@@ -30,7 +30,7 @@ func FormatSource(src []byte) ([]byte, []*diag.Diagnostic, error) {
 
 // FormatCheck reports whether FormatSource would change the original source
 // bytes. Raw-byte comparison is intentional so BOM/CRLF normalization counts
-// as a formatting change just like the public `osty fmt --engine=osty` path.
+// as a formatting change just like the public `osty fmt` path.
 func FormatCheck(src []byte) (FormatterCheckResult, []*diag.Diagnostic, error) {
 	normalized := normalizeFormatterInput(src)
 	formatted := ostyFormatSource(string(normalized))


### PR DESCRIPTION
## Summary

Three SAFE Go legacy long-tail removals bundled together — all accepted-but-ignored CLI surface and dead code with zero external callers.

### What's removed

**1. `--engine go|osty` fmt flag** (P1) — was accepted-but-ignored since the formatter consolidated to a single self-host engine. The `engineUnused` placeholder and its `fs.StringVar(...)` registration were pure tax.

**2. `--native` no-op flag stripper** (P2) — `--legacy` was retired in Phase 1c.5, leaving `--native` as a backwards-compat no-op stripped by special-case code in `main.go`. Removes the strippers and updates the 13 `runOstyCLI(t, "check"/"typecheck", "--native", ...)` test invocations to drop the dead flag.

**3. Dead `LegacyCachePath` cluster** (P3) — `profile.LegacyCachePath`, `profile.ReadLegacyFingerprint`, and `backend.Layout.LegacyCachePath()` were retained only for "migration diagnostics" with zero external callers. The wrapper chain (`Layout.LegacyCachePath()` → `profile.LegacyCachePath` → `ReadLegacyFingerprint`) was self-referential dead code.

### Doc updates
- `README.md`: drop `--engine` flag docs and `--native` no-op mention.
- `SELFHOST_PORT_MATRIX.md`: update the three references that called `--native` a backwards-compat no-op.
- `LLVM_MIGRATION_PLAN.md`: simplify the CLI happy-path table (drop the `--native` prefixes; happy-path tests still exist under their renamed names from #1956).
- `LLVM_ARTIFACT_LAYOUT.md`: note the legacy fingerprint cluster is retired.
- `internal/selfhost/format_adapter.go`: scrub `--engine=osty` reference from a doc comment.

Net: **10 files, +39 / -88 LOC**.

### Continues the long-tail thread

Follows #1956 (FrontendRun.File removal). The "Phase 1c.5 final cleanup" arc — `--legacy`, `--native`, `--engine`, FrontendRun.File, and AstbridgeLowerCount were all artifacts of the bridge era; this PR closes the CLI-flag side and the orphaned cache-fingerprint helpers.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 -short ./cmd/osty/` passes (97s — covers the 13 retargeted test invocations)
- [x] `go test -count=1 -short ./internal/profile/` passes
- [x] `./internal/backend` `TestStage0RealMIRBaseline` failures pre-exist on clean `origin/main` (unrelated)
- [ ] CI green

https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ)_