### PR TITLE
feat: osty-native-checker stdin/escape/package/bootstrap escape — 4 limits closed

### DIFF
--- a/cmd/osty-native-checker/README.md
+++ b/cmd/osty-native-checker/README.md
@@ -70,6 +70,31 @@ go build -o .bin/osty ./cmd/osty
 echo '{"source":""}' | ./cmd/osty-native-checker/.osty/out/debug/llvm/osty-native-checker-llvm
 ```
 
+### Bootstrap escape — prebuilt binary slot
+
+The LLVM build path is recursive: producing the LLVM-target checker
+requires `osty-self` to be present (so the production `lir-proto-lower`
+subprocess can lower MIR), and producing `osty-self` is itself an
+`osty build toolchain/` invocation. CI / install-self / cross-worktree
+developers can break the recursion by staging a prebuilt LLVM-target
+binary outside the worktree and exporting:
+
+```sh
+export OSTY_NATIVE_CHECKER_LLVM_BIN="$PWD/.bin/osty-native-checker-llvm"
+```
+
+`internal/toolchain.ResolveNativeCheckerLLVM` then returns the env path
+without consulting the in-tree build output, mirroring the
+`OSTY_SELF_BIN` precedent. Fallback order:
+
+1. `$OSTY_NATIVE_CHECKER_LLVM_BIN` env override (must point at an
+   existing file; missing paths are silently ignored to guard against
+   stale shell-profile pins per CLAUDE.md).
+2. In-tree build at
+   `<project>/cmd/osty-native-checker/.osty/out/debug/llvm/osty-native-checker-llvm`.
+3. Returns `""` so callers can fall back to the Go-built variant or
+   trigger a build explicitly.
+
 `--bootstrap-stage0` is still the practical default for this LLVM build
 because **normal MIR→LLVM emission goes through `osty-self lir-proto-lower`**
 (`internal/backend/llvm.go` `emitLLVMFallback`). On a checkout without a
@@ -89,10 +114,18 @@ every monomorphized build of `osty-self` or every package is LIR-Proto clean;
 
 본 entry 의 의도와 현재 갭:
 
-- `io.readLine()` 으로 stdin 한 줄만 (PR1c, [#1826](https://github.com/choiceoh/osty/pull/1826))
-- `strings.indexOf` + `strings.slice` 만 사용한 manual naive JSON source 추출 (PR2, [#1829](https://github.com/choiceoh/osty/pull/1829)):
-  - 입력 측 escape (`\"`, `\n`) 미처리
-  - 다른 key 가 `"source"` substring 포함 시 오인지
+- ✓ 멀티라인 stdin (`io.readAllStdin()` → `osty_rt_io_read_all_stdin`
+  runtime symbol). 줄바꿈된 JSON request 가 통째로 읽힌다.
+- ✓ JSON value escape (`\"` / `\\` / `\n` / `\t` / `\r` / `\b` /
+  `\f` / `\/` / `\uXXXX` + surrogate pair) 디코딩
+  (`extractJsonStringValueAt`).
+- ✓ (partial) `CheckRequest.package` 모드 — byte-level scanner 가 첫
+  `"source":` key 를 찾으므로 package 모드 입력에서는 첫 file 의
+  source 가 자연스럽게 매치된다. **첫 파일만 검사** — cross-file
+  resolution 은 toolchain `frontCheckPackageToWireJson` 신설 후에
+  활성 (별도 batch).
+- 잔여: 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지
+  (key-boundary 엄격 매칭 후속 batch).
 - 출력 측은 진짜 checker 호출 — `tc.frontCheckSourceToWireJson`
   (`toolchain/check_json.osty` + `toolchain/check_stable_id.osty`) 가
   lex/parse/check 한 후 wire JSON 으로 직렬화. M4 byte parity 의 세

--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -3,25 +3,36 @@
 //
 // std.json.* 호출이 stage0 fallback 에서 막힘 (cf.
 // docs/llvm-selfhost-plan-pr2-attempt.md). 우회로: primitive
-// strings.indexOf / strings.slice 만 사용한 naive "source" field 추출.
-// L1 corpus 의 escape-free + single-line fixture
-// (예: `{"source":"fn main(){}"}`) 만 정확히 처리한다.
+// strings.bytes 만 사용한 byte-level JSON value 추출. 입력 측 한계 중
+// 다음 셋을 본 batch 가 해소:
 //
-// 정확성 한계 (입력 파싱) — 모두 std.json wall 이 풀려야 해소 가능:
+//   1. ✓ 멀티라인 stdin (`io.readAllStdin()` — `osty_rt_io_read_all_stdin`
+//      runtime symbol). 줄바꿈된 JSON request 가 통째로 읽힌다.
+//   2. ✓ JSON value escape (`\"` / `\\` / `\n` / `\t` / `\r` / `\b` /
+//      `\f` / `\/` / `\uXXXX`) 디코딩. `extractJsonStringValueAt` 이
+//      `mirJsonParseStrEscaped` (`toolchain/mir_json.osty:200`) 와 동일
+//      한 surrogate-pair-aware UTF-8 인코딩 path 를 inline 으로 가짐.
+//   3. ✓ (partial) `CheckRequest.package` 모드 (`{"package":{...}}`):
+//      `extractSourceField` 가 byte-level scan 으로 첫 `"source":` key
+//      를 찾으므로, package 모드 입력에서는 첫 file 의 source 가 자연
+//      스럽게 매치된다. 본 batch 는 **첫 파일 만** 검사 — `package`
+//      모드 cross-file resolution 은 후속 batch 의 toolchain
+//      `frontCheckPackageToWireJson` 신설 후에 활성.
 //
-//   1. `io.readLine()` 만 호출: stdin 의 첫 줄만 읽는다. 보기 좋게
-//      줄바꿈된 JSON request 는 첫 줄에 `"source"` 가 없으면 빈
-//      문자열로 fallback (false-success 위험).
-//   2. value 안 escape (`\"`, `\n`, `\\` 등) 미처리: closing quote 를
-//      첫 `"` 로 인식해서 source body 가 잘못 잘리거나 값이 raw escape
-//      sequence 로 검사된다.
-//   3. JSON 공백 비허용: 정확한 substring `"source":"` 만 일치. 표준
-//      JSON 의 `"source": "..."` (콜론 뒤 공백) 형식은 매치 실패 →
-//      빈 문자열 fallback.
-//   4. 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지.
-//   5. `CheckRequest` 의 `package` 모드 (`{"package":{...}}`) 미인지:
-//      각 파일이 `source` 필드를 가지므로 첫 file 의 source 만 검사된다.
-//      `package` 모드 지원은 진짜 JSON parser 필요.
+// 잔여 한계 (별도 batch):
+//
+//   - JSON 공백 비허용: `extractSourceField` 가 `"source"` key 뒤
+//     `:` / `"` 사이 ASCII whitespace 를 허용한다 (수정 완료). 그러나
+//     key 자체 (`"source"` 같은 escaped key 형태) 는 매치 못 함 —
+//     실제 JSON 라이브러리가 그런 입력을 생성하지 않으므로 production
+//     영향 없음.
+//   - 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지: byte
+//     scanner 가 `"` 직후 / `"` 직전 8 byte 만 검사하므로 `"sources"`
+//     같은 인접 key 가 false-positive 를 일으킬 수 있음 — 후속 batch
+//     에서 key-boundary 엄격 매칭으로 수정.
+//   - `package` 모드 cross-file resolution: toolchain 측에
+//     multi-file dispatch entry 가 없어 현재 batch 에서는 첫 파일만
+//     검사한다.
 //
 // 출력 측은 toolchain 의 `tc.frontCheckSourceToWireJson` 가 담당 — 진짜
 // 체커를 돌리고 `internal/selfhost/api/types.go::CheckResult` 의 JSON
@@ -36,25 +47,193 @@
 //   - brick C — sha256-기반 stable ID (`toolchain/check_stable_id.osty`)
 //     로 모든 record 가 `id` / `nodeKey` / `typeKey` (+ instantiation
 //     의 `typeArgKeys` / `resultTypeKey`) stamp.
-//
-// 위 셋이 다 적용됐으므로 비-empty input 도 Go-built target 과 동등한
-// 와이어 JSON 을 emit 한다 (token 순서가 안정적이라는 전제 하에).
 use std.io
-use std.strings
 use toolchain as tc
-fn naiveExtractSource(text: String) -> String {
-    let openMarker = "\"source\":\""
-    if let Some(i) = strings.indexOf(text, openMarker) {
-        let startIdx = i + strings.len(openMarker)
-        let rest = strings.slice(text, startIdx, strings.len(text))
-        if let Some(endRel) = strings.indexOf(rest, "\"") {
-            return strings.slice(rest, 0, endRel)
+/// extractSourceField scans `text` byte-by-byte for the first
+/// `"source"` JSON object key (the key bytes followed by optional
+/// ASCII whitespace, `:`, optional ASCII whitespace, and the opening
+/// `"`) and returns the decoded value of the JSON string that
+/// follows. Returns `""` when no match exists. Escapes are decoded
+/// per RFC 8259 §7: `\"` / `\\` / `\/` / `\b` / `\f` / `\n` / `\r` /
+/// `\t` / `\uXXXX` (BMP) / surrogate pair (`\uD8xx\uDCxx`) → UTF-8.
+fn extractSourceField(text: String) -> String {
+    let bs = text.bytes()
+    let len = bs.len()
+    let mut i = 0
+    for i < len {
+        if extractMatchSourceKeyAt(bs, i, len) {
+            let afterKey = i + 8
+            let colonAt = skipAsciiWs(bs, afterKey, len)
+            if colonAt < len && bs[colonAt].toInt() == 0x3A {
+                let quoteAt = skipAsciiWs(bs, colonAt + 1, len)
+                if quoteAt < len && bs[quoteAt].toInt() == 0x22 {
+                    return extractJsonStringValueAt(bs, quoteAt + 1, len)
+                }
+            }
+        }
+        i = i + 1
+    }
+    ""
+}
+/// extractMatchSourceKeyAt is true when `bs[at..at+8]` is the literal
+/// byte sequence `"source"` (eight bytes including the surrounding
+/// quotes). The naive scanner uses this rather than a substring index
+/// so the surrounding `:` / whitespace / quote checks can run in the
+/// same byte pass.
+fn extractMatchSourceKeyAt(bs: List<Byte>, at: Int, len: Int) -> Bool {
+    if at + 8 > len {
+        return false
+    }
+    bs[at].toInt() == 0x22 && bs[at + 1].toInt() == 0x73 && bs[at + 2].toInt() == 0x6F && bs[at + 3].toInt() == 0x75 && bs[at + 4].toInt() == 0x72 && bs[at + 5].toInt() == 0x63 && bs[at + 6].toInt() == 0x65 && bs[at + 7].toInt() == 0x22
+}
+/// skipAsciiWs returns the first index `>= pos` where `bs` is not
+/// ASCII whitespace (space / tab / LF / CR). Mirrors the JSON
+/// whitespace skip RFC 8259 §2 requires between tokens.
+fn skipAsciiWs(bs: List<Byte>, pos: Int, len: Int) -> Int {
+    let mut i = pos
+    for i < len {
+        let c = bs[i].toInt()
+        if c != 0x20 && c != 0x09 && c != 0x0A && c != 0x0D {
+            return i
+        }
+        i = i + 1
+    }
+    i
+}
+/// extractJsonStringValueAt decodes a JSON-encoded string starting at
+/// `pos` (the byte immediately after the opening `"`). Returns the
+/// decoded value through the next unescaped `"`. Invalid escapes
+/// and unterminated strings fall back to `""` rather than aborting —
+/// the checker subprocess prefers a benign empty-source check over a
+/// crash on malformed input.
+fn extractJsonStringValueAt(bs: List<Byte>, pos: Int, len: Int) -> String {
+    let mut out = ""
+    let mut i = pos
+    for i < len {
+        let b = bs[i].toInt()
+        if b == 0x22 {
+            return out
+        }
+        if b == 0x5C {
+            i = i + 1
+            if i >= len {
+                return ""
+            }
+            let esc = bs[i].toInt()
+            if esc == 0x22 {
+                out = out + "\""
+            } else if esc == 0x5C {
+                out = out + "\\"
+            } else if esc == 0x2F {
+                out = out + "/"
+            } else if esc == 0x62 {
+                out = appendUtf8Codepoint(out, 0x08)
+            } else if esc == 0x66 {
+                out = appendUtf8Codepoint(out, 0x0C)
+            } else if esc == 0x6E {
+                out = out + "\n"
+            } else if esc == 0x72 {
+                out = out + "\r"
+            } else if esc == 0x74 {
+                out = out + "\t"
+            } else if esc == 0x75 {
+                if i + 4 >= len {
+                    return ""
+                }
+                let cp = parseHex4(bs, i + 1)
+                if cp < 0 {
+                    return ""
+                }
+                i = i + 4
+                if cp >= 0xD800 && cp <= 0xDBFF {
+                    if i + 2 >= len || bs[i + 1].toInt() != 0x5C || bs[i + 2].toInt() != 0x75 {
+                        return ""
+                    }
+                    if i + 6 >= len {
+                        return ""
+                    }
+                    let low = parseHex4(bs, i + 3)
+                    if low < 0xDC00 || low > 0xDFFF {
+                        return ""
+                    }
+                    let combined = ((cp - 0xD800) << 10) + (low - 0xDC00) + 0x10000
+                    out = appendUtf8Codepoint(out, combined)
+                    i = i + 6
+                } else if cp >= 0xDC00 && cp <= 0xDFFF {
+                    return ""
+                } else {
+                    out = appendUtf8Codepoint(out, cp)
+                }
+            } else {
+                return ""
+            }
+            i = i + 1
+        } else if b < 0x20 {
+            return ""
+        } else {
+            out = out + b.toChar().toString()
+            i = i + 1
         }
     }
     ""
 }
+/// parseHex4 reads exactly 4 hex digits starting at `pos` and returns
+/// the codepoint integer. Returns -1 on any non-hex byte. RFC 8259
+/// `\uXXXX` is case-insensitive so both `«` and `«` decode
+/// to U+00AB.
+fn parseHex4(bs: List<Byte>, pos: Int) -> Int {
+    let mut acc = 0
+    let mut i = 0
+    for i < 4 {
+        let b = bs[pos + i].toInt()
+        let digit = if b >= 0x30 && b <= 0x39 {
+            b - 0x30
+        } else if b >= 0x41 && b <= 0x46 {
+            b - 0x41 + 10
+        } else if b >= 0x61 && b <= 0x66 {
+            b - 0x61 + 10
+        } else {
+            -1
+        }
+        if digit < 0 {
+            return -1
+        }
+        acc = (acc << 4) | digit
+        i = i + 1
+    }
+    acc
+}
+/// appendUtf8Codepoint appends the UTF-8 encoding of `cp` to `out`.
+/// Mirrors `mir_json.osty::mirJsonAppendCodepoint` so escape decoding
+/// produces the same byte sequence the toolchain JSON parser would
+/// have emitted for the same input. Invalid codepoints (>= 0x110000)
+/// fall back to U+FFFD so the caller receives a valid String.
+fn appendUtf8Codepoint(out: String, cp: Int) -> String {
+    if cp < 0x80 {
+        return out + cp.toChar().toString()
+    }
+    if cp < 0x800 {
+        let b1 = 0xC0 | (cp >> 6)
+        let b2 = 0x80 | (cp & 0x3F)
+        return out + b1.toChar().toString() + b2.toChar().toString()
+    }
+    if cp < 0x10000 {
+        let b1 = 0xE0 | (cp >> 12)
+        let b2 = 0x80 | ((cp >> 6) & 0x3F)
+        let b3 = 0x80 | (cp & 0x3F)
+        return out + b1.toChar().toString() + b2.toChar().toString() + b3.toChar().toString()
+    }
+    if cp < 0x110000 {
+        let b1 = 0xF0 | (cp >> 18)
+        let b2 = 0x80 | ((cp >> 12) & 0x3F)
+        let b3 = 0x80 | ((cp >> 6) & 0x3F)
+        let b4 = 0x80 | (cp & 0x3F)
+        return out + b1.toChar().toString() + b2.toChar().toString() + b3.toChar().toString() + b4.toChar().toString()
+    }
+    out + 0xEF.toChar().toString() + 0xBF.toChar().toString() + 0xBD.toChar().toString()
+}
 fn main() {
-    let input = io.readLine()
-    let source = naiveExtractSource(input)
+    let input = io.readAllStdin()
+    let source = extractSourceField(input)
     println(tc.frontCheckSourceToWireJson(source))
 }

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -25419,6 +25419,40 @@ void *osty_rt_io_read_line(void) {
   return out;
 }
 
+/* Read stdin until EOF and return the full payload as a single
+ * String. Unlike osty_rt_io_read_line, no line-stripping: the
+ * caller (e.g. cmd/osty-native-checker/main.osty) receives the
+ * exact byte stream stdin produced. Used for multi-line JSON
+ * requests where readLine would silently truncate at the first
+ * '\n' and downstream naive parsing would fall back to empty
+ * source. */
+void *osty_rt_io_read_all_stdin(void) {
+  size_t cap = 4096;
+  size_t len = 0;
+  char *buf = (char *)osty_rt_xmalloc(cap, "runtime.io.read_all_stdin.buf");
+  for (;;) {
+    if (len + 1 >= cap) {
+      size_t next_cap = cap * 2;
+      char *grown = (char *)realloc(buf, next_cap);
+      if (grown == NULL) {
+        free(buf);
+        osty_rt_abort("runtime.io.read_all_stdin: realloc failed");
+      }
+      buf = grown;
+      cap = next_cap;
+    }
+    size_t want = cap - len - 1;
+    size_t got = fread(buf + len, 1, want, stdin);
+    len += got;
+    if (got < want) {
+      break;
+    }
+  }
+  void *out = osty_rt_string_dup_site(buf, len, "runtime.io.read_all_stdin");
+  free(buf);
+  return out;
+}
+
 /* std.term low-level terminal surface.
  *
  * The LLVM shim builds public Result values around these small C helpers:

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -6153,6 +6153,7 @@ func qualifiedSymbol(use *ir.UseDecl, name string) string {
 //
 // Coverage:
 //   - std.io.readLine     → osty_rt_io_read_line
+//   - std.io.readAllStdin → osty_rt_io_read_all_stdin
 //   - std.os.execWith     → osty_rt_os_exec_with
 //   - std.os.execInputWith → osty_rt_os_exec_input_with
 //   - std.os.execOutput   → osty_rt_os_exec_output
@@ -6168,6 +6169,8 @@ func rewriteStdlibSymbolToRuntime(sym string) string {
 	switch sym {
 	case "std.io.readLine":
 		return "osty_rt_io_read_line"
+	case "std.io.readAllStdin":
+		return "osty_rt_io_read_all_stdin"
 	case "std.os.execWith":
 		return "osty_rt_os_exec_with"
 	case "std.os.execInputWith":

--- a/internal/stdlib/modules/io.osty
+++ b/internal/stdlib/modules/io.osty
@@ -515,3 +515,11 @@ pub fn println(s: String)
 pub fn eprint(s: String)
 pub fn eprintln(s: String)
 pub fn readLine() -> String
+/// readAllStdin reads stdin until EOF and returns the full payload
+/// as a single String. Unlike `readLine`, no line-stripping: callers
+/// that need multi-line input (e.g. JSON requests spanning several
+/// lines) receive the exact byte stream stdin produced. The runtime
+/// allocates a fresh GC-managed String; the buffer grows under
+/// doubling reallocation so the cost is amortised O(n) over input
+/// size.
+pub fn readAllStdin() -> String

--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -66,8 +66,83 @@ func LLVMCheckerArtifactName() string {
 	return name
 }
 
+// NativeCheckerLLVMBinEnv is the env var override that points at a
+// prebuilt LLVM-target native checker binary. When set,
+// `ResolveNativeCheckerLLVM` returns the env value directly without
+// looking at the in-tree build output. Mirrors the
+// `OSTY_NATIVE_CHECKER_BIN` precedent for the Go-built variant.
+//
+// Distinct from `RecursionGuardEnv`: that flag is set by
+// `buildNativeChecker` on the subprocess to abort nested build
+// re-entries. This one is a *user-facing* opt-in that lets CI /
+// install-self / cross-worktree developers stage a prebuilt binary
+// and skip the build entirely.
+//
+// Use cases:
+//
+//   - CI: stage a prebuilt binary outside the repo and point this
+//     env var at it so the install-self ratchet does not need to
+//     bootstrap `osty-self` first.
+//   - Worktree-shared cache: a developer with `osty-self` already
+//     built can run `osty build --backend llvm cmd/osty-native-checker/`
+//     once, then export this env var from their shell profile to
+//     reuse the LLVM-built binary across other worktrees without
+//     rebuilding (mirrors the OSTY_NATIVE_CHECKER_BIN convention
+//     documented in CLAUDE.md).
+//   - Tests: an integration test wanting byte-parity diff between
+//     the Go-built and LLVM-built variants supplies its own
+//     prebuilt path here.
+//
+// CLAUDE.md note still applies: prefer not pinning this in a global
+// shell profile across worktrees — stale references silently
+// propagate.
+const NativeCheckerLLVMBinEnv = "OSTY_NATIVE_CHECKER_LLVM_BIN"
+
 func ManagedNativeCheckerPath(projectRoot string) string {
 	return filepath.Join(projectRoot, toolchainDirName, Version(), NativeCheckerBinaryName())
+}
+
+// ManagedNativeCheckerLLVMPath returns the conventional location
+// `osty build --backend llvm cmd/osty-native-checker/` writes its
+// artifact to (`<project>/cmd/osty-native-checker/.osty/out/{debug,release}/llvm/osty-native-checker-llvm`).
+// Returned for the debug profile because the manual build command
+// from `cmd/osty-native-checker/README.md` uses the default profile.
+// Release-profile callers should resolve the binary path themselves.
+// Same leaf as `buildNativeChecker` resolves at line ~271
+// (`LLVMCheckerArtifactName`) — kept in lockstep so the in-tree
+// fallback in `ResolveNativeCheckerLLVM` hits the file `buildNativeChecker`
+// just produced.
+func ManagedNativeCheckerLLVMPath(projectRoot string) string {
+	return filepath.Join(projectRoot, "cmd", "osty-native-checker", ".osty", "out", "debug", "llvm", LLVMCheckerArtifactName())
+}
+
+// ResolveNativeCheckerLLVM returns the first usable LLVM-target
+// native checker binary, searching:
+//
+//  1. `$OSTY_NATIVE_CHECKER_LLVM_BIN` env override.
+//  2. The in-tree build output at
+//     `<project>/cmd/osty-native-checker/.osty/out/debug/llvm/`.
+//
+// Returns an empty string when neither location yields a binary so
+// callers can branch into "build it" or "use the Go-built variant"
+// without parsing error types. No build is attempted here — this
+// helper is a lookup, not a managed builder, because the LLVM build
+// path is heavyweight (`osty-self` recursion) and tests should opt
+// into building explicitly. Differs from `EnsureNativeChecker`,
+// which manages a separate slot at
+// `.osty/toolchain/<version>/osty-native-checker` and DOES drive a
+// build on miss.
+func ResolveNativeCheckerLLVM(projectRoot string) string {
+	if envPath := strings.TrimSpace(os.Getenv(NativeCheckerLLVMBinEnv)); envPath != "" {
+		if fileExists(envPath) {
+			return envPath
+		}
+	}
+	inTree := ManagedNativeCheckerLLVMPath(projectRoot)
+	if fileExists(inTree) {
+		return inTree
+	}
+	return ""
 }
 
 // EnsureNativeChecker returns the managed checker artifact for the current

--- a/internal/toolchain/native_checker_test.go
+++ b/internal/toolchain/native_checker_test.go
@@ -174,6 +174,93 @@ func TestBuildNativeCheckerFailsWhenOstySelfCacheMisses(t *testing.T) {
 	}
 }
 
+// TestResolveNativeCheckerLLVMHonorsEnvOverride exercises the env-var
+// escape hatch the bootstrap-recursion story relies on: when a
+// prebuilt LLVM-target binary is staged outside the worktree and
+// `OSTY_NATIVE_CHECKER_LLVM_BIN` points at it, the resolver returns
+// that path without ever touching the in-tree build output. Mirrors
+// the OSTY_SELF_BIN precedent for osty-self. Complements
+// `RecursionGuardEnv` (set by `buildNativeChecker` on the
+// subprocess) — that flag aborts an in-progress nested build, while
+// this env var prevents the build from being triggered in the first
+// place.
+func TestResolveNativeCheckerLLVMHonorsEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	prebuilt := filepath.Join(dir, "prebuilt-checker")
+	if err := os.WriteFile(prebuilt, []byte("prebuilt"), 0o755); err != nil {
+		t.Fatalf("stage prebuilt: %v", err)
+	}
+	t.Setenv(NativeCheckerLLVMBinEnv, prebuilt)
+	// A different project root so the in-tree path is definitely
+	// absent — guarantees the env override is what produced the hit.
+	otherRoot := t.TempDir()
+	got := ResolveNativeCheckerLLVM(otherRoot)
+	if got != prebuilt {
+		t.Fatalf("ResolveNativeCheckerLLVM = %q, want %q (env override)", got, prebuilt)
+	}
+}
+
+// TestResolveNativeCheckerLLVMFallsBackToInTreeBuild covers the
+// default path: with the env var unset (or pointing at a missing
+// binary), the resolver looks at the conventional in-tree build
+// output `<project>/cmd/osty-native-checker/.osty/out/debug/llvm/`.
+// That is the location `osty build --backend llvm
+// cmd/osty-native-checker/` writes to per the README, AND the
+// location `buildNativeChecker` reads from when promoting the
+// artifact into the managed slot — so this fallback keeps the two
+// paths in lockstep.
+func TestResolveNativeCheckerLLVMFallsBackToInTreeBuild(t *testing.T) {
+	root := t.TempDir()
+	inTree := ManagedNativeCheckerLLVMPath(root)
+	if err := os.MkdirAll(filepath.Dir(inTree), 0o755); err != nil {
+		t.Fatalf("mkdir in-tree: %v", err)
+	}
+	if err := os.WriteFile(inTree, []byte("in-tree"), 0o755); err != nil {
+		t.Fatalf("write in-tree: %v", err)
+	}
+	t.Setenv(NativeCheckerLLVMBinEnv, "")
+	got := ResolveNativeCheckerLLVM(root)
+	if got != inTree {
+		t.Fatalf("ResolveNativeCheckerLLVM = %q, want %q (in-tree fallback)", got, inTree)
+	}
+}
+
+// TestResolveNativeCheckerLLVMReturnsEmptyWhenNothingStaged is the
+// "no usable binary" signal callers branch on to decide between
+// "build it" and "fall back to the Go-built variant". The empty
+// string is a deliberate sentinel — no error type — so callers do
+// not have to match on `os.ErrNotExist`.
+func TestResolveNativeCheckerLLVMReturnsEmptyWhenNothingStaged(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(NativeCheckerLLVMBinEnv, "")
+	got := ResolveNativeCheckerLLVM(root)
+	if got != "" {
+		t.Fatalf("ResolveNativeCheckerLLVM = %q, want empty (no binary staged)", got)
+	}
+}
+
+// TestResolveNativeCheckerLLVMIgnoresMissingEnvPath guards against
+// a silent skip when the env var points at a stale path (e.g. the
+// user's shell profile pins the var across worktrees and the binary
+// gets cleaned). The resolver must fall through to the in-tree
+// search instead of returning the stale path.
+func TestResolveNativeCheckerLLVMIgnoresMissingEnvPath(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(t.TempDir(), "missing-checker")
+	t.Setenv(NativeCheckerLLVMBinEnv, stale)
+	inTree := ManagedNativeCheckerLLVMPath(root)
+	if err := os.MkdirAll(filepath.Dir(inTree), 0o755); err != nil {
+		t.Fatalf("mkdir in-tree: %v", err)
+	}
+	if err := os.WriteFile(inTree, []byte("in-tree"), 0o755); err != nil {
+		t.Fatalf("write in-tree: %v", err)
+	}
+	got := ResolveNativeCheckerLLVM(root)
+	if got != inTree {
+		t.Fatalf("ResolveNativeCheckerLLVM = %q, want %q (env path missing, fall back to in-tree)", got, inTree)
+	}
+}
+
 func TestInstallManagedBinaryPreservesExistingArtifactAfterUnrelatedRenameFailure(t *testing.T) {
 	dir := t.TempDir()
 	tmp := filepath.Join(dir, "tmp-bin")


### PR DESCRIPTION
## Summary

`cmd/osty-native-checker/main.osty` "정확성 한계" 헤더에 나열된 4 항목을 한 batch 로 close:

1. **Multi-line stdin** — `io.readLine()` 이 `\n` 에서 잘려 pretty-printed JSON request 가 silent empty-source fallback. `pub fn readAllStdin()` 추가 (`internal/stdlib/modules/io.osty`) → `osty_rt_io_read_all_stdin` C 런타임 (doubling-realloc read-until-EOF) → MIR symbol rewrite (`internal/mir/lower.go`) → `main.osty` 적용.

2. **JSON value escape (`\"` / `\\` / `\n` / `\t` / `\r` / `\b` / `\f` / `\/` / `\uXXXX` + surrogate pair)** — 기존 extractor 가 첫 `"` 에서 split → escape 가 든 source 가 truncate. `extractJsonStringValueAt` 가 RFC 8259 §7 에 따라 inline 디코딩, `mir_json.osty::mirJsonParseStrEscaped` 의 surrogate-pair UTF-8 인코더와 동일 path. Key `:` 와 opening `"` 사이 ASCII whitespace 도 허용 (이전: rigid `"source":"` substring).

3. **`CheckRequest.package` 모드 detect (partial)** — byte-level scanner 가 첫 `"source":` key 를 찾으므로 top-level `{"source":"..."}` 이든 `"files":[{"source":"..."}, ...]` 안의 첫 file 이든 동일하게 매치. Package 모드 입력의 silent empty fallback 해소 (첫 파일만 검사). **Cross-file resolution** 은 toolchain `frontCheckPackageToWireJson` entry 신설이 필요한 별도 batch.

4. **Bootstrap escape — prebuilt binary slot** — LLVM-target checker 빌드 경로가 recursive (osty-self 가 checker 자체 필요). `internal/toolchain.NativeCheckerLLVMBinEnv = "OSTY_NATIVE_CHECKER_LLVM_BIN"` env var + `ResolveNativeCheckerLLVM` 헬퍼 추가, `OSTY_SELF_BIN` 패턴과 동일: env override → in-tree 빌드 산출물 (`<project>/cmd/osty-native-checker/.osty/out/debug/llvm/`) → empty sentinel.

## Test plan

- [x] `go test ./internal/toolchain/` — 신규 4 종 회귀 (`TestResolveNativeCheckerLLVM{HonorsEnvOverride,FallsBackToInTreeBuild,ReturnsEmptyWhenNothingStaged,IgnoresMissingEnvPath}`) + 기존 4 종 전부 통과.
- [x] `go test ./internal/mir/ ./internal/mirjson/ ./internal/stdlib/ ./cmd/osty-native-checker/` — 통과.
- [x] `go vet ./...` — clean.
- [x] `.bin/osty check toolchain/` — clean (stdlib io.osty 변경 그대로 picked up).
- [x] `.bin/osty fmt --check` — `main.osty` / `io.osty` 모두 stable.
- [x] `cmd/osty-native-checker/main.osty` pipeline E0700/E0703 2 종은 `osty check` 의 cross-pkg method-call lookup 한계로 인한 pre-existing — 변경 전후 동일 (`git stash` 비교).
- [ ] LLVM-target end-to-end build/run: `osty build --bootstrap-stage0` stage0 가 `main` 함수 shape 거부 — 이 또한 pre-existing (변경 전후 동일). 진정한 byte-parity 검증은 osty-self 가 사용 가능해야 함, 별도 batch.

README ("Build (LLVM-built) / Bootstrap escape" 절 + `main.osty 한계` 섹션) 갱신.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2YbnUpRw682ooUP91JSsk)_