### PR TITLE
fix: rename FrontCheckedNode/Binding .node → .nodeId stragglers

### DIFF
--- a/toolchain/inspect.osty
+++ b/toolchain/inspect.osty
@@ -455,7 +455,7 @@ fn inspectThreadHintsThroughContainers(arena: AstArena, checked: FrontCheckResul
 fn inspectBindingTypeByPattern(checked: FrontCheckResult) -> List<InspectBindingEntry> {
     let mut out: List<InspectBindingEntry> = []
     for bnd in checked.bindings {
-        out.push(InspectBindingEntry {node: bnd.node, typeRepr: bnd.typeRepr})
+        out.push(InspectBindingEntry {node: bnd.nodeId, typeRepr: bnd.typeRepr})
     }
     out
 }
@@ -568,7 +568,7 @@ fn inspectBuildRecords(arena: AstArena, checked: FrontCheckResult, letPatterns: 
         if bnd.name == "" || bnd.name == "_" {
             continue
         }
-        let isLocalLet = inspectIsLetPatternIdx(letPatterns, bnd.node)
+        let isLocalLet = inspectIsLetPatternIdx(letPatterns, bnd.nodeId)
         let rule = if isLocalLet {
             "LET"
         } else {
@@ -589,7 +589,7 @@ fn inspectBuildRecords(arena: AstArena, checked: FrontCheckResult, letPatterns: 
             }
         }
         let span = if isLocalLet {
-            inspectLookupLetSpan(letSpanByPattern, bnd.node, bnd.start, bnd.end)
+            inspectLookupLetSpan(letSpanByPattern, bnd.nodeId, bnd.start, bnd.end)
         } else {
             InspectSpan {start: bnd.start, end: bnd.end}
         }

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -2061,7 +2061,7 @@ fn selfLintTypeHintsFromChecked(checked: FrontCheckResult) -> SelfLintTypeHints 
     let mut nodes: List<Int> = []
     let mut types: List<FrontTypeRepr> = []
     for tn in checked.typedNodes {
-        nodes.push(tn.node)
+        nodes.push(tn.nodeId)
         types.push(tn.typeRepr)
     }
     SelfLintTypeHints {enabled: true, nodes, types}


### PR DESCRIPTION
## Summary

PR #1968 이 `FrontCheckedNode` / `FrontCheckedBinding` / `FrontCheckedSymbol` / `FrontCheckInstantiation` 의 `Node` legacy alias 를 제거하고 모든 `.node` 필드를 `.nodeId` 로 rename 했는데, `toolchain/` 의 4 call site 가 누락:

- `inspect.osty:458` — `InspectBindingEntry {node: bnd.node, ...}` (구조체 리터럴의 `node:` key 는 local field name 이라 유지, RHS `bnd.node` 만 `.nodeId` 로 migrate)
- `inspect.osty:571` — `inspectIsLetPatternIdx(letPatterns, bnd.node)`
- `inspect.osty:592` — `inspectLookupLetSpan(letSpanByPattern, bnd.node, ...)`
- `lint.osty:2064` — `nodes.push(tn.node)` (`for tn in checked.typedNodes` walk 안)

`osty check toolchain/` 와 Go-side `selfhost` / `check` 테스트 둘 다 E0702 (`no field 'node' on type 'FrontCheckedNode|Binding'`) 로 fail closed. 체커가 같은 suggested fix wording (`= note: hint: did you mean nodeId?`) 을 제공하므로 4-line mechanical rename.

## Test plan

- [x] `.bin/osty check toolchain/` — clean.
- [x] `.bin/osty install-self` — 본 fix 적용 전: `osty build toolchain/: exit status 1` 로 위 4 E0702. 적용 후: source bootstrap end-to-end 통과, `.osty/cache/self-host/<sha>-<triple>/osty-self` cache slot 에 artifact landing.
- [x] `go test ./internal/check/ ./internal/selfhost/` — 통과.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2YbnUpRw682ooUP91JSsk)_