### PR TITLE
feat: per-file token layout + PackageCheckFile metadata in package mode

### DIFF
--- a/cmd/osty-native-checker/README.md
+++ b/cmd/osty-native-checker/README.md
@@ -119,11 +119,13 @@ every monomorphized build of `osty-self` or every package is LIR-Proto clean;
 - ✓ JSON value escape (`\"` / `\\` / `\n` / `\t` / `\r` / `\b` /
   `\f` / `\/` / `\uXXXX` + surrogate pair) 디코딩
   (`extractJsonStringValueAt`).
-- ✓ (partial) `CheckRequest.package` 모드 — byte-level scanner 가 첫
-  `"source":` key 를 찾으므로 package 모드 입력에서는 첫 file 의
-  source 가 자연스럽게 매치된다. **첫 파일만 검사** — cross-file
-  resolution 은 toolchain `frontCheckPackageToWireJson` 신설 후에
-  활성 (별도 batch).
+- ✓ `CheckRequest.package` 모드 — multi-file dispatch 가 `frontExtractPackageFiles`
+  로 `{source, name, path, base, sourceFileId}` 메타데이터 전체를 추출하고
+  `frontCheckPackageToWireJson` 으로 라우팅. 각 파일의 combined-buffer
+  시작 byte / line 을 기록한 `FrontPackageFileTable` 이 와이어 mapper 에
+  threading 되어 모든 record 의 `start` / `end` / `startLine` / `endLine`
+  이 file-local 좌표로 환산되고, diagnostic 은 추가로 `file` /
+  `sourceFileId` 필드 + telemetry suffix `<file>:@L<line>:C<col>` 를 받는다.
 - 잔여: 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지
   (key-boundary 엄격 매칭 후속 batch).
 - 출력 측은 진짜 checker 호출 — `tc.frontCheckSourceToWireJson`

--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -20,6 +20,15 @@
 //      Package-level top-level scope 가 공유되므로 cross-file 참조 +
 //      duplicate-decl collision 둘 다 정상 발화.
 //
+//   4. ✓ `CheckRequest.package` per-file token layout — `frontExtractPackageFiles`
+//      이 `{source, name, path, base, sourceFileId}` 메타데이터 전체를 추출
+//      하고 `FrontPackageFileTable` 이 각 파일의 combined-buffer 시작
+//      byte / line offset 을 기록. 와이어 mapper 는 모든 record 의
+//      `start` / `end` / `startLine` / `endLine` 을 file-local 좌표로
+//      환산하며, diagnostic 은 추가로 `file` + `sourceFileId` 필드를
+//      받는다. Telemetry detail suffix 도 `<file>:@L<line>:C<col>` 으로
+//      파일명 prefix 를 붙인다 (Go-side `selfhostLayoutTokenPos` 동등).
+//
 // 잔여 한계 (별도 batch):
 //
 //   - JSON 공백 비허용: `extractSourceField` 가 `"source"` key 뒤
@@ -31,11 +40,6 @@
 //     scanner 가 `"` 직후 / `"` 직전 8 byte 만 검사하므로 `"sources"`
 //     같은 인접 key 가 false-positive 를 일으킬 수 있음 — 후속 batch
 //     에서 key-boundary 엄격 매칭으로 수정.
-//   - `CheckRequest.package` 모드의 per-file token layout: 진단의
-//     `start` / `end` / `startLine` / `startColumn` 은 concat 된
-//     package-wide 버퍼 기준 offset 으로 나간다 (Go-side
-//     `selfhost.CheckPackageStructured` 의 `selfhostPackageTokenLayout`
-//     같은 file-id 매퍼 부재). 별도 batch.
 //   - `PackageCheckInput.imports` 미처리: cross-package 참조
 //     (`use std.io`, `use toolchain as tc` 등) 는 E0501 unresolved-name
 //     으로 떨어진다. `selfhostInstallImportSurfaces` 의 toolchain

--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -68,100 +68,482 @@ pub fn frontCheckSourceToWireJson(source: String) -> String {
 ///
 /// Wire shape — accepted: the full raw JSON request body
 /// (`internal/selfhost/api/types.go::CheckRequest`). The function
-/// extracts every `"source"` string value embedded inside
-/// `"files":[...]`, concatenates the source bytes with a single `\n`
-/// separator, and runs the standard single-file check pipeline on the
-/// combined buffer. The combined-source approach gives multi-file
-/// callers package-level top-level scope for free — duplicate
-/// top-level decls across files correctly trigger E0501 / E0103
-/// collisions just like the Go-side `selfhost.CheckPackageStructured`
-/// — at the cost of byte-parity in `start` / `end` offsets relative
-/// to the original per-file sources.
+/// extracts every file object inside `"files":[...]` (carrying
+/// `source` plus the per-file metadata `name` / `path` / `base` /
+/// `sourceFileId` from `PackageCheckFile`), concatenates the source
+/// bytes with a single `\n` separator, and runs the standard
+/// single-file check pipeline on the combined buffer. The
+/// combined-source approach gives multi-file callers package-level
+/// top-level scope for free — duplicate top-level decls across files
+/// correctly trigger E0501 / E0103 collisions just like the Go-side
+/// `selfhost.CheckPackageStructured`.
 ///
-/// Limitations relative to `selfhost.CheckPackageStructured` (Go-side
+/// Per-file token layout: a `FrontPackageFileTable` records each
+/// file's cumulative byte offset + start line in the combined buffer.
+/// `frontWireMapperFromLexedAndPackage` threads the table into the
+/// wire mapper so every wire `start` / `end` is translated back to
+/// the file-local byte offset (Go-side `selfhostAppendTokenLayout`
+/// parity — token positions report `base + offsetWithinFile`).
+/// `startLine` / `endLine` are likewise rebased to file-local 1-based
+/// lines. Diagnostics gain a `file` field carrying the owning file's
+/// display name (preferring `path` over `name`, matching the Go
+/// `displayName` selection in `selfhostBuildPackageAst`) and a
+/// `sourceFileId` field when the request supplied one.
+///
+/// Telemetry detail suffix mirrors the Go shape:
+/// `<file>:@L<line>:C<col>` when the owning file is known, falling
+/// back to `@L<line>:C<col>` for tokens whose owner cannot be
+/// resolved (degenerate stdin-style requests with empty `name` /
+/// `path` / `sourceFileId`).
+///
+/// Limitation relative to `selfhost.CheckPackageStructured` (Go-side
 /// production path, `internal/selfhost/package_adapter.go`):
 ///
-///   1. Token positions in the wire output are **package-wide**
-///      offsets into the concatenated buffer rather than per-file
-///      offsets. Diagnostic `start` / `end` / `startLine` /
-///      `startColumn` still resolve through the same byte-table
-///      machinery `frontCheckSourceToWireJson` uses, but the file
-///      identity is lost — telemetry suffixes drop back to
-///      `@L<line>:C<col>` without a `<filename>:` prefix.
-///   2. The `imports` array (`PackageCheckInput.Imports`, carrying
-///      cross-package surfaces — exported fns, fields, variants,
-///      type decls) is **not consumed**. References that need an
-///      installed import surface (typical `use std.io` / `use
-///      toolchain as tc`) will surface as E0501 unresolved-name
-///      diagnostics. Closing this requires a toolchain analogue of
-///      `selfhostInstallImportSurfaces` plus the full
-///      `PackageCheckImport` JSON decoder — explicitly out of scope
-///      for the initial multi-file landing (tracked as a separate
-///      batch in `SPEC_GAPS.md::cross-pkg-module-resolution`).
-///   3. File-level metadata (`PackageCheckFile.Name`, `.Path`,
-///      `.SourceFileID`, `.Base`) is ignored. The concatenated
-///      check does not need per-file naming to produce correct
-///      cross-file resolution within the package; surfacing those
-///      names in diagnostic telemetry is the same per-file token
-///      layout work item as (1).
+///   - The `imports` array (`PackageCheckInput.Imports`, carrying
+///     cross-package surfaces — exported fns, fields, variants,
+///     type decls) is **not consumed**. References that need an
+///     installed import surface (typical `use std.io` / `use
+///     toolchain as tc`) will surface as E0501 unresolved-name
+///     diagnostics. Closing this requires a toolchain analogue of
+///     `selfhostInstallImportSurfaces` plus the full
+///     `PackageCheckImport` JSON decoder — explicitly out of scope
+///     for this landing (tracked as a separate batch in
+///     `SPEC_GAPS.md::cross-pkg-module-resolution`).
 pub fn frontCheckPackageToWireJson(packageJson: String) -> String {
-    let sources = frontExtractPackageFileSources(packageJson)
-    let combined = strings.join(sources, "\n")
-    frontCheckSourceToWireJson(combined)
+    let files = frontExtractPackageFiles(packageJson)
+    let table = frontBuildPackageFileTable(files)
+    let combined = table.combined
+    let lexed = ostyLexSource(combined)
+    let result = frontendCheckLexedSourceStructured(lexed)
+    frontCheckResultToWireJsonForLexedAndPackage(result, lexed, table)
 }
-/// frontExtractPackageFileSources scans `packageJson` for every
-/// `"source"` JSON object key found inside an enclosing `"files":[...]`
-/// array and returns the decoded string values in document order.
-///
-/// Implementation: a single byte pass that locates each `"source"`
-/// key (key-boundary aware so `"sources"` does not false-positive),
-/// skips ASCII whitespace + `:` + ASCII whitespace + opening `"`,
-/// then decodes the JSON string body honouring `\"` / `\\` / `\/` /
-/// `\b` / `\f` / `\n` / `\r` / `\t` / `\uXXXX` (BMP) / surrogate
-/// pair (`\uD8xx\uDCxx`) → UTF-8 — same escape semantics as
-/// `cmd/osty-native-checker/main.osty::extractJsonStringValueAt`
-/// and the proven `mir_json.osty::mirJsonParseStrEscaped` path.
-///
-/// A truly bullet-proof JSON parser would also distinguish a `source`
-/// key at top level (`{"source":"..."}` single-file request shape)
-/// from a `source` key nested inside `files[]`. This scanner does
-/// not — it returns every `source` value it finds. The native checker
-/// dispatches to this entry only on `{"package":...}` shape so a
-/// stray top-level `"source"` does not occur in practice, and even
-/// if it did, the concatenation step would still produce a valid
-/// combined source.
+/// frontExtractPackageFileSources is the legacy single-key extractor
+/// kept for callers (e.g. focused tests) that only need the decoded
+/// `source` strings. New code should prefer `frontExtractPackageFiles`
+/// which preserves the per-file `name` / `path` / `base` /
+/// `sourceFileId` metadata alongside the source body.
 pub fn frontExtractPackageFileSources(packageJson: String) -> List<String> {
-    let bs = packageJson.bytes()
-    let len = bs.len()
+    let files = frontExtractPackageFiles(packageJson)
     let mut sources: List<String> = []
+    for f in files {
+        sources.push(f.source)
+    }
+    sources
+}
+/// FrontPackageFile is the per-file payload extracted from the
+/// `{"package":{"files":[{...},...]}}` wire shape. Mirrors the
+/// Go-side `api.PackageCheckFile` (`internal/selfhost/api/package.go`).
+///
+/// `name` is the display filename surfaced in diagnostic telemetry
+/// (typically a basename like `user.osty`). `path` is the owning
+/// source path when known and takes precedence over `name` for the
+/// diagnostic `file` field (matching the Go-side `displayName`
+/// selection in `selfhostBuildPackageAst`). `base` is the byte offset
+/// to add to per-file token positions before reporting them on the
+/// wire — defaults to 0 for plain stdin-style requests. `sourceFileId`
+/// passes through unchanged.
+pub struct FrontPackageFile {
+    pub source: String,
+    pub name: String,
+    pub path: String,
+    pub base: Int,
+    pub sourceFileId: String,
+}
+/// FrontPackageFileTable holds the cumulative byte / line offsets
+/// each file occupies inside the concatenated combined buffer.
+/// `frontBuildPackageFileTable` builds the table; the wire mapper
+/// consults it via `frontPackageTableLookup` to translate combined
+/// positions back to file-local positions.
+///
+/// Slice layout: `fileBaseByte[i]` and `fileStartLine[i]` are the
+/// combined-buffer byte offset / 1-based line number where file `i`
+/// begins. The separator between consecutive files is a single LF
+/// byte, so `fileBaseByte[i+1] = fileBaseByte[i] + bytesOf(file[i]) +
+/// 1` and `fileStartLine[i+1] = fileStartLine[i] + linesOf(file[i]) +
+/// 1`. `combined` is the joined source the lexer will see. Sources
+/// are pre-normalised (CRLF → LF) so the recorded byte / line totals
+/// match the byte offsets `ostyLexSource` emits.
+pub struct FrontPackageFileTable {
+    pub files: List<FrontPackageFile>,
+    pub fileBaseByte: List<Int>,
+    pub fileStartLine: List<Int>,
+    pub combined: String,
+}
+/// frontBuildPackageFileTable normalises each file's source (CRLF →
+/// LF), concatenates the normalised bodies with a single LF
+/// separator, and records each file's start byte / start line in the
+/// combined buffer. The returned `combined` field is what the caller
+/// should feed into the lex / parse / check pipeline; the parallel
+/// `fileBaseByte` / `fileStartLine` lists let the wire mapper map
+/// every diagnostic position back to its owning file.
+pub fn frontBuildPackageFileTable(files: List<FrontPackageFile>) -> FrontPackageFileTable {
+    let mut normFiles: List<FrontPackageFile> = []
+    let mut fileBaseByte: List<Int> = []
+    let mut fileStartLine: List<Int> = []
+    let mut byteCursor = 0
+    let mut lineCursor = 1
+    let mut parts: List<String> = []
+    let mut idx = 0
+    let n = files.len()
+    for idx < n {
+        let f = files[idx]
+        let normalised = ostyNormalizeSource(f.source)
+        let norm = FrontPackageFile {source: normalised, name: f.name, path: f.path, base: f.base, sourceFileId: f.sourceFileId}
+        normFiles.push(norm)
+        fileBaseByte.push(byteCursor)
+        fileStartLine.push(lineCursor)
+        parts.push(normalised)
+        byteCursor = byteCursor + normalised.bytes().len()
+        lineCursor = lineCursor + frontCountLfBytes(normalised)
+        if idx < n - 1 {
+            byteCursor = byteCursor + 1
+            lineCursor = lineCursor + 1
+        }
+        idx = idx + 1
+    }
+    FrontPackageFileTable {files: normFiles, fileBaseByte, fileStartLine, combined: strings.join(parts, "\n")}
+}
+fn frontCountLfBytes(s: String) -> Int {
+    let bs = s.bytes()
+    let len = bs.len()
+    let mut count = 0
     let mut i = 0
     for i < len {
-        if frontMatchSourceKeyAt(bs, i, len) {
-            let afterKey = i + 8
-            let colonAt = frontSkipAsciiWs(bs, afterKey, len)
-            if colonAt < len && bs[colonAt].toInt() == 0x3A {
-                let quoteAt = frontSkipAsciiWs(bs, colonAt + 1, len)
-                if quoteAt < len && bs[quoteAt].toInt() == 0x22 {
-                    let scan = frontDecodeJsonStringAt(bs, quoteAt + 1, len)
-                    sources.push(scan.value)
-                    i = scan.next
-                    continue
-                }
-            }
+        if bs[i].toInt() == 0x0A {
+            count = count + 1
         }
         i = i + 1
     }
-    sources
+    count
+}
+/// FrontPackageLookup is the per-position resolution result returned
+/// by `frontPackageTableLookup`. `fileIdx` is -1 when the offset
+/// could not be attributed to any file (e.g. degenerate
+/// empty-package input). When `fileIdx >= 0`, the caller subtracts
+/// `fileBaseByte[fileIdx]` (and adds `files[fileIdx].base`) to derive
+/// the file-local byte offset to report on the wire.
+pub struct FrontPackageLookup {
+    pub fileIdx: Int,
+}
+fn frontPackageTableLookupByte(table: FrontPackageFileTable, combinedByte: Int) -> FrontPackageLookup {
+    let n = table.files.len()
+    if n == 0 || combinedByte < 0 {
+        return FrontPackageLookup {fileIdx: -1}
+    }
+    let mut idx = n - 1
+    for idx >= 0 {
+        if table.fileBaseByte[idx] <= combinedByte {
+            return FrontPackageLookup {fileIdx: idx}
+        }
+        idx = idx - 1
+    }
+    FrontPackageLookup {fileIdx: -1}
+}
+/// frontExtractPackageFiles parses the `"files"` array of a
+/// `{"package":{...}}` request body and returns one
+/// `FrontPackageFile` per `{...}` element. Per-file keys recognised:
+/// `source` / `name` / `path` / `base` / `sourceFileId` — anything
+/// else is skipped. Decoding shares the same escape semantics as
+/// `frontDecodeJsonStringAt` so the request shape stays byte-parity
+/// with the Go-side `encoding/json` wire decoder.
+///
+/// The scanner respects JSON string boundaries (escapes + `"`
+/// terminators) while tracking object / array depth, so the absence
+/// of a real JSON parser does not let a `"name"` substring inside a
+/// `source` body false-positive as a sibling key.
+pub fn frontExtractPackageFiles(packageJson: String) -> List<FrontPackageFile> {
+    let bs = packageJson.bytes()
+    let len = bs.len()
+    let mut files: List<FrontPackageFile> = []
+    let openAt = frontFindFilesArrayOpen(bs, len)
+    if openAt < 0 {
+        return files
+    }
+    let mut i = openAt + 1
+    for i < len {
+        let pos = frontSkipAsciiWs(bs, i, len)
+        if pos >= len {
+            return files
+        }
+        let b = bs[pos].toInt()
+        if b == 0x5D {
+            return files
+        }
+        if b == 0x2C {
+            i = pos + 1
+            continue
+        }
+        if b == 0x7B {
+            let parsed = frontParseFileObject(bs, pos, len)
+            if !parsed.errored {
+                files.push(parsed.file)
+            }
+            i = parsed.next
+            continue
+        }
+        i = pos + 1
+    }
+    files
+}
+fn frontFindFilesArrayOpen(bs: List<Byte>, len: Int) -> Int {
+    let mut i = 0
+    for i < len {
+        let b = bs[i].toInt()
+        if b == 0x22 {
+            if frontMatchKeyBytes(bs, i, len, "files") {
+                let afterKey = i + 7
+                let colonAt = frontSkipAsciiWs(bs, afterKey, len)
+                if colonAt < len && bs[colonAt].toInt() == 0x3A {
+                    let openAt = frontSkipAsciiWs(bs, colonAt + 1, len)
+                    if openAt < len && bs[openAt].toInt() == 0x5B {
+                        return openAt
+                    }
+                }
+            }
+            let stringEnd = frontSkipJsonString(bs, i, len)
+            i = stringEnd
+            continue
+        }
+        i = i + 1
+    }
+    -1
+}
+fn frontMatchKeyBytes(bs: List<Byte>, at: Int, len: Int, key: String) -> Bool {
+    let keyBytes = key.bytes()
+    let keyLen = keyBytes.len()
+    if at + keyLen + 2 > len {
+        return false
+    }
+    if bs[at].toInt() != 0x22 || bs[at + keyLen + 1].toInt() != 0x22 {
+        return false
+    }
+    let mut k = 0
+    for k < keyLen {
+        if bs[at + 1 + k].toInt() != keyBytes[k].toInt() {
+            return false
+        }
+        k = k + 1
+    }
+    true
+}
+pub struct FrontFileObjectScan {
+    pub file: FrontPackageFile,
+    pub next: Int,
+    pub errored: Bool,
+}
+fn frontParseFileObject(bs: List<Byte>, openAt: Int, len: Int) -> FrontFileObjectScan {
+    let mut source = ""
+    let mut name = ""
+    let mut path = ""
+    let mut base = 0
+    let mut sourceFileId = ""
+    let mut i = openAt + 1
+    for i < len {
+        let pos = frontSkipAsciiWs(bs, i, len)
+        if pos >= len {
+            return FrontFileObjectScan {file: frontEmptyPackageFile(), next: len, errored: true}
+        }
+        let b = bs[pos].toInt()
+        if b == 0x7D {
+            let file = FrontPackageFile {source, name, path, base, sourceFileId}
+            return FrontFileObjectScan {file, next: pos + 1, errored: false}
+        }
+        if b == 0x2C {
+            i = pos + 1
+            continue
+        }
+        if b != 0x22 {
+            return FrontFileObjectScan {file: frontEmptyPackageFile(), next: len, errored: true}
+        }
+        let keyScan = frontDecodeJsonStringAt(bs, pos + 1, len)
+        let key = keyScan.value
+        let afterKey = keyScan.next
+        let colonAt = frontSkipAsciiWs(bs, afterKey, len)
+        if colonAt >= len || bs[colonAt].toInt() != 0x3A {
+            return FrontFileObjectScan {file: frontEmptyPackageFile(), next: len, errored: true}
+        }
+        let valStart = frontSkipAsciiWs(bs, colonAt + 1, len)
+        if valStart >= len {
+            return FrontFileObjectScan {file: frontEmptyPackageFile(), next: len, errored: true}
+        }
+        let valByte = bs[valStart].toInt()
+        if valByte == 0x22 {
+            let strScan = frontDecodeJsonStringAt(bs, valStart + 1, len)
+            if key == "source" {
+                source = strScan.value
+            } else if key == "name" {
+                name = strScan.value
+            } else if key == "path" {
+                path = strScan.value
+            } else if key == "sourceFileId" {
+                sourceFileId = strScan.value
+            }
+            i = strScan.next
+            continue
+        }
+        if (valByte >= 0x30 && valByte <= 0x39) || valByte == 0x2D {
+            let numScan = frontScanJsonInt(bs, valStart, len)
+            if key == "base" {
+                base = numScan.value
+            }
+            i = numScan.next
+            continue
+        }
+        i = frontSkipJsonValue(bs, valStart, len)
+    }
+    FrontFileObjectScan {file: frontEmptyPackageFile(), next: len, errored: true}
+}
+fn frontEmptyPackageFile() -> FrontPackageFile {
+    FrontPackageFile {source: "", name: "", path: "", base: 0, sourceFileId: ""}
+}
+pub struct FrontJsonIntScan {
+    pub value: Int,
+    pub next: Int,
+}
+fn frontScanJsonInt(bs: List<Byte>, pos: Int, len: Int) -> FrontJsonIntScan {
+    let mut i = pos
+    let mut sign = 1
+    if i < len && bs[i].toInt() == 0x2D {
+        sign = -1
+        i = i + 1
+    }
+    let mut acc = 0
+    let mut seenDigit = false
+    for i < len {
+        let b = bs[i].toInt()
+        if b < 0x30 || b > 0x39 {
+            break
+        }
+        acc = acc * 10 + (b - 0x30)
+        seenDigit = true
+        i = i + 1
+    }
+    if i < len {
+        let b = bs[i].toInt()
+        if b == 0x2E || b == 0x65 || b == 0x45 {
+            let after = frontSkipJsonNumberTail(bs, i, len)
+            return FrontJsonIntScan {value: 0, next: after}
+        }
+    }
+    if !seenDigit {
+        return FrontJsonIntScan {value: 0, next: i}
+    }
+    FrontJsonIntScan {value: sign * acc, next: i}
+}
+fn frontSkipJsonNumberTail(bs: List<Byte>, pos: Int, len: Int) -> Int {
+    let mut i = pos
+    for i < len {
+        let b = bs[i].toInt()
+        if !((b >= 0x30 && b <= 0x39) || b == 0x2E || b == 0x65 || b == 0x45 || b == 0x2B || b == 0x2D) {
+            return i
+        }
+        i = i + 1
+    }
+    i
+}
+fn frontSkipJsonValue(bs: List<Byte>, pos: Int, len: Int) -> Int {
+    if pos >= len {
+        return len
+    }
+    let b = bs[pos].toInt()
+    if b == 0x22 {
+        return frontSkipJsonString(bs, pos, len)
+    }
+    if b == 0x7B {
+        return frontSkipJsonObject(bs, pos, len)
+    }
+    if b == 0x5B {
+        return frontSkipJsonArray(bs, pos, len)
+    }
+    if b == 0x74 || b == 0x66 || b == 0x6E {
+        return frontSkipJsonLiteral(bs, pos, len)
+    }
+    if (b >= 0x30 && b <= 0x39) || b == 0x2D {
+        return frontSkipJsonNumberTail(bs, pos, len)
+    }
+    pos + 1
+}
+fn frontSkipJsonString(bs: List<Byte>, openAt: Int, len: Int) -> Int {
+    let mut i = openAt + 1
+    for i < len {
+        let b = bs[i].toInt()
+        if b == 0x5C {
+            i = i + 2
+            continue
+        }
+        if b == 0x22 {
+            return i + 1
+        }
+        i = i + 1
+    }
+    len
+}
+fn frontSkipJsonObject(bs: List<Byte>, openAt: Int, len: Int) -> Int {
+    let mut depth = 1
+    let mut i = openAt + 1
+    for i < len {
+        let b = bs[i].toInt()
+        if b == 0x22 {
+            i = frontSkipJsonString(bs, i, len)
+            continue
+        }
+        if b == 0x7B {
+            depth = depth + 1
+            i = i + 1
+            continue
+        }
+        if b == 0x7D {
+            depth = depth - 1
+            if depth == 0 {
+                return i + 1
+            }
+            i = i + 1
+            continue
+        }
+        i = i + 1
+    }
+    len
+}
+fn frontSkipJsonArray(bs: List<Byte>, openAt: Int, len: Int) -> Int {
+    let mut depth = 1
+    let mut i = openAt + 1
+    for i < len {
+        let b = bs[i].toInt()
+        if b == 0x22 {
+            i = frontSkipJsonString(bs, i, len)
+            continue
+        }
+        if b == 0x5B {
+            depth = depth + 1
+            i = i + 1
+            continue
+        }
+        if b == 0x5D {
+            depth = depth - 1
+            if depth == 0 {
+                return i + 1
+            }
+            i = i + 1
+            continue
+        }
+        i = i + 1
+    }
+    len
+}
+fn frontSkipJsonLiteral(bs: List<Byte>, pos: Int, len: Int) -> Int {
+    let mut i = pos
+    for i < len {
+        let b = bs[i].toInt()
+        if !((b >= 0x61 && b <= 0x7A) || (b >= 0x41 && b <= 0x5A)) {
+            return i
+        }
+        i = i + 1
+    }
+    i
 }
 pub struct FrontJsonStringScan {
     pub value: String,
     pub next: Int,
-}
-fn frontMatchSourceKeyAt(bs: List<Byte>, at: Int, len: Int) -> Bool {
-    if at + 8 > len {
-        return false
-    }
-    bs[at].toInt() == 0x22 && bs[at + 1].toInt() == 0x73 && bs[at + 2].toInt() == 0x6F && bs[at + 3].toInt() == 0x75 && bs[at + 4].toInt() == 0x72 && bs[at + 5].toInt() == 0x63 && bs[at + 6].toInt() == 0x65 && bs[at + 7].toInt() == 0x22
 }
 fn frontSkipAsciiWs(bs: List<Byte>, pos: Int, len: Int) -> Int {
     let mut i = pos
@@ -306,6 +688,16 @@ pub fn frontCheckResultToWireJson(result: FrontCheckResult) -> String {
 pub fn frontCheckResultToWireJsonForLexed(result: FrontCheckResult, lexed: OstyLexedSource) -> String {
     frontCheckResultToWireJsonInner(result, frontWireMapperFromLexed(lexed))
 }
+/// frontCheckResultToWireJsonForLexedAndPackage serialises a
+/// `FrontCheckResult` produced by the multi-file dispatch path,
+/// threading a `FrontPackageFileTable` so every record (typed-node,
+/// binding, symbol, instantiation, diagnostic) reports file-local
+/// byte offsets + lines and diagnostics carry the owning file's
+/// display name + sourceFileId. Mirrors the Go-side
+/// `adaptCheckResultWithTokenLayout` (`internal/selfhost/package_adapter.go`).
+pub fn frontCheckResultToWireJsonForLexedAndPackage(result: FrontCheckResult, lexed: OstyLexedSource, table: FrontPackageFileTable) -> String {
+    frontCheckResultToWireJsonInner(result, frontWireMapperFromLexedAndPackage(lexed, table))
+}
 fn frontCheckResultToWireJsonInner(result: FrontCheckResult, mapper: FrontWireMapper) -> String {
     let telemetry = frontWireBuildTelemetry(result.diagnostics, mapper)
     let mut parts: List<String> = []
@@ -331,6 +723,8 @@ pub struct FrontWireMapper {
     pub byteStart: List<Int>,
     pub byteTotal: Int,
     pub tokens: List<FrontLexToken>,
+    pub hasPackage: Bool,
+    pub package: FrontPackageFileTable,
 }
 pub struct FrontWireRange {
     pub start: Int,
@@ -339,11 +733,19 @@ pub struct FrontWireRange {
     pub startColumn: Int,
     pub endLine: Int,
     pub endColumn: Int,
+    pub file: String,
+    pub sourceFileId: String,
+}
+fn frontEmptyPackageTable() -> FrontPackageFileTable {
+    let emptyFiles: List<FrontPackageFile> = []
+    let emptyInts: List<Int> = []
+    let emptyInts2: List<Int> = []
+    FrontPackageFileTable {files: emptyFiles, fileBaseByte: emptyInts, fileStartLine: emptyInts2, combined: ""}
 }
 pub fn frontWireMapperIdentity() -> FrontWireMapper {
     let emptyStart: List<Int> = []
     let emptyTokens: List<FrontLexToken> = []
-    FrontWireMapper {identity: true, byteStart: emptyStart, byteTotal: 0, tokens: emptyTokens}
+    FrontWireMapper {identity: true, byteStart: emptyStart, byteTotal: 0, tokens: emptyTokens, hasPackage: false, package: frontEmptyPackageTable()}
 }
 pub fn frontWireMapperFromLexed(lexed: OstyLexedSource) -> FrontWireMapper {
     let byteStart = frontWireBuildByteStart(lexed.source)
@@ -352,7 +754,16 @@ pub fn frontWireMapperFromLexed(lexed: OstyLexedSource) -> FrontWireMapper {
     } else {
         byteStart[byteStart.len() - 1]
     }
-    FrontWireMapper {identity: false, byteStart, byteTotal, tokens: lexed.stream.tokens}
+    FrontWireMapper {identity: false, byteStart, byteTotal, tokens: lexed.stream.tokens, hasPackage: false, package: frontEmptyPackageTable()}
+}
+pub fn frontWireMapperFromLexedAndPackage(lexed: OstyLexedSource, table: FrontPackageFileTable) -> FrontWireMapper {
+    let byteStart = frontWireBuildByteStart(lexed.source)
+    let byteTotal = if byteStart.len() == 0 {
+        0
+    } else {
+        byteStart[byteStart.len() - 1]
+    }
+    FrontWireMapper {identity: false, byteStart, byteTotal, tokens: lexed.stream.tokens, hasPackage: true, package: table}
 }
 fn frontWireBuildByteStart(source: String) -> List<Int> {
     let mut byteStart: List<Int> = []
@@ -394,11 +805,11 @@ fn frontWireRuneToByte(m: FrontWireMapper, runeOff: Int) -> Int {
 }
 fn frontWireMapperOffsets(m: FrontWireMapper, startToken: Int, endToken: Int) -> FrontWireRange {
     if m.identity {
-        return FrontWireRange {start: startToken, end: endToken, startLine: 0, startColumn: 0, endLine: 0, endColumn: 0}
+        return FrontWireRange {start: startToken, end: endToken, startLine: 0, startColumn: 0, endLine: 0, endColumn: 0, file: "", sourceFileId: ""}
     }
     let tokensLen = m.tokens.len()
     if tokensLen == 0 {
-        return FrontWireRange {start: 0, end: 0, startLine: 0, startColumn: 0, endLine: 0, endColumn: 0}
+        return FrontWireRange {start: 0, end: 0, startLine: 0, startColumn: 0, endLine: 0, endColumn: 0, file: "", sourceFileId: ""}
     }
     let mut startIdx = startToken
     if startIdx < 0 {
@@ -421,7 +832,43 @@ fn frontWireMapperOffsets(m: FrontWireMapper, startToken: Int, endToken: Int) ->
     if endByte < startByte {
         endByte = startByte
     }
-    FrontWireRange {start: startByte, end: endByte, startLine: startTok.start.line, startColumn: startTok.start.column, endLine: endTok.end.line, endColumn: endTok.end.column}
+    if !m.hasPackage {
+        return FrontWireRange {start: startByte, end: endByte, startLine: startTok.start.line, startColumn: startTok.start.column, endLine: endTok.end.line, endColumn: endTok.end.column, file: "", sourceFileId: ""}
+    }
+    frontWireApplyPackageTable(m.package, startByte, endByte, startTok, endTok)
+}
+fn frontWireApplyPackageTable(table: FrontPackageFileTable, startByte: Int, endByte: Int, startTok: FrontLexToken, endTok: FrontLexToken) -> FrontWireRange {
+    let lookup = frontPackageTableLookupByte(table, startByte)
+    let idx = lookup.fileIdx
+    if idx < 0 {
+        return FrontWireRange {start: startByte, end: endByte, startLine: startTok.start.line, startColumn: startTok.start.column, endLine: endTok.end.line, endColumn: endTok.end.column, file: "", sourceFileId: ""}
+    }
+    let file = table.files[idx]
+    let baseByte = table.fileBaseByte[idx]
+    let startLineBase = table.fileStartLine[idx]
+    let endLookup = frontPackageTableLookupByte(table, endByte)
+    let endIdx = if endLookup.fileIdx < 0 {
+        idx
+    } else {
+        endLookup.fileIdx
+    }
+    let endBaseByte = table.fileBaseByte[endIdx]
+    let endLineBase = table.fileStartLine[endIdx]
+    let localStart = startByte - baseByte + file.base
+    let mut localEnd = endByte - endBaseByte + table.files[endIdx].base
+    if endIdx == idx && localEnd < localStart {
+        localEnd = localStart
+    }
+    let localStartLine = startTok.start.line - startLineBase + 1
+    let localEndLine = endTok.end.line - endLineBase + 1
+    let display = frontPackageFileDisplayName(file)
+    FrontWireRange {start: localStart, end: localEnd, startLine: localStartLine, startColumn: startTok.start.column, endLine: localEndLine, endColumn: endTok.end.column, file: display, sourceFileId: file.sourceFileId}
+}
+fn frontPackageFileDisplayName(file: FrontPackageFile) -> String {
+    if file.path != "" {
+        return file.path
+    }
+    file.name
 }
 // ---------------------------------------------------------------------
 // FrontWireTelemetry — errorsByContext + errorDetails aggregation,
@@ -511,7 +958,22 @@ fn frontWireDiagPosSuffix(d: CheckDiagnostic, m: FrontWireMapper) -> String {
     if line <= 0 || col <= 0 {
         return ""
     }
-    "@L{line}:C{col}"
+    if !m.hasPackage {
+        return "@L{line}:C{col}"
+    }
+    let startByte = frontWireRuneToByte(m, tok.start.offset)
+    let lookup = frontPackageTableLookupByte(m.package, startByte)
+    let idx = lookup.fileIdx
+    if idx < 0 {
+        return "@L{line}:C{col}"
+    }
+    let file = m.package.files[idx]
+    let localLine = line - m.package.fileStartLine[idx] + 1
+    let display = frontPackageFileDisplayName(file)
+    if display == "" {
+        return "@L{localLine}:C{col}"
+    }
+    "{display}:@L{localLine}:C{col}"
 }
 // ---------------------------------------------------------------------
 // Serializer body — each item carries (start, end) explicitly so the
@@ -666,12 +1128,18 @@ fn checkDiagnosticBodyJson(d: CheckDiagnostic, r: FrontWireRange) -> String {
     if r.endColumn > 0 {
         out = out + ",\"endColumn\":{r.endColumn}"
     }
+    if r.file != "" {
+        out = out + ",\"file\":" + frontJsonString(r.file)
+    }
     if d.notes.len() > 0 {
         let mut notesParts: List<String> = []
         for n in d.notes {
             notesParts.push(frontJsonString(n))
         }
         out = out + ",\"notes\":[" + strings.join(notesParts, ",") + "]"
+    }
+    if r.sourceFileId != "" {
+        out = out + ",\"sourceFileId\":" + frontJsonString(r.sourceFileId)
     }
     out + "\}"
 }

--- a/toolchain/check_json_test.osty
+++ b/toolchain/check_json_test.osty
@@ -588,3 +588,119 @@ fn testCheckPackageToWireJsonConcatenatesFilesWithNewline() {
     let out = frontCheckPackageToWireJson("\{\"package\":\{\"files\":[\{\"source\":\"\"\},\{\"source\":\"\"\}]\}\}")
     testing.assertEq(out, "\{\"summary\":\{\"assignments\":0,\"accepted\":0,\"errors\":0\},\"typedNodes\":[],\"bindings\":[],\"symbols\":[],\"instantiations\":[]\}")
 }
+// ---------------------------------------------------------------------
+// Per-file token layout + metadata propagation tests (closure of
+// PR #1966 limits 1 + 3). `frontExtractPackageFiles` exposes the full
+// `{source, name, path, base, sourceFileId}` payload; the package
+// pipeline rebases token positions back to the owning file and
+// stamps diagnostics with `file` / `sourceFileId` + a
+// `<file>:@L<line>:C<col>` telemetry suffix.
+// ---------------------------------------------------------------------
+fn testExtractPackageFilesCarriesNameAndPath() {
+    let body = "\{\"package\":\{\"files\":[\{\"name\":\"a.osty\",\"path\":\"/repo/a.osty\",\"source\":\"fn a()\{\}\"\},\{\"name\":\"b.osty\",\"path\":\"/repo/b.osty\",\"source\":\"fn b()\{\}\"\}]\}\}"
+    let got = frontExtractPackageFiles(body)
+    testing.assertEq(got.len(), 2)
+    testing.assertEq(got[0].name, "a.osty")
+    testing.assertEq(got[0].path, "/repo/a.osty")
+    testing.assertEq(got[0].source, "fn a()\{\}")
+    testing.assertEq(got[1].name, "b.osty")
+    testing.assertEq(got[1].path, "/repo/b.osty")
+}
+// Per-file `name` + `path` must round-trip through the extractor.
+// Order is document order; sibling keys do not interfere with each
+// other regardless of position relative to `source`.
+fn testExtractPackageFilesCarriesBaseAndSourceFileId() {
+    let body = "\{\"package\":\{\"files\":[\{\"source\":\"fn a()\{\}\",\"base\":100,\"sourceFileId\":\"sfid-a\"\}]\}\}"
+    let got = frontExtractPackageFiles(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].base, 100)
+    testing.assertEq(got[0].sourceFileId, "sfid-a")
+}
+// `base` is a numeric value, `sourceFileId` is a string — the
+// extractor must decode both shapes without confusing the JSON
+// value-type scanner.
+fn testExtractPackageFilesNameSubstringInSourceIgnored() {
+    let body = "\{\"package\":\{\"files\":[\{\"source\":\"// \\\"name\\\":\\\"phantom.osty\\\"\\nfn a()\{\}\",\"name\":\"real.osty\"\}]\}\}"
+    let got = frontExtractPackageFiles(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].name, "real.osty")
+    testing.assert(strings.contains(got[0].source, "phantom.osty"))
+}
+// A `"name"` substring embedded inside a `source` string body
+// (escaped quotes) must NOT be confused for a sibling `name` key.
+// The JSON-aware scanner tracks string boundaries so the false
+// positive is impossible.
+fn testCheckPackageToWireJsonDiagnosticCarriesFileField() {
+    let body = "\{\"package\":\{\"files\":[\{\"name\":\"mismatch.osty\",\"path\":\"/repo/mismatch.osty\",\"source\":\"fn main() \{ let x: Int = \\\"hello\\\" \}\"\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(strings.contains(out, "\"diagnostics\":["))
+    testing.assert(strings.contains(out, "\"file\":\"/repo/mismatch.osty\""))
+}
+// Force E0700 via mismatched let binding in a named file. The
+// diagnostic record must carry the file display name (preferring
+// `path` over `name`, mirroring `selfhostBuildPackageAst`).
+fn testCheckPackageToWireJsonDiagnosticPrefersPathOverName() {
+    let body = "\{\"package\":\{\"files\":[\{\"name\":\"basename.osty\",\"path\":\"/full/path.osty\",\"source\":\"fn main() \{ let x: Int = \\\"hello\\\" \}\"\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(strings.contains(out, "\"file\":\"/full/path.osty\""))
+    testing.assert(!strings.contains(out, "\"file\":\"basename.osty\""))
+}
+// When both `path` and `name` are supplied, `path` wins. The
+// telemetry suffix follows the same rule.
+fn testCheckPackageToWireJsonDiagnosticFallsBackToNameWhenPathMissing() {
+    let body = "\{\"package\":\{\"files\":[\{\"name\":\"only-name.osty\",\"source\":\"fn main() \{ let x: Int = \\\"hello\\\" \}\"\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(strings.contains(out, "\"file\":\"only-name.osty\""))
+}
+// `name` is used when `path` is empty — degenerates to the same
+// behaviour as the Go bridge for stdin-style requests.
+fn testCheckPackageToWireJsonTelemetrySuffixHasFilePrefix() {
+    let body = "\{\"package\":\{\"files\":[\{\"path\":\"/repo/mismatch.osty\",\"source\":\"fn main() \{ let x: Int = \\\"hello\\\" \}\"\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(strings.contains(out, "\"errorsByContext\":"))
+    testing.assert(strings.contains(out, "/repo/mismatch.osty:@L"))
+}
+// Telemetry detail suffix matches `selfhostLayoutTokenPos` shape:
+// `<file>:@L<line>:C<col>` when the file display name is known.
+fn testCheckPackageToWireJsonSourceFileIdSurfaces() {
+    let body = "\{\"package\":\{\"files\":[\{\"path\":\"/repo/p.osty\",\"sourceFileId\":\"sfid-42\",\"source\":\"fn main() \{ let x: Int = \\\"hello\\\" \}\"\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(strings.contains(out, "\"sourceFileId\":\"sfid-42\""))
+}
+// `sourceFileId` round-trips into every diagnostic record when
+// supplied — matches the Go `CheckDiagnosticRecord.SourceFileID`
+// JSON tag.
+fn testCheckPackageToWireJsonSecondFileGetsFileLocalPositions() {
+    let body = "\{\"package\":\{\"files\":[\{\"path\":\"first.osty\",\"source\":\"fn alpha() \{\}\"\},\{\"path\":\"second.osty\",\"source\":\"fn main() \{ let x: Int = \\\"hi\\\" \}\"\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(strings.contains(out, "\"file\":\"second.osty\""))
+    testing.assert(strings.contains(out, "\"startLine\":1"))
+    testing.assert(strings.contains(out, "second.osty:@L1:C"))
+}
+// File 0 is `fn alpha() {}` (1 line). File 1's `fn main()` mismatch
+// sits on combined-buffer line 3 (file 0 line 1 + separator line 2
+// + file 1 line 1). Per-file rebasing maps that back to file 1
+// line 1, so the diagnostic `startLine` is 1 (not 3) and the
+// telemetry suffix reads `second.osty:@L1:Cxx`.
+fn testCheckPackageToWireJsonBaseAddsToFileLocalOffsets() {
+    let bodyWithoutBase = "\{\"package\":\{\"files\":[\{\"path\":\"a.osty\",\"source\":\"fn id<T>(value: T) -> T \{ value \}\"\}]\}\}"
+    let bodyWithBase = "\{\"package\":\{\"files\":[\{\"path\":\"a.osty\",\"base\":1000,\"source\":\"fn id<T>(value: T) -> T \{ value \}\"\}]\}\}"
+    let outWithout = frontCheckPackageToWireJson(bodyWithoutBase)
+    let outWith = frontCheckPackageToWireJson(bodyWithBase)
+    testing.assert(strings.contains(outWithout, "\"name\":\"value\""))
+    testing.assert(strings.contains(outWith, "\"name\":\"value\""))
+    let startWithout = extractIntFieldAfter(outWithout, "\"name\":\"value\"", "\"start\":")
+    let startWith = extractIntFieldAfter(outWith, "\"name\":\"value\"", "\"start\":")
+    testing.assertEq(startWithout, "9")
+    testing.assertEq(startWith, "1009")
+}
+// `base` from `PackageCheckFile.Base` adds a constant to every
+// per-file position. The Go-side `selfhostAppendTokenLayout` does
+// the same — `layout.starts = append(..., base + rt.byteOffset(...))`.
+fn testCheckPackageToWireJsonEmptyMetadataKeepsBareSuffix() {
+    let body = "\{\"package\":\{\"files\":[\{\"source\":\"fn main() \{ let x: Int = \\\"hello\\\" \}\"\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(strings.contains(out, "\"errorsByContext\":"))
+    testing.assert(strings.contains(out, "@L1:C"))
+    testing.assert(!strings.contains(out, "\"file\":"))
+}


### PR DESCRIPTION
## Summary

Closes PR #1966 limits **1** + **3**. `frontCheckPackageToWireJson` (`toolchain/check_json.osty`) now extracts the full `{source, name, path, base, sourceFileId}` payload from each `PackageCheckFile`, builds a `FrontPackageFileTable` recording each file's cumulative byte / line offset in the combined buffer, and threads the table into the wire mapper so every record reports file-local positions — matching the Go-side `selfhostAppendTokenLayout` (`internal/selfhost/package_adapter.go`).

### What changed

- **Per-file token layout (limit 1)**: `start` / `end` / `startLine` / `endLine` on every typed-node / binding / symbol / instantiation / diagnostic record now use file-local coordinates instead of combined-buffer offsets. `endLine` / `endColumn` follow the owning file's table entry too — cross-file spans (rare) attribute the end to whichever file the end byte lands in.
- **File metadata propagation (limit 3)**:
  - `frontExtractPackageFiles` replaces the single-key `frontExtractPackageFileSources` scanner. The new JSON-aware walker tracks string boundaries + brace / bracket depth so a `"name"` substring inside an Osty source body cannot false-positive as a sibling key.
  - Diagnostics gain a `file` field (preferring `path` over `name`, mirroring `selfhostBuildPackageAst`'s `displayName` selection) and a `sourceFileId` field when supplied. Field-emission ordering matches Go's `CheckDiagnosticRecord` JSON tag order.
  - Telemetry detail suffix upgrades from `@L<line>:C<col>` to `<file>:@L<line>:C<col>` when the owning file is known; bare suffix preserved for stdin-style requests without metadata.
  - `PackageCheckFile.Base` adds to per-file positions verbatim (Go-side `layout.starts = append(..., base + rt.byteOffset(...))` parity).
- **Legacy entry preserved**: `frontExtractPackageFileSources` stays as a thin wrapper for callers that only need the source bodies. Single-file `frontCheckSourceToWireJson` is untouched (identity / non-package mapper paths preserved).

### Explicitly out of scope

Cross-pkg imports (PR #1966 limit **2**) remain a separate batch — `PackageCheckImport` JSON decoder + `selfhostInstallImportSurfaces` analogue is a substantially larger lift (toolchain analogues for `checkRegisterFn` / `checkRegisterField` / `checkRegisterVariant` / `checkRegisterAlias` / `checkRegisterType` / `checkRegisterInterfaceExtends` + the full `TypeRepr` JSON decoder over nested generic args). Tracked under `SPEC_GAPS.md::cross-pkg-module-resolution`.

### Tests

11 new focused tests under `toolchain/check_json_test.osty`:

- `testExtractPackageFilesCarriesNameAndPath` — full metadata round-trip
- `testExtractPackageFilesCarriesBaseAndSourceFileId` — numeric `base` + string `sourceFileId`
- `testExtractPackageFilesNameSubstringInSourceIgnored` — JSON string-boundary respect
- `testCheckPackageToWireJsonDiagnosticCarriesFileField` — `file` field emission
- `testCheckPackageToWireJsonDiagnosticPrefersPathOverName` — display name precedence
- `testCheckPackageToWireJsonDiagnosticFallsBackToNameWhenPathMissing`
- `testCheckPackageToWireJsonTelemetrySuffixHasFilePrefix`
- `testCheckPackageToWireJsonSourceFileIdSurfaces`
- `testCheckPackageToWireJsonSecondFileGetsFileLocalPositions` — file 1 line 1 reported as line 1 (not combined-buffer line 3)
- `testCheckPackageToWireJsonBaseAddsToFileLocalOffsets` — `base=1000` shifts every reported position by 1000
- `testCheckPackageToWireJsonEmptyMetadataKeepsBareSuffix` — degenerate stdin path

## Test plan

- [x] `.bin/osty check toolchain/` — no new errors in `check_json.osty` (4 pre-existing `inspect.osty` / `lint.osty` errors are from PR #1968's `Node` alias removal and unrelated to this PR)
- [x] `.bin/osty fmt --check` on touched `.osty` files — clean
- [x] `go test ./internal/toolchain/ ./internal/mir/ ./internal/mirjson/` — pass
- [x] `go vet ./internal/toolchain/ ./internal/selfhost/api/` — clean
- [ ] Osty-native `osty test toolchain/` runner — blocked by pre-existing `manifest_emit_test.osty:180` parse error per PR #1966 test plan, out of scope

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRYJBZ3Q5nLJQr5yaXsWXE)_