### PR TITLE
refactor: drop redundant Node legacy alias from CheckedNode/Binding/Symbol/Instantiation

### DIFF
--- a/internal/check/host_boundary_native_overlay_test.go
+++ b/internal/check/host_boundary_native_overlay_test.go
@@ -32,7 +32,6 @@ func TestOverlaySelfhostResultPrefersNativeNodeIDForTypedNodes(t *testing.T) {
 
 	overlaySelfhostResult(result, nativeIDTestSource(file), api.CheckResult{
 		TypedNodes: []api.CheckedNode{{
-			Node:   0,
 			NodeID: 0,
 			Kind:   "Ident",
 			Type:   &api.TypeRepr{Kind: "primitive", Name: "Int"},
@@ -73,7 +72,6 @@ func TestOverlaySelfhostResultPrefersNativeNodeIDForInstantiations(t *testing.T)
 
 	overlaySelfhostResult(result, nativeIDTestSource(file), api.CheckResult{
 		Instantiations: []api.CheckInstantiation{{
-			Node:     18,
 			NodeID:   18,
 			Callee:   "id",
 			TypeArgs: []api.TypeRepr{{Kind: "primitive", Name: "Int"}},
@@ -111,7 +109,6 @@ func TestOverlaySelfhostResultPrefersNativeNodeIDForBindings(t *testing.T) {
 
 	overlaySelfhostResult(result, nativeIDTestSource(file), api.CheckResult{
 		Bindings: []api.CheckedBinding{{
-			Node:   39,
 			NodeID: 39,
 			Name:   "value",
 			Type:   &api.TypeRepr{Kind: "primitive", Name: "Bool"},

--- a/internal/check/host_boundary_overlay.go
+++ b/internal/check/host_boundary_overlay.go
@@ -22,7 +22,7 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 		indexes = append(indexes, buildOverlaySegmentIndex(seg))
 	}
 	for _, rec := range checked.TypedNodes {
-		node := overlayNodeForRecord(indexes, rec.NodeID, rec.Node, rec.Start, rec.End)
+		node := overlayNodeForRecord(indexes, rec.NodeID, rec.Start, rec.End)
 		expr, ok := node.(ast.Expr)
 		if !ok {
 			continue
@@ -30,7 +30,7 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 		result.Types[expr] = typeReprToType(rec.Type)
 	}
 	for _, rec := range checked.Bindings {
-		node := overlayNodeForRecord(indexes, rec.NodeID, rec.Node, rec.Start, rec.End)
+		node := overlayNodeForRecord(indexes, rec.NodeID, rec.Start, rec.End)
 		if node == nil {
 			continue
 		}
@@ -41,7 +41,7 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 		result.LetTypes[target] = typeReprToType(rec.Type)
 	}
 	for _, rec := range checked.Instantiations {
-		node := overlayNodeForRecord(indexes, rec.NodeID, rec.Node, rec.Start, rec.End)
+		node := overlayNodeForRecord(indexes, rec.NodeID, rec.Start, rec.End)
 		call, ok := node.(*ast.CallExpr)
 		if !ok || call == nil {
 			continue
@@ -99,15 +99,10 @@ func buildOverlaySegmentIndex(seg selfhostFileSegment) overlaySegmentIndex {
 	return idx
 }
 
-func overlayNodeForRecord(indexes []overlaySegmentIndex, nodeID, legacyNode, start, end int) ast.Node {
+func overlayNodeForRecord(indexes []overlaySegmentIndex, nodeID, start, end int) ast.Node {
 	for _, idx := range indexes {
 		if nodeID >= 0 {
 			if node, ok := idx.nativeNodes[nodeID]; ok {
-				return node
-			}
-		}
-		if legacyNode >= 0 {
-			if node, ok := idx.nativeNodes[legacyNode]; ok {
 				return node
 			}
 		}

--- a/internal/ir/native_check.go
+++ b/internal/ir/native_check.go
@@ -39,7 +39,7 @@ func (l *lowerer) nativeIndex() (api.CheckResultIndex, bool) {
 func typedNodesByNodeID(nodes []api.CheckedNode) map[int][]*api.CheckedNode {
 	out := make(map[int][]*api.CheckedNode, len(nodes))
 	for i := range nodes {
-		id := nativeRecordNodeID(nodes[i].NodeID, nodes[i].Node)
+		id := nodes[i].NodeID
 		if id == 0 {
 			continue
 		}
@@ -96,12 +96,6 @@ func symbolsByByteRange(ss []api.CheckedSymbol) map[[2]int][]*api.CheckedSymbol 
 	return out
 }
 
-func nativeRecordNodeID(nodeID, legacyNode int) int {
-	if nodeID != 0 {
-		return nodeID
-	}
-	return legacyNode
-}
 
 func (l *lowerer) nativeCheckedType(e ast.Expr) Type {
 	_, ok := l.nativeIndex()

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -477,9 +477,6 @@ func nativeCheckSymbolTypes(checked api.CheckResult) map[int]string {
 			continue
 		}
 		node := sym.NodeID
-		if node == 0 {
-			node = sym.Node
-		}
 		if node < 0 {
 			continue
 		}

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -141,7 +141,6 @@ func joinTypeReprStrings(ss []string, sep string) string {
 type CheckedNode struct {
 	ID      string    `json:"id,omitempty"`      // stable record identity
 	NodeKey string    `json:"nodeKey,omitempty"` // stable node identity
-	Node    int       `json:"node"`              // legacy alias for NodeID
 	NodeID  int       `json:"nodeId"`            // selfhost arena id, stable only within one check run
 	Kind    string    `json:"kind"`
 	Type    *TypeRepr `json:"type"`
@@ -155,7 +154,6 @@ type CheckedNode struct {
 type CheckedBinding struct {
 	ID        string    `json:"id,omitempty"`
 	NodeKey   string    `json:"nodeKey,omitempty"`
-	Node      int       `json:"node"` // legacy alias for NodeID
 	NodeID    int       `json:"nodeId"`
 	BindingID int       `json:"bindingId"` // legacy sequential id
 	Name      string    `json:"name"`
@@ -171,7 +169,6 @@ type CheckedBinding struct {
 type CheckedSymbol struct {
 	ID       string    `json:"id,omitempty"`
 	NodeKey  string    `json:"nodeKey,omitempty"`
-	Node     int       `json:"node"` // legacy alias for NodeID
 	NodeID   int       `json:"nodeId"`
 	SymbolID int       `json:"symbolId"` // legacy sequential id
 	Kind     string    `json:"kind"`
@@ -188,7 +185,6 @@ type CheckedSymbol struct {
 type CheckInstantiation struct {
 	ID              string     `json:"id,omitempty"`
 	NodeKey         string     `json:"nodeKey,omitempty"`
-	Node            int        `json:"node"` // legacy alias for NodeID
 	NodeID          int        `json:"nodeId"`
 	InstantiationID int        `json:"instantiationId"` // legacy sequential id
 	Callee          string     `json:"callee"`
@@ -347,11 +343,11 @@ func (r *CheckResult) Index() CheckResultIndex {
 		if key := stableCheckedNodeKey(rec); key != "" {
 			idx.TypedNodesByNodeKey[key] = rec
 		}
-		idx.TypedNodesByNodeID[checkRecordNodeID(rec.NodeID, rec.Node)] = rec
+		idx.TypedNodesByNodeID[rec.NodeID] = rec
 	}
 	for i := range r.Bindings {
 		rec := &r.Bindings[i]
-		nodeID := checkRecordNodeID(rec.NodeID, rec.Node)
+		nodeID := rec.NodeID
 		if id := stableCheckedBindingID(rec); id != "" {
 			idx.BindingsByStableID[id] = rec
 		}
@@ -363,7 +359,7 @@ func (r *CheckResult) Index() CheckResultIndex {
 	}
 	for i := range r.Symbols {
 		rec := &r.Symbols[i]
-		nodeID := checkRecordNodeID(rec.NodeID, rec.Node)
+		nodeID := rec.NodeID
 		if id := stableCheckedSymbolID(rec); id != "" {
 			idx.SymbolsByStableID[id] = rec
 		}
@@ -375,7 +371,7 @@ func (r *CheckResult) Index() CheckResultIndex {
 	}
 	for i := range r.Instantiations {
 		rec := &r.Instantiations[i]
-		nodeID := checkRecordNodeID(rec.NodeID, rec.Node)
+		nodeID := rec.NodeID
 		if id := stableCheckInstantiationID(rec); id != "" {
 			idx.InstantiationsByStableID[id] = rec
 		}
@@ -386,13 +382,6 @@ func (r *CheckResult) Index() CheckResultIndex {
 		idx.InstantiationsByNodeID[nodeID] = append(idx.InstantiationsByNodeID[nodeID], rec)
 	}
 	return idx
-}
-
-func checkRecordNodeID(nodeID, legacyNode int) int {
-	if nodeID != 0 {
-		return nodeID
-	}
-	return legacyNode
 }
 
 func stableCheckedNodeID(rec *CheckedNode) string {

--- a/internal/selfhost/api/types_test.go
+++ b/internal/selfhost/api/types_test.go
@@ -5,18 +5,18 @@ import "testing"
 func TestCheckResultIndexUsesStableIDs(t *testing.T) {
 	result := CheckResult{
 		TypedNodes: []CheckedNode{
-			{Node: 0, NodeID: 0, Kind: "Root", TypeID: 7},
-			{Node: 901, NodeID: 42, Kind: "Call", TypeID: 8},
+			{NodeID: 0, Kind: "Root", TypeID: 7},
+			{NodeID: 42, Kind: "Call", TypeID: 8},
 		},
 		Bindings: []CheckedBinding{
-			{Node: 0, NodeID: 0, BindingID: 11, Name: "root", TypeID: 7},
-			{Node: 901, NodeID: 42, BindingID: 12, Name: "value", TypeID: 8},
+			{NodeID: 0, BindingID: 11, Name: "root", TypeID: 7},
+			{NodeID: 42, BindingID: 12, Name: "value", TypeID: 8},
 		},
 		Symbols: []CheckedSymbol{
-			{Node: 901, NodeID: 42, SymbolID: 21, Name: "value", TypeID: 8},
+			{NodeID: 42, SymbolID: 21, Name: "value", TypeID: 8},
 		},
 		Instantiations: []CheckInstantiation{
-			{Node: 901, NodeID: 42, InstantiationID: 31, Callee: "id", TypeArgIDs: []int{8}, ResultTypeID: 8},
+			{NodeID: 42, InstantiationID: 31, Callee: "id", TypeArgIDs: []int{8}, ResultTypeID: 8},
 		},
 	}
 	result.EnsureStableIDs()
@@ -58,21 +58,6 @@ func TestCheckResultIndexUsesStableIDs(t *testing.T) {
 	}
 	if got := idx.InstantiationsByStableID[result.Instantiations[0].ID]; got == nil || got.Callee != "id" {
 		t.Fatalf("instantiation stable id = %#v, want id", got)
-	}
-}
-
-func TestCheckResultIndexFallsBackToLegacyNodeAlias(t *testing.T) {
-	result := CheckResult{
-		TypedNodes: []CheckedNode{{Node: 77, Kind: "IntLit"}},
-		Bindings:   []CheckedBinding{{Node: 77, BindingID: 1, Name: "value"}},
-	}
-
-	idx := result.Index()
-	if got := idx.TypedNodesByNodeID[77]; got == nil || got.Kind != "IntLit" {
-		t.Fatalf("legacy typed node 77 = %#v, want IntLit", got)
-	}
-	if got := idx.BindingsByNodeID[77]; len(got) != 1 || got[0].Name != "value" {
-		t.Fatalf("legacy bindings by node 77 = %#v, want value", got)
 	}
 }
 

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -220,7 +220,6 @@ func adaptCheckResultWithTokenMapper(checked *FrontCheckResult, mapper checkResu
 		}
 		start, end := mapper.offsets(node.start, node.end)
 		result.TypedNodes = append(result.TypedNodes, CheckedNode{
-			Node:   node.node,
 			NodeID: node.nodeId,
 			Kind:   node.kind,
 			Type:   frontTypeReprToAPI(node.typeRepr),
@@ -235,7 +234,6 @@ func adaptCheckResultWithTokenMapper(checked *FrontCheckResult, mapper checkResu
 		}
 		start, end := mapper.offsets(binding.start, binding.end)
 		result.Bindings = append(result.Bindings, CheckedBinding{
-			Node:      binding.node,
 			NodeID:    binding.nodeId,
 			BindingID: binding.bindingId,
 			Name:      binding.name,
@@ -252,7 +250,6 @@ func adaptCheckResultWithTokenMapper(checked *FrontCheckResult, mapper checkResu
 		}
 		start, end := mapper.offsets(symbol.start, symbol.end)
 		result.Symbols = append(result.Symbols, CheckedSymbol{
-			Node:     symbol.node,
 			NodeID:   symbol.nodeId,
 			SymbolID: symbol.symbolId,
 			Kind:     symbol.kind,
@@ -270,7 +267,6 @@ func adaptCheckResultWithTokenMapper(checked *FrontCheckResult, mapper checkResu
 		}
 		start, end := mapper.offsets(inst.start, inst.end)
 		result.Instantiations = append(result.Instantiations, CheckInstantiation{
-			Node:            inst.node,
 			NodeID:          inst.nodeId,
 			InstantiationID: inst.instantiationId,
 			Callee:          inst.callee,

--- a/internal/selfhost/check_query_test.go
+++ b/internal/selfhost/check_query_test.go
@@ -129,9 +129,6 @@ func TestSymbolAtOffsetReturnsStructuredStableRecord(t *testing.T) {
 	if sym.Type == nil || sym.Type.Kind != "fn" {
 		t.Fatalf("symbol type = %#v, want structured fn TypeRepr", sym.Type)
 	}
-	if sym.NodeID != sym.Node {
-		t.Fatalf("symbol node ids = nodeId %d / node %d, want stable id mirrored to legacy alias", sym.NodeID, sym.Node)
-	}
 	idx := r.Index()
 	if got := idx.SymbolsByID[sym.SymbolID]; got == nil || got.Name != "helper" {
 		t.Fatalf("Index().SymbolsByID[%d] = %#v, want helper", sym.SymbolID, got)

--- a/internal/selfhost/check_snapshot_test.go
+++ b/internal/selfhost/check_snapshot_test.go
@@ -99,20 +99,20 @@ func dumpCheckSnapshot(r CheckResult) string {
 
 	b.WriteString("typedNodes\n")
 	for _, node := range r.TypedNodes {
-		fmt.Fprintf(&b, "  id=%s nodeKey=%s typeKey=%s node=%d nodeId=%d typeId=%d kind=%s span=%d:%d type=%s\n",
-			shortCheckID(node.ID), shortCheckID(node.NodeKey), shortCheckID(node.TypeKey), node.Node, node.NodeID, node.TypeID, node.Kind, node.Start, node.End, checkSnapshotTypeString(node.Type))
+		fmt.Fprintf(&b, "  id=%s nodeKey=%s typeKey=%s nodeId=%d typeId=%d kind=%s span=%d:%d type=%s\n",
+			shortCheckID(node.ID), shortCheckID(node.NodeKey), shortCheckID(node.TypeKey), node.NodeID, node.TypeID, node.Kind, node.Start, node.End, checkSnapshotTypeString(node.Type))
 	}
 
 	b.WriteString("bindings\n")
 	for _, binding := range r.Bindings {
-		fmt.Fprintf(&b, "  id=%s nodeKey=%s typeKey=%s bindingId=%d node=%d nodeId=%d name=%s mutable=%t typeId=%d span=%d:%d type=%s\n",
-			shortCheckID(binding.ID), shortCheckID(binding.NodeKey), shortCheckID(binding.TypeKey), binding.BindingID, binding.Node, binding.NodeID, binding.Name, binding.Mutable, binding.TypeID, binding.Start, binding.End, checkSnapshotTypeString(binding.Type))
+		fmt.Fprintf(&b, "  id=%s nodeKey=%s typeKey=%s bindingId=%d nodeId=%d name=%s mutable=%t typeId=%d span=%d:%d type=%s\n",
+			shortCheckID(binding.ID), shortCheckID(binding.NodeKey), shortCheckID(binding.TypeKey), binding.BindingID, binding.NodeID, binding.Name, binding.Mutable, binding.TypeID, binding.Start, binding.End, checkSnapshotTypeString(binding.Type))
 	}
 
 	b.WriteString("symbols\n")
 	for _, symbol := range r.Symbols {
-		fmt.Fprintf(&b, "  id=%s nodeKey=%s typeKey=%s symbolId=%d node=%d nodeId=%d kind=%s name=%s owner=%s typeId=%d span=%d:%d type=%s\n",
-			shortCheckID(symbol.ID), shortCheckID(symbol.NodeKey), shortCheckID(symbol.TypeKey), symbol.SymbolID, symbol.Node, symbol.NodeID, symbol.Kind, symbol.Name, symbol.Owner, symbol.TypeID, symbol.Start, symbol.End, checkSnapshotTypeString(symbol.Type))
+		fmt.Fprintf(&b, "  id=%s nodeKey=%s typeKey=%s symbolId=%d nodeId=%d kind=%s name=%s owner=%s typeId=%d span=%d:%d type=%s\n",
+			shortCheckID(symbol.ID), shortCheckID(symbol.NodeKey), shortCheckID(symbol.TypeKey), symbol.SymbolID, symbol.NodeID, symbol.Kind, symbol.Name, symbol.Owner, symbol.TypeID, symbol.Start, symbol.End, checkSnapshotTypeString(symbol.Type))
 	}
 
 	b.WriteString("instantiations\n")
@@ -121,8 +121,8 @@ func dumpCheckSnapshot(r CheckResult) string {
 		for i := range inst.TypeArgs {
 			typeArgs = append(typeArgs, inst.TypeArgs[i].String())
 		}
-		fmt.Fprintf(&b, "  id=%s nodeKey=%s resultTypeKey=%s instantiationId=%d node=%d nodeId=%d callee=%s span=%d:%d typeArgIds=%v typeArgKeys=%v typeArgs=[%s] resultTypeId=%d resultType=%s\n",
-			shortCheckID(inst.ID), shortCheckID(inst.NodeKey), shortCheckID(inst.ResultTypeKey), inst.InstantiationID, inst.Node, inst.NodeID, inst.Callee, inst.Start, inst.End, inst.TypeArgIDs, shortCheckIDs(inst.TypeArgKeys), strings.Join(typeArgs, ", "), inst.ResultTypeID, checkSnapshotTypeString(inst.ResultType))
+		fmt.Fprintf(&b, "  id=%s nodeKey=%s resultTypeKey=%s instantiationId=%d nodeId=%d callee=%s span=%d:%d typeArgIds=%v typeArgKeys=%v typeArgs=[%s] resultTypeId=%d resultType=%s\n",
+			shortCheckID(inst.ID), shortCheckID(inst.NodeKey), shortCheckID(inst.ResultTypeKey), inst.InstantiationID, inst.NodeID, inst.Callee, inst.Start, inst.End, inst.TypeArgIDs, shortCheckIDs(inst.TypeArgKeys), strings.Join(typeArgs, ", "), inst.ResultTypeID, checkSnapshotTypeString(inst.ResultType))
 	}
 
 	b.WriteString("diagnostics\n")

--- a/internal/selfhost/package_adapter_test.go
+++ b/internal/selfhost/package_adapter_test.go
@@ -35,9 +35,6 @@ func TestCheckPackageStructuredSingleFileKeepsLetBindings(t *testing.T) {
 	if item == nil || value == nil {
 		t.Fatalf("missing item/value bindings in structured result: %#v", checked.Bindings)
 	}
-	if item.NodeID != item.Node || value.NodeID != value.Node {
-		t.Fatalf("binding NodeID should mirror stable checker node: item=%+v value=%+v", *item, *value)
-	}
 	if item.BindingID == value.BindingID {
 		t.Fatalf("binding ids should be stable and distinct: item=%+v value=%+v", *item, *value)
 	}

--- a/internal/selfhost/testdata/check_snapshots/basic-let.txt
+++ b/internal/selfhost/testdata/check_snapshots/basic-let.txt
@@ -1,10 +1,10 @@
 summary assignments=0 accepted=0 errors=0
 typedNodes
-  id=typed-node:3d354c652 nodeKey=node:b6e3a2daed64c0e typeKey=type:0cbe92b642f4e2f node=2 nodeId=2 typeId=2 kind=IntLit span=34:36 type=Int
-  id=typed-node:ea5c0ce48 nodeKey=node:31d75de96585a6b typeKey=type:520c4bf26e2fabc node=4 nodeId=4 typeId=19 kind=Block span=10:38 type=()
+  id=typed-node:3d354c652 nodeKey=node:b6e3a2daed64c0e typeKey=type:0cbe92b642f4e2f nodeId=2 typeId=2 kind=IntLit span=34:36 type=Int
+  id=typed-node:ea5c0ce48 nodeKey=node:31d75de96585a6b typeKey=type:520c4bf26e2fabc nodeId=4 typeId=19 kind=Block span=10:38 type=()
 bindings
-  id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 node=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
+  id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
 symbols
-  id=symbol:b682ed2ca7f2d nodeKey=node:b61dae7153803e3 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=135 span=0:38 type=fn() -> ()
+  id=symbol:b682ed2ca7f2d nodeKey=node:b61dae7153803e3 typeKey=type:b4f942e1ed0777f symbolId=0 nodeId=5 kind=fn name=main owner= typeId=135 span=0:38 type=fn() -> ()
 instantiations
 diagnostics

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-field-not-found.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-field-not-found.txt
@@ -2,17 +2,17 @@ summary assignments=1 accepted=1 errors=1
 errorsByContext E0702=1
 errorDetails E0702 no field `age` on type `User` @L4:C19=1
 typedNodes
-  id=typed-node:b78cfb3ed nodeKey=node:53b25d7ecdff87a typeKey=type:27afd946bb3613d node=5 nodeId=5 typeId=17 kind=StringLit span=69:74 type=String
-  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=135 kind=StructLit span=61:76 type=User
-  id=typed-node:b56e41f63 nodeKey=node:ab31c47955150d2 typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=135 kind=Ident span=91:95 type=User
-  id=typed-node:fc919e5a0 nodeKey=node:4c84bd6cefe7767 typeKey=type:520c4bf26e2fabc node=13 nodeId=13 typeId=19 kind=Block span=39:101 type=()
+  id=typed-node:b78cfb3ed nodeKey=node:53b25d7ecdff87a typeKey=type:27afd946bb3613d nodeId=5 typeId=17 kind=StringLit span=69:74 type=String
+  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 nodeId=7 typeId=135 kind=StructLit span=61:76 type=User
+  id=typed-node:b56e41f63 nodeKey=node:ab31c47955150d2 typeKey=type:addc461d1f10d07 nodeId=10 typeId=135 kind=Ident span=91:95 type=User
+  id=typed-node:fc919e5a0 nodeKey=node:4c84bd6cefe7767 typeKey=type:520c4bf26e2fabc nodeId=13 typeId=19 kind=Block span=39:101 type=()
 bindings
-  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
-  id=binding:cf88212b883f nodeKey=node:12aeb24100020eb typeKey=type:50eaecf185276b1 bindingId=1 node=9 nodeId=9 name=age mutable=false typeId=1 span=85:88 type=Poison
+  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
+  id=binding:cf88212b883f nodeKey=node:12aeb24100020eb typeKey=type:50eaecf185276b1 bindingId=1 nodeId=9 name=age mutable=false typeId=1 span=85:88 type=Poison
 symbols
-  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=135 span=0:28 type=User
-  id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 node=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String
-  id=symbol:09e0892a953e6 nodeKey=node:3932e8355a8e183 typeKey=type:b4f942e1ed0777f symbolId=2 node=14 nodeId=14 kind=fn name=main owner= typeId=136 span=29:101 type=fn() -> ()
+  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 nodeId=2 kind=struct name=User owner= typeId=135 span=0:28 type=User
+  id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String
+  id=symbol:09e0892a953e6 nodeKey=node:3932e8355a8e183 typeKey=type:b4f942e1ed0777f symbolId=2 nodeId=14 kind=fn name=main owner= typeId=136 span=29:101 type=fn() -> ()
 instantiations
 diagnostics
   code=E0702 severity=error span=95:99 line=4:19-4:23 message=no field `age` on type `User`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-generic-arity.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-generic-arity.txt
@@ -2,17 +2,17 @@ summary assignments=1 accepted=1 errors=1
 errorsByContext E0727=1
 errorDetails E0727 `id` requires 1 type argument(s) but 2 were supplied @L2:C28=1
 typedNodes
-  id=typed-node:9614d550a nodeKey=node:03659ce7f2ea7f4 typeKey=type:2cd1fe7afffe1ac node=4 nodeId=4 typeId=25 kind=Ident span=26:31 type=T
-  id=typed-node:746ba9163 nodeKey=node:6bd91ca9a7ee7d3 typeKey=type:2cd1fe7afffe1ac node=6 nodeId=6 typeId=25 kind=Block span=24:33 type=T
-  id=typed-node:97d06312a nodeKey=node:75f4a7394aa932a typeKey=type:819354aa58f2166 node=13 nodeId=13 typeId=21 kind=IntLit span=77:78 type=UntypedInt
-  id=typed-node:3530bc6f1 nodeKey=node:5d35234adab89ca typeKey=type:819354aa58f2166 node=14 nodeId=14 typeId=21 kind=Call span=76:79 type=UntypedInt
-  id=typed-node:8f2af9078 nodeKey=node:2f5dabb0b8da532 typeKey=type:520c4bf26e2fabc node=16 nodeId=16 typeId=19 kind=Block span=44:81 type=()
+  id=typed-node:9614d550a nodeKey=node:03659ce7f2ea7f4 typeKey=type:2cd1fe7afffe1ac nodeId=4 typeId=25 kind=Ident span=26:31 type=T
+  id=typed-node:746ba9163 nodeKey=node:6bd91ca9a7ee7d3 typeKey=type:2cd1fe7afffe1ac nodeId=6 typeId=25 kind=Block span=24:33 type=T
+  id=typed-node:97d06312a nodeKey=node:75f4a7394aa932a typeKey=type:819354aa58f2166 nodeId=13 typeId=21 kind=IntLit span=77:78 type=UntypedInt
+  id=typed-node:3530bc6f1 nodeKey=node:5d35234adab89ca typeKey=type:819354aa58f2166 nodeId=14 typeId=21 kind=Call span=76:79 type=UntypedInt
+  id=typed-node:8f2af9078 nodeKey=node:2f5dabb0b8da532 typeKey=type:520c4bf26e2fabc nodeId=16 typeId=19 kind=Block span=44:81 type=()
 bindings
-  id=binding:36a65d5fffc6 nodeKey=node:943860bfc5f7e91 typeKey=type:819354aa58f2166 bindingId=0 node=8 nodeId=8 name=answer mutable=false typeId=21 span=50:56 type=UntypedInt
+  id=binding:36a65d5fffc6 nodeKey=node:943860bfc5f7e91 typeKey=type:819354aa58f2166 bindingId=0 nodeId=8 name=answer mutable=false typeId=21 span=50:56 type=UntypedInt
 symbols
-  id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 node=7 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
-  id=symbol:ccd3fe9f277c8 nodeKey=node:2a72dc672708fa9 typeKey=type:b4f942e1ed0777f symbolId=1 node=17 nodeId=17 kind=fn name=main owner= typeId=135 span=34:81 type=fn() -> ()
+  id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
+  id=symbol:ccd3fe9f277c8 nodeKey=node:2a72dc672708fa9 typeKey=type:b4f942e1ed0777f symbolId=1 nodeId=17 kind=fn name=main owner= typeId=135 span=34:81 type=fn() -> ()
 instantiations
-  id=instantiation:0e805f nodeKey=node:c75801d39c9edaa resultTypeKey=type:819354aa58f2166 instantiationId=0 node=14 nodeId=14 callee=id span=76:79 typeArgIds=[21] typeArgKeys=[type:819354aa58f2166] typeArgs=[UntypedInt] resultTypeId=21 resultType=UntypedInt
+  id=instantiation:0e805f nodeKey=node:c75801d39c9edaa resultTypeKey=type:819354aa58f2166 instantiationId=0 nodeId=14 callee=id span=76:79 typeArgIds=[21] typeArgKeys=[type:819354aa58f2166] typeArgs=[UntypedInt] resultTypeId=21 resultType=UntypedInt
 diagnostics
   code=E0727 severity=error span=61:76 line=2:28-2:43 message=`id` requires 1 type argument(s) but 2 were supplied

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-interface-bound.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-interface-bound.txt
@@ -2,25 +2,25 @@ summary assignments=1 accepted=1 errors=1
 errorsByContext E0749=1
 errorDetails E0749 type parameter `T` requires bound `Named`, but `User` does not satisfy it @L6:C32=1
 typedNodes
-  id=typed-node:4c70e8550 nodeKey=node:21bb6ade4db9011 typeKey=type:2cd1fe7afffe1ac node=12 nodeId=12 typeId=25 kind=Ident span=112:117 type=T
-  id=typed-node:3c357a296 nodeKey=node:9440cf586cde53e typeKey=type:27afd946bb3613d node=14 nodeId=14 typeId=17 kind=Call span=122:124 type=String
-  id=typed-node:f9acd80ba nodeKey=node:e4abda096343b5c typeKey=type:27afd946bb3613d node=16 nodeId=16 typeId=17 kind=Block span=110:126 type=String
-  id=typed-node:22c21819d nodeKey=node:09faed5a8f0e6ee typeKey=type:0cbe92b642f4e2f node=21 nodeId=21 typeId=2 kind=IntLit span=172:174 type=Int
-  id=typed-node:ef9b548ba nodeKey=node:5bfa5a210ff801e typeKey=type:addc461d1f10d07 node=23 nodeId=23 typeId=137 kind=StructLit span=165:176 type=User
-  id=typed-node:bb04ebdbc nodeKey=node:8ff867d22716d38 typeKey=type:addc461d1f10d07 node=28 nodeId=28 typeId=137 kind=Ident span=209:213 type=User
-  id=typed-node:985a6b5a7 nodeKey=node:3cc4b7378e4d535 typeKey=type:27afd946bb3613d node=29 nodeId=29 typeId=17 kind=Call span=208:214 type=String
-  id=typed-node:eb39bd0b2 nodeKey=node:598cc8b8332a80c typeKey=type:520c4bf26e2fabc node=31 nodeId=31 typeId=19 kind=Block span=137:216 type=()
+  id=typed-node:4c70e8550 nodeKey=node:21bb6ade4db9011 typeKey=type:2cd1fe7afffe1ac nodeId=12 typeId=25 kind=Ident span=112:117 type=T
+  id=typed-node:3c357a296 nodeKey=node:9440cf586cde53e typeKey=type:27afd946bb3613d nodeId=14 typeId=17 kind=Call span=122:124 type=String
+  id=typed-node:f9acd80ba nodeKey=node:e4abda096343b5c typeKey=type:27afd946bb3613d nodeId=16 typeId=17 kind=Block span=110:126 type=String
+  id=typed-node:22c21819d nodeKey=node:09faed5a8f0e6ee typeKey=type:0cbe92b642f4e2f nodeId=21 typeId=2 kind=IntLit span=172:174 type=Int
+  id=typed-node:ef9b548ba nodeKey=node:5bfa5a210ff801e typeKey=type:addc461d1f10d07 nodeId=23 typeId=137 kind=StructLit span=165:176 type=User
+  id=typed-node:bb04ebdbc nodeKey=node:8ff867d22716d38 typeKey=type:addc461d1f10d07 nodeId=28 typeId=137 kind=Ident span=209:213 type=User
+  id=typed-node:985a6b5a7 nodeKey=node:3cc4b7378e4d535 typeKey=type:27afd946bb3613d nodeId=29 typeId=17 kind=Call span=208:214 type=String
+  id=typed-node:eb39bd0b2 nodeKey=node:598cc8b8332a80c typeKey=type:520c4bf26e2fabc nodeId=31 typeId=19 kind=Block span=137:216 type=()
 bindings
-  id=binding:ddf28dba2fe5 nodeKey=node:beda8c03414007c typeKey=type:addc461d1f10d07 bindingId=0 node=18 nodeId=18 name=user mutable=false typeId=137 span=147:151 type=User
-  id=binding:0b0c94771576 nodeKey=node:7abebfc4521a235 typeKey=type:27afd946bb3613d bindingId=1 node=25 nodeId=25 name=label mutable=false typeId=17 span=185:190 type=String
+  id=binding:ddf28dba2fe5 nodeKey=node:beda8c03414007c typeKey=type:addc461d1f10d07 bindingId=0 nodeId=18 name=user mutable=false typeId=137 span=147:151 type=User
+  id=binding:0b0c94771576 nodeKey=node:7abebfc4521a235 typeKey=type:27afd946bb3613d bindingId=1 nodeId=25 name=label mutable=false typeId=17 span=185:190 type=String
 symbols
-  id=symbol:89f31eaf230bd nodeKey=node:9ffc38d169fb3d4 typeKey=type:65086d14233556d symbolId=0 node=3 nodeId=3 kind=interface name=Named owner= typeId=135 span=0:43 type=Named
-  id=symbol:f5ec71b67ce18 nodeKey=node:571a54f97380c51 typeKey=type:1e90da063ee133a symbolId=1 node=2 nodeId=2 kind=fn name=name owner=Named typeId=136 span=18:41 type=fn() -> String
-  id=symbol:0ccf810404e77 nodeKey=node:8c94107f83ab34c typeKey=type:addc461d1f10d07 symbolId=2 node=6 nodeId=6 kind=struct name=User owner= typeId=137 span=44:68 type=User
-  id=symbol:01d01384e52f6 nodeKey=node:48daa8c06dff3ae typeKey=type:0cbe92b642f4e2f symbolId=3 node=5 nodeId=5 kind=field name=age owner=User typeId=2 span=58:66 type=Int
-  id=symbol:0a9f88b56493a nodeKey=node:7a741eb7444e054 typeKey=type:943d867c4f1392a symbolId=4 node=17 nodeId=17 kind=fn name=display owner= typeId=138 span=69:126 type=fn(T) -> String
-  id=symbol:ecda378af8c7c nodeKey=node:cdcb78ae39bfed2 typeKey=type:b4f942e1ed0777f symbolId=5 node=32 nodeId=32 kind=fn name=main owner= typeId=139 span=127:216 type=fn() -> ()
+  id=symbol:89f31eaf230bd nodeKey=node:9ffc38d169fb3d4 typeKey=type:65086d14233556d symbolId=0 nodeId=3 kind=interface name=Named owner= typeId=135 span=0:43 type=Named
+  id=symbol:f5ec71b67ce18 nodeKey=node:571a54f97380c51 typeKey=type:1e90da063ee133a symbolId=1 nodeId=2 kind=fn name=name owner=Named typeId=136 span=18:41 type=fn() -> String
+  id=symbol:0ccf810404e77 nodeKey=node:8c94107f83ab34c typeKey=type:addc461d1f10d07 symbolId=2 nodeId=6 kind=struct name=User owner= typeId=137 span=44:68 type=User
+  id=symbol:01d01384e52f6 nodeKey=node:48daa8c06dff3ae typeKey=type:0cbe92b642f4e2f symbolId=3 nodeId=5 kind=field name=age owner=User typeId=2 span=58:66 type=Int
+  id=symbol:0a9f88b56493a nodeKey=node:7a741eb7444e054 typeKey=type:943d867c4f1392a symbolId=4 nodeId=17 kind=fn name=display owner= typeId=138 span=69:126 type=fn(T) -> String
+  id=symbol:ecda378af8c7c nodeKey=node:cdcb78ae39bfed2 typeKey=type:b4f942e1ed0777f symbolId=5 nodeId=32 kind=fn name=main owner= typeId=139 span=127:216 type=fn() -> ()
 instantiations
-  id=instantiation:379f55 nodeKey=node:b34a4a91d02c6dd resultTypeKey=type:27afd946bb3613d instantiationId=0 node=29 nodeId=29 callee=display span=208:214 typeArgIds=[137] typeArgKeys=[type:addc461d1f10d07] typeArgs=[User] resultTypeId=17 resultType=String
+  id=instantiation:379f55 nodeKey=node:b34a4a91d02c6dd resultTypeKey=type:27afd946bb3613d instantiationId=0 nodeId=29 callee=display span=208:214 typeArgIds=[137] typeArgKeys=[type:addc461d1f10d07] typeArgs=[User] resultTypeId=17 resultType=String
 diagnostics
   code=E0749 severity=error span=208:214 line=6:32-6:38 message=type parameter `T` requires bound `Named`, but `User` does not satisfy it

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-intrinsic-violation.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-intrinsic-violation.txt
@@ -4,11 +4,11 @@ errorsByContext E0773=1
 errorDetails E0770 runtime sublanguage surface used outside a privileged package: `#[intrinsic]` is a runtime-only annotation @L1:C1=1
 errorDetails E0773 `#[intrinsic]` function `bad` must have an empty body @L2:C17=1
 typedNodes
-  id=typed-node:d29660728 nodeKey=node:28aa8e4746a3dc1 typeKey=type:0cbe92b642f4e2f node=2 nodeId=2 typeId=2 kind=IntLit span=35:37 type=Int
-  id=typed-node:d1cd82bc0 nodeKey=node:4013449fff6a7f8 typeKey=type:0cbe92b642f4e2f node=4 nodeId=4 typeId=2 kind=Block span=29:39 type=Int
+  id=typed-node:d29660728 nodeKey=node:28aa8e4746a3dc1 typeKey=type:0cbe92b642f4e2f nodeId=2 typeId=2 kind=IntLit span=35:37 type=Int
+  id=typed-node:d1cd82bc0 nodeKey=node:4013449fff6a7f8 typeKey=type:0cbe92b642f4e2f nodeId=4 typeId=2 kind=Block span=29:39 type=Int
 bindings
 symbols
-  id=symbol:0866a9ff21ddc nodeKey=node:ddfbf48157208d0 typeKey=type:ff113f463eecce4 symbolId=0 node=5 nodeId=5 kind=fn name=bad owner= typeId=135 span=13:39 type=fn() -> Int
+  id=symbol:0866a9ff21ddc nodeKey=node:ddfbf48157208d0 typeKey=type:ff113f463eecce4 symbolId=0 nodeId=5 kind=fn name=bad owner= typeId=135 span=13:39 type=fn() -> Int
 instantiations
 diagnostics
   code=E0773 severity=error span=29:39 line=2:17-4:2 message=`#[intrinsic]` function `bad` must have an empty body

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-method-not-found.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-method-not-found.txt
@@ -2,17 +2,17 @@ summary assignments=1 accepted=1 errors=1
 errorsByContext E0703=1
 errorDetails E0703 no method `label` on type `User` @L4:C21=1
 typedNodes
-  id=typed-node:b78cfb3ed nodeKey=node:53b25d7ecdff87a typeKey=type:27afd946bb3613d node=5 nodeId=5 typeId=17 kind=StringLit span=69:74 type=String
-  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=135 kind=StructLit span=61:76 type=User
-  id=typed-node:71017d305 nodeKey=node:b4407dfff4e4dce typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=135 kind=Ident span=93:97 type=User
-  id=typed-node:afa66bade nodeKey=node:e5353e717457cf8 typeKey=type:520c4bf26e2fabc node=14 nodeId=14 typeId=19 kind=Block span=39:107 type=()
+  id=typed-node:b78cfb3ed nodeKey=node:53b25d7ecdff87a typeKey=type:27afd946bb3613d nodeId=5 typeId=17 kind=StringLit span=69:74 type=String
+  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 nodeId=7 typeId=135 kind=StructLit span=61:76 type=User
+  id=typed-node:71017d305 nodeKey=node:b4407dfff4e4dce typeKey=type:addc461d1f10d07 nodeId=10 typeId=135 kind=Ident span=93:97 type=User
+  id=typed-node:afa66bade nodeKey=node:e5353e717457cf8 typeKey=type:520c4bf26e2fabc nodeId=14 typeId=19 kind=Block span=39:107 type=()
 bindings
-  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
-  id=binding:695f342d6c1a nodeKey=node:3a87cbd6fc03914 typeKey=type:50eaecf185276b1 bindingId=1 node=9 nodeId=9 name=label mutable=false typeId=1 span=85:90 type=Poison
+  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
+  id=binding:695f342d6c1a nodeKey=node:3a87cbd6fc03914 typeKey=type:50eaecf185276b1 bindingId=1 nodeId=9 name=label mutable=false typeId=1 span=85:90 type=Poison
 symbols
-  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=135 span=0:28 type=User
-  id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 node=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String
-  id=symbol:e5420eab90bbb nodeKey=node:3842cd891441c4f typeKey=type:b4f942e1ed0777f symbolId=2 node=15 nodeId=15 kind=fn name=main owner= typeId=136 span=29:107 type=fn() -> ()
+  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 nodeId=2 kind=struct name=User owner= typeId=135 span=0:28 type=User
+  id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String
+  id=symbol:e5420eab90bbb nodeKey=node:3842cd891441c4f typeKey=type:b4f942e1ed0777f symbolId=2 nodeId=15 kind=fn name=main owner= typeId=136 span=29:107 type=fn() -> ()
 instantiations
 diagnostics
   code=E0703 severity=error span=97:103 line=4:21-4:27 message=no method `label` on type `User`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-non-exhaustive-match.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-non-exhaustive-match.txt
@@ -2,14 +2,14 @@ summary assignments=0 accepted=0 errors=1
 errorsByContext E0731=1
 errorDetails E0731 match is not exhaustive: missing `Option.Some(_)` @L2:C5=1
 typedNodes
-  id=typed-node:bb45f0d2f nodeKey=node:e821fb1de8a7b54 typeKey=type:a2841dcf374046a node=4 nodeId=4 typeId=135 kind=Ident span=43:44 type=Option<Int>
-  id=typed-node:68a6ad56e nodeKey=node:fd8a7b5bb1b9812 typeKey=type:0cbe92b642f4e2f node=7 nodeId=7 typeId=2 kind=IntLit span=67:68 type=Int
-  id=typed-node:f658257e8 nodeKey=node:e113441d9af13f2 typeKey=type:0cbe92b642f4e2f node=10 nodeId=10 typeId=2 kind=IntLit span=86:87 type=Int
-  id=typed-node:44bdcc86c nodeKey=node:0f2924b336195c7 typeKey=type:0cbe92b642f4e2f node=12 nodeId=12 typeId=2 kind=Match span=37:94 type=Int
-  id=typed-node:6ae0146ac nodeKey=node:64e465f56c81267 typeKey=type:0cbe92b642f4e2f node=14 nodeId=14 typeId=2 kind=Block span=31:96 type=Int
+  id=typed-node:bb45f0d2f nodeKey=node:e821fb1de8a7b54 typeKey=type:a2841dcf374046a nodeId=4 typeId=135 kind=Ident span=43:44 type=Option<Int>
+  id=typed-node:68a6ad56e nodeKey=node:fd8a7b5bb1b9812 typeKey=type:0cbe92b642f4e2f nodeId=7 typeId=2 kind=IntLit span=67:68 type=Int
+  id=typed-node:f658257e8 nodeKey=node:e113441d9af13f2 typeKey=type:0cbe92b642f4e2f nodeId=10 typeId=2 kind=IntLit span=86:87 type=Int
+  id=typed-node:44bdcc86c nodeKey=node:0f2924b336195c7 typeKey=type:0cbe92b642f4e2f nodeId=12 typeId=2 kind=Match span=37:94 type=Int
+  id=typed-node:6ae0146ac nodeKey=node:64e465f56c81267 typeKey=type:0cbe92b642f4e2f nodeId=14 typeId=2 kind=Block span=31:96 type=Int
 bindings
 symbols
-  id=symbol:8f9c4d6ff5c6e nodeKey=node:05c11385a8c46d8 typeKey=type:b094483ff5bf7fd symbolId=0 node=15 nodeId=15 kind=fn name=code owner= typeId=136 span=0:96 type=fn(Option<Int>) -> Int
+  id=symbol:8f9c4d6ff5c6e nodeKey=node:05c11385a8c46d8 typeKey=type:b094483ff5bf7fd symbolId=0 nodeId=15 kind=fn name=code owner= typeId=136 span=0:96 type=fn(Option<Int>) -> Int
 instantiations
 diagnostics
   code=E0731 severity=error span=37:94 line=2:5-5:6 message=match is not exhaustive: missing `Option.Some(_)`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-pure-violation.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-pure-violation.txt
@@ -3,17 +3,17 @@ errorsByContext E0775=2
 errorDetails E0775 `#[pure]` function `bad` cannot allocate a list literal @L4:C14=1
 errorDetails E0775 `#[pure]` function `bad` cannot call a function that is not `#[pure]` @L5:C11=1
 typedNodes
-  id=typed-node:a08c373e0 nodeKey=node:9acea2dec56778f typeKey=type:0cbe92b642f4e2f node=1 nodeId=1 typeId=2 kind=IntLit span=21:22 type=Int
-  id=typed-node:3841a2ccd nodeKey=node:eb04cb8f98779ee typeKey=type:0cbe92b642f4e2f node=3 nodeId=3 typeId=2 kind=Block span=19:24 type=Int
-  id=typed-node:700baee84 nodeKey=node:c4e2dcbcd3d09ec typeKey=type:819354aa58f2166 node=8 nodeId=8 typeId=21 kind=IntLit span=65:66 type=UntypedInt
-  id=typed-node:0b55f7e33 nodeKey=node:e7dbda617f05f05 typeKey=type:ff4343a0a88abb8 node=9 nodeId=9 typeId=136 kind=List span=64:67 type=List<UntypedInt>
-  id=typed-node:7e899069d nodeKey=node:650466afaa8a5a9 typeKey=type:0cbe92b642f4e2f node=12 nodeId=12 typeId=2 kind=Call span=78:80 type=Int
-  id=typed-node:bff73e1c9 nodeKey=node:06207226247d8ec typeKey=type:0cbe92b642f4e2f node=14 nodeId=14 typeId=2 kind=Block span=49:82 type=Int
+  id=typed-node:a08c373e0 nodeKey=node:9acea2dec56778f typeKey=type:0cbe92b642f4e2f nodeId=1 typeId=2 kind=IntLit span=21:22 type=Int
+  id=typed-node:3841a2ccd nodeKey=node:eb04cb8f98779ee typeKey=type:0cbe92b642f4e2f nodeId=3 typeId=2 kind=Block span=19:24 type=Int
+  id=typed-node:700baee84 nodeKey=node:c4e2dcbcd3d09ec typeKey=type:819354aa58f2166 nodeId=8 typeId=21 kind=IntLit span=65:66 type=UntypedInt
+  id=typed-node:0b55f7e33 nodeKey=node:e7dbda617f05f05 typeKey=type:ff4343a0a88abb8 nodeId=9 typeId=136 kind=List span=64:67 type=List<UntypedInt>
+  id=typed-node:7e899069d nodeKey=node:650466afaa8a5a9 typeKey=type:0cbe92b642f4e2f nodeId=12 typeId=2 kind=Call span=78:80 type=Int
+  id=typed-node:bff73e1c9 nodeKey=node:06207226247d8ec typeKey=type:0cbe92b642f4e2f nodeId=14 typeId=2 kind=Block span=49:82 type=Int
 bindings
-  id=binding:2e6f5cce2dd9 nodeKey=node:468f9067f9e4bd4 typeKey=type:ff4343a0a88abb8 bindingId=0 node=7 nodeId=7 name=xs mutable=false typeId=136 span=59:61 type=List<UntypedInt>
+  id=binding:2e6f5cce2dd9 nodeKey=node:468f9067f9e4bd4 typeKey=type:ff4343a0a88abb8 bindingId=0 nodeId=7 name=xs mutable=false typeId=136 span=59:61 type=List<UntypedInt>
 symbols
-  id=symbol:66a5491bf4c48 nodeKey=node:cebd2ca3b324195 typeKey=type:ff113f463eecce4 symbolId=0 node=4 nodeId=4 kind=fn name=impure owner= typeId=135 span=0:24 type=fn() -> Int
-  id=symbol:edca6562653ad nodeKey=node:da87a9c5de0b1c9 typeKey=type:ff113f463eecce4 symbolId=1 node=15 nodeId=15 kind=fn name=bad owner= typeId=135 span=33:82 type=fn() -> Int
+  id=symbol:66a5491bf4c48 nodeKey=node:cebd2ca3b324195 typeKey=type:ff113f463eecce4 symbolId=0 nodeId=4 kind=fn name=impure owner= typeId=135 span=0:24 type=fn() -> Int
+  id=symbol:edca6562653ad nodeKey=node:da87a9c5de0b1c9 typeKey=type:ff113f463eecce4 symbolId=1 nodeId=15 kind=fn name=bad owner= typeId=135 span=33:82 type=fn() -> Int
 instantiations
 diagnostics
   code=E0775 severity=error span=64:67 line=4:14-4:17 message=`#[pure]` function `bad` cannot allocate a list literal

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-type-mismatch.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-type-mismatch.txt
@@ -2,12 +2,12 @@ summary assignments=1 accepted=0 errors=1
 errorsByContext E0700=1
 errorDetails E0700 type mismatch: expected `Int`, found `String` @L2:C23=1
 typedNodes
-  id=typed-node:5a97c2edd nodeKey=node:da5ea6c1f8fb6e2 typeKey=type:27afd946bb3613d node=2 nodeId=2 typeId=17 kind=StringLit span=34:40 type=String
-  id=typed-node:ca6fca23c nodeKey=node:3106e72fe5db50e typeKey=type:520c4bf26e2fabc node=4 nodeId=4 typeId=19 kind=Block span=10:42 type=()
+  id=typed-node:5a97c2edd nodeKey=node:da5ea6c1f8fb6e2 typeKey=type:27afd946bb3613d nodeId=2 typeId=17 kind=StringLit span=34:40 type=String
+  id=typed-node:ca6fca23c nodeKey=node:3106e72fe5db50e typeKey=type:520c4bf26e2fabc nodeId=4 typeId=19 kind=Block span=10:42 type=()
 bindings
-  id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 node=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
+  id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
 symbols
-  id=symbol:da63c620bc2ef nodeKey=node:22ddf6ed93d17e1 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=135 span=0:42 type=fn() -> ()
+  id=symbol:da63c620bc2ef nodeKey=node:22ddf6ed93d17e1 typeKey=type:b4f942e1ed0777f symbolId=0 nodeId=5 kind=fn name=main owner= typeId=135 span=0:42 type=fn() -> ()
 instantiations
 diagnostics
   code=E0700 severity=error span=34:40 line=2:23-2:29 message=type mismatch: expected `Int`, found `String`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-unknown-symbol.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-unknown-symbol.txt
@@ -2,10 +2,10 @@ summary assignments=0 accepted=0 errors=1
 errorsByContext E0745=1
 errorDetails E0745 cannot find `missing` in this scope @L2:C5=1
 typedNodes
-  id=typed-node:ec3886d99 nodeKey=node:c936a377e1a93a2 typeKey=type:520c4bf26e2fabc node=2 nodeId=2 typeId=19 kind=Block span=10:25 type=()
+  id=typed-node:ec3886d99 nodeKey=node:c936a377e1a93a2 typeKey=type:520c4bf26e2fabc nodeId=2 typeId=19 kind=Block span=10:25 type=()
 bindings
 symbols
-  id=symbol:a5aa59b65ce7c nodeKey=node:0669292999162b9 typeKey=type:b4f942e1ed0777f symbolId=0 node=3 nodeId=3 kind=fn name=main owner= typeId=135 span=0:25 type=fn() -> ()
+  id=symbol:a5aa59b65ce7c nodeKey=node:0669292999162b9 typeKey=type:b4f942e1ed0777f symbolId=0 nodeId=3 kind=fn name=main owner= typeId=135 span=0:25 type=fn() -> ()
 instantiations
 diagnostics
   code=E0745 severity=error span=16:23 line=2:5-2:12 message=cannot find `missing` in this scope

--- a/internal/selfhost/testdata/check_snapshots/generic-instantiation.txt
+++ b/internal/selfhost/testdata/check_snapshots/generic-instantiation.txt
@@ -1,15 +1,15 @@
 summary assignments=1 accepted=1 errors=0
 typedNodes
-  id=typed-node:9614d550a nodeKey=node:03659ce7f2ea7f4 typeKey=type:2cd1fe7afffe1ac node=4 nodeId=4 typeId=25 kind=Ident span=26:31 type=T
-  id=typed-node:746ba9163 nodeKey=node:6bd91ca9a7ee7d3 typeKey=type:2cd1fe7afffe1ac node=6 nodeId=6 typeId=25 kind=Block span=24:33 type=T
-  id=typed-node:2144a1905 nodeKey=node:4d0c2eccc4c3126 typeKey=type:0cbe92b642f4e2f node=12 nodeId=12 typeId=2 kind=IntLit span=69:70 type=Int
-  id=typed-node:e8a8faf85 nodeKey=node:33fed6004b55fa7 typeKey=type:0cbe92b642f4e2f node=13 nodeId=13 typeId=2 kind=Call span=68:71 type=Int
-  id=typed-node:dd6cc8b79 nodeKey=node:ff211993b5265fe typeKey=type:520c4bf26e2fabc node=15 nodeId=15 typeId=19 kind=Block span=44:73 type=()
+  id=typed-node:9614d550a nodeKey=node:03659ce7f2ea7f4 typeKey=type:2cd1fe7afffe1ac nodeId=4 typeId=25 kind=Ident span=26:31 type=T
+  id=typed-node:746ba9163 nodeKey=node:6bd91ca9a7ee7d3 typeKey=type:2cd1fe7afffe1ac nodeId=6 typeId=25 kind=Block span=24:33 type=T
+  id=typed-node:2144a1905 nodeKey=node:4d0c2eccc4c3126 typeKey=type:0cbe92b642f4e2f nodeId=12 typeId=2 kind=IntLit span=69:70 type=Int
+  id=typed-node:e8a8faf85 nodeKey=node:33fed6004b55fa7 typeKey=type:0cbe92b642f4e2f nodeId=13 typeId=2 kind=Call span=68:71 type=Int
+  id=typed-node:dd6cc8b79 nodeKey=node:ff211993b5265fe typeKey=type:520c4bf26e2fabc nodeId=15 typeId=19 kind=Block span=44:73 type=()
 bindings
-  id=binding:46a24bc911e8 nodeKey=node:943860bfc5f7e91 typeKey=type:0cbe92b642f4e2f bindingId=0 node=8 nodeId=8 name=answer mutable=false typeId=2 span=50:56 type=Int
+  id=binding:46a24bc911e8 nodeKey=node:943860bfc5f7e91 typeKey=type:0cbe92b642f4e2f bindingId=0 nodeId=8 name=answer mutable=false typeId=2 span=50:56 type=Int
 symbols
-  id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 node=7 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
-  id=symbol:b8e98828503be nodeKey=node:3370ff521ebcb76 typeKey=type:b4f942e1ed0777f symbolId=1 node=16 nodeId=16 kind=fn name=main owner= typeId=135 span=34:73 type=fn() -> ()
+  id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
+  id=symbol:b8e98828503be nodeKey=node:3370ff521ebcb76 typeKey=type:b4f942e1ed0777f symbolId=1 nodeId=16 kind=fn name=main owner= typeId=135 span=34:73 type=fn() -> ()
 instantiations
-  id=instantiation:7468aa nodeKey=node:81030ece726c8c2 resultTypeKey=type:0cbe92b642f4e2f instantiationId=0 node=13 nodeId=13 callee=id span=68:71 typeArgIds=[2] typeArgKeys=[type:0cbe92b642f4e2f] typeArgs=[Int] resultTypeId=2 resultType=Int
+  id=instantiation:7468aa nodeKey=node:81030ece726c8c2 resultTypeKey=type:0cbe92b642f4e2f instantiationId=0 nodeId=13 callee=id span=68:71 typeArgIds=[2] typeArgKeys=[type:0cbe92b642f4e2f] typeArgs=[Int] resultTypeId=2 resultType=Int
 diagnostics

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -149,7 +149,6 @@ pub fn frontTypeReprToString(repr: FrontTypeRepr) -> String {
     }
 }
 pub struct FrontCheckedNode {
-    pub node: Int,
     pub nodeId: Int,
     pub kind: String,
     pub typeRepr: FrontTypeRepr,
@@ -158,7 +157,6 @@ pub struct FrontCheckedNode {
     pub end: Int,
 }
 pub struct FrontCheckedBinding {
-    pub node: Int,
     pub nodeId: Int,
     pub bindingId: Int,
     pub name: String,
@@ -169,7 +167,6 @@ pub struct FrontCheckedBinding {
     pub end: Int,
 }
 pub struct FrontCheckedSymbol {
-    pub node: Int,
     pub nodeId: Int,
     pub symbolId: Int,
     pub kind: String,
@@ -181,7 +178,6 @@ pub struct FrontCheckedSymbol {
     pub end: Int,
 }
 pub struct FrontCheckInstantiation {
-    pub node: Int,
     pub nodeId: Int,
     pub instantiationId: Int,
     pub callee: String,
@@ -1227,18 +1223,18 @@ fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
             continue
         }
         let astNode = astArenaNodeAt(cx.ast.arena, node.originAst)
-        typedNodes.push(FrontCheckedNode {node: node.originAst, nodeId: node.originAst, kind, typeRepr: tyToRepr(cx.env.tys, node.ty), typeId: node.ty, start: astNode.start, end: astNode.end})
+        typedNodes.push(FrontCheckedNode {nodeId: node.originAst, kind, typeRepr: tyToRepr(cx.env.tys, node.ty), typeId: node.ty, start: astNode.start, end: astNode.end})
     }
     let mut bindings: List<FrontCheckedBinding> = []
     let mut bindingId = 0
     for b in cx.env.local.bindingRecords {
-        bindings.push(FrontCheckedBinding {node: b.node, nodeId: b.node, bindingId, name: b.name, typeRepr: tyToRepr(cx.env.tys, b.ty), typeId: b.ty, mutable: b.mutable, start: b.start, end: b.end})
+        bindings.push(FrontCheckedBinding {nodeId: b.node, bindingId, name: b.name, typeRepr: tyToRepr(cx.env.tys, b.ty), typeId: b.ty, mutable: b.mutable, start: b.start, end: b.end})
         bindingId = bindingId + 1
     }
     let mut symbols: List<FrontCheckedSymbol> = []
     let mut symbolId = 0
     for s in cx.env.local.symbolRecords {
-        symbols.push(FrontCheckedSymbol {node: s.node, nodeId: s.node, symbolId, kind: s.kind, name: s.name, owner: s.owner, typeRepr: tyToRepr(cx.env.tys, s.ty), typeId: s.ty, start: s.start, end: s.end})
+        symbols.push(FrontCheckedSymbol {nodeId: s.node, symbolId, kind: s.kind, name: s.name, owner: s.owner, typeRepr: tyToRepr(cx.env.tys, s.ty), typeId: s.ty, start: s.start, end: s.end})
         symbolId = symbolId + 1
     }
     let mut instantiations: List<FrontCheckInstantiation> = []
@@ -1250,7 +1246,7 @@ fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
             typeArgReprs.push(tyToRepr(cx.env.tys, tyArg))
             typeArgIds.push(tyArg)
         }
-        instantiations.push(FrontCheckInstantiation {node: inst.node, nodeId: inst.node, instantiationId, callee: inst.callee, typeArgs: typeArgReprs, typeArgIds, resultType: tyToRepr(cx.env.tys, inst.resultTy), resultTypeId: inst.resultTy, start: inst.start, end: inst.end})
+        instantiations.push(FrontCheckInstantiation {nodeId: inst.node, instantiationId, callee: inst.callee, typeArgs: typeArgReprs, typeArgIds, resultType: tyToRepr(cx.env.tys, inst.resultTy), resultTypeId: inst.resultTy, start: inst.start, end: inst.end})
         instantiationId = instantiationId + 1
     }
     FrontCheckResult {summary, typedNodes, bindings, symbols, instantiations, diagnostics: cx.env.local.diagnostics}

--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -560,7 +560,7 @@ fn frontCheckedNodeBodyJson(n: FrontCheckedNode, start: Int, end: Int) -> String
     let typeKey = frontWireStableTypeKey(n.typeRepr)
     let nodeKey = frontWireStableNodeKey("", n.kind, start, end)
     let id = frontWireStableID("typed-node", [nodeKey, n.kind, typeKey])
-    "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"node\":{n.node},\"nodeId\":{n.nodeId},\"kind\":" + frontJsonString(n.kind) + ",\"type\":" + frontTypeReprToWireJson(n.typeRepr) + ",\"typeId\":{n.typeId},\"typeKey\":" + frontJsonString(typeKey) + ",\"start\":{start},\"end\":{end}\}"
+    "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"nodeId\":{n.nodeId},\"kind\":" + frontJsonString(n.kind) + ",\"type\":" + frontTypeReprToWireJson(n.typeRepr) + ",\"typeId\":{n.typeId},\"typeKey\":" + frontJsonString(typeKey) + ",\"start\":{start},\"end\":{end}\}"
 }
 fn frontCheckedBindingsToWireJson(bindings: List<FrontCheckedBinding>, m: FrontWireMapper) -> String {
     if bindings.len() == 0 {
@@ -577,7 +577,7 @@ fn frontCheckedBindingBodyJson(b: FrontCheckedBinding, start: Int, end: Int) -> 
     let typeKey = frontWireStableTypeKey(b.typeRepr)
     let nodeKey = frontWireStableNodeKey("", "binding:" + b.name, start, end)
     let id = frontWireStableID("binding", [nodeKey, b.name, frontWireBoolText(b.mutable), typeKey])
-    "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"node\":{b.node},\"nodeId\":{b.nodeId},\"bindingId\":{b.bindingId},\"name\":" + frontJsonString(b.name) + ",\"type\":" + frontTypeReprToWireJson(b.typeRepr) + ",\"typeId\":{b.typeId},\"typeKey\":" + frontJsonString(typeKey) + ",\"mutable\":" + frontJsonBool(b.mutable) + ",\"start\":{start},\"end\":{end}\}"
+    "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"nodeId\":{b.nodeId},\"bindingId\":{b.bindingId},\"name\":" + frontJsonString(b.name) + ",\"type\":" + frontTypeReprToWireJson(b.typeRepr) + ",\"typeId\":{b.typeId},\"typeKey\":" + frontJsonString(typeKey) + ",\"mutable\":" + frontJsonBool(b.mutable) + ",\"start\":{start},\"end\":{end}\}"
 }
 fn frontCheckedSymbolsToWireJson(symbols: List<FrontCheckedSymbol>, m: FrontWireMapper) -> String {
     if symbols.len() == 0 {
@@ -595,7 +595,7 @@ fn frontCheckedSymbolBodyJson(s: FrontCheckedSymbol, start: Int, end: Int) -> St
     let kindTag = "symbol:" + s.kind + ":" + s.owner + ":" + s.name
     let nodeKey = frontWireStableNodeKey("", kindTag, start, end)
     let id = frontWireStableID("symbol", [nodeKey, s.kind, s.owner, s.name, typeKey])
-    "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"node\":{s.node},\"nodeId\":{s.nodeId},\"symbolId\":{s.symbolId},\"kind\":" + frontJsonString(s.kind) + ",\"name\":" + frontJsonString(s.name) + ",\"owner\":" + frontJsonString(s.owner) + ",\"type\":" + frontTypeReprToWireJson(s.typeRepr) + ",\"typeId\":{s.typeId},\"typeKey\":" + frontJsonString(typeKey) + ",\"start\":{start},\"end\":{end}\}"
+    "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"nodeId\":{s.nodeId},\"symbolId\":{s.symbolId},\"kind\":" + frontJsonString(s.kind) + ",\"name\":" + frontJsonString(s.name) + ",\"owner\":" + frontJsonString(s.owner) + ",\"type\":" + frontTypeReprToWireJson(s.typeRepr) + ",\"typeId\":{s.typeId},\"typeKey\":" + frontJsonString(typeKey) + ",\"start\":{start},\"end\":{end}\}"
 }
 fn frontCheckInstantiationsToWireJson(insts: List<FrontCheckInstantiation>, m: FrontWireMapper) -> String {
     if insts.len() == 0 {
@@ -624,7 +624,7 @@ fn frontCheckInstantiationBodyJson(i: FrontCheckInstantiation, start: Int, end: 
         idParts.push(k)
     }
     let id = frontWireStableID("instantiation", idParts)
-    let mut out = "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"node\":{i.node},\"nodeId\":{i.nodeId},\"instantiationId\":{i.instantiationId},\"callee\":" + frontJsonString(i.callee) + ",\"typeArgs\":" + typeArgsJson
+    let mut out = "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"nodeId\":{i.nodeId},\"instantiationId\":{i.instantiationId},\"callee\":" + frontJsonString(i.callee) + ",\"typeArgs\":" + typeArgsJson
     if i.typeArgIds.len() > 0 {
         let mut typeArgIdsParts: List<String> = []
         for tid in i.typeArgIds {

--- a/toolchain/check_json_test.osty
+++ b/toolchain/check_json_test.osty
@@ -37,7 +37,7 @@ fn testCheckJsonSummaryCarriesRealCounts() {
 fn testCheckJsonTypeReprPrimitiveAndOptional() {
     let intRepr = FrontTypeRepr {kind: "primitive", name: "Int", path: "", args: [], ret: None, paramNames: []}
     let optInt = FrontTypeRepr {kind: "optional", name: "", path: "", args: [], ret: Some(intRepr), paramNames: []}
-    let node = FrontCheckedNode {node: 1, nodeId: 1, kind: "ident", typeRepr: optInt, typeId: 42, start: 5, end: 10}
+    let node = FrontCheckedNode {nodeId: 1, kind: "ident", typeRepr: optInt, typeId: 42, start: 5, end: 10}
     let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
     let bindings: List<FrontCheckedBinding> = []
     let symbols: List<FrontCheckedSymbol> = []
@@ -62,7 +62,7 @@ fn testCheckJsonFnTypeUsesParamNamesJsonKey() {
     let strRepr = FrontTypeRepr {kind: "primitive", name: "String", path: "", args: [], ret: None, paramNames: []}
     let unitRepr = FrontTypeRepr {kind: "tuple", name: "", path: "", args: [], ret: None, paramNames: []}
     let fnRepr = FrontTypeRepr {kind: "fn", name: "", path: "", args: [strRepr], ret: Some(unitRepr), paramNames: ["msg"]}
-    let binding = FrontCheckedBinding {node: 7, nodeId: 7, bindingId: 0, name: "log", typeRepr: fnRepr, typeId: 9, mutable: false, start: 0, end: 3}
+    let binding = FrontCheckedBinding {nodeId: 7, bindingId: 0, name: "log", typeRepr: fnRepr, typeId: 9, mutable: false, start: 0, end: 3}
     let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
     let nodes: List<FrontCheckedNode> = []
     let symbols: List<FrontCheckedSymbol> = []
@@ -77,7 +77,7 @@ fn testCheckJsonFnTypeUsesParamNamesJsonKey() {
 // Osty field `paramNames` must serialize as `param_names`.
 fn testCheckJsonMutableBindingSerializesTrue() {
     let intRepr = FrontTypeRepr {kind: "primitive", name: "Int", path: "", args: [], ret: None, paramNames: []}
-    let binding = FrontCheckedBinding {node: 3, nodeId: 3, bindingId: 0, name: "x", typeRepr: intRepr, typeId: 1, mutable: true, start: 0, end: 1}
+    let binding = FrontCheckedBinding {nodeId: 3, bindingId: 0, name: "x", typeRepr: intRepr, typeId: 1, mutable: true, start: 0, end: 1}
     let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
     let nodes: List<FrontCheckedNode> = []
     let symbols: List<FrontCheckedSymbol> = []
@@ -146,7 +146,7 @@ fn testCheckJsonInstantiationOmitsEmptyTypeArgIds() {
     let strRepr = FrontTypeRepr {kind: "primitive", name: "String", path: "", args: [], ret: None, paramNames: []}
     let resultRepr = FrontTypeRepr {kind: "primitive", name: "Int", path: "", args: [], ret: None, paramNames: []}
     let typeArgIds: List<Int> = []
-    let inst = FrontCheckInstantiation {node: 11, nodeId: 11, instantiationId: 0, callee: "id", typeArgs: [strRepr], typeArgIds, resultType: resultRepr, resultTypeId: 7, start: 0, end: 5}
+    let inst = FrontCheckInstantiation {nodeId: 11, instantiationId: 0, callee: "id", typeArgs: [strRepr], typeArgIds, resultType: resultRepr, resultTypeId: 7, start: 0, end: 5}
     let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
     let nodes: List<FrontCheckedNode> = []
     let bindings: List<FrontCheckedBinding> = []
@@ -409,7 +409,7 @@ fn testCheckStableIDInstantiationCarriesResultTypeKey() {
     let strRepr = FrontTypeRepr {kind: "primitive", name: "String", path: "", args: [], ret: None, paramNames: []}
     let intRepr = FrontTypeRepr {kind: "primitive", name: "Int", path: "", args: [], ret: None, paramNames: []}
     let typeArgIds: List<Int> = [3]
-    let inst = FrontCheckInstantiation {node: 11, nodeId: 11, instantiationId: 0, callee: "id", typeArgs: [strRepr], typeArgIds, resultType: intRepr, resultTypeId: 7, start: 0, end: 5}
+    let inst = FrontCheckInstantiation {nodeId: 11, instantiationId: 0, callee: "id", typeArgs: [strRepr], typeArgIds, resultType: intRepr, resultTypeId: 7, start: 0, end: 5}
     let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
     let nodes: List<FrontCheckedNode> = []
     let bindings: List<FrontCheckedBinding> = []
@@ -448,8 +448,8 @@ fn testCheckStableIDDifferentBindingNamesProduceDifferentIDs() {
     let symbols: List<FrontCheckedSymbol> = []
     let insts: List<FrontCheckInstantiation> = []
     let diags: List<CheckDiagnostic> = []
-    let bindA = FrontCheckedBinding {node: 1, nodeId: 1, bindingId: 0, name: "alpha", typeRepr: intRepr, typeId: 1, mutable: false, start: 0, end: 5}
-    let bindB = FrontCheckedBinding {node: 2, nodeId: 2, bindingId: 1, name: "beta", typeRepr: intRepr, typeId: 1, mutable: false, start: 0, end: 5}
+    let bindA = FrontCheckedBinding {nodeId: 1, bindingId: 0, name: "alpha", typeRepr: intRepr, typeId: 1, mutable: false, start: 0, end: 5}
+    let bindB = FrontCheckedBinding {nodeId: 2, bindingId: 1, name: "beta", typeRepr: intRepr, typeId: 1, mutable: false, start: 0, end: 5}
     let result = FrontCheckResult {summary, typedNodes: nodes, bindings: [bindA, bindB], symbols, instantiations: insts, diagnostics: diags}
     let out = frontCheckResultToWireJson(result)
     let idA = extractStableIDSuffix(out, "\"name\":\"alpha\"")

--- a/toolchain/inspect.osty
+++ b/toolchain/inspect.osty
@@ -273,8 +273,8 @@ fn inspectTypeNameByNode(arena: AstArena, checked: FrontCheckResult) -> List<Str
         out.push("")
     }
     for tn in checked.typedNodes {
-        if tn.node >= 0 && tn.node < n {
-            out[tn.node] = frontTypeReprToString(tn.typeRepr)
+        if tn.nodeId >= 0 && tn.nodeId < n {
+            out[tn.nodeId] = frontTypeReprToString(tn.typeRepr)
         }
     }
     out
@@ -412,10 +412,10 @@ fn inspectThreadHintsThroughContainers(arena: AstArena, checked: FrontCheckResul
     }
     let bindingTypeByPattern = inspectBindingTypeByPattern(checked)
     for sym in checked.symbols {
-        if sym.node < 0 || sym.node >= n {
+        if sym.nodeId < 0 || sym.nodeId >= n {
             continue
         }
-        let declNode = arena.nodes[sym.node]
+        let declNode = arena.nodes[sym.nodeId]
         if sym.kind == "fn" {
             let sig = hintFnSignature(frontTypeReprToString(sym.typeRepr))
             if !sig.ok || sig.returnType == "" {
@@ -545,8 +545,8 @@ fn inspectBuildRecords(arena: AstArena, checked: FrontCheckResult, letPatterns: 
         if rule == "" {
             continue
         }
-        let hint = inspectHintForNode(hintsByNode, tn.node)
-        let span = inspectCoverSpan(arena, tn.node, tn.start, tn.end)
+        let hint = inspectHintForNode(hintsByNode, tn.nodeId)
+        let span = inspectCoverSpan(arena, tn.nodeId, tn.start, tn.end)
         let notes = inspectNotesForTypedNode(arena, instNotesByNode, tn)
         out.push(InspectRecord {start: span.start, end: span.end, nodeKind: tn.kind, rule, typeRepr: tn.typeRepr, hintName: hint, notes})
     }
@@ -931,7 +931,7 @@ fn inspectInstantiationNotesByNode(arena: AstArena, checked: FrontCheckResult) -
         notes.push("")
     }
     for inst in checked.instantiations {
-        if inst.node < 0 || inst.node >= n {
+        if inst.nodeId < 0 || inst.nodeId >= n {
             continue
         }
         if inst.typeArgs.len() == 0 {
@@ -941,7 +941,7 @@ fn inspectInstantiationNotesByNode(arena: AstArena, checked: FrontCheckResult) -
         for ta in inst.typeArgs {
             argStrs.push(frontTypeReprToString(ta))
         }
-        notes[inst.node] = "instantiated [" + strings.join(argStrs, ", ") + "]"
+        notes[inst.nodeId] = "instantiated [" + strings.join(argStrs, ", ") + "]"
     }
     notes
 }
@@ -955,8 +955,8 @@ fn inspectNotesForTypedNode(arena: AstArena, instNotesByNode: List<String>, tn: 
         return out
     }
     let n = arena.nodes.len()
-    if tn.node >= 0 && tn.node < n {
-        let callNode = arena.nodes[tn.node]
+    if tn.nodeId >= 0 && tn.nodeId < n {
+        let callNode = arena.nodes[tn.nodeId]
         if callNode.left >= 0 && callNode.left < n {
             let callee = arena.nodes[callNode.left]
             if callee.kind == AstNField {
@@ -964,8 +964,8 @@ fn inspectNotesForTypedNode(arena: AstArena, instNotesByNode: List<String>, tn: 
             }
         }
     }
-    if tn.node >= 0 && tn.node < instNotesByNode.len() {
-        let inst = instNotesByNode[tn.node]
+    if tn.nodeId >= 0 && tn.nodeId < instNotesByNode.len() {
+        let inst = instNotesByNode[tn.nodeId]
         if inst != "" {
             out.push(inst)
         }


### PR DESCRIPTION
## Summary

Removes the redundant `Node` legacy alias from the 4 self-host structured check records (`CheckedNode`, `CheckedBinding`, `CheckedSymbol`, `CheckInstantiation`).

Each struct carried a `Node int json:"node"` field commented as "legacy alias for NodeID" alongside the canonical `NodeID int`. The Osty side at `toolchain/check.osty:1226–1249` always emitted both fields with the same value (`node.originAst` / `b.node` / `s.node` / `inst.node`), making the alias pure duplication — `Node == NodeID` by construction.

### Changes

**Go side (consumers + struct)**:
- `internal/selfhost/api/types.go`: drop `Node int` from 4 structs; delete `checkRecordNodeID(nodeID, legacyNode)` helper — 4 callers in `(*CheckResult).Index()` now read `rec.NodeID` directly.
- `internal/selfhost/check_adapter.go`: drop the 4 `Node: node.node` assignments.
- `internal/check/host_boundary_overlay.go`: simplify `overlayNodeForRecord(indexes, nodeID, legacyNode, start, end)` → `overlayNodeForRecord(indexes, nodeID, start, end)`.
- `internal/ir/native_check.go`: delete `nativeRecordNodeID` helper.
- `internal/resolve/native_adapter.go`: drop the `if node == 0 { node = sym.Node }` fallback.

**Osty side (toolchain producer)**:
- `toolchain/check.osty`: drop `pub node: Int` from 4 FrontChecked* structs + 4 push sites.
- `toolchain/check_json.osty`: drop `,\"node\":{x.node}` from 4 wire emitters.
- `toolchain/inspect.osty`: rewrite 12 `tn.node` / `sym.node` / `inst.node` reads → `.nodeId` (only Osty-side readers).
- `toolchain/check_json_test.osty`: drop `node: N,` from 7 struct fixtures.

**Tests**:
- Delete `TestCheckResultIndexFallsBackToLegacyNodeAlias` (alias is gone).
- Drop `NodeID != Node` invariant checks from `check_query_test.go` + `package_adapter_test.go` (now structurally true).
- Strip the `node=...` column from `check_snapshot_test.go`; regenerated 11 snapshot fixtures via `UPDATE_SNAPSHOT=1`.
- `host_boundary_native_overlay_test.go`: drop `Node:` from CheckedNode/Binding/Instantiation literals.

### Wire-format compatibility

The frozen seed `internal/selfhost/generated.go` still has an internal `node int` field on its `FrontCheckedNode` struct (and 3 siblings), but nothing reads it now. Go's JSON decoder silently ignores unknown keys, so an older cached `osty-native-checker` subprocess that still emits `"node":` round-trips into the slimmer struct without complaint. Forward-compat is preserved.

Net **−57 LOC across 25 files**.

### Continues the Go legacy long-tail arc

- #1956 FrontendRun.File + AstbridgeLowerCount
- #1960 `--engine` / `--native` / LegacyCachePath
- #1962 Native-* identifier rename sweep
- #1965 stale framing scrub
- **This PR**: Node legacy alias removal across the structured-check wire

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 -short` passes on `./internal/{selfhost,selfhost/api,selfhost/bundle,check,ir,resolve,lsp}` and `./cmd/osty`
- [x] Snapshot fixtures regenerated; `./internal/speccorpus` clean
- [ ] CI green

https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ)_