### PR TITLE
fix: unblock osty test toolchain/ — parse fix + lift main-gate

### DIFF
--- a/cmd/osty/llvm_external_emit.go
+++ b/cmd/osty/llvm_external_emit.go
@@ -15,13 +15,41 @@ var tryExternalPackageLLVMIR = func(entryPath string, pkg *resolve.Package) ([]b
 	return nativellvmgen.TryPackage(".", entryPath, pkg)
 }
 
+// tryExternalPackageLibraryLLVMIR is the test-bundle variant of
+// `tryExternalPackageLLVMIR`. It uses `nativellvmgen.TryPackageLibrary`
+// so the subprocess applies `stripMainForLibraryMode` to the lowered
+// MIR — leaving the user's `main` out of the resulting LLVM IR. The
+// C test driver (`buildNativeTestDriver` in `test_native.go`) supplies
+// the binary's `main` symbol; without this variant a binary-style
+// package like `toolchain/` would hit a duplicate-symbol error at
+// link time, which used to be guarded by an outright E_RUNNER refusal
+// in `discoverNativeTests`.
+var tryExternalPackageLibraryLLVMIR = func(entryPath string, pkg *resolve.Package) ([]byte, bool, []error, error) {
+	if pkg == nil {
+		return nil, false, nil, nil
+	}
+	return nativellvmgen.TryPackageLibrary(".", entryPath, pkg)
+}
+
 var emitPrebuiltLLVMIR = backend.EmitPrebuiltLLVMIR
 
 func tryExternalPackageLLVMArtifacts(ctx context.Context, emitMode backend.EmitMode, layout backend.Layout, binaryName string, features []string, linkLibraries []string, extraObjects []string, entryPath string, pkg *resolve.Package) (*backend.Result, bool, error) {
+	return tryExternalPackageLLVMArtifactsImpl(ctx, emitMode, layout, binaryName, features, linkLibraries, extraObjects, entryPath, pkg, tryExternalPackageLLVMIR)
+}
+
+// tryExternalPackageLLVMArtifactsForTests mirrors
+// `tryExternalPackageLLVMArtifacts` but routes through the library-mode
+// subprocess wrapper so the user's `main` does not leak into the
+// emitted object. Used only from `compileNativeTestBundle`.
+func tryExternalPackageLLVMArtifactsForTests(ctx context.Context, emitMode backend.EmitMode, layout backend.Layout, binaryName string, features []string, linkLibraries []string, extraObjects []string, entryPath string, pkg *resolve.Package) (*backend.Result, bool, error) {
+	return tryExternalPackageLLVMArtifactsImpl(ctx, emitMode, layout, binaryName, features, linkLibraries, extraObjects, entryPath, pkg, tryExternalPackageLibraryLLVMIR)
+}
+
+func tryExternalPackageLLVMArtifactsImpl(ctx context.Context, emitMode backend.EmitMode, layout backend.Layout, binaryName string, features []string, linkLibraries []string, extraObjects []string, entryPath string, pkg *resolve.Package, tryFn func(string, *resolve.Package) ([]byte, bool, []error, error)) (*backend.Result, bool, error) {
 	if pkg == nil || !backend.UseNativeOwnedLLVMIR(features, emitMode) {
 		return nil, false, nil
 	}
-	out, ok, warnings, err := tryExternalPackageLLVMIR(entryPath, pkg)
+	out, ok, warnings, err := tryFn(entryPath, pkg)
 	if err != nil || !ok {
 		return nil, false, nil
 	}

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -24,6 +24,7 @@ import (
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/llvmabi"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/runner"
@@ -547,8 +548,19 @@ func discoverNativeTests(pkg *resolve.Package, filters []string, benchMode bool)
 		}
 		if pf.Run != nil {
 			for _, fn := range selfhost.PackageFunctionsFromRun(pf.Run) {
+				// The user's `main` is filtered from discovery (it's not
+				// a test, and `isDiscoverableNativeTestFn` would reject
+				// it on the test/bench name-prefix check anyway). The
+				// link-time symbol collision between the user's `main`
+				// and the C test driver's `main` is handled at compile
+				// time by stripping `main` from the lowered MIR/IR —
+				// see `stripMainFromEntry` below. Pre-strip refactor
+				// rejected the whole package here with E_RUNNER; we
+				// keep the discovery filter as a no-op skip so test
+				// packages that happen to define `main` (binary-style
+				// packages like `toolchain/`) can run their tests.
 				if fn.Name == "main" {
-					return nil, fmt.Errorf("package %s already defines main; native test runner currently requires a library-style package", pkg.Dir)
+					continue
 				}
 				if !isDiscoverableNativeTestFn(fn, benchMode) {
 					continue
@@ -575,8 +587,13 @@ func discoverNativeTests(pkg *resolve.Package, filters []string, benchMode bool)
 			if fn.Recv != nil || len(fn.Generics) != 0 {
 				continue
 			}
+			// See discoverNativeTests above (the Run-path arm): `main`
+			// is a no-op skip at discovery time because the C test
+			// driver provides the binary's `main` and the lowered MIR/IR
+			// for the package gets its user `main` stripped by
+			// `stripMainFromEntry` before LLVM emission.
 			if fn.Name == "main" {
-				return nil, fmt.Errorf("package %s already defines main; native test runner currently requires a library-style package", pkg.Dir)
+				continue
 			}
 			// `testing` is the stdlib module helper name; skip it in
 			// either mode so it can't shadow a real test.
@@ -696,7 +713,7 @@ func compileNativeTestBundle(ctx context.Context, b backend.Backend, tmpRoot str
 		binName = "osty_test_bundle_probe"
 	}
 	layoutRoot := filepath.Join(tmpRoot, "bundle-"+binName)
-	if result, usedExternal, err := tryExternalPackageLLVMArtifacts(ctx, backend.EmitObject, backend.Layout{
+	if result, usedExternal, err := tryExternalPackageLLVMArtifactsForTests(ctx, backend.EmitObject, backend.Layout{
 		Root:    layoutRoot,
 		Profile: "test",
 	}, "", nil, nil, nil, sourcePath, pkg); usedExternal {
@@ -764,6 +781,7 @@ func prepareNativeTestBackendEntry(sourcePath string, pkg *resolve.Package) (bac
 		if entryFile != nil {
 			entry.Source = entryFile.Source
 		}
+		stripMainFromEntry(&entry)
 		return entry, nil
 	}
 	file, src, err := parseGenEmitFile(pkg)
@@ -777,7 +795,55 @@ func prepareNativeTestBackendEntry(sourcePath string, pkg *resolve.Package) (bac
 		return backend.Entry{}, err
 	}
 	entry.Source = src
+	stripMainFromEntry(&entry)
 	return entry, nil
+}
+
+// stripMainFromEntry removes the user's top-level `main` function from
+// the lowered MIR and IR carried on the test-bundle Entry. The C test
+// driver (`buildNativeTestDriver`) supplies the binary's `main` symbol;
+// leaving the user's `main` in the lowered object would cause a
+// duplicate-symbol error at link time and the runner used to refuse
+// such packages outright (E_RUNNER). Stripping at this stage matches
+// the cross-pkg dep library build's `stripMainForLibraryMode`
+// (`cmd/osty-native-llvmgen/main.go`) which removes `main` from the
+// MIR before LLVM emission for the same reason. Tests never call
+// the user's `main` so the strip is loss-free for test runs.
+//
+// The in-process backend path consumes `entry.MIR` / `entry.IR`
+// directly; the external subprocess path is wired separately by
+// `tryExternalPackageLLVMArtifactsForTests` so the subprocess's own
+// `stripMainForLibraryMode` arm runs.
+func stripMainFromEntry(entry *backend.Entry) {
+	if entry == nil {
+		return
+	}
+	if entry.MIR != nil {
+		filtered := entry.MIR.Functions[:0]
+		for _, fn := range entry.MIR.Functions {
+			if fn == nil {
+				continue
+			}
+			if fn.Name == "main" {
+				continue
+			}
+			filtered = append(filtered, fn)
+		}
+		entry.MIR.Functions = filtered
+	}
+	if entry.IR != nil {
+		filtered := entry.IR.Decls[:0]
+		for _, decl := range entry.IR.Decls {
+			if decl == nil {
+				continue
+			}
+			if fn, ok := decl.(*ir.FnDecl); ok && fn != nil && fn.Name == "main" {
+				continue
+			}
+			filtered = append(filtered, decl)
+		}
+		entry.IR.Decls = filtered
+	}
 }
 
 func linkNativeTestBundleBinary(ctx context.Context, assets nativeTestBundleAssets, tmpRoot string, bundle nativeTestBundle) (string, error) {

--- a/cmd/osty/test_native_inline_test.go
+++ b/cmd/osty/test_native_inline_test.go
@@ -4,6 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
 )
@@ -227,4 +230,118 @@ func mustResolveSingleFilePackage(t *testing.T, path string, src []byte) *resolv
 		}},
 	}
 	return pkg
+}
+
+// TestDiscoverNativeTestsAcceptsPackageWithMain locks the gate-lift:
+// the test runner used to refuse any package that defined a top-level
+// `main()` ("native test runner currently requires a library-style
+// package"). That gate blocked `osty test toolchain/` because the
+// toolchain CLI itself is a binary-style package (`toolchain/main.osty`
+// declares `fn main()`). The discovery pass now skips `main` silently
+// — same way it already skipped `testing` — and the link-time symbol
+// clash with the C test driver's `main` is handled later by
+// `stripMainFromEntry` filtering the lowered MIR + IR.
+func TestDiscoverNativeTestsAcceptsPackageWithMain(t *testing.T) {
+	src := []byte(`fn main() {
+    let _ = 1
+}
+
+fn testReal() {
+    let _ = 2
+}
+
+#[test]
+fn inline_case() {
+    let _ = 3
+}
+`)
+	pkg := mustResolveSingleFilePackage(t, "with_main_test.osty", src)
+	tests, err := discoverNativeTests(pkg, nil, false)
+	if err != nil {
+		t.Fatalf("discoverNativeTests returned error on package with main(): %v", err)
+	}
+	names := map[string]bool{}
+	for _, tc := range tests {
+		names[tc.Name] = true
+	}
+	if names["main"] {
+		t.Error(`main must NOT be discovered as a test`)
+	}
+	if !names["testReal"] || !names["inline_case"] {
+		t.Errorf("expected real tests to be discovered alongside main(), got %v", names)
+	}
+}
+
+// TestStripMainFromEntryRemovesMainFromMIRAndIR pins the lowering-side
+// half of the gate-lift: even though discovery accepts packages with
+// `main()`, the LLVM backend would still produce a duplicate-symbol
+// error when linked against the C test driver's `main`. The strip
+// helper removes `main` from both the MIR and IR carried on the
+// backend entry, mirroring `cmd/osty-native-llvmgen.stripMainForLibraryMode`
+// which the external subprocess path triggers via `TryPackageLibrary`.
+func TestStripMainFromEntryRemovesMainFromMIRAndIR(t *testing.T) {
+	entry := &backend.Entry{
+		MIR: &mir.Module{
+			Functions: []*mir.Function{
+				{Name: "main"},
+				{Name: "testReal"},
+				{Name: "helper"},
+			},
+		},
+		IR: &ir.Module{
+			Decls: []ir.Decl{
+				&ir.FnDecl{Name: "main"},
+				&ir.FnDecl{Name: "testReal"},
+				&ir.FnDecl{Name: "helper"},
+			},
+		},
+	}
+	stripMainFromEntry(entry)
+	if len(entry.MIR.Functions) != 2 {
+		t.Fatalf("after strip MIR.Functions count = %d, want 2 (main removed)", len(entry.MIR.Functions))
+	}
+	for _, fn := range entry.MIR.Functions {
+		if fn.Name == "main" {
+			t.Fatal("stripMainFromEntry left main in MIR.Functions")
+		}
+	}
+	if len(entry.IR.Decls) != 2 {
+		t.Fatalf("after strip IR.Decls count = %d, want 2 (main removed)", len(entry.IR.Decls))
+	}
+	for _, d := range entry.IR.Decls {
+		if fn, ok := d.(*ir.FnDecl); ok && fn.Name == "main" {
+			t.Fatal("stripMainFromEntry left main in IR.Decls")
+		}
+	}
+}
+
+// TestStripMainFromEntryHandlesNilSafely guards the defensive nil
+// branches; the helper is called unconditionally from
+// `prepareNativeTestBackendEntry` and must not panic on the legitimate
+// "MIR-only" or "IR-only" entry shapes the backend produces for
+// different lowering routes.
+func TestStripMainFromEntryHandlesNilSafely(t *testing.T) {
+	// nil entry
+	stripMainFromEntry(nil)
+	// nil MIR + IR
+	stripMainFromEntry(&backend.Entry{})
+	// IR present, MIR nil
+	stripMainFromEntry(&backend.Entry{IR: &ir.Module{Decls: []ir.Decl{&ir.FnDecl{Name: "main"}}}})
+	// MIR present, IR nil
+	stripMainFromEntry(&backend.Entry{MIR: &mir.Module{Functions: []*mir.Function{{Name: "main"}}}})
+	// nil entries inside Functions / Decls
+	entry := &backend.Entry{
+		MIR: &mir.Module{Functions: []*mir.Function{nil, {Name: "main"}, nil, {Name: "ok"}}},
+		IR:  &ir.Module{Decls: []ir.Decl{nil, &ir.FnDecl{Name: "main"}, nil, &ir.FnDecl{Name: "ok"}}},
+	}
+	stripMainFromEntry(entry)
+	if len(entry.MIR.Functions) != 1 || entry.MIR.Functions[0].Name != "ok" {
+		t.Fatalf("nil/main filter MIR result = %v, want [ok]", entry.MIR.Functions)
+	}
+	if len(entry.IR.Decls) != 1 {
+		t.Fatalf("nil/main filter IR result count = %d, want 1", len(entry.IR.Decls))
+	}
+	if fn, ok := entry.IR.Decls[0].(*ir.FnDecl); !ok || fn.Name != "ok" {
+		t.Fatalf("nil/main filter IR result = %v, want [ok]", entry.IR.Decls)
+	}
 }

--- a/toolchain/manifest_emit_test.osty
+++ b/toolchain/manifest_emit_test.osty
@@ -34,7 +34,7 @@ fn testRenderManifestDepLineLongWithPath() {
         ..defaultDep("local"),
         path: "../local",
     }
-    testing.assertEq(renderManifestDepLine(d), "local = { path = \"../local\" }\n")
+    testing.assertEq(renderManifestDepLine(d), "local = \{ path = \"../local\" \}\n")
 }
 fn testRenderManifestDepLineLongVersionPlusPath() {
     // Version + path => long form (mixed shape disqualifies short).
@@ -45,7 +45,7 @@ fn testRenderManifestDepLineLongVersionPlusPath() {
     }
     testing.assertEq(
         renderManifestDepLine(d),
-        "local = { version = \"1.0.0\", path = \"../local\" }\n",
+        "local = \{ version = \"1.0.0\", path = \"../local\" \}\n",
     )
 }
 fn testRenderManifestDepLineGitTagBranchRev() {
@@ -61,7 +61,7 @@ fn testRenderManifestDepLineGitTagBranchRev() {
     }
     testing.assertEq(
         renderManifestDepLine(d),
-        "x = { git = \"https://example.com/x.git\", tag = \"v1.0.0\", branch = \"main\", rev = \"abc1234\" }\n",
+        "x = \{ git = \"https://example.com/x.git\", tag = \"v1.0.0\", branch = \"main\", rev = \"abc1234\" \}\n",
     )
 }
 fn testRenderManifestDepLinePackageRename() {
@@ -72,7 +72,7 @@ fn testRenderManifestDepLinePackageRename() {
     }
     testing.assertEq(
         renderManifestDepLine(d),
-        "alias = { version = \"1.0.0\", package = \"real-name\" }\n",
+        "alias = \{ version = \"1.0.0\", package = \"real-name\" \}\n",
     )
 }
 fn testRenderManifestDepLineRegistry() {
@@ -83,7 +83,7 @@ fn testRenderManifestDepLineRegistry() {
     }
     testing.assertEq(
         renderManifestDepLine(d),
-        "x = { version = \"1.0.0\", registry = \"custom\" }\n",
+        "x = \{ version = \"1.0.0\", registry = \"custom\" \}\n",
     )
 }
 fn testRenderManifestDepLineOptional() {
@@ -94,7 +94,7 @@ fn testRenderManifestDepLineOptional() {
     }
     testing.assertEq(
         renderManifestDepLine(d),
-        "x = { version = \"1.0.0\", optional = true }\n",
+        "x = \{ version = \"1.0.0\", optional = true \}\n",
     )
 }
 fn testRenderManifestDepLineFeatures() {
@@ -105,7 +105,7 @@ fn testRenderManifestDepLineFeatures() {
     }
     testing.assertEq(
         renderManifestDepLine(d),
-        "x = { version = \"1.0.0\", features = [\"a\", \"b\"] }\n",
+        "x = \{ version = \"1.0.0\", features = [\"a\", \"b\"] \}\n",
     )
 }
 fn testRenderManifestDepLineDefaultFeaturesFalse() {
@@ -116,7 +116,7 @@ fn testRenderManifestDepLineDefaultFeaturesFalse() {
     }
     testing.assertEq(
         renderManifestDepLine(d),
-        "x = { version = \"1.0.0\", default-features = false }\n",
+        "x = \{ version = \"1.0.0\", default-features = false \}\n",
     )
 }
 fn testRenderManifestDepLineCombined() {
@@ -131,13 +131,13 @@ fn testRenderManifestDepLineCombined() {
     }
     testing.assertEq(
         renderManifestDepLine(d),
-        "x = { version = \"1.0.0\", optional = true, features = [\"foo\"], default-features = false }\n",
+        "x = \{ version = \"1.0.0\", optional = true, features = [\"foo\"], default-features = false \}\n",
     )
 }
 fn testRenderManifestDepLineNoFieldsLongForm() {
     // No version, no path, no git — degenerate but still emits long form.
     let d = defaultDep("x")
-    testing.assertEq(renderManifestDepLine(d), "x = {  }\n")
+    testing.assertEq(renderManifestDepLine(d), "x = \{  \}\n")
 }
 fn testRenderManifestStringField() {
     testing.assertEq(renderManifestStringField("name", "demo"), "name = \"demo\"\n")
@@ -177,7 +177,7 @@ fn testRenderManifestDepsSectionHonorsDepLineForm() {
     let short = ManifestDepEmitSpec {..defaultDep("a"), versionReq: "1.0.0"}
     let long = ManifestDepEmitSpec {..defaultDep("b"), path: "../b"}
     let out = renderManifestDepsSection("dev-dependencies", [short, long])
-    let expected = "\n[dev-dependencies]\na = \"1.0.0\"\nb = { path = \"../b\" }\n"
+    let expected = "\n[dev-dependencies]\na = \"1.0.0\"\nb = \{ path = \"../b\" \}\n"
     testing.assertEq(out, expected)
 }
 fn testRenderManifestBinSectionBothEmpty() {


### PR DESCRIPTION
## Summary

`osty test toolchain/` 는 **두 개의 pre-existing blocker** 에 막혀 있었음. 본 PR 이 둘 다 해소 → 네이티브 test runner 가 per-test compilation 까지 advance. (각 test 의 실제 성공 여부는 별도 `osty-self` cache-miss wall 에 bound — 본 PR scope 밖.)

### Blocker 1 — `manifest_emit_test.osty:180` parse error

LANG_SPEC v0.5 §1.6.3: 문자열 보간 `{expr}`, 리터럴 `{` / `}` 는 `\{` / `\}` 로 escape 필수. `toolchain/manifest_emit_test.osty` 의 11개 string literal 이 TOML inline-table 문법 (`{ key = "value" }`) 을 unescape 한 상태로 포함 → lexer 가 매번 `{` 를 보간 opener 로 해석 → 파일당 ~22 errors → toolchain-wide test runner 가 parse phase 에서 거부.

**수정**: 11개 literal (lines 37, 48, 64, 75, 86, 97, 108, 119, 134, 140, 180) 의 `{` → `\{`, `}` → `\}`. Escape 가 런타임에서 동일 `{`/`}` 바이트로 디코딩되므로 `renderManifestDepLine` 출력 equality assert 는 그대로 유지.

### Blocker 2 — `discoverNativeTests` rejected packages defining `main()`

`*ast.FnDecl{Name: "main"}` 발견 시 runner 가 `package %s already defines main; native test runner currently requires a library-style package` 로 거부 (`test_native.go:551, 579`). `toolchain/` 에서는 `toolchain/main.osty:663` 의 `osty-self` CLI entry 가 trigger — 그 자리에 있어야 함.

근본 원인: C 테스트 driver (`buildNativeTestDriver`) 가 binary 의 `main` symbol 을 제공. user package 의 lowered object 가 `main` 도 export 하면 linker 가 duplicate-symbol error. Pre-flight refusal 이 보수적 대응이었음.

**수정**: discovery 가 아닌 lowering time 에 `main` strip (cross-pkg dep library build 의 `cmd/osty-native-llvmgen.stripMainForLibraryMode` 와 동일 패턴):

1. **discoverNativeTests** — `main` arm 을 hard `return nil, err` → no-op `continue` (기존 `testing` name-collision skip 과 동일 shape). `main` 은 어차피 test/bench name-prefix filter 통과 못 함 → loss-free skip.
2. **stripMainFromEntry** (`test_native.go` 신규 헬퍼) — `entry.MIR.Functions` 와 `entry.IR.Decls` 양쪽에서 `main` 필터링. `prepareNativeTestBackendEntry` 끝에서 unconditional 호출 → 모든 in-process backend lowering path 가 strip 적용.
3. **tryExternalPackageLibraryLLVMIR / tryExternalPackageLLVMArtifactsForTests** — `nativellvmgen.TryPackageLibrary` 경유 (subprocess 의 `PackageInput.LibraryMode = true` 가 `stripMainForLibraryMode` 발동). `compileNativeTestBundle` 이 `*ForTests` variant 호출 → external path 도 link 전에 strip.

In-process strip 은 LLVM subprocess 가 package decline 한 경우 cover, external strip 은 production fast path cover.

## Tests

`cmd/osty/test_native_inline_test.go` 신규 3종:

- `TestDiscoverNativeTestsAcceptsPackageWithMain` — `fn main()` + `testReal` + `#[test] inline_case` 가 있는 package 가 2 tests discover, `main` 제외, no error.
- `TestStripMainFromEntryRemovesMainFromMIRAndIR` — `main` 이 MIR.Functions + IR.Decls 양쪽에서 filter, sibling decl 보존.
- `TestStripMainFromEntryHandlesNilSafely` — nil 방어 branch: nil entry, nil MIR/IR, slice 내부 nil entries.

기존 `TestPrepareNativeTestBackendEntryFallbackKeepsNativePackageScopes` 포함 8종 모두 통과.

## Test plan

- [x] `.bin/osty check toolchain/` — clean (parse fix 가 `manifest_emit_test.osty` 를 22 errors → 0 errors).
- [x] `go test ./cmd/osty/ -run 'TestDiscoverNativeTests|TestStripMainFromEntry|TestPrepareNativeTest'` — 8/8 통과.
- [x] `go vet ./...` — clean.
- [x] `.bin/osty test --serial --jobs=1 toolchain/ testCheckJsonEmptySourceMatchesGoStub` — discovery + lowering + LLVM emit 까지 advance, 그 다음 `osty-self not found` (별도 layer-3 blocker — 본 PR scope 밖).
- [ ] Full `osty test toolchain/` byte-parity: layer-3 (`osty-self` cache) 가 unblock 되어야 의미 있음 — 별도 batch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2YbnUpRw682ooUP91JSsk)_