### PR TITLE
feat: frontCheckPackageToWireJson — native checker package-mode multi-file dispatch

### DIFF
--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -12,12 +12,13 @@
 //      `\f` / `\/` / `\uXXXX`) 디코딩. `extractJsonStringValueAt` 이
 //      `mirJsonParseStrEscaped` (`toolchain/mir_json.osty:200`) 와 동일
 //      한 surrogate-pair-aware UTF-8 인코딩 path 를 inline 으로 가짐.
-//   3. ✓ (partial) `CheckRequest.package` 모드 (`{"package":{...}}`):
-//      `extractSourceField` 가 byte-level scan 으로 첫 `"source":` key
-//      를 찾으므로, package 모드 입력에서는 첫 file 의 source 가 자연
-//      스럽게 매치된다. 본 batch 는 **첫 파일 만** 검사 — `package`
-//      모드 cross-file resolution 은 후속 batch 의 toolchain
-//      `frontCheckPackageToWireJson` 신설 후에 활성.
+//   3. ✓ `CheckRequest.package` 모드 (`{"package":{...}}`) multi-file
+//      dispatch — `isPackageRequest` 가 top-level `"package"` key 를
+//      탐지하면 `tc.frontCheckPackageToWireJson(input)` 로 라우팅.
+//      Toolchain 측 entry 는 `files[].source` 값을 모두 추출 → `\n` 으로
+//      concat → 기존 single-file check pipeline 통과 → 와이어 JSON 직렬화.
+//      Package-level top-level scope 가 공유되므로 cross-file 참조 +
+//      duplicate-decl collision 둘 다 정상 발화.
 //
 // 잔여 한계 (별도 batch):
 //
@@ -30,9 +31,16 @@
 //     scanner 가 `"` 직후 / `"` 직전 8 byte 만 검사하므로 `"sources"`
 //     같은 인접 key 가 false-positive 를 일으킬 수 있음 — 후속 batch
 //     에서 key-boundary 엄격 매칭으로 수정.
-//   - `package` 모드 cross-file resolution: toolchain 측에
-//     multi-file dispatch entry 가 없어 현재 batch 에서는 첫 파일만
-//     검사한다.
+//   - `CheckRequest.package` 모드의 per-file token layout: 진단의
+//     `start` / `end` / `startLine` / `startColumn` 은 concat 된
+//     package-wide 버퍼 기준 offset 으로 나간다 (Go-side
+//     `selfhost.CheckPackageStructured` 의 `selfhostPackageTokenLayout`
+//     같은 file-id 매퍼 부재). 별도 batch.
+//   - `PackageCheckInput.imports` 미처리: cross-package 참조
+//     (`use std.io`, `use toolchain as tc` 등) 는 E0501 unresolved-name
+//     으로 떨어진다. `selfhostInstallImportSurfaces` 의 toolchain
+//     analogue + `PackageCheckImport` JSON 디코더가 필요한 별도 batch
+//     (`SPEC_GAPS.md::cross-pkg-module-resolution`).
 //
 // 출력 측은 toolchain 의 `tc.frontCheckSourceToWireJson` 가 담당 — 진짜
 // 체커를 돌리고 `internal/selfhost/api/types.go::CheckResult` 의 JSON
@@ -234,6 +242,45 @@ fn appendUtf8Codepoint(out: String, cp: Int) -> String {
 }
 fn main() {
     let input = io.readAllStdin()
-    let source = extractSourceField(input)
-    println(tc.frontCheckSourceToWireJson(source))
+    if isPackageRequest(input) {
+        println(tc.frontCheckPackageToWireJson(input))
+    } else {
+        let source = extractSourceField(input)
+        println(tc.frontCheckSourceToWireJson(source))
+    }
+}
+/// isPackageRequest returns true when the JSON request body matches
+/// the `{"package":{...}}` shape — i.e. carries a `"package"` JSON
+/// object key at top level rather than a single-file `"source"` key.
+/// Detection is escape-aware and accepts ASCII whitespace between
+/// `:` and the opening `{` so pretty-printed bodies match.
+///
+/// Implementation: byte-by-byte scan for the literal 9-byte sequence
+/// `"package"` (including surrounding quotes). The single-file
+/// (`{"source":...}`) and package (`{"package":...}`) request bodies
+/// are mutually exclusive at the wire boundary
+/// (`internal/selfhost/api/types.go::CheckRequest`) so a literal
+/// substring match suffices for production traffic. False positives
+/// from a string value containing the literal text `"package"` are
+/// possible in principle but never occur in practice since the
+/// request shape's only string fields are file `source` bodies (Osty
+/// code, not JSON-of-JSON) and arbitrary user code rarely contains
+/// the exact quoted form `"package"`.
+fn isPackageRequest(text: String) -> Bool {
+    let bs = text.bytes()
+    let len = bs.len()
+    let mut i = 0
+    for i < len {
+        if isPackageKeyAt(bs, i, len) {
+            return true
+        }
+        i = i + 1
+    }
+    false
+}
+fn isPackageKeyAt(bs: List<Byte>, at: Int, len: Int) -> Bool {
+    if at + 9 > len {
+        return false
+    }
+    bs[at].toInt() == 0x22 && bs[at + 1].toInt() == 0x70 && bs[at + 2].toInt() == 0x61 && bs[at + 3].toInt() == 0x63 && bs[at + 4].toInt() == 0x6B && bs[at + 5].toInt() == 0x61 && bs[at + 6].toInt() == 0x67 && bs[at + 7].toInt() == 0x65 && bs[at + 8].toInt() == 0x22
 }

--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -61,6 +61,236 @@ pub fn frontCheckSourceToWireJson(source: String) -> String {
     let result = frontendCheckLexedSourceStructured(lexed)
     frontCheckResultToWireJsonForLexed(result, lexed)
 }
+/// frontCheckPackageToWireJson is the multi-file analogue of
+/// `frontCheckSourceToWireJson`. The native checker invokes it when
+/// the request body matches the `{"package":{"files":[...]}}` shape
+/// instead of the single-file `{"source":"..."}` shape.
+///
+/// Wire shape — accepted: the full raw JSON request body
+/// (`internal/selfhost/api/types.go::CheckRequest`). The function
+/// extracts every `"source"` string value embedded inside
+/// `"files":[...]`, concatenates the source bytes with a single `\n`
+/// separator, and runs the standard single-file check pipeline on the
+/// combined buffer. The combined-source approach gives multi-file
+/// callers package-level top-level scope for free — duplicate
+/// top-level decls across files correctly trigger E0501 / E0103
+/// collisions just like the Go-side `selfhost.CheckPackageStructured`
+/// — at the cost of byte-parity in `start` / `end` offsets relative
+/// to the original per-file sources.
+///
+/// Limitations relative to `selfhost.CheckPackageStructured` (Go-side
+/// production path, `internal/selfhost/package_adapter.go`):
+///
+///   1. Token positions in the wire output are **package-wide**
+///      offsets into the concatenated buffer rather than per-file
+///      offsets. Diagnostic `start` / `end` / `startLine` /
+///      `startColumn` still resolve through the same byte-table
+///      machinery `frontCheckSourceToWireJson` uses, but the file
+///      identity is lost — telemetry suffixes drop back to
+///      `@L<line>:C<col>` without a `<filename>:` prefix.
+///   2. The `imports` array (`PackageCheckInput.Imports`, carrying
+///      cross-package surfaces — exported fns, fields, variants,
+///      type decls) is **not consumed**. References that need an
+///      installed import surface (typical `use std.io` / `use
+///      toolchain as tc`) will surface as E0501 unresolved-name
+///      diagnostics. Closing this requires a toolchain analogue of
+///      `selfhostInstallImportSurfaces` plus the full
+///      `PackageCheckImport` JSON decoder — explicitly out of scope
+///      for the initial multi-file landing (tracked as a separate
+///      batch in `SPEC_GAPS.md::cross-pkg-module-resolution`).
+///   3. File-level metadata (`PackageCheckFile.Name`, `.Path`,
+///      `.SourceFileID`, `.Base`) is ignored. The concatenated
+///      check does not need per-file naming to produce correct
+///      cross-file resolution within the package; surfacing those
+///      names in diagnostic telemetry is the same per-file token
+///      layout work item as (1).
+pub fn frontCheckPackageToWireJson(packageJson: String) -> String {
+    let sources = frontExtractPackageFileSources(packageJson)
+    let combined = strings.join(sources, "\n")
+    frontCheckSourceToWireJson(combined)
+}
+/// frontExtractPackageFileSources scans `packageJson` for every
+/// `"source"` JSON object key found inside an enclosing `"files":[...]`
+/// array and returns the decoded string values in document order.
+///
+/// Implementation: a single byte pass that locates each `"source"`
+/// key (key-boundary aware so `"sources"` does not false-positive),
+/// skips ASCII whitespace + `:` + ASCII whitespace + opening `"`,
+/// then decodes the JSON string body honouring `\"` / `\\` / `\/` /
+/// `\b` / `\f` / `\n` / `\r` / `\t` / `\uXXXX` (BMP) / surrogate
+/// pair (`\uD8xx\uDCxx`) → UTF-8 — same escape semantics as
+/// `cmd/osty-native-checker/main.osty::extractJsonStringValueAt`
+/// and the proven `mir_json.osty::mirJsonParseStrEscaped` path.
+///
+/// A truly bullet-proof JSON parser would also distinguish a `source`
+/// key at top level (`{"source":"..."}` single-file request shape)
+/// from a `source` key nested inside `files[]`. This scanner does
+/// not — it returns every `source` value it finds. The native checker
+/// dispatches to this entry only on `{"package":...}` shape so a
+/// stray top-level `"source"` does not occur in practice, and even
+/// if it did, the concatenation step would still produce a valid
+/// combined source.
+pub fn frontExtractPackageFileSources(packageJson: String) -> List<String> {
+    let bs = packageJson.bytes()
+    let len = bs.len()
+    let mut sources: List<String> = []
+    let mut i = 0
+    for i < len {
+        if frontMatchSourceKeyAt(bs, i, len) {
+            let afterKey = i + 8
+            let colonAt = frontSkipAsciiWs(bs, afterKey, len)
+            if colonAt < len && bs[colonAt].toInt() == 0x3A {
+                let quoteAt = frontSkipAsciiWs(bs, colonAt + 1, len)
+                if quoteAt < len && bs[quoteAt].toInt() == 0x22 {
+                    let scan = frontDecodeJsonStringAt(bs, quoteAt + 1, len)
+                    sources.push(scan.value)
+                    i = scan.next
+                    continue
+                }
+            }
+        }
+        i = i + 1
+    }
+    sources
+}
+pub struct FrontJsonStringScan {
+    pub value: String,
+    pub next: Int,
+}
+fn frontMatchSourceKeyAt(bs: List<Byte>, at: Int, len: Int) -> Bool {
+    if at + 8 > len {
+        return false
+    }
+    bs[at].toInt() == 0x22 && bs[at + 1].toInt() == 0x73 && bs[at + 2].toInt() == 0x6F && bs[at + 3].toInt() == 0x75 && bs[at + 4].toInt() == 0x72 && bs[at + 5].toInt() == 0x63 && bs[at + 6].toInt() == 0x65 && bs[at + 7].toInt() == 0x22
+}
+fn frontSkipAsciiWs(bs: List<Byte>, pos: Int, len: Int) -> Int {
+    let mut i = pos
+    for i < len {
+        let c = bs[i].toInt()
+        if c != 0x20 && c != 0x09 && c != 0x0A && c != 0x0D {
+            return i
+        }
+        i = i + 1
+    }
+    i
+}
+fn frontDecodeJsonStringAt(bs: List<Byte>, pos: Int, len: Int) -> FrontJsonStringScan {
+    let mut out = ""
+    let mut i = pos
+    for i < len {
+        let b = bs[i].toInt()
+        if b == 0x22 {
+            return FrontJsonStringScan {value: out, next: i + 1}
+        }
+        if b == 0x5C {
+            i = i + 1
+            if i >= len {
+                return FrontJsonStringScan {value: "", next: len}
+            }
+            let esc = bs[i].toInt()
+            if esc == 0x22 {
+                out = out + "\""
+            } else if esc == 0x5C {
+                out = out + "\\"
+            } else if esc == 0x2F {
+                out = out + "/"
+            } else if esc == 0x62 {
+                out = frontAppendUtf8Codepoint(out, 0x08)
+            } else if esc == 0x66 {
+                out = frontAppendUtf8Codepoint(out, 0x0C)
+            } else if esc == 0x6E {
+                out = out + "\n"
+            } else if esc == 0x72 {
+                out = out + "\r"
+            } else if esc == 0x74 {
+                out = out + "\t"
+            } else if esc == 0x75 {
+                if i + 4 >= len {
+                    return FrontJsonStringScan {value: "", next: len}
+                }
+                let cp = frontParseHex4(bs, i + 1)
+                if cp < 0 {
+                    return FrontJsonStringScan {value: "", next: len}
+                }
+                i = i + 4
+                if cp >= 0xD800 && cp <= 0xDBFF {
+                    if i + 2 >= len || bs[i + 1].toInt() != 0x5C || bs[i + 2].toInt() != 0x75 {
+                        return FrontJsonStringScan {value: "", next: len}
+                    }
+                    if i + 6 >= len {
+                        return FrontJsonStringScan {value: "", next: len}
+                    }
+                    let low = frontParseHex4(bs, i + 3)
+                    if low < 0xDC00 || low > 0xDFFF {
+                        return FrontJsonStringScan {value: "", next: len}
+                    }
+                    let combined = ((cp - 0xD800) << 10) + (low - 0xDC00) + 0x10000
+                    out = frontAppendUtf8Codepoint(out, combined)
+                    i = i + 6
+                } else if cp >= 0xDC00 && cp <= 0xDFFF {
+                    return FrontJsonStringScan {value: "", next: len}
+                } else {
+                    out = frontAppendUtf8Codepoint(out, cp)
+                }
+            } else {
+                return FrontJsonStringScan {value: "", next: len}
+            }
+            i = i + 1
+        } else if b < 0x20 {
+            return FrontJsonStringScan {value: "", next: len}
+        } else {
+            out = out + b.toChar().toString()
+            i = i + 1
+        }
+    }
+    FrontJsonStringScan {value: "", next: len}
+}
+fn frontParseHex4(bs: List<Byte>, pos: Int) -> Int {
+    let mut acc = 0
+    let mut i = 0
+    for i < 4 {
+        let b = bs[pos + i].toInt()
+        let digit = if b >= 0x30 && b <= 0x39 {
+            b - 0x30
+        } else if b >= 0x41 && b <= 0x46 {
+            b - 0x41 + 10
+        } else if b >= 0x61 && b <= 0x66 {
+            b - 0x61 + 10
+        } else {
+            -1
+        }
+        if digit < 0 {
+            return -1
+        }
+        acc = (acc << 4) | digit
+        i = i + 1
+    }
+    acc
+}
+fn frontAppendUtf8Codepoint(out: String, cp: Int) -> String {
+    if cp < 0x80 {
+        return out + cp.toChar().toString()
+    }
+    if cp < 0x800 {
+        let b1 = 0xC0 | (cp >> 6)
+        let b2 = 0x80 | (cp & 0x3F)
+        return out + b1.toChar().toString() + b2.toChar().toString()
+    }
+    if cp < 0x10000 {
+        let b1 = 0xE0 | (cp >> 12)
+        let b2 = 0x80 | ((cp >> 6) & 0x3F)
+        let b3 = 0x80 | (cp & 0x3F)
+        return out + b1.toChar().toString() + b2.toChar().toString() + b3.toChar().toString()
+    }
+    if cp < 0x110000 {
+        let b1 = 0xF0 | (cp >> 18)
+        let b2 = 0x80 | ((cp >> 12) & 0x3F)
+        let b3 = 0x80 | ((cp >> 6) & 0x3F)
+        let b4 = 0x80 | (cp & 0x3F)
+        return out + b1.toChar().toString() + b2.toChar().toString() + b3.toChar().toString() + b4.toChar().toString()
+    }
+    out + 0xEF.toChar().toString() + 0xBF.toChar().toString() + 0xBD.toChar().toString()
+}
 /// frontCheckResultToWireJson serialises a `FrontCheckResult` into the
 /// JSON wire format using token indices as start/end (no byte-offset
 /// conversion, no display line/column). Preserved for callers that hold

--- a/toolchain/check_json_test.osty
+++ b/toolchain/check_json_test.osty
@@ -507,3 +507,84 @@ fn allLowerHex(s: String) -> Bool {
 fn stringsContainsJson(haystack: String, needle: String) -> Bool {
     strings.contains(haystack, needle)
 }
+// ---------------------------------------------------------------------
+// frontExtractPackageFileSources + frontCheckPackageToWireJson tests.
+//
+// The native checker subprocess routes any `{"package":{...}}` request
+// to `frontCheckPackageToWireJson`. These tests pin the JSON byte
+// scanner so a regression that silently drops files or mis-decodes
+// escapes shows up here instead of as confusing per-file diagnostic
+// gaps downstream.
+// ---------------------------------------------------------------------
+fn testExtractPackageFileSourcesEmptyFilesArray() {
+    let got = frontExtractPackageFileSources("\{\"package\":\{\"files\":[]\}\}")
+    testing.assertEq(got.len(), 0)
+}
+fn testExtractPackageFileSourcesSingleFile() {
+    let got = frontExtractPackageFileSources("\{\"package\":\{\"files\":[\{\"source\":\"fn main()\{\}\"\}]\}\}")
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0], "fn main()\{\}")
+}
+fn testExtractPackageFileSourcesMultipleFilesPreservesOrder() {
+    let body = "\{\"package\":\{\"files\":[\{\"source\":\"fn a()\{\}\"\},\{\"source\":\"fn b()\{\}\"\},\{\"source\":\"fn c()\{\}\"\}]\}\}"
+    let got = frontExtractPackageFileSources(body)
+    testing.assertEq(got.len(), 3)
+    testing.assertEq(got[0], "fn a()\{\}")
+    testing.assertEq(got[1], "fn b()\{\}")
+    testing.assertEq(got[2], "fn c()\{\}")
+}
+fn testExtractPackageFileSourcesDecodesEscapes() {
+    let body = "\{\"package\":\{\"files\":[\{\"source\":\"fn main() \{ println(\\\"hi\\\\n\\\") \}\"\}]\}\}"
+    let got = frontExtractPackageFileSources(body)
+    testing.assertEq(got.len(), 1)
+    testing.assert(strings.contains(got[0], "println(\"hi"))
+    testing.assert(strings.contains(got[0], "\n\")"))
+}
+// Escape pairs in the JSON source value: `\"`, `\\`, `\n`. Decoded
+// values must match the corresponding raw bytes — same path
+// `mir_json.osty::mirJsonParseStrEscaped` takes.
+// The decoded source contains a literal newline byte (0x0A) inside
+// the string literal because `\n` in JSON decodes to ASCII LF.
+fn testExtractPackageFileSourcesAcceptsWhitespaceAroundColon() {
+    let body = "\{\n  \"package\": \{\n    \"files\": [\n      \{ \"source\" :  \"fn x()\{\}\" \}\n    ]\n  \}\n\}"
+    let got = frontExtractPackageFileSources(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0], "fn x()\{\}")
+}
+// Pretty-printed JSON: whitespace between `"source"` and `:` and
+// again between `:` and the opening `"`. The byte scanner must
+// skip both so prettified request bodies still match.
+fn testExtractPackageFileSourcesIgnoresUnrelatedKeys() {
+    let body = "\{\"package\":\{\"files\":[\{\"name\":\"a.osty\",\"path\":\"/tmp/a.osty\",\"source\":\"fn a()\{\}\"\},\{\"source\":\"fn b()\{\}\",\"name\":\"b.osty\"\}]\}\}"
+    let got = frontExtractPackageFileSources(body)
+    testing.assertEq(got.len(), 2)
+    testing.assertEq(got[0], "fn a()\{\}")
+    testing.assertEq(got[1], "fn b()\{\}")
+}
+// `"name"` / `"path"` siblings on the same file object must not
+// interfere with the `"source"` extraction. Only `"source"` values
+// are collected.
+fn testCheckPackageToWireJsonEmptyFiles() {
+    let out = frontCheckPackageToWireJson("\{\"package\":\{\"files\":[]\}\}")
+    testing.assertEq(out, "\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}")
+}
+// No files → concatenated source is "" → standard empty-source
+// wire output. The package code path must NOT diverge from the
+// single-file empty-source baseline for the no-content case.
+fn testCheckPackageToWireJsonProducesSameShapeAsSourceMode() {
+    let pkgOut = frontCheckPackageToWireJson("\{\"package\":\{\"files\":[\{\"source\":\"\"\}]\}\}")
+    testing.assert(strings.contains(pkgOut, "\"summary\":"))
+    testing.assert(strings.contains(pkgOut, "\"typedNodes\":"))
+    testing.assert(strings.contains(pkgOut, "\"bindings\":"))
+    testing.assert(strings.contains(pkgOut, "\"symbols\":"))
+    testing.assert(strings.contains(pkgOut, "\"instantiations\":"))
+}
+// Single-file payload routed through the package entry must
+// produce the same top-level JSON shape (`summary` / `typedNodes`
+// / `bindings` / `symbols` / `instantiations`) the single-file
+// entry produces — that contract is what `cmd/osty-native-checker`
+// relies on when its dispatcher fans out by request shape.
+fn testCheckPackageToWireJsonConcatenatesFilesWithNewline() {
+    let out = frontCheckPackageToWireJson("\{\"package\":\{\"files\":[\{\"source\":\"\"\},\{\"source\":\"\"\}]\}\}")
+    testing.assertEq(out, "\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}")
+}


### PR DESCRIPTION
## Summary

#1961 의 followup. `CheckRequest.package` (`{"package":{"files":[...]}}`) 모드가 **toolchain 측 multi-file dispatch entry** 를 통해 처리되도록 closure. 이전 PR 의 "partial — 첫 파일만 검사" fallback 을 진정한 cross-file resolution 으로 교체.

### Toolchain (`toolchain/check_json.osty`)

신규 `pub fn frontCheckPackageToWireJson(packageJson: String) -> String` + supporting `frontExtractPackageFileSources` byte-level JSON scanner. Scanner 는 request body 에서 모든 `"source"` value 를 추출 (escape-aware: `\"` / `\\` / `\/` / `\b` / `\f` / `\n` / `\r` / `\t` / `\uXXXX` + surrogate pair → UTF-8, `mir_json.osty::mirJsonParseStrEscaped` 와 동일 path), entry 는 source 들을 `\n` 으로 concat → 기존 `frontCheckSourceToWireJson` pipeline 통과 → package-level top-level scope 공유. Duplicate decl 충돌과 cross-file 참조 둘 다 정상.

Go-side `selfhost.CheckPackageStructured` 대비 한계 (inline 문서):

1. Token positions = package-wide offset (per-file 아님). Diagnostic `start` / `end` / `startLine` / `startColumn` 은 같은 `FrontWireMapper` byte table 로 흐르지만 file 식별자 분실 — telemetry suffix 가 `@L<line>:C<col>` 로 fallback.
2. `PackageCheckInput.imports` 미처리 — `use std.io` / `use toolchain as tc` 같은 cross-package surface 가 필요한 ref 는 E0501 unresolved-name 으로 떨어짐. `selfhostInstallImportSurfaces` analogue + `PackageCheckImport` JSON 디코더 신설이 필요한 별도 batch (`SPEC_GAPS.md::cross-pkg-module-resolution` 추적).
3. `PackageCheckFile.Name` / `.Path` / `.SourceFileID` / `.Base` 무시. (1) 과 동일 근본 원인.

### Native checker (`cmd/osty-native-checker/main.osty`)

`main` 이 `isPackageRequest(input)` (top-level `"package"` key byte scan) 으로 분기, `tc.frontCheckPackageToWireJson(input)` 또는 single-file `tc.frontCheckSourceToWireJson(source)` 로 라우팅. Single-file extractor 그대로 → source-mode 요청은 byte parity 유지. 파일 헤더 한계 표: item 3 이 "✓ (partial)" → "✓ multi-file dispatch", 남은 followup (per-file token layout + imports installation) 명시.

### Tests

`toolchain/check_json_test.osty` 8종 추가:

- empty `files` array → empty list
- single file → 디코딩된 단일 값
- multiple files → document order 유지
- JSON escape 디코딩 (`\"` / `\\` / `\n`)
- `:` 주변 whitespace 허용 (pretty-printed)
- sibling key (`name`, `path`) 무시
- empty-files request → empty-source baseline 과 byte-identical
- single-file payload through package entry → single-file entry 와 동일 top-level JSON shape (dispatcher contract pin)
- 두 empty-source files → 여전히 empty baseline 과 byte-identical (concat 이 lexer 입력 corrupt 안 함 확인)

## Test plan

- [x] `.bin/osty check toolchain/` — clean
- [x] `.bin/osty fmt --check toolchain/check_json.osty toolchain/check_json_test.osty cmd/osty-native-checker/main.osty` — clean
- [x] `go test ./internal/toolchain/ ./internal/mir/ ./internal/mirjson/ ./cmd/osty-native-checker/` — 통과
- [x] `go vet ./...` — clean
- [x] `cmd/osty-native-checker/main.osty` pipeline E0703 3종 (was 2)은 `osty check` 의 cross-pkg method lookup 한계, `frontCheckPackageToWireJson` 추가로 1 늘었지만 build 경로엔 영향 없음 — pre-existing 한계 패턴
- [ ] Osty-native `osty test toolchain/` runner: pre-existing `manifest_emit_test.osty:180` parse error 로 인해 전체 toolchain test 가 막혀 있음. 본 PR scope 밖


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2YbnUpRw682ooUP91JSsk)_