### PR TITLE
refactor: drop CheckedBinding.BindingID legacy sequential id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ graphify-out/
 # `go build ./cmd/osty-vs-go` artifact when built outside .bin/.
 /osty-vs-go
 
+# `go build ./cmd/osty-native-checker` artifact when built outside .bin/.
+/osty-native-checker
+
 # osty.lock for cmd/*/ — these are dep-driven manifests; cmd subprojects
 # with [dependencies] empty regenerate a stale lock on each build.
 # examples/<name>/main.osty.lock is a different naming and stays tracked.

--- a/cmd/osty-native-checker/main_test.go
+++ b/cmd/osty-native-checker/main_test.go
@@ -121,9 +121,6 @@ func assertStableCheckIDs(t *testing.T, resp api.CheckResult) {
 
 	seenNonZeroNodeID := false
 	for _, node := range resp.TypedNodes {
-		if node.NodeID != node.Node {
-			t.Fatalf("typed node stable id mismatch: %#v", node)
-		}
 		if node.NodeID != 0 {
 			seenNonZeroNodeID = true
 		}
@@ -135,15 +132,15 @@ func assertStableCheckIDs(t *testing.T, resp api.CheckResult) {
 		t.Fatalf("typed nodes did not expose any non-zero stable node ids: %#v", resp.TypedNodes)
 	}
 
-	seenBindingIDs := map[int]bool{}
+	seenBindingIDs := map[string]bool{}
 	for _, binding := range resp.Bindings {
-		if binding.NodeID != binding.Node {
-			t.Fatalf("binding stable id mismatch: %#v", binding)
+		if binding.ID == "" {
+			t.Fatalf("binding missing stable id: %#v", binding)
 		}
-		if seenBindingIDs[binding.BindingID] {
-			t.Fatalf("duplicate binding id %d in %#v", binding.BindingID, resp.Bindings)
+		if seenBindingIDs[binding.ID] {
+			t.Fatalf("duplicate binding id %q in %#v", binding.ID, resp.Bindings)
 		}
-		seenBindingIDs[binding.BindingID] = true
+		seenBindingIDs[binding.ID] = true
 		if binding.Type == nil {
 			t.Fatalf("binding missing structured type: %#v", binding)
 		}
@@ -151,9 +148,6 @@ func assertStableCheckIDs(t *testing.T, resp api.CheckResult) {
 
 	seenSymbolIDs := map[int]bool{}
 	for _, symbol := range resp.Symbols {
-		if symbol.NodeID != symbol.Node {
-			t.Fatalf("symbol stable id mismatch: %#v", symbol)
-		}
 		if seenSymbolIDs[symbol.SymbolID] {
 			t.Fatalf("duplicate symbol id %d in %#v", symbol.SymbolID, resp.Symbols)
 		}
@@ -164,9 +158,6 @@ func assertStableCheckIDs(t *testing.T, resp api.CheckResult) {
 	}
 
 	for _, inst := range resp.Instantiations {
-		if inst.NodeID != inst.Node {
-			t.Fatalf("instantiation stable id mismatch: %#v", inst)
-		}
 		if len(inst.TypeArgIDs) != len(inst.TypeArgs) {
 			t.Fatalf("instantiation type arg ids = %#v, type args = %#v", inst.TypeArgIDs, inst.TypeArgs)
 		}

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -152,17 +152,16 @@ type CheckedNode struct {
 
 // CheckedBinding records a local binding that the bootstrapped checker typed.
 type CheckedBinding struct {
-	ID        string    `json:"id,omitempty"`
-	NodeKey   string    `json:"nodeKey,omitempty"`
-	NodeID    int       `json:"nodeId"`
-	BindingID int       `json:"bindingId"` // legacy sequential id
-	Name      string    `json:"name"`
-	Type      *TypeRepr `json:"type"`
-	TypeID    int       `json:"typeId"` // legacy checker-arena type id
-	TypeKey   string    `json:"typeKey,omitempty"`
-	Mutable   bool      `json:"mutable"`
-	Start     int       `json:"start"`
-	End       int       `json:"end"`
+	ID      string    `json:"id,omitempty"`
+	NodeKey string    `json:"nodeKey,omitempty"`
+	NodeID  int       `json:"nodeId"`
+	Name    string    `json:"name"`
+	Type    *TypeRepr `json:"type"`
+	TypeID  int       `json:"typeId"` // legacy checker-arena type id
+	TypeKey string    `json:"typeKey,omitempty"`
+	Mutable bool      `json:"mutable"`
+	Start   int       `json:"start"`
+	End     int       `json:"end"`
 }
 
 // CheckedSymbol records a declaration collected by the bootstrapped checker.
@@ -240,7 +239,6 @@ type CheckResultIndex struct {
 	TypedNodesByNodeID       map[int]*CheckedNode
 	TypedNodesByNodeKey      map[string]*CheckedNode
 	BindingsByStableID       map[string]*CheckedBinding
-	BindingsByID             map[int]*CheckedBinding
 	BindingsByNodeID         map[int][]*CheckedBinding
 	BindingsByNodeKey        map[string][]*CheckedBinding
 	SymbolsByStableID        map[string]*CheckedSymbol
@@ -254,9 +252,9 @@ type CheckResultIndex struct {
 }
 
 // EnsureStableIDs fills the content-derived identities for every checker
-// record. The integer NodeID / TypeID / BindingID / SymbolID fields remain for
-// legacy consumers, but new consumers should prefer the string IDs and keys:
-// they are derived from source span, record kind, names, and structured type
+// record. The integer NodeID / TypeID / SymbolID fields remain for legacy
+// consumers, but new consumers should prefer the string IDs and keys: they
+// are derived from source span, record kind, names, and structured type
 // shapes instead of checker arena allocation order.
 func (r *CheckResult) EnsureStableIDs() {
 	if r == nil {
@@ -305,7 +303,6 @@ func (r *CheckResult) Index() CheckResultIndex {
 			TypedNodesByNodeID:       map[int]*CheckedNode{},
 			TypedNodesByNodeKey:      map[string]*CheckedNode{},
 			BindingsByStableID:       map[string]*CheckedBinding{},
-			BindingsByID:             map[int]*CheckedBinding{},
 			BindingsByNodeID:         map[int][]*CheckedBinding{},
 			BindingsByNodeKey:        map[string][]*CheckedBinding{},
 			SymbolsByStableID:        map[string]*CheckedSymbol{},
@@ -323,7 +320,6 @@ func (r *CheckResult) Index() CheckResultIndex {
 		TypedNodesByNodeID:       make(map[int]*CheckedNode, len(r.TypedNodes)),
 		TypedNodesByNodeKey:      make(map[string]*CheckedNode, len(r.TypedNodes)),
 		BindingsByStableID:       make(map[string]*CheckedBinding, len(r.Bindings)),
-		BindingsByID:             make(map[int]*CheckedBinding, len(r.Bindings)),
 		BindingsByNodeID:         make(map[int][]*CheckedBinding),
 		BindingsByNodeKey:        make(map[string][]*CheckedBinding),
 		SymbolsByStableID:        make(map[string]*CheckedSymbol, len(r.Symbols)),
@@ -354,7 +350,6 @@ func (r *CheckResult) Index() CheckResultIndex {
 		if key := stableCheckedBindingNodeKey(rec); key != "" {
 			idx.BindingsByNodeKey[key] = append(idx.BindingsByNodeKey[key], rec)
 		}
-		idx.BindingsByID[rec.BindingID] = rec
 		idx.BindingsByNodeID[nodeID] = append(idx.BindingsByNodeID[nodeID], rec)
 	}
 	for i := range r.Symbols {

--- a/internal/selfhost/api/types_test.go
+++ b/internal/selfhost/api/types_test.go
@@ -9,8 +9,8 @@ func TestCheckResultIndexUsesStableIDs(t *testing.T) {
 			{NodeID: 42, Kind: "Call", TypeID: 8},
 		},
 		Bindings: []CheckedBinding{
-			{NodeID: 0, BindingID: 11, Name: "root", TypeID: 7},
-			{NodeID: 42, BindingID: 12, Name: "value", TypeID: 8},
+			{NodeID: 0, Name: "root", TypeID: 7},
+			{NodeID: 42, Name: "value", TypeID: 8},
 		},
 		Symbols: []CheckedSymbol{
 			{NodeID: 42, SymbolID: 21, Name: "value", TypeID: 8},
@@ -29,11 +29,8 @@ func TestCheckResultIndexUsesStableIDs(t *testing.T) {
 	if got := idx.TypedNodesByNodeID[42]; got == nil || got.Kind != "Call" {
 		t.Fatalf("typed node 42 = %#v, want Call", got)
 	}
-	if got := idx.BindingsByID[12]; got == nil || got.Name != "value" {
-		t.Fatalf("binding 12 = %#v, want value", got)
-	}
-	if got := idx.BindingsByNodeID[42]; len(got) != 1 || got[0].BindingID != 12 {
-		t.Fatalf("bindings by node 42 = %#v, want binding 12", got)
+	if got := idx.BindingsByNodeID[42]; len(got) != 1 || got[0].Name != "value" {
+		t.Fatalf("bindings by node 42 = %#v, want binding value", got)
 	}
 	if got := idx.SymbolsByID[21]; got == nil || got.Name != "value" {
 		t.Fatalf("symbol 21 = %#v, want value", got)
@@ -93,7 +90,6 @@ func TestNilCheckResultIndexIsEmpty(t *testing.T) {
 	idx := (*CheckResult)(nil).Index()
 	if len(idx.TypedNodesByNodeID) != 0 ||
 		len(idx.TypedNodesByStableID) != 0 ||
-		len(idx.BindingsByID) != 0 ||
 		len(idx.BindingsByStableID) != 0 ||
 		len(idx.SymbolsByID) != 0 ||
 		len(idx.SymbolsByStableID) != 0 ||

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -234,14 +234,13 @@ func adaptCheckResultWithTokenMapper(checked *FrontCheckResult, mapper checkResu
 		}
 		start, end := mapper.offsets(binding.start, binding.end)
 		result.Bindings = append(result.Bindings, CheckedBinding{
-			NodeID:    binding.nodeId,
-			BindingID: binding.bindingId,
-			Name:      binding.name,
-			Type:      frontTypeReprToAPI(binding.typeRepr),
-			TypeID:    binding.typeId,
-			Mutable:   binding.mutable,
-			Start:     start,
-			End:       end,
+			NodeID:  binding.nodeId,
+			Name:    binding.name,
+			Type:    frontTypeReprToAPI(binding.typeRepr),
+			TypeID:  binding.typeId,
+			Mutable: binding.mutable,
+			Start:   start,
+			End:     end,
 		})
 	}
 	for _, symbol := range checked.symbols {

--- a/internal/selfhost/check_snapshot_test.go
+++ b/internal/selfhost/check_snapshot_test.go
@@ -105,8 +105,8 @@ func dumpCheckSnapshot(r CheckResult) string {
 
 	b.WriteString("bindings\n")
 	for _, binding := range r.Bindings {
-		fmt.Fprintf(&b, "  id=%s nodeKey=%s typeKey=%s bindingId=%d nodeId=%d name=%s mutable=%t typeId=%d span=%d:%d type=%s\n",
-			shortCheckID(binding.ID), shortCheckID(binding.NodeKey), shortCheckID(binding.TypeKey), binding.BindingID, binding.NodeID, binding.Name, binding.Mutable, binding.TypeID, binding.Start, binding.End, checkSnapshotTypeString(binding.Type))
+		fmt.Fprintf(&b, "  id=%s nodeKey=%s typeKey=%s nodeId=%d name=%s mutable=%t typeId=%d span=%d:%d type=%s\n",
+			shortCheckID(binding.ID), shortCheckID(binding.NodeKey), shortCheckID(binding.TypeKey), binding.NodeID, binding.Name, binding.Mutable, binding.TypeID, binding.Start, binding.End, checkSnapshotTypeString(binding.Type))
 	}
 
 	b.WriteString("symbols\n")

--- a/internal/selfhost/package_adapter_test.go
+++ b/internal/selfhost/package_adapter_test.go
@@ -35,7 +35,7 @@ func TestCheckPackageStructuredSingleFileKeepsLetBindings(t *testing.T) {
 	if item == nil || value == nil {
 		t.Fatalf("missing item/value bindings in structured result: %#v", checked.Bindings)
 	}
-	if item.BindingID == value.BindingID {
+	if item.ID == "" || value.ID == "" || item.ID == value.ID {
 		t.Fatalf("binding ids should be stable and distinct: item=%+v value=%+v", *item, *value)
 	}
 	if item.TypeID < 0 || value.TypeID < 0 {

--- a/internal/selfhost/testdata/check_snapshots/basic-let.txt
+++ b/internal/selfhost/testdata/check_snapshots/basic-let.txt
@@ -3,7 +3,7 @@ typedNodes
   id=typed-node:3d354c652 nodeKey=node:b6e3a2daed64c0e typeKey=type:0cbe92b642f4e2f nodeId=2 typeId=2 kind=IntLit span=34:36 type=Int
   id=typed-node:ea5c0ce48 nodeKey=node:31d75de96585a6b typeKey=type:520c4bf26e2fabc nodeId=4 typeId=19 kind=Block span=10:38 type=()
 bindings
-  id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
+  id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
 symbols
   id=symbol:b682ed2ca7f2d nodeKey=node:b61dae7153803e3 typeKey=type:b4f942e1ed0777f symbolId=0 nodeId=5 kind=fn name=main owner= typeId=135 span=0:38 type=fn() -> ()
 instantiations

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-field-not-found.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-field-not-found.txt
@@ -7,8 +7,8 @@ typedNodes
   id=typed-node:b56e41f63 nodeKey=node:ab31c47955150d2 typeKey=type:addc461d1f10d07 nodeId=10 typeId=135 kind=Ident span=91:95 type=User
   id=typed-node:fc919e5a0 nodeKey=node:4c84bd6cefe7767 typeKey=type:520c4bf26e2fabc nodeId=13 typeId=19 kind=Block span=39:101 type=()
 bindings
-  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
-  id=binding:cf88212b883f nodeKey=node:12aeb24100020eb typeKey=type:50eaecf185276b1 bindingId=1 nodeId=9 name=age mutable=false typeId=1 span=85:88 type=Poison
+  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
+  id=binding:cf88212b883f nodeKey=node:12aeb24100020eb typeKey=type:50eaecf185276b1 nodeId=9 name=age mutable=false typeId=1 span=85:88 type=Poison
 symbols
   id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 nodeId=2 kind=struct name=User owner= typeId=135 span=0:28 type=User
   id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-generic-arity.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-generic-arity.txt
@@ -8,7 +8,7 @@ typedNodes
   id=typed-node:3530bc6f1 nodeKey=node:5d35234adab89ca typeKey=type:819354aa58f2166 nodeId=14 typeId=21 kind=Call span=76:79 type=UntypedInt
   id=typed-node:8f2af9078 nodeKey=node:2f5dabb0b8da532 typeKey=type:520c4bf26e2fabc nodeId=16 typeId=19 kind=Block span=44:81 type=()
 bindings
-  id=binding:36a65d5fffc6 nodeKey=node:943860bfc5f7e91 typeKey=type:819354aa58f2166 bindingId=0 nodeId=8 name=answer mutable=false typeId=21 span=50:56 type=UntypedInt
+  id=binding:36a65d5fffc6 nodeKey=node:943860bfc5f7e91 typeKey=type:819354aa58f2166 nodeId=8 name=answer mutable=false typeId=21 span=50:56 type=UntypedInt
 symbols
   id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
   id=symbol:ccd3fe9f277c8 nodeKey=node:2a72dc672708fa9 typeKey=type:b4f942e1ed0777f symbolId=1 nodeId=17 kind=fn name=main owner= typeId=135 span=34:81 type=fn() -> ()

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-interface-bound.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-interface-bound.txt
@@ -11,8 +11,8 @@ typedNodes
   id=typed-node:985a6b5a7 nodeKey=node:3cc4b7378e4d535 typeKey=type:27afd946bb3613d nodeId=29 typeId=17 kind=Call span=208:214 type=String
   id=typed-node:eb39bd0b2 nodeKey=node:598cc8b8332a80c typeKey=type:520c4bf26e2fabc nodeId=31 typeId=19 kind=Block span=137:216 type=()
 bindings
-  id=binding:ddf28dba2fe5 nodeKey=node:beda8c03414007c typeKey=type:addc461d1f10d07 bindingId=0 nodeId=18 name=user mutable=false typeId=137 span=147:151 type=User
-  id=binding:0b0c94771576 nodeKey=node:7abebfc4521a235 typeKey=type:27afd946bb3613d bindingId=1 nodeId=25 name=label mutable=false typeId=17 span=185:190 type=String
+  id=binding:ddf28dba2fe5 nodeKey=node:beda8c03414007c typeKey=type:addc461d1f10d07 nodeId=18 name=user mutable=false typeId=137 span=147:151 type=User
+  id=binding:0b0c94771576 nodeKey=node:7abebfc4521a235 typeKey=type:27afd946bb3613d nodeId=25 name=label mutable=false typeId=17 span=185:190 type=String
 symbols
   id=symbol:89f31eaf230bd nodeKey=node:9ffc38d169fb3d4 typeKey=type:65086d14233556d symbolId=0 nodeId=3 kind=interface name=Named owner= typeId=135 span=0:43 type=Named
   id=symbol:f5ec71b67ce18 nodeKey=node:571a54f97380c51 typeKey=type:1e90da063ee133a symbolId=1 nodeId=2 kind=fn name=name owner=Named typeId=136 span=18:41 type=fn() -> String

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-method-not-found.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-method-not-found.txt
@@ -7,8 +7,8 @@ typedNodes
   id=typed-node:71017d305 nodeKey=node:b4407dfff4e4dce typeKey=type:addc461d1f10d07 nodeId=10 typeId=135 kind=Ident span=93:97 type=User
   id=typed-node:afa66bade nodeKey=node:e5353e717457cf8 typeKey=type:520c4bf26e2fabc nodeId=14 typeId=19 kind=Block span=39:107 type=()
 bindings
-  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
-  id=binding:695f342d6c1a nodeKey=node:3a87cbd6fc03914 typeKey=type:50eaecf185276b1 bindingId=1 nodeId=9 name=label mutable=false typeId=1 span=85:90 type=Poison
+  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
+  id=binding:695f342d6c1a nodeKey=node:3a87cbd6fc03914 typeKey=type:50eaecf185276b1 nodeId=9 name=label mutable=false typeId=1 span=85:90 type=Poison
 symbols
   id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 nodeId=2 kind=struct name=User owner= typeId=135 span=0:28 type=User
   id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-pure-violation.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-pure-violation.txt
@@ -10,7 +10,7 @@ typedNodes
   id=typed-node:7e899069d nodeKey=node:650466afaa8a5a9 typeKey=type:0cbe92b642f4e2f nodeId=12 typeId=2 kind=Call span=78:80 type=Int
   id=typed-node:bff73e1c9 nodeKey=node:06207226247d8ec typeKey=type:0cbe92b642f4e2f nodeId=14 typeId=2 kind=Block span=49:82 type=Int
 bindings
-  id=binding:2e6f5cce2dd9 nodeKey=node:468f9067f9e4bd4 typeKey=type:ff4343a0a88abb8 bindingId=0 nodeId=7 name=xs mutable=false typeId=136 span=59:61 type=List<UntypedInt>
+  id=binding:2e6f5cce2dd9 nodeKey=node:468f9067f9e4bd4 typeKey=type:ff4343a0a88abb8 nodeId=7 name=xs mutable=false typeId=136 span=59:61 type=List<UntypedInt>
 symbols
   id=symbol:66a5491bf4c48 nodeKey=node:cebd2ca3b324195 typeKey=type:ff113f463eecce4 symbolId=0 nodeId=4 kind=fn name=impure owner= typeId=135 span=0:24 type=fn() -> Int
   id=symbol:edca6562653ad nodeKey=node:da87a9c5de0b1c9 typeKey=type:ff113f463eecce4 symbolId=1 nodeId=15 kind=fn name=bad owner= typeId=135 span=33:82 type=fn() -> Int

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-type-mismatch.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-type-mismatch.txt
@@ -5,7 +5,7 @@ typedNodes
   id=typed-node:5a97c2edd nodeKey=node:da5ea6c1f8fb6e2 typeKey=type:27afd946bb3613d nodeId=2 typeId=17 kind=StringLit span=34:40 type=String
   id=typed-node:ca6fca23c nodeKey=node:3106e72fe5db50e typeKey=type:520c4bf26e2fabc nodeId=4 typeId=19 kind=Block span=10:42 type=()
 bindings
-  id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
+  id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
 symbols
   id=symbol:da63c620bc2ef nodeKey=node:22ddf6ed93d17e1 typeKey=type:b4f942e1ed0777f symbolId=0 nodeId=5 kind=fn name=main owner= typeId=135 span=0:42 type=fn() -> ()
 instantiations

--- a/internal/selfhost/testdata/check_snapshots/generic-instantiation.txt
+++ b/internal/selfhost/testdata/check_snapshots/generic-instantiation.txt
@@ -6,7 +6,7 @@ typedNodes
   id=typed-node:e8a8faf85 nodeKey=node:33fed6004b55fa7 typeKey=type:0cbe92b642f4e2f nodeId=13 typeId=2 kind=Call span=68:71 type=Int
   id=typed-node:dd6cc8b79 nodeKey=node:ff211993b5265fe typeKey=type:520c4bf26e2fabc nodeId=15 typeId=19 kind=Block span=44:73 type=()
 bindings
-  id=binding:46a24bc911e8 nodeKey=node:943860bfc5f7e91 typeKey=type:0cbe92b642f4e2f bindingId=0 nodeId=8 name=answer mutable=false typeId=2 span=50:56 type=Int
+  id=binding:46a24bc911e8 nodeKey=node:943860bfc5f7e91 typeKey=type:0cbe92b642f4e2f nodeId=8 name=answer mutable=false typeId=2 span=50:56 type=Int
 symbols
   id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
   id=symbol:b8e98828503be nodeKey=node:3370ff521ebcb76 typeKey=type:b4f942e1ed0777f symbolId=1 nodeId=16 kind=fn name=main owner= typeId=135 span=34:73 type=fn() -> ()

--- a/internal/semanticdb/db_test.go
+++ b/internal/semanticdb/db_test.go
@@ -79,11 +79,11 @@ func TestWithCheckKeepsResolveDBImmutable(t *testing.T) {
 	base := New(nil, api.ResolveResult{PackageID: "pkg"})
 	checked := api.CheckResult{
 		TypedNodes: []api.CheckedNode{{
-			Node:  1,
-			Kind:  "Ident",
-			Start: 0,
-			End:   1,
-			Type:  &api.TypeRepr{Kind: "primitive", Name: "Int"},
+			NodeID: 1,
+			Kind:   "Ident",
+			Start:  0,
+			End:    1,
+			Type:   &api.TypeRepr{Kind: "primitive", Name: "Int"},
 		}},
 	}
 

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -158,7 +158,6 @@ pub struct FrontCheckedNode {
 }
 pub struct FrontCheckedBinding {
     pub nodeId: Int,
-    pub bindingId: Int,
     pub name: String,
     pub typeRepr: FrontTypeRepr,
     pub typeId: Int,
@@ -1226,10 +1225,8 @@ fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
         typedNodes.push(FrontCheckedNode {nodeId: node.originAst, kind, typeRepr: tyToRepr(cx.env.tys, node.ty), typeId: node.ty, start: astNode.start, end: astNode.end})
     }
     let mut bindings: List<FrontCheckedBinding> = []
-    let mut bindingId = 0
     for b in cx.env.local.bindingRecords {
-        bindings.push(FrontCheckedBinding {nodeId: b.node, bindingId, name: b.name, typeRepr: tyToRepr(cx.env.tys, b.ty), typeId: b.ty, mutable: b.mutable, start: b.start, end: b.end})
-        bindingId = bindingId + 1
+        bindings.push(FrontCheckedBinding {nodeId: b.node, name: b.name, typeRepr: tyToRepr(cx.env.tys, b.ty), typeId: b.ty, mutable: b.mutable, start: b.start, end: b.end})
     }
     let mut symbols: List<FrontCheckedSymbol> = []
     let mut symbolId = 0

--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -577,7 +577,7 @@ fn frontCheckedBindingBodyJson(b: FrontCheckedBinding, start: Int, end: Int) -> 
     let typeKey = frontWireStableTypeKey(b.typeRepr)
     let nodeKey = frontWireStableNodeKey("", "binding:" + b.name, start, end)
     let id = frontWireStableID("binding", [nodeKey, b.name, frontWireBoolText(b.mutable), typeKey])
-    "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"nodeId\":{b.nodeId},\"bindingId\":{b.bindingId},\"name\":" + frontJsonString(b.name) + ",\"type\":" + frontTypeReprToWireJson(b.typeRepr) + ",\"typeId\":{b.typeId},\"typeKey\":" + frontJsonString(typeKey) + ",\"mutable\":" + frontJsonBool(b.mutable) + ",\"start\":{start},\"end\":{end}\}"
+    "\{\"id\":" + frontJsonString(id) + ",\"nodeKey\":" + frontJsonString(nodeKey) + ",\"nodeId\":{b.nodeId},\"name\":" + frontJsonString(b.name) + ",\"type\":" + frontTypeReprToWireJson(b.typeRepr) + ",\"typeId\":{b.typeId},\"typeKey\":" + frontJsonString(typeKey) + ",\"mutable\":" + frontJsonBool(b.mutable) + ",\"start\":{start},\"end\":{end}\}"
 }
 fn frontCheckedSymbolsToWireJson(symbols: List<FrontCheckedSymbol>, m: FrontWireMapper) -> String {
     if symbols.len() == 0 {

--- a/toolchain/check_json_test.osty
+++ b/toolchain/check_json_test.osty
@@ -62,7 +62,7 @@ fn testCheckJsonFnTypeUsesParamNamesJsonKey() {
     let strRepr = FrontTypeRepr {kind: "primitive", name: "String", path: "", args: [], ret: None, paramNames: []}
     let unitRepr = FrontTypeRepr {kind: "tuple", name: "", path: "", args: [], ret: None, paramNames: []}
     let fnRepr = FrontTypeRepr {kind: "fn", name: "", path: "", args: [strRepr], ret: Some(unitRepr), paramNames: ["msg"]}
-    let binding = FrontCheckedBinding {nodeId: 7, bindingId: 0, name: "log", typeRepr: fnRepr, typeId: 9, mutable: false, start: 0, end: 3}
+    let binding = FrontCheckedBinding {nodeId: 7, name: "log", typeRepr: fnRepr, typeId: 9, mutable: false, start: 0, end: 3}
     let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
     let nodes: List<FrontCheckedNode> = []
     let symbols: List<FrontCheckedSymbol> = []
@@ -77,7 +77,7 @@ fn testCheckJsonFnTypeUsesParamNamesJsonKey() {
 // Osty field `paramNames` must serialize as `param_names`.
 fn testCheckJsonMutableBindingSerializesTrue() {
     let intRepr = FrontTypeRepr {kind: "primitive", name: "Int", path: "", args: [], ret: None, paramNames: []}
-    let binding = FrontCheckedBinding {nodeId: 3, bindingId: 0, name: "x", typeRepr: intRepr, typeId: 1, mutable: true, start: 0, end: 1}
+    let binding = FrontCheckedBinding {nodeId: 3, name: "x", typeRepr: intRepr, typeId: 1, mutable: true, start: 0, end: 1}
     let summary = FrontCheckSummary {assignments: 0, accepted: 0, errors: 0}
     let nodes: List<FrontCheckedNode> = []
     let symbols: List<FrontCheckedSymbol> = []
@@ -448,8 +448,8 @@ fn testCheckStableIDDifferentBindingNamesProduceDifferentIDs() {
     let symbols: List<FrontCheckedSymbol> = []
     let insts: List<FrontCheckInstantiation> = []
     let diags: List<CheckDiagnostic> = []
-    let bindA = FrontCheckedBinding {nodeId: 1, bindingId: 0, name: "alpha", typeRepr: intRepr, typeId: 1, mutable: false, start: 0, end: 5}
-    let bindB = FrontCheckedBinding {nodeId: 2, bindingId: 1, name: "beta", typeRepr: intRepr, typeId: 1, mutable: false, start: 0, end: 5}
+    let bindA = FrontCheckedBinding {nodeId: 1, name: "alpha", typeRepr: intRepr, typeId: 1, mutable: false, start: 0, end: 5}
+    let bindB = FrontCheckedBinding {nodeId: 2, name: "beta", typeRepr: intRepr, typeId: 1, mutable: false, start: 0, end: 5}
     let result = FrontCheckResult {summary, typedNodes: nodes, bindings: [bindA, bindB], symbols, instantiations: insts, diagnostics: diags}
     let out = frontCheckResultToWireJson(result)
     let idA = extractStableIDSuffix(out, "\"name\":\"alpha\"")


### PR DESCRIPTION
## Summary

Follow-up to #1968's Node removal. `CheckedBinding.BindingID int` was the "legacy sequential id" populated by the Osty checker's `let mut bindingId = 0; bindingId++` counter and surfaced as `idx.BindingsByID[int]`.

Audit showed:
- No production Go code reads `binding.BindingID` or `idx.BindingsByID[N]` — only `Index()` populates the map.
- Tests used it as a distinctness key (`item.BindingID != value.BindingID`) or uniqueness key (`seenBindingIDs map[int]bool`). Both replacements use the stable string `binding.ID`, already populated by `EnsureStableIDs`.

### Changes

**Go side**:
- `internal/selfhost/api/types.go`: drop `BindingID int` from `CheckedBinding`; drop `BindingsByID map[int]*CheckedBinding` from `CheckResultIndex`; drop allocation + population in `Index()`.
- `internal/selfhost/check_adapter.go`: drop `BindingID: binding.bindingId` assignment.
- `internal/selfhost/check_snapshot_test.go`: drop `bindingId=` column.
- `internal/selfhost/api/types_test.go`: drop `BindingID:` from fixtures + drop `BindingsByID[12]` lookup.
- `internal/selfhost/package_adapter_test.go`: distinctness check uses `item.ID / value.ID` (stable string).
- `cmd/osty-native-checker/main_test.go`: `seenBindingIDs` map switches to `map[string]bool` keyed by `binding.ID`. **Also fixes stale `node.Node / binding.Node / symbol.Node / inst.Node` refs that #1968 missed** — this test isn't part of `go test ./...` so the breakage hid until now.
- `internal/semanticdb/db_test.go`: same — fix one stale `Node: 1` literal #1968 missed.

**Osty toolchain side**:
- `toolchain/check.osty`: drop `pub bindingId: Int` field + counter loop + push assignment.
- `toolchain/check_json.osty`: drop `,\"bindingId\":{b.bindingId}` from binding emitter.
- `toolchain/check_json_test.osty`: drop `bindingId: N,` from 4 fixtures.

**Snapshot fixtures**: 8 regenerated via `UPDATE_SNAPSHOT=1`.

**Housekeeping**: `.gitignore` updated to exclude `/osty-native-checker` built binary (was accidentally untracked but easy to commit by mistake).

Net **+58 / −77 LOC across 19 files**.

### Continues the Go legacy long-tail arc

- #1956 FrontendRun.File + AstbridgeLowerCount
- #1960 `--engine` / `--native` / LegacyCachePath
- #1962 Native-* identifier rename sweep
- #1965 stale framing scrub
- #1968 Node legacy alias removal
- **This PR**: BindingID legacy sequential id removal + #1968 follow-up fixes

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 -short` passes on `./internal/{selfhost,selfhost/api,semanticdb,check,ir,resolve,lsp}` and `./cmd/{osty,osty-native-checker}`
- [x] Snapshot fixtures regenerated
- [ ] CI green

https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sf5zcHs2KaugrWBnBuoQWQ)_