### PR TITLE
docs: scrub stale Phase 1c.5 / Go-hosted-checker / bootstrap framing

### DIFF
--- a/cmd/codesdoc/main.go
+++ b/cmd/codesdoc/main.go
@@ -628,13 +628,15 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
 // frontendCheckSource / selfLintSource based on this phase string;
 // the table itself lives in `codesdoc_policy.osty::harvestPhaseFor`.
 
-// unsafeForBootstrapGen reports whether an example string would trip
-// the Go-hosted bootstrap transpiler's lexer when embedded as an Osty
-// string literal. Today the known trigger is the `\{` + `=>` pair; add
-// more conditions here (instead of broadening the filter) so each
-// carved-out code stays traceable.
-// unsafeForBootstrapGen / proseExample / ostyEscape delegate to
-// toolchain/codesdoc_policy.osty.
+// unsafeForBootstrapGen reports whether an example string trips the
+// historical bootstrap-gen lexer when embedded as an Osty string
+// literal — the `\{` + `=>` pair. The Osty→Go bootstrap transpiler
+// was retired in PR #854, but the filter remains as a defensive guard
+// for the harvest pipeline (the selfhost bundle that consumes
+// `toolchain/diag_examples.osty` shares the same brace/interpolation
+// shape). Add new conditions here instead of broadening the filter so
+// each carved-out code stays traceable. Delegates with proseExample
+// and ostyEscape to toolchain/codesdoc_policy.osty.
 func unsafeForBootstrapGen(example string) bool {
 	return runner.UnsafeForBootstrapGen(example)
 }
@@ -681,13 +683,11 @@ pub fn diagHarvestCases() -> List<DiagHarvestCase> {
 			if e.Doc.Example == "" {
 				continue
 			}
-			// Bootstrap-gen's lexer mishandles Osty's `\{` brace-escape
-			// inside string literals — it treats it as an interpolation
-			// opener and then chokes on the "code" between the braces.
-			// Until the Go-hosted transpiler is retired, drop any
-			// example that would be embedded into the selfhost bundle
-			// with both a `\{` escape and a token (`=>`) that's a
-			// static error outside an expression context.
+			// Defensive: skip examples whose `\{` + `=>` pair tripped
+			// the (now-retired) bootstrap-gen lexer when embedded
+			// into the selfhost bundle as a string literal. The
+			// transpiler is gone but the filter stays — the selfhost
+			// harvest still reads diag_examples.osty as Osty source.
 			if unsafeForBootstrapGen(e.Doc.Example) || proseExample(e.Doc.Example) {
 				continue
 			}

--- a/cmd/osty/check_cmd.go
+++ b/cmd/osty/check_cmd.go
@@ -27,10 +27,8 @@ import (
 //     more subdirectories do. The whole tree is loaded via Workspace
 //     so cross-package `use` declarations resolve.
 //
-// Always routes through the self-host native path since Phase 1c.5
-// retired the Go-hosted legacy alternative. Diagnostics are rendered
-// with each file's own formatter so source snippets point at the right
-// lines even when spanning packages.
+// Diagnostics are rendered with each file's own formatter so source
+// snippets point at the right lines even when spanning packages.
 func runCheckPackage(dir string, flags cliFlags) {
 	if root, ok, abort := workspaceRoot(dir, flags); abort {
 		os.Exit(2)
@@ -189,11 +187,10 @@ func runResolveFile(path string, src []byte, formatter *diag.Formatter, flags cl
 	return 0
 }
 
-// runTypecheckPackageDir is the DIR sibling of
-// runTypecheckFile and the typecheck sibling of
-// runCheckPackageDir. After the package check runs astbridge-free
-// over the merged arena, it emits a per-file type dump with each
-// file's header so `osty typecheck --native DIR` output stays
+// runTypecheckPackageDir is the DIR sibling of runTypecheckFile and
+// the typecheck sibling of runCheckPackageDir. After the package check
+// runs astbridge-free over the merged arena, it emits a per-file type
+// dump with each file's header so `osty typecheck DIR` output stays
 // readable for packages with more than one source file. Returns the
 // subcommand exit code.
 func runTypecheckPackageDir(dir string, flags cliFlags) int {
@@ -575,9 +572,9 @@ func byteOffsetLineCol(src []byte, offset int) (int, int) {
 	return line, col
 }
 
-// runCheckFile drives `osty check --native FILE` end-to-end on
-// the self-host arena pipeline. Files without imports still take the
-// direct source path; files with bundled stdlib imports use the same
+// runCheckFile drives `osty check FILE` end-to-end on the self-host
+// arena pipeline. Files without imports still take the direct source
+// path; files with bundled stdlib imports use the same
 // structured package import surface as package/workspace checks, so
 // calls like `strings.trim(...)` and `gui.renderHtml(...)` are checked
 // against real exported signatures. Both paths stay astbridge-free.

--- a/cmd/osty/check_cmd_test.go
+++ b/cmd/osty/check_cmd_test.go
@@ -482,13 +482,11 @@ func TestRunCheckFileDumpTelemetry(t *testing.T) {
 	}
 }
 
-// TestCheckCLIDefaultPathUsesSelfhostArena is the production-default
-// companion to TestRunCheckFileDumpTelemetry: after the
-// 1c.1 flip (SELFHOST_PORT_MATRIX.md), `osty check FILE` routes
-// through the self-host arena pipeline. Run the subprocess CLI so
-// dispatch actually goes through clicmd.ParseArgs, then verify exit 0
-// on a well-typed input. Phase 1c.5 retired the Go-hosted escape
-// hatch — the self-host path is the only path now.
+// TestCheckCLIDefaultPathExitsZero is the production-default companion
+// to TestRunCheckFileDumpTelemetry: `osty check FILE` routes through
+// the self-host arena pipeline. Run the subprocess CLI so dispatch
+// actually goes through clicmd.ParseArgs, then verify exit 0 on a
+// well-typed input — the self-host path is the only path.
 func TestCheckCLIDefaultPathExitsZero(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.osty")

--- a/internal/backend/stdlib_check.go
+++ b/internal/backend/stdlib_check.go
@@ -27,13 +27,11 @@ type checkCacheEntry struct {
 // that nil straight through to ir.LowerFnDecl, which degrades to
 // ErrTypeVal the same way it does for any missing checker output.
 //
-// Uses check.SelfhostFile instead of check.File so stdlib compilation
-// skips the AST-level builder-desugar pass: stdlib sources are first-
-// party and don't exercise the user-facing `.builder()` / `.build()`
-// auto-derive chains that desugar targets. Shaves a linear walk per
-// module off the cold path; more importantly, makes the stdlib side of
-// the Phase 1c.4 migration the first production site to bypass the
-// check.File "everything" wrapper.
+// Uses check.SelfhostFile so stdlib compilation skips the AST-level
+// builder-desugar pass: stdlib sources are first-party and don't
+// exercise the user-facing `.builder()` / `.build()` auto-derive
+// chains that desugar targets. Shaves a linear walk per module off
+// the cold path.
 //
 // Concurrency: sync.Once guarantees at-most-once checker invocation per
 // module even if multiple PrepareEntry calls race.

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -265,13 +265,11 @@ func diagsHaveError(diags []*diag.Diagnostic) bool {
 // returned in Result.Diags; they may be concatenated with the parser's
 // and resolver's diagnostics before display.
 //
-// Phase 1c.5 collapsed the earlier File / SelfhostFile pair into this
-// single entry. The native checker is authoritative for builder-chain
-// typing and diagnostics after #833 ported builder auto-derive into
-// the selfhost checker + on-demand IR rewriting; the Go-side
-// `DesugarBuildersInFile` prepass that File used to carry is gone.
-// OnDecl timing bookkeeping moved into this function so no caller
-// loses the per-decl phase dump `osty pipeline --per-decl` emits.
+// The native checker is authoritative for builder-chain typing and
+// diagnostics after #833 ported builder auto-derive into the selfhost
+// checker + on-demand IR rewriting; the Go-side `DesugarBuildersInFile`
+// prepass has been removed. OnDecl timing bookkeeping lives here so
+// `osty pipeline --per-decl` keeps its per-decl phase dump.
 func SelfhostFile(f *ast.File, rr *resolve.Result, opts ...Opts) *Result {
 	opt := firstOpt(opts)
 	result := newResult()

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -2597,8 +2597,8 @@ func (l *lowerer) lowerExpr(e ast.Expr) Expr {
 		if t == ErrTypeVal {
 			// Default int-literal type when the checker didn't
 			// populate Types[e] — covers literals nested inside
-			// contexts the Go-hosted checker skips (string interp
-			// parts, match arm bodies, etc.). Without this, a
+			// contexts the checker skips (string interp parts,
+			// match arm bodies, etc.). Without this, a
 			// stray `+ 1` poisons the enclosing BinaryExpr to
 			// ErrType, which cascades to every consumer of the
 			// match / block result.
@@ -4057,8 +4057,8 @@ func (l *lowerer) lowerQualifiedCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArg
 	if t == ErrTypeVal {
 		t = recoverCallReturnType(callee)
 	}
-	// The Go-hosted checker doesn't register `use X { fn Y(...) -> R
-	// }` member signatures on the package symbol, so `host.Y` ends up
+	// The checker doesn't register `use X { fn Y(...) -> R }`
+	// member signatures on the package symbol, so `host.Y` ends up
 	// as <error> in both the checker types map and the callee's
 	// FnType. Fall back to reading the UseDecl body (for inline FFI
 	// signatures) or the resolved package scope (for stdlib /
@@ -5413,8 +5413,8 @@ func (l *lowerer) enumDeclByName(name string) *ast.EnumDecl {
 // recoverMethodReturnType derives the return type of a receiver-and-
 // method pair for the subset of stdlib intrinsics where the return
 // shape is fixed by the name alone. Used as a fallback when the
-// Go-hosted checker didn't populate `Types[e]` for the call. Mirrors
-// the routing in internal/mir/lower.go:methodToIntrinsic.
+// checker doesn't populate `Types[e]` for the call. Mirrors the
+// routing in internal/mir/lower.go:methodToIntrinsic.
 func recoverMethodReturnType(name string, recv Expr) Type {
 	if recv == nil {
 		return nil

--- a/internal/nativellvmgen/exec.go
+++ b/internal/nativellvmgen/exec.go
@@ -50,9 +50,8 @@ type PackageInput struct {
 	// callers — which mangle via
 	// `internal/mir/lower.go::qualifiedSymbol` as
 	// `<use.RawPath>.<fn>` — find a matching `define` at link time.
-	// Empty PackageName falls back to the historical bare-name
-	// emission (no rename) for backwards compatibility with callers
-	// that haven't filled the field yet.
+	// Empty PackageName disables the rename (defensive: every
+	// production caller now derives Name via the package loader).
 	PackageName string `json:"packageName,omitempty"`
 }
 

--- a/internal/selfhost/check_diag_convert_test.go
+++ b/internal/selfhost/check_diag_convert_test.go
@@ -13,7 +13,7 @@ import (
 // `#[intrinsic]` non-empty-body violation produces a record that, after
 // conversion, renders as an *diag.Diagnostic with the expected code,
 // severity, primary span, and notes. This is the CLI-side contract
-// that future `osty check --native` wiring relies on.
+// the `osty check` wiring relies on.
 func TestCheckDiagnosticsAsDiagSurfacesIntrinsicViolation(t *testing.T) {
 	src := []byte(`#[intrinsic]
 fn bad() -> Int {


### PR DESCRIPTION
## Summary

Comment-only tidy-up following the Phase 1c.5 cleanup arc (#1956 / #1960 / #1962). Several doc comments still narrated their context as if the migration were in flight, and the codesdoc bootstrap-gen guard's comment claimed the bootstrap transpiler was still active (it was retired in PR #854).

### Changes (all comment-only, no behavior)

| File | What was stale | New framing |
|---|---|---|
| `internal/ir/lower.go` (×3) | "Go-hosted checker skips/doesn't register/didn't populate" | "the checker skips/doesn't register/doesn't populate" — there's one checker |
| `internal/check/check.go::SelfhostFile` | "Phase 1c.5 collapsed the earlier File / SelfhostFile pair" | dropped the migration framing; consolidation is a fact now |
| `internal/backend/stdlib_check.go` | "Phase 1c.4 migration" / "check.File 'everything' wrapper" | dropped — SelfhostFile is the only entry point |
| `internal/selfhost/check_diag_convert_test.go` | "future `osty check --native` wiring relies on" | "the `osty check` wiring relies on" — no `--native` flag exists |
| `cmd/osty/check_cmd.go` (×3) | "Phase 1c.5 retired the Go-hosted legacy alternative" + `--native FILE` / `--native DIR` references | rewritten without Phase 1c.5 history; flag references dropped |
| `cmd/osty/check_cmd_test.go` | `TestCheckCLIDefaultPathExitsZero` preamble invoked Phase 1c.5 | simplified |
| `cmd/codesdoc/main.go::unsafeForBootstrapGen` + call site | "Until the Go-hosted transpiler is retired..." | reframed as defensive guard; bootstrap is retired but filter stays since the selfhost harvest still reads `diag_examples.osty` as Osty source |
| `internal/nativellvmgen/exec.go::PackageInput.PackageName` | "for backwards compatibility with callers that haven't filled the field yet" | dropped — every production caller now derives Name via the package loader |

### Audits with no code change

- `internal/lsp/handlers.go::semanticHoverLegacyContext` + the `Go resolver Symbol fallback` in `handleDefinition` (line 423): both paths are still reachable when the selfhost structured result returns nothing for a given identifier (jump-to-def + hover fall through intentionally). **Kept.**
- `internal/nativellvmgen/exec.go::PackageName` empty-string fallback: every production caller (`RequestFromPackage`, `RequestFromMIR`, `cmd/osty/build.go`, `cmd/osty/gen_emit.go`) fills the field. The fallback stays as a defensive `pkg.Name == ""` guard, just with honest doc framing.

Net **−10 LOC across 8 files**.

### Continues the Phase 1c.5 final cleanup arc

- #1956 FrontendRun.File + AstbridgeLowerCount
- #1960 `--engine` + `--native` + LegacyCachePath cluster
- #1962 Native-* identifier rename sweep
- **This PR**: stale framing/comment cleanup

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 -short` passes on `./internal/{ir,check,selfhost,lsp,nativellvmgen}` and `./cmd/osty`
- [x] `./internal/backend` `TestStage0RealMIRBaseline` failures pre-exist on clean `origin/main` (verified via `git stash` round-trip) — unrelated
- [ ] CI green

https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ)_