### PR TITLE
feat: PackageCheckImport JSON decoder + frontInstallImportSurfaces

### DIFF
--- a/cmd/osty-native-checker/README.md
+++ b/cmd/osty-native-checker/README.md
@@ -126,6 +126,15 @@ every monomorphized build of `osty-self` or every package is LIR-Proto clean;
   threading 되어 모든 record 의 `start` / `end` / `startLine` / `endLine`
   이 file-local 좌표로 환산되고, diagnostic 은 추가로 `file` /
   `sourceFileId` 필드 + telemetry suffix `<file>:@L<line>:C<col>` 를 받는다.
+- ✓ `PackageCheckInput.imports` cross-package surface — `frontExtractPackageImports`
+  가 `imports` 배열을 `FrontPackageImport` 로 디코드 (Functions + Fields +
+  Variants + Aliases + TypeDecls + InterfaceExts + RegisterAsIface 전부;
+  nested `TypeRepr` 재귀 디코드 포함). `frontInstallImportSurfaces` 가
+  `newElabCx` 와 `elabFile` 사이에서 각 alias 를 모듈-like named type
+  binding + import alias 마킹 + 모든 exported surface 등록. Go-side
+  `selfhostInstallImportSurfaces` (`internal/selfhost/package_adapter.go`)
+  와 동등. `use std.io` / `use toolchain as tc` 같은 cross-pkg 참조가
+  E0501 / E0703 / E0702 없이 정상 resolve.
 - 잔여: 다른 key 가 `"source"` 를 substring 으로 포함하면 오인지
   (key-boundary 엄격 매칭 후속 batch).
 - 출력 측은 진짜 checker 호출 — `tc.frontCheckSourceToWireJson`

--- a/cmd/osty-native-checker/main.osty
+++ b/cmd/osty-native-checker/main.osty
@@ -28,6 +28,14 @@
 //      환산하며, diagnostic 은 추가로 `file` + `sourceFileId` 필드를
 //      받는다. Telemetry detail suffix 도 `<file>:@L<line>:C<col>` 으로
 //      파일명 prefix 를 붙인다 (Go-side `selfhostLayoutTokenPos` 동등).
+//   5. ✓ `PackageCheckInput.imports` cross-package surface installation —
+//      `frontExtractPackageImports` 가 wire 의 `imports` 배열을
+//      `FrontPackageImport` 로 디코드 (fns + fields + variants + aliases
+//      + typeDecls + interfaceExts + registerAsIface 전부; nested
+//      `TypeRepr` 재귀 디코더 포함). `frontInstallImportSurfaces` 가
+//      `newElabCx` 와 `elabFile` 사이에서 각 alias 를 모듈-like named
+//      type 으로 binding + import alias 마킹 + 모든 exported surface
+//      등록. Go-side `selfhostInstallImportSurfaces` 와 동등.
 //
 // 잔여 한계 (별도 batch):
 //
@@ -40,11 +48,6 @@
 //     scanner 가 `"` 직후 / `"` 직전 8 byte 만 검사하므로 `"sources"`
 //     같은 인접 key 가 false-positive 를 일으킬 수 있음 — 후속 batch
 //     에서 key-boundary 엄격 매칭으로 수정.
-//   - `PackageCheckInput.imports` 미처리: cross-package 참조
-//     (`use std.io`, `use toolchain as tc` 등) 는 E0501 unresolved-name
-//     으로 떨어진다. `selfhostInstallImportSurfaces` 의 toolchain
-//     analogue + `PackageCheckImport` JSON 디코더가 필요한 별도 batch
-//     (`SPEC_GAPS.md::cross-pkg-module-resolution`).
 //
 // 출력 측은 toolchain 의 `tc.frontCheckSourceToWireJson` 가 담당 — 진짜
 // 체커를 돌리고 `internal/selfhost/api/types.go::CheckResult` 의 JSON

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -42,10 +42,10 @@ pub struct FrontTypeRepr {
     pub path: String,
     pub args: List<FrontTypeRepr>,
     pub ret: Option<FrontTypeRepr>,
-    /// paramNames: G20. For fn-type reprs, carries parameter names.
-    /// Empty when no names are available.
     pub paramNames: List<String>,
 }
+/// paramNames: G20. For fn-type reprs, carries parameter names.
+/// Empty when no names are available.
 /// tyToRepr converts a TyArena index into a structured FrontTypeRepr,
 /// eliminating the string-based round-trip on the Go ↔ Osty boundary.
 pub fn tyToRepr(arena: TyArena, idx: Int) -> FrontTypeRepr {
@@ -77,7 +77,6 @@ pub fn tyToRepr(arena: TyArena, idx: Int) -> FrontTypeRepr {
             for p in node.args {
                 paramReprs.push(tyToRepr(arena, p))
             }
-            // G20: propagate param names from the TyNode.
             let names = node.fnParamNames
             FrontTypeRepr {kind: "fn", name: "", path: "", args: paramReprs, ret: Some(tyToRepr(arena, node.ret)), paramNames: names}
         },
@@ -92,6 +91,7 @@ pub fn tyToRepr(arena: TyArena, idx: Int) -> FrontTypeRepr {
         TkSelf -> FrontTypeRepr {kind: "self", name: "Self", path: "", args: [], ret: None, paramNames: []},
     }
 }
+// G20: propagate param names from the TyNode.
 pub fn frontInvalidTypeRepr() -> FrontTypeRepr {
     FrontTypeRepr {kind: "error", name: "Invalid", path: "", args: [], ret: None, paramNames: []}
 }
@@ -126,7 +126,6 @@ pub fn frontTypeReprToString(repr: FrontTypeRepr) -> String {
         let mut parts: List<String> = []
         let mut i = 0
         for p in repr.args {
-            // G20: include param name when available.
             if repr.paramNames.len() > 0 && i < repr.paramNames.len() {
                 let name = repr.paramNames[i]
                 if name != "" {
@@ -148,6 +147,7 @@ pub fn frontTypeReprToString(repr: FrontTypeRepr) -> String {
         repr.name
     }
 }
+// G20: include param name when available.
 pub struct FrontCheckedNode {
     pub nodeId: Int,
     pub kind: String,
@@ -218,6 +218,25 @@ pub fn frontendCheckAst(file: AstFile) -> FrontCheckSummary {
 pub fn frontendCheckAstStructured(file: AstFile) -> FrontCheckResult {
     let tys = emptyTyArena()
     let cx = newElabCx(file, tys)
+    elabFile(cx)
+    serializeCheckResult(cx)
+}
+/// frontendCheckLexedSourceWithImports is the multi-file analogue
+/// entry called by `frontCheckPackageToWireJson`. It installs the
+/// supplied import surfaces (`FrontPackageImport` carrying exported
+/// fns / fields / variants / aliases / type decls / interface
+/// extensions / register-as-iface markers) into the check env
+/// between `newElabCx` and `elabFile`. Mirrors the Go-side
+/// `selfhost.CheckPackageStructured` flow:
+///
+///     cx := newElabCx(file, nil)
+///     selfhostInstallImportSurfaces(cx.env, input.Imports)
+///     elabFile(cx)
+pub fn frontendCheckLexedSourceWithImports(lexed: OstyLexedSource, imports: List<FrontPackageImport>) -> FrontCheckResult {
+    let parsed = astParseLexedSource(lexed)
+    let tys = emptyTyArena()
+    let cx = newElabCx(parsed, tys)
+    frontInstallImportSurfaces(cx.env, imports)
     elabFile(cx)
     serializeCheckResult(cx)
 }
@@ -734,16 +753,10 @@ fn collectFnDecl(cx: ElabCx, declIdx: Int, node: AstNode, owner: String, ownerGe
     } else {
         let _ = node
     }
-    // G20: build fn-type with param names. Strip the "?" prefix
-    // that arity-tracking uses — the fn-type metadata wants clean names.
     let fnTy = if sig.paramNames.len() > 0 {
         let mut cleanNames: List<String> = []
         for pn in sig.paramNames {
             if pn.startsWith("?") {
-                // String has no 1-arg `slice` intrinsic method; use the
-                // free-function form `strings.slice(s, start, end)`
-                // which the native checker recognises and the MIR
-                // emitter lowers to `MirIntrinsicStringSubstring`.
                 cleanNames.push(strings.slice(pn, 1, pn.len()))
             } else {
                 cleanNames.push(pn)
@@ -755,6 +768,12 @@ fn collectFnDecl(cx: ElabCx, declIdx: Int, node: AstNode, owner: String, ownerGe
     }
     checkRecordSymbol(cx.env, declIdx, "fn", name, owner, fnTy, node.start, node.end)
 }
+// G20: build fn-type with param names. Strip the "?" prefix
+// that arity-tracking uses — the fn-type metadata wants clean names.
+// String has no 1-arg `slice` intrinsic method; use the
+// free-function form `strings.slice(s, start, end)`
+// which the native checker recognises and the MIR
+// emitter lowers to `MirIntrinsicStringSubstring`.
 // Build paramTys / paramNames from node.children (AstNParam entries).
 // Prefix default-carrying params with "?" so the arity check
 // (see paramDefaultCount in elab.osty) can count trailing

--- a/toolchain/check_imports.osty
+++ b/toolchain/check_imports.osty
@@ -463,15 +463,16 @@ fn frontDecodeImportEntry(v: FrontJsonValue) -> FrontPackageImport {
     FrontPackageImport {alias, functions, fields, variants, aliases, typeDecls, interfaceExts, registerAsIface}
 }
 // =====================================================================
-// 6. Top-level `imports` array locator.
+// 6. `package.imports` array locator.
 //
 // The request body shape is
 // `{"package":{"files":[...],"imports":[...]}}`. The byte scanner
-// finds the first `"imports"` key whose immediate JSON value is an
-// array, builds the value tree from there, and decodes each entry.
-// Like `frontFindFilesArrayOpen`, the search respects string
-// boundaries so a stray `"imports"` substring inside a source body
-// cannot false-positive.
+// locates the `"package":{...}` object bounds first, then scans only
+// within its interior for a direct-child `"imports"` array — so a
+// sibling top-level `"imports"` key or a nested `"imports"` inside
+// some other shape cannot false-positive. Matches the Go-side
+// `CheckRequest.Package.Imports` decoding semantics — only keys
+// nested under `package` count as part of the package shape.
 // =====================================================================
 pub fn frontExtractPackageImports(packageJson: String) -> List<FrontPackageImport> {
     let bs = packageJson.bytes()
@@ -491,27 +492,11 @@ pub fn frontExtractPackageImports(packageJson: String) -> List<FrontPackageImpor
     out
 }
 fn frontFindImportsArrayOpen(bs: List<Byte>, len: Int) -> Int {
-    let mut i = 0
-    for i < len {
-        let b = bs[i].toInt()
-        if b == 0x22 {
-            if frontMatchKeyBytes(bs, i, len, "imports") {
-                let afterKey = i + 9
-                let colonAt = frontSkipAsciiWs(bs, afterKey, len)
-                if colonAt < len && bs[colonAt].toInt() == 0x3A {
-                    let openAt = frontSkipAsciiWs(bs, colonAt + 1, len)
-                    if openAt < len && bs[openAt].toInt() == 0x5B {
-                        return openAt
-                    }
-                }
-            }
-            let stringEnd = frontSkipJsonString(bs, i, len)
-            i = stringEnd
-            continue
-        }
-        i = i + 1
+    let bounds = frontFindPackageObjectBounds(bs, len)
+    if bounds.start < 0 {
+        return -1
     }
-    -1
+    frontFindArrayOpenForKey(bs, bounds.start, bounds.end, "imports")
 }
 // =====================================================================
 // 7. TypeRepr → ty Int translator.
@@ -697,9 +682,9 @@ pub fn frontInstallImportSurfaces(env: CheckEnv, imports: List<FrontPackageImpor
                 frontTypeNameToTy(env, impFn.returnTypeName)
             }
             let paramNames = frontImportFnParamNames(impFn.paramNames, impFn.paramDefaults, paramTys.len())
-            checkRegisterFn(env, CheckFnSig {name: impFn.name, owner: imp.alias, receiverTy, hasReceiver: impFn.hasReceiver, retTy, paramNames, paramTys, generics: impFn.generics, genericBounds: frontMaterializeBounds(env, impFn.genericBounds)})
+            checkRegisterFn(env, CheckFnSig {name: impFn.name, owner: impFn.owner, receiverTy, hasReceiver: impFn.hasReceiver, retTy, paramNames, paramTys, generics: impFn.generics, genericBounds: frontMaterializeBounds(env, impFn.genericBounds)})
             if impFn.hasBody {
-                checkMarkFnHasBody(env, impFn.name, imp.alias)
+                checkMarkFnHasBody(env, impFn.name, impFn.owner)
             }
         }
     }

--- a/toolchain/check_imports.osty
+++ b/toolchain/check_imports.osty
@@ -1,0 +1,761 @@
+// check_imports.osty - PackageCheckImport JSON decoder + install surfaces.
+//
+// Closes PR #1966 limit 2 (cross-pkg imports in package mode). Mirrors
+// the Go-side `internal/selfhost/package_adapter.go::selfhostInstallImportSurfaces`
+// + `selfhostTypeReprToTy` + the wire shape from
+// `internal/selfhost/api/package.go::PackageCheckImport`.
+//
+// Pipeline:
+//
+//   1. `frontExtractPackageImports(packageJson)` walks the request
+//      body's `imports` array and decodes each `PackageCheckImport`
+//      object into a `FrontPackageImport`. Each entry carries the
+//      alias name plus the surfaces it exports — fns, fields,
+//      variants, aliases, type decls, interface extensions, and a
+//      list of interface types it claims to satisfy via structural
+//      `register_as_iface`.
+//
+//   2. `frontInstallImportSurfaces(env, imports)` walks the decoded
+//      list, binds each alias into the check env as a module-like
+//      named type (so `tc.foo()` member-access resolves), marks the
+//      alias as an import alias, then registers every imported
+//      surface (interfaces, type decls, interface extensions,
+//      aliases, fields, variants, functions) under the alias as
+//      owner. Functions tagged `hasBody` additionally get marked
+//      with `checkMarkFnHasBody` so the cross-pkg method dispatcher
+//      can tell stubs from real implementations.
+//
+//   3. `frontendCheckLexedSourceWithImports` (`check.osty`) calls
+//      `frontInstallImportSurfaces` between `newElabCx` and
+//      `elabFile` so the collect / elaborate two-phase walk sees
+//      the imported names before any body is visited.
+//
+// Without this pipeline, multi-file requests carrying cross-package
+// surfaces produced spurious E0501 unresolved-name diagnostics for
+// every `tc.foo` / `std.io.bar` reference — see PR #1966 limit 2.
+use std.strings as strings
+// =====================================================================
+// 1. Top-level shapes — mirror api.PackageCheckImport + sub-types.
+// =====================================================================
+pub struct FrontPackageImportGenericBound {
+    pub tyParam: String,
+    pub interfaceTypeRepr: FrontTypeRepr,
+    pub interfaceTypeName: String,
+}
+pub struct FrontPackageImportFn {
+    pub name: String,
+    pub owner: String,
+    pub receiverTypeRepr: FrontTypeRepr,
+    pub receiverTypeName: String,
+    pub hasReceiver: Bool,
+    pub returnTypeRepr: FrontTypeRepr,
+    pub returnTypeName: String,
+    pub hasReturn: Bool,
+    pub hasBody: Bool,
+    pub paramNames: List<String>,
+    pub paramTypeReprs: List<FrontTypeRepr>,
+    pub paramTypeNames: List<String>,
+    pub paramDefaults: List<Bool>,
+    pub generics: List<String>,
+    pub genericBounds: List<FrontPackageImportGenericBound>,
+}
+pub struct FrontPackageImportField {
+    pub owner: String,
+    pub name: String,
+    pub typeRepr: FrontTypeRepr,
+    pub typeName: String,
+    pub exported: Bool,
+    pub hasDefault: Bool,
+}
+pub struct FrontPackageImportVariant {
+    pub owner: String,
+    pub name: String,
+    pub fieldTypeReprs: List<FrontTypeRepr>,
+    pub fieldTypeNames: List<String>,
+    pub generics: List<String>,
+}
+pub struct FrontPackageImportAlias {
+    pub name: String,
+    pub targetRepr: FrontTypeRepr,
+    pub targetName: String,
+    pub generics: List<String>,
+}
+pub struct FrontPackageImportType {
+    pub name: String,
+    pub kind: String,
+    pub generics: List<String>,
+    pub genericBounds: List<FrontPackageImportGenericBound>,
+}
+pub struct FrontPackageImportInterfaceExt {
+    pub owner: String,
+    pub interfaceTypeRepr: FrontTypeRepr,
+    pub interfaceTypeName: String,
+}
+pub struct FrontPackageImport {
+    pub alias: String,
+    pub functions: List<FrontPackageImportFn>,
+    pub fields: List<FrontPackageImportField>,
+    pub variants: List<FrontPackageImportVariant>,
+    pub aliases: List<FrontPackageImportAlias>,
+    pub typeDecls: List<FrontPackageImportType>,
+    pub interfaceExts: List<FrontPackageImportInterfaceExt>,
+    pub registerAsIface: List<String>,
+}
+fn frontEmptyTypeRepr() -> FrontTypeRepr {
+    FrontTypeRepr {kind: "", name: "", path: "", args: [], ret: None, paramNames: []}
+}
+// =====================================================================
+// 2. Generic JSON value tree.
+//
+// The byte-level scanner in `check_json.osty` is sufficient for flat
+// field extraction, but PackageCheckImport carries deeply nested
+// shapes (TypeRepr recurses through args + return; per-import lists
+// each carry their own object schema). Building a generic value
+// tree keeps the downstream decoders short and uniform — every
+// decoder just reads expected keys off a `FrontJsonObject` and
+// recurses through `FrontJsonArray`s.
+// =====================================================================
+pub enum FrontJsonValue {
+    FJString(String),
+    FJBool(Bool),
+    FJInt(Int),
+    FJNull,
+    FJArray(List<FrontJsonValue>),
+    FJObject(List<FrontJsonField>),
+}
+pub struct FrontJsonField {
+    pub key: String,
+    pub value: FrontJsonValue,
+}
+pub struct FrontJsonValueScan {
+    pub value: FrontJsonValue,
+    pub next: Int,
+}
+fn frontParseJsonValueAt(bs: List<Byte>, pos: Int, len: Int) -> FrontJsonValueScan {
+    let p = frontSkipAsciiWs(bs, pos, len)
+    if p >= len {
+        return FrontJsonValueScan {value: FJNull, next: len}
+    }
+    let b = bs[p].toInt()
+    if b == 0x22 {
+        let scan = frontDecodeJsonStringAt(bs, p + 1, len)
+        return FrontJsonValueScan {value: FJString(scan.value), next: scan.next}
+    }
+    if b == 0x7B {
+        return frontParseJsonObjectAt(bs, p, len)
+    }
+    if b == 0x5B {
+        return frontParseJsonArrayAt(bs, p, len)
+    }
+    if b == 0x74 {
+        if frontMatchLiteral(bs, p, len, "true") {
+            return FrontJsonValueScan {value: FJBool(true), next: p + 4}
+        }
+        return FrontJsonValueScan {value: FJNull, next: frontSkipJsonLiteral(bs, p, len)}
+    }
+    if b == 0x66 {
+        if frontMatchLiteral(bs, p, len, "false") {
+            return FrontJsonValueScan {value: FJBool(false), next: p + 5}
+        }
+        return FrontJsonValueScan {value: FJNull, next: frontSkipJsonLiteral(bs, p, len)}
+    }
+    if b == 0x6E {
+        if frontMatchLiteral(bs, p, len, "null") {
+            return FrontJsonValueScan {value: FJNull, next: p + 4}
+        }
+        return FrontJsonValueScan {value: FJNull, next: frontSkipJsonLiteral(bs, p, len)}
+    }
+    if (b >= 0x30 && b <= 0x39) || b == 0x2D {
+        let numScan = frontScanJsonInt(bs, p, len)
+        return FrontJsonValueScan {value: FJInt(numScan.value), next: numScan.next}
+    }
+    FrontJsonValueScan {value: FJNull, next: p + 1}
+}
+fn frontMatchLiteral(bs: List<Byte>, at: Int, len: Int, literal: String) -> Bool {
+    let lb = literal.bytes()
+    let n = lb.len()
+    if at + n > len {
+        return false
+    }
+    let mut i = 0
+    for i < n {
+        if bs[at + i].toInt() != lb[i].toInt() {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+fn frontParseJsonArrayAt(bs: List<Byte>, openAt: Int, len: Int) -> FrontJsonValueScan {
+    let mut items: List<FrontJsonValue> = []
+    let mut i = openAt + 1
+    for i < len {
+        let pos = frontSkipAsciiWs(bs, i, len)
+        if pos >= len {
+            return FrontJsonValueScan {value: FJArray(items), next: len}
+        }
+        let b = bs[pos].toInt()
+        if b == 0x5D {
+            return FrontJsonValueScan {value: FJArray(items), next: pos + 1}
+        }
+        if b == 0x2C {
+            i = pos + 1
+            continue
+        }
+        let scan = frontParseJsonValueAt(bs, pos, len)
+        items.push(scan.value)
+        i = scan.next
+    }
+    FrontJsonValueScan {value: FJArray(items), next: len}
+}
+fn frontParseJsonObjectAt(bs: List<Byte>, openAt: Int, len: Int) -> FrontJsonValueScan {
+    let mut entries: List<FrontJsonField> = []
+    let mut i = openAt + 1
+    for i < len {
+        let pos = frontSkipAsciiWs(bs, i, len)
+        if pos >= len {
+            return FrontJsonValueScan {value: FJObject(entries), next: len}
+        }
+        let b = bs[pos].toInt()
+        if b == 0x7D {
+            return FrontJsonValueScan {value: FJObject(entries), next: pos + 1}
+        }
+        if b == 0x2C {
+            i = pos + 1
+            continue
+        }
+        if b != 0x22 {
+            i = pos + 1
+            continue
+        }
+        let keyScan = frontDecodeJsonStringAt(bs, pos + 1, len)
+        let key = keyScan.value
+        let colonAt = frontSkipAsciiWs(bs, keyScan.next, len)
+        if colonAt >= len || bs[colonAt].toInt() != 0x3A {
+            return FrontJsonValueScan {value: FJObject(entries), next: len}
+        }
+        let valScan = frontParseJsonValueAt(bs, colonAt + 1, len)
+        entries.push(FrontJsonField {key, value: valScan.value})
+        i = valScan.next
+    }
+    FrontJsonValueScan {value: FJObject(entries), next: len}
+}
+// =====================================================================
+// 3. JSON value accessors.
+//
+// Decoders below treat absent / wrong-typed fields as zero values
+// (empty string / 0 / false / empty list / empty struct). Matches the
+// Go-side `encoding/json` behaviour where unmarshalling onto a struct
+// leaves zero-valued fields zero-valued.
+// =====================================================================
+fn frontJsonObjectGet(obj: List<FrontJsonField>, key: String) -> FrontJsonValue {
+    for f in obj {
+        if f.key == key {
+            return f.value
+        }
+    }
+    FJNull
+}
+fn frontJsonAsString(v: FrontJsonValue) -> String {
+    match v {
+        FJString(s) -> s,
+        _ -> "",
+    }
+}
+fn frontJsonAsBool(v: FrontJsonValue) -> Bool {
+    match v {
+        FJBool(b) -> b,
+        _ -> false,
+    }
+}
+fn frontJsonAsInt(v: FrontJsonValue) -> Int {
+    match v {
+        FJInt(n) -> n,
+        _ -> 0,
+    }
+}
+fn frontJsonAsArray(v: FrontJsonValue) -> List<FrontJsonValue> {
+    match v {
+        FJArray(items) -> items,
+        _ -> {
+            let empty: List<FrontJsonValue> = []
+            empty
+        },
+    }
+}
+fn frontJsonAsObject(v: FrontJsonValue) -> List<FrontJsonField> {
+    match v {
+        FJObject(fields) -> fields,
+        _ -> {
+            let empty: List<FrontJsonField> = []
+            empty
+        },
+    }
+}
+fn frontJsonAsStringList(v: FrontJsonValue) -> List<String> {
+    let mut out: List<String> = []
+    for item in frontJsonAsArray(v) {
+        out.push(frontJsonAsString(item))
+    }
+    out
+}
+fn frontJsonAsBoolList(v: FrontJsonValue) -> List<Bool> {
+    let mut out: List<Bool> = []
+    for item in frontJsonAsArray(v) {
+        out.push(frontJsonAsBool(item))
+    }
+    out
+}
+fn frontJsonIsNull(v: FrontJsonValue) -> Bool {
+    match v {
+        FJNull -> true,
+        _ -> false,
+    }
+}
+// =====================================================================
+// 4. TypeRepr decoder.
+//
+// `TypeRepr` is recursive (args + return). The decoder mirrors the Go
+// struct field tags from `api.TypeRepr`. Missing fields default to
+// their zero values; `param_names` is the underscored JSON tag for the
+// Osty-side `paramNames`.
+// =====================================================================
+fn frontDecodeTypeReprValue(v: FrontJsonValue) -> FrontTypeRepr {
+    if frontJsonIsNull(v) {
+        return frontEmptyTypeRepr()
+    }
+    let obj = frontJsonAsObject(v)
+    if obj.len() == 0 {
+        return frontEmptyTypeRepr()
+    }
+    let kind = frontJsonAsString(frontJsonObjectGet(obj, "kind"))
+    let name = frontJsonAsString(frontJsonObjectGet(obj, "name"))
+    let path = frontJsonAsString(frontJsonObjectGet(obj, "path"))
+    let mut args: List<FrontTypeRepr> = []
+    for item in frontJsonAsArray(frontJsonObjectGet(obj, "args")) {
+        args.push(frontDecodeTypeReprValue(item))
+    }
+    let retField = frontJsonObjectGet(obj, "return")
+    let ret = if frontJsonIsNull(retField) {
+        let none: Option<FrontTypeRepr> = None
+        none
+    } else {
+        Some(frontDecodeTypeReprValue(retField))
+    }
+    let paramNames = frontJsonAsStringList(frontJsonObjectGet(obj, "param_names"))
+    FrontTypeRepr {kind, name, path, args, ret, paramNames}
+}
+// =====================================================================
+// 5. Per-surface decoders.
+// =====================================================================
+fn frontDecodeGenericBound(v: FrontJsonValue) -> FrontPackageImportGenericBound {
+    let obj = frontJsonAsObject(v)
+    let tyParam = frontJsonAsString(frontJsonObjectGet(obj, "tyParam"))
+    let interfaceTypeName = frontJsonAsString(frontJsonObjectGet(obj, "interfaceType"))
+    let interfaceTypeRepr = frontDecodeTypeReprValue(frontJsonObjectGet(obj, "interfaceTypeRepr"))
+    FrontPackageImportGenericBound {tyParam, interfaceTypeRepr, interfaceTypeName}
+}
+fn frontDecodeGenericBoundList(v: FrontJsonValue) -> List<FrontPackageImportGenericBound> {
+    let mut out: List<FrontPackageImportGenericBound> = []
+    for item in frontJsonAsArray(v) {
+        out.push(frontDecodeGenericBound(item))
+    }
+    out
+}
+fn frontDecodeTypeReprList(v: FrontJsonValue) -> List<FrontTypeRepr> {
+    let mut out: List<FrontTypeRepr> = []
+    for item in frontJsonAsArray(v) {
+        out.push(frontDecodeTypeReprValue(item))
+    }
+    out
+}
+fn frontDecodeImportFn(v: FrontJsonValue) -> FrontPackageImportFn {
+    let obj = frontJsonAsObject(v)
+    let name = frontJsonAsString(frontJsonObjectGet(obj, "name"))
+    let owner = frontJsonAsString(frontJsonObjectGet(obj, "owner"))
+    let receiverTypeName = frontJsonAsString(frontJsonObjectGet(obj, "receiverType"))
+    let receiverField = frontJsonObjectGet(obj, "receiverTypeRepr")
+    let hasReceiver = !frontJsonIsNull(receiverField) || receiverTypeName != ""
+    let receiverTypeRepr = frontDecodeTypeReprValue(receiverField)
+    let returnTypeName = frontJsonAsString(frontJsonObjectGet(obj, "returnType"))
+    let returnField = frontJsonObjectGet(obj, "returnTypeRepr")
+    let hasReturn = !frontJsonIsNull(returnField)
+    let returnTypeRepr = frontDecodeTypeReprValue(returnField)
+    let hasBody = frontJsonAsBool(frontJsonObjectGet(obj, "hasBody"))
+    let paramNames = frontJsonAsStringList(frontJsonObjectGet(obj, "paramNames"))
+    let paramTypeNames = frontJsonAsStringList(frontJsonObjectGet(obj, "paramTypes"))
+    let paramTypeReprs = frontDecodeTypeReprList(frontJsonObjectGet(obj, "paramTypeReprs"))
+    let paramDefaults = frontJsonAsBoolList(frontJsonObjectGet(obj, "paramDefaults"))
+    let generics = frontJsonAsStringList(frontJsonObjectGet(obj, "generics"))
+    let genericBounds = frontDecodeGenericBoundList(frontJsonObjectGet(obj, "genericBounds"))
+    FrontPackageImportFn {name, owner, receiverTypeRepr, receiverTypeName, hasReceiver, returnTypeRepr, returnTypeName, hasReturn, hasBody, paramNames, paramTypeReprs, paramTypeNames, paramDefaults, generics, genericBounds}
+}
+fn frontDecodeImportField(v: FrontJsonValue) -> FrontPackageImportField {
+    let obj = frontJsonAsObject(v)
+    let owner = frontJsonAsString(frontJsonObjectGet(obj, "owner"))
+    let name = frontJsonAsString(frontJsonObjectGet(obj, "name"))
+    let typeName = frontJsonAsString(frontJsonObjectGet(obj, "typeName"))
+    let typeRepr = frontDecodeTypeReprValue(frontJsonObjectGet(obj, "type"))
+    let exported = frontJsonAsBool(frontJsonObjectGet(obj, "exported"))
+    let hasDefault = frontJsonAsBool(frontJsonObjectGet(obj, "hasDefault"))
+    FrontPackageImportField {owner, name, typeRepr, typeName, exported, hasDefault}
+}
+fn frontDecodeImportVariant(v: FrontJsonValue) -> FrontPackageImportVariant {
+    let obj = frontJsonAsObject(v)
+    let owner = frontJsonAsString(frontJsonObjectGet(obj, "owner"))
+    let name = frontJsonAsString(frontJsonObjectGet(obj, "name"))
+    let fieldTypeNames = frontJsonAsStringList(frontJsonObjectGet(obj, "fieldTypes"))
+    let fieldTypeReprs = frontDecodeTypeReprList(frontJsonObjectGet(obj, "fieldTypeReprs"))
+    let generics = frontJsonAsStringList(frontJsonObjectGet(obj, "generics"))
+    FrontPackageImportVariant {owner, name, fieldTypeReprs, fieldTypeNames, generics}
+}
+fn frontDecodeImportAlias(v: FrontJsonValue) -> FrontPackageImportAlias {
+    let obj = frontJsonAsObject(v)
+    let name = frontJsonAsString(frontJsonObjectGet(obj, "name"))
+    let targetName = frontJsonAsString(frontJsonObjectGet(obj, "target"))
+    let targetRepr = frontDecodeTypeReprValue(frontJsonObjectGet(obj, "targetRepr"))
+    let generics = frontJsonAsStringList(frontJsonObjectGet(obj, "generics"))
+    FrontPackageImportAlias {name, targetRepr, targetName, generics}
+}
+fn frontDecodeImportType(v: FrontJsonValue) -> FrontPackageImportType {
+    let obj = frontJsonAsObject(v)
+    let name = frontJsonAsString(frontJsonObjectGet(obj, "name"))
+    let kind = frontJsonAsString(frontJsonObjectGet(obj, "kind"))
+    let generics = frontJsonAsStringList(frontJsonObjectGet(obj, "generics"))
+    let genericBounds = frontDecodeGenericBoundList(frontJsonObjectGet(obj, "genericBounds"))
+    FrontPackageImportType {name, kind, generics, genericBounds}
+}
+fn frontDecodeImportInterfaceExt(v: FrontJsonValue) -> FrontPackageImportInterfaceExt {
+    let obj = frontJsonAsObject(v)
+    let owner = frontJsonAsString(frontJsonObjectGet(obj, "owner"))
+    let interfaceTypeName = frontJsonAsString(frontJsonObjectGet(obj, "interfaceType"))
+    let interfaceTypeRepr = frontDecodeTypeReprValue(frontJsonObjectGet(obj, "interfaceTypeRepr"))
+    FrontPackageImportInterfaceExt {owner, interfaceTypeRepr, interfaceTypeName}
+}
+fn frontDecodeImportEntry(v: FrontJsonValue) -> FrontPackageImport {
+    let obj = frontJsonAsObject(v)
+    let alias = frontJsonAsString(frontJsonObjectGet(obj, "alias"))
+    let mut functions: List<FrontPackageImportFn> = []
+    for item in frontJsonAsArray(frontJsonObjectGet(obj, "functions")) {
+        functions.push(frontDecodeImportFn(item))
+    }
+    let mut fields: List<FrontPackageImportField> = []
+    for item in frontJsonAsArray(frontJsonObjectGet(obj, "fields")) {
+        fields.push(frontDecodeImportField(item))
+    }
+    let mut variants: List<FrontPackageImportVariant> = []
+    for item in frontJsonAsArray(frontJsonObjectGet(obj, "variants")) {
+        variants.push(frontDecodeImportVariant(item))
+    }
+    let mut aliases: List<FrontPackageImportAlias> = []
+    for item in frontJsonAsArray(frontJsonObjectGet(obj, "aliases")) {
+        aliases.push(frontDecodeImportAlias(item))
+    }
+    let mut typeDecls: List<FrontPackageImportType> = []
+    for item in frontJsonAsArray(frontJsonObjectGet(obj, "typeDecls")) {
+        typeDecls.push(frontDecodeImportType(item))
+    }
+    let mut interfaceExts: List<FrontPackageImportInterfaceExt> = []
+    for item in frontJsonAsArray(frontJsonObjectGet(obj, "interfaceExts")) {
+        interfaceExts.push(frontDecodeImportInterfaceExt(item))
+    }
+    let registerAsIface = frontJsonAsStringList(frontJsonObjectGet(obj, "registerAsIface"))
+    FrontPackageImport {alias, functions, fields, variants, aliases, typeDecls, interfaceExts, registerAsIface}
+}
+// =====================================================================
+// 6. Top-level `imports` array locator.
+//
+// The request body shape is
+// `{"package":{"files":[...],"imports":[...]}}`. The byte scanner
+// finds the first `"imports"` key whose immediate JSON value is an
+// array, builds the value tree from there, and decodes each entry.
+// Like `frontFindFilesArrayOpen`, the search respects string
+// boundaries so a stray `"imports"` substring inside a source body
+// cannot false-positive.
+// =====================================================================
+pub fn frontExtractPackageImports(packageJson: String) -> List<FrontPackageImport> {
+    let bs = packageJson.bytes()
+    let len = bs.len()
+    let mut out: List<FrontPackageImport> = []
+    let openAt = frontFindImportsArrayOpen(bs, len)
+    if openAt < 0 {
+        return out
+    }
+    let scan = frontParseJsonArrayAt(bs, openAt, len)
+    for item in frontJsonAsArray(scan.value) {
+        let entry = frontDecodeImportEntry(item)
+        if entry.alias != "" {
+            out.push(entry)
+        }
+    }
+    out
+}
+fn frontFindImportsArrayOpen(bs: List<Byte>, len: Int) -> Int {
+    let mut i = 0
+    for i < len {
+        let b = bs[i].toInt()
+        if b == 0x22 {
+            if frontMatchKeyBytes(bs, i, len, "imports") {
+                let afterKey = i + 9
+                let colonAt = frontSkipAsciiWs(bs, afterKey, len)
+                if colonAt < len && bs[colonAt].toInt() == 0x3A {
+                    let openAt = frontSkipAsciiWs(bs, colonAt + 1, len)
+                    if openAt < len && bs[openAt].toInt() == 0x5B {
+                        return openAt
+                    }
+                }
+            }
+            let stringEnd = frontSkipJsonString(bs, i, len)
+            i = stringEnd
+            continue
+        }
+        i = i + 1
+    }
+    -1
+}
+// =====================================================================
+// 7. TypeRepr → ty Int translator.
+//
+// Mirrors `internal/selfhost/package_adapter.go::selfhostTypeReprToTy`.
+// The structured `FrontTypeRepr` takes precedence; when its `kind` is
+// blank we fall back to parsing the legacy string typeName via
+// `tyFromString` (same fallback the Go side uses for older wire
+// shapes that did not yet carry TypeRepr).
+//
+// Inputs whose `kind` is `unit` / `never` / `error` / `poison` / `self`
+// short-circuit to their canonical TyArena singletons; `primitive`
+// looks up the prim kind by name and falls back to a named-type when
+// the prim name is unknown. `optional` recurses through `return`,
+// `tuple` / `fn` / `named` recurse through `args`, and `fn`
+// additionally takes the `return` as its return type (defaulting to
+// `()` when missing).
+// =====================================================================
+pub fn frontTypeReprToTy(env: CheckEnv, repr: FrontTypeRepr, fallback: String) -> Int {
+    if repr.kind == "" {
+        return frontTypeNameToTy(env, fallback)
+    }
+    if repr.kind == "unit" {
+        return tUnit(env.tys)
+    }
+    if repr.kind == "never" {
+        return tNever(env.tys)
+    }
+    if repr.kind == "error" {
+        return tErr(env.tys)
+    }
+    if repr.kind == "poison" {
+        return tPoison(env.tys)
+    }
+    if repr.kind == "self" {
+        return tySelf(env.tys, "")
+    }
+    if repr.kind == "primitive" {
+        let prim = primKindFromName(repr.name)
+        if frontIsValidPrimKind(prim) || repr.name == "Invalid" {
+            return tyPrim(env.tys, prim)
+        }
+        return tyNamed(env.tys, repr.name, [])
+    }
+    if repr.kind == "named" {
+        return tyNamed(env.tys, repr.name, frontTypeReprListToTys(env, repr.args))
+    }
+    if repr.kind == "optional" {
+        let inner = match repr.ret {
+            Some(r) -> frontTypeReprToTy(env, r, ""),
+            None -> tErr(env.tys),
+        }
+        return tyOptional(env.tys, inner)
+    }
+    if repr.kind == "tuple" {
+        return tyTuple(env.tys, frontTypeReprListToTys(env, repr.args))
+    }
+    if repr.kind == "fn" {
+        let retTy = match repr.ret {
+            Some(r) -> frontTypeReprToTy(env, r, ""),
+            None -> tUnit(env.tys),
+        }
+        return tyFn(env.tys, frontTypeReprListToTys(env, repr.args), retTy)
+    }
+    if repr.kind == "typevar" {
+        if repr.name == "" {
+            return tErr(env.tys)
+        }
+        return tyNamed(env.tys, repr.name, [])
+    }
+    if repr.name != "" {
+        return tyNamed(env.tys, repr.name, frontTypeReprListToTys(env, repr.args))
+    }
+    frontTypeNameToTy(env, fallback)
+}
+fn frontTypeReprListToTys(env: CheckEnv, reprs: List<FrontTypeRepr>) -> List<Int> {
+    let mut out: List<Int> = []
+    for r in reprs {
+        out.push(frontTypeReprToTy(env, r, ""))
+    }
+    out
+}
+fn frontTypeReprListWithFallback(env: CheckEnv, reprs: List<FrontTypeRepr>, fallback: List<String>) -> List<Int> {
+    let nr = reprs.len()
+    let nf = fallback.len()
+    let n = if nr >= nf {
+        nr
+    } else {
+        nf
+    }
+    let mut out: List<Int> = []
+    let mut i = 0
+    for i < n {
+        let r = if i < nr {
+            reprs[i]
+        } else {
+            frontEmptyTypeRepr()
+        }
+        let f = if i < nf {
+            fallback[i]
+        } else {
+            ""
+        }
+        out.push(frontTypeReprToTy(env, r, f))
+        i = i + 1
+    }
+    out
+}
+fn frontTypeNameToTy(env: CheckEnv, typeName: String) -> Int {
+    if typeName == "" {
+        return tErr(env.tys)
+    }
+    if typeName == "()" {
+        return tUnit(env.tys)
+    }
+    if typeName == "Invalid" || typeName == "Poison" {
+        return tErr(env.tys)
+    }
+    tyFromString(env.tys, typeName)
+}
+fn frontIsValidPrimKind(prim: PrimKind) -> Bool {
+    match prim {
+        PkInvalid -> false,
+        _ -> true,
+    }
+}
+// =====================================================================
+// 8. Install surfaces.
+//
+// Mirrors `internal/selfhost/package_adapter.go::selfhostInstallImportSurfaces`.
+// Walk order matches the Go side (interfaces → type decls → interface
+// exts → aliases → fields → variants → fns) so the check env build-up
+// is deterministic regardless of wire shape variation.
+// =====================================================================
+pub fn frontInstallImportSurfaces(env: CheckEnv, imports: List<FrontPackageImport>) {
+    for imp in imports {
+        if imp.alias == "" {
+            continue
+        }
+        let aliasTy = tyNamed(env.tys, imp.alias, [])
+        checkBind(env, imp.alias, aliasTy)
+        checkMarkImportAlias(env, imp.alias)
+        for iface in imp.registerAsIface {
+            if iface != "" {
+                checkRegisterInterface(env, iface)
+            }
+        }
+        for decl in imp.typeDecls {
+            checkRegisterType(env, CheckTypeSig {name: decl.name, generics: decl.generics, genericBounds: frontMaterializeBounds(env, decl.genericBounds), kind: decl.kind})
+        }
+        for ext in imp.interfaceExts {
+            let ifaceTy = frontTypeReprToTy(env, ext.interfaceTypeRepr, ext.interfaceTypeName)
+            if ifaceTy >= 0 {
+                let emptyNames: List<String> = []
+                let emptyNodes: List<Int> = []
+                checkRegisterInterfaceExtends(env, CheckInterfaceExt {owner: ext.owner, ifaceTy, defaultBodyNames: emptyNames, defaultBodyNodes: emptyNodes})
+            }
+        }
+        for alias in imp.aliases {
+            let ty = frontTypeReprToTy(env, alias.targetRepr, alias.targetName)
+            checkRegisterAlias(env, CheckAliasSig {name: alias.name, ty, generics: alias.generics})
+        }
+        for field in imp.fields {
+            let ty = frontTypeReprToTy(env, field.typeRepr, field.typeName)
+            checkRegisterField(env, CheckFieldSig {owner: field.owner, name: field.name, ty, exported: field.exported, hasDefault: field.hasDefault})
+        }
+        for variant in imp.variants {
+            let fieldTys = frontTypeReprListWithFallback(env, variant.fieldTypeReprs, variant.fieldTypeNames)
+            checkRegisterVariant(env, CheckVariantSig {owner: variant.owner, name: variant.name, fieldTys, generics: variant.generics})
+        }
+        for impFn in imp.functions {
+            let paramTys = frontTypeReprListWithFallback(env, impFn.paramTypeReprs, impFn.paramTypeNames)
+            let receiverTy = if impFn.hasReceiver {
+                frontTypeReprToTy(env, impFn.receiverTypeRepr, impFn.receiverTypeName)
+            } else {
+                -1
+            }
+            let retTy = if impFn.hasReturn {
+                frontTypeReprToTy(env, impFn.returnTypeRepr, impFn.returnTypeName)
+            } else if impFn.returnTypeName == "" || impFn.returnTypeName == "()" {
+                tUnit(env.tys)
+            } else {
+                frontTypeNameToTy(env, impFn.returnTypeName)
+            }
+            let paramNames = frontImportFnParamNames(impFn.paramNames, impFn.paramDefaults, paramTys.len())
+            checkRegisterFn(env, CheckFnSig {name: impFn.name, owner: imp.alias, receiverTy, hasReceiver: impFn.hasReceiver, retTy, paramNames, paramTys, generics: impFn.generics, genericBounds: frontMaterializeBounds(env, impFn.genericBounds)})
+            if impFn.hasBody {
+                checkMarkFnHasBody(env, impFn.name, imp.alias)
+            }
+        }
+    }
+}
+fn frontMaterializeBounds(env: CheckEnv, bounds: List<FrontPackageImportGenericBound>) -> List<CheckGenericBound> {
+    let mut out: List<CheckGenericBound> = []
+    for b in bounds {
+        let iface = frontTypeReprToTy(env, b.interfaceTypeRepr, b.interfaceTypeName)
+        out.push(CheckGenericBound {tyParam: b.tyParam, iface})
+    }
+    out
+}
+/// frontImportFnParamNames mirrors
+/// `internal/selfhost/package_adapter.go::selfhostImportFnParamNames`.
+/// Trailing `paramDefaults[true]` entries earn a `?` prefix on the
+/// corresponding param name so `paramDefaultCount` (in check.osty)
+/// recovers the trailing-default count. Pre-prefixed names (the
+/// arena-walking import surface already encodes `?`) survive
+/// unchanged. Synthesised `arg<idx>` names backfill missing entries
+/// so the trailing-default scanner has something to read from.
+fn frontImportFnParamNames(paramNames: List<String>, paramDefaults: List<Bool>, paramArity: Int) -> List<String> {
+    let mut out: List<String> = []
+    for name in paramNames {
+        out.push(name)
+    }
+    let mut target = paramArity
+    if out.len() > target {
+        target = out.len()
+    }
+    if paramDefaults.len() > target {
+        target = paramDefaults.len()
+    }
+    for out.len() < target {
+        out.push("arg{out.len()}")
+    }
+    if paramDefaults.len() == 0 {
+        return out
+    }
+    let mut trailingStart = paramDefaults.len()
+    let mut i = paramDefaults.len() - 1
+    for i >= 0 {
+        if !paramDefaults[i] {
+            i = -1
+            continue
+        }
+        trailingStart = i
+        i = i - 1
+    }
+    let mut j = trailingStart
+    let outLen = out.len()
+    let defaultsLen = paramDefaults.len()
+    for j < defaultsLen && j < outLen {
+        if !strings.hasPrefix(out[j], "?") {
+            out[j] = "?" + out[j]
+        }
+        j = j + 1
+    }
+    out
+}

--- a/toolchain/check_imports_test.osty
+++ b/toolchain/check_imports_test.osty
@@ -272,3 +272,49 @@ fn testCheckPackageToWireJsonFnWithBodyMarked() {
     let out = frontCheckPackageToWireJson(body)
     testing.assert(!strings.contains(out, "\"code\":\"E0501\""))
 }
+// =====================================================================
+// Scoping: only `package.imports` / `package.files` count.
+// =====================================================================
+fn testExtractPackageImportsIgnoresTopLevelImportsKey() {
+    let body = "\{\"imports\":[\{\"alias\":\"phantom\"\}],\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"real\"\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].alias, "real")
+}
+// A sibling `"imports"` array OUTSIDE the `"package"` object must
+// not be picked up — only the nested `package.imports` counts.
+// Matches the Go `CheckRequest.Package.Imports` decoding shape.
+fn testExtractPackageImportsTopLevelOnlyWithoutPackageReturnsEmpty() {
+    let body = "\{\"imports\":[\{\"alias\":\"phantom\"\}]\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 0)
+}
+// Without a `"package":{...}` wrapper, no imports surface — even
+// a syntactically valid top-level `imports` array is rejected
+// because the wire shape requires the `package` envelope.
+fn testExtractPackageImportsIgnoresNestedImportsKey() {
+    let body = "\{\"package\":\{\"files\":[\{\"source\":\"\",\"meta\":\{\"imports\":[\{\"alias\":\"phantom\"\}]\}\}],\"imports\":[\{\"alias\":\"real\"\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].alias, "real")
+}
+// A nested `"imports"` key deeper inside a file object (some
+// hypothetical user-extension metadata) must not match — the
+// scanner only walks direct children of `package`.
+fn testExtractPackageFilesIgnoresTopLevelFilesKey() {
+    let body = "\{\"files\":[\{\"source\":\"phantom\"\}],\"package\":\{\"files\":[\{\"source\":\"real\"\}]\}\}"
+    let got = frontExtractPackageFiles(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].source, "real")
+}
+// `frontFindFilesArrayOpen` must scope its scan to `package.files`,
+// not the first `"files"` array anywhere in the document.
+// =====================================================================
+// P1: imported fns get registered under their declared owner, not
+// the alias.
+// =====================================================================
+fn testCheckPackageToWireJsonImportedMethodRegistersUnderReceiverOwner() {
+    let body = "\{\"package\":\{\"files\":[\{\"path\":\"main.osty\",\"source\":\"struct Err \{ msg: String \}\\nfn use(e: Err) -> String \{ e.toString() \}\"\}],\"imports\":[\{\"alias\":\"tc\",\"functions\":[\{\"name\":\"toString\",\"owner\":\"Err\",\"receiverTypeRepr\":\{\"kind\":\"named\",\"name\":\"Err\"\},\"returnTypeRepr\":\{\"kind\":\"primitive\",\"name\":\"String\"\}\}]\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(!strings.contains(out, "\"code\":\"E0703\""))
+}

--- a/toolchain/check_imports_test.osty
+++ b/toolchain/check_imports_test.osty
@@ -1,0 +1,274 @@
+// check_imports_test.osty — focused fixtures for the PackageCheckImport
+// JSON decoder + install surfaces pipeline introduced by
+// `toolchain/check_imports.osty`. The native checker subprocess
+// dispatch through `frontCheckPackageToWireJson` routes cross-pkg
+// surface requests here; a regression that drops a fn / field /
+// variant / alias / type / interface extension surfaces silently as
+// confusing E0501 / E0703 / E0702 diagnostics downstream.
+use std.testing
+use std.strings as strings
+// =====================================================================
+// JSON value tree round-trip.
+// =====================================================================
+fn testCheckImportsJsonValueParsesString() {
+    let bs = "\"hello\"".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    testing.assertEq(frontJsonAsString(scan.value), "hello")
+}
+fn testCheckImportsJsonValueParsesInt() {
+    let bs = "42".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    testing.assertEq(frontJsonAsInt(scan.value), 42)
+}
+fn testCheckImportsJsonValueParsesNegativeInt() {
+    let bs = "-7".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    testing.assertEq(frontJsonAsInt(scan.value), -7)
+}
+fn testCheckImportsJsonValueParsesBoolean() {
+    let trueScan = frontParseJsonValueAt("true".bytes(), 0, 4)
+    testing.assert(frontJsonAsBool(trueScan.value))
+    let falseScan = frontParseJsonValueAt("false".bytes(), 0, 5)
+    testing.assert(!frontJsonAsBool(falseScan.value))
+}
+fn testCheckImportsJsonValueParsesNull() {
+    let bs = "null".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    testing.assert(frontJsonIsNull(scan.value))
+}
+fn testCheckImportsJsonValueParsesArray() {
+    let bs = "[1,2,3]".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    let items = frontJsonAsArray(scan.value)
+    testing.assertEq(items.len(), 3)
+    testing.assertEq(frontJsonAsInt(items[0]), 1)
+    testing.assertEq(frontJsonAsInt(items[1]), 2)
+    testing.assertEq(frontJsonAsInt(items[2]), 3)
+}
+fn testCheckImportsJsonValueParsesObject() {
+    let bs = "\{\"a\":1,\"b\":\"two\"\}".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    let fields = frontJsonAsObject(scan.value)
+    testing.assertEq(fields.len(), 2)
+    testing.assertEq(frontJsonAsInt(frontJsonObjectGet(fields, "a")), 1)
+    testing.assertEq(frontJsonAsString(frontJsonObjectGet(fields, "b")), "two")
+}
+fn testCheckImportsJsonValueParsesNestedObject() {
+    let bs = "\{\"outer\":\{\"inner\":42\}\}".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    let fields = frontJsonAsObject(scan.value)
+    let inner = frontJsonAsObject(frontJsonObjectGet(fields, "outer"))
+    testing.assertEq(frontJsonAsInt(frontJsonObjectGet(inner, "inner")), 42)
+}
+fn testCheckImportsJsonValueRoundtripsStringEscapes() {
+    let bs = "\"hi\\\"there\\nworld\"".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    testing.assertEq(frontJsonAsString(scan.value), "hi\"there\nworld")
+}
+// JSON `\"` and `\n` must decode to literal `"` and LF inside the
+// returned string. Same path `mir_json.osty::mirJsonParseStrEscaped`
+// takes for module JSON.
+// =====================================================================
+// TypeRepr decoder round-trip — every legal `kind` covered.
+// =====================================================================
+fn testCheckImportsTypeReprDecodesPrimitive() {
+    let bs = "\{\"kind\":\"primitive\",\"name\":\"Int\"\}".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    let repr = frontDecodeTypeReprValue(scan.value)
+    testing.assertEq(repr.kind, "primitive")
+    testing.assertEq(repr.name, "Int")
+}
+fn testCheckImportsTypeReprDecodesOptional() {
+    let bs = "\{\"kind\":\"optional\",\"return\":\{\"kind\":\"primitive\",\"name\":\"String\"\}\}".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    let repr = frontDecodeTypeReprValue(scan.value)
+    testing.assertEq(repr.kind, "optional")
+    match repr.ret {
+        Some(inner) -> {
+            testing.assertEq(inner.kind, "primitive")
+            testing.assertEq(inner.name, "String")
+        },
+        None -> testing.assert(false),
+    }
+}
+fn testCheckImportsTypeReprDecodesNamedGeneric() {
+    let bs = "\{\"kind\":\"named\",\"name\":\"List\",\"args\":[\{\"kind\":\"primitive\",\"name\":\"Int\"\}]\}".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    let repr = frontDecodeTypeReprValue(scan.value)
+    testing.assertEq(repr.kind, "named")
+    testing.assertEq(repr.name, "List")
+    testing.assertEq(repr.args.len(), 1)
+    testing.assertEq(repr.args[0].name, "Int")
+}
+fn testCheckImportsTypeReprDecodesFnWithParamNames() {
+    let bs = "\{\"kind\":\"fn\",\"args\":[\{\"kind\":\"primitive\",\"name\":\"String\"\}],\"return\":\{\"kind\":\"unit\"\},\"param_names\":[\"msg\"]\}".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    let repr = frontDecodeTypeReprValue(scan.value)
+    testing.assertEq(repr.kind, "fn")
+    testing.assertEq(repr.args.len(), 1)
+    testing.assertEq(repr.paramNames.len(), 1)
+    testing.assertEq(repr.paramNames[0], "msg")
+    match repr.ret {
+        Some(inner) -> testing.assertEq(inner.kind, "unit"),
+        None -> testing.assert(false),
+    }
+}
+fn testCheckImportsTypeReprMissingKindIsBlank() {
+    let bs = "\{\"name\":\"Whatever\"\}".bytes()
+    let scan = frontParseJsonValueAt(bs, 0, bs.len())
+    let repr = frontDecodeTypeReprValue(scan.value)
+    testing.assertEq(repr.kind, "")
+    testing.assertEq(repr.name, "Whatever")
+}
+// Empty `kind` triggers fallback to legacy string-name in
+// `frontTypeReprToTy` — keep the field accessible.
+// =====================================================================
+// PackageCheckImport JSON extraction.
+// =====================================================================
+fn testExtractPackageImportsEmpty() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 0)
+}
+fn testExtractPackageImportsNoImportsKey() {
+    let body = "\{\"package\":\{\"files\":[]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 0)
+}
+fn testExtractPackageImportsSingleAliasOnly() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"tc\"\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].alias, "tc")
+    testing.assertEq(got[0].functions.len(), 0)
+}
+fn testExtractPackageImportsDropsEntriesWithBlankAlias() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"\"\},\{\"alias\":\"valid\"\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].alias, "valid")
+}
+fn testExtractPackageImportsCarriesFunction() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"tc\",\"functions\":[\{\"name\":\"checkSource\",\"owner\":\"tc\",\"returnType\":\"String\",\"paramNames\":[\"src\"],\"paramTypes\":[\"String\"]\}]\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].functions.len(), 1)
+    let fn0 = got[0].functions[0]
+    testing.assertEq(fn0.name, "checkSource")
+    testing.assertEq(fn0.owner, "tc")
+    testing.assertEq(fn0.returnTypeName, "String")
+    testing.assertEq(fn0.paramNames.len(), 1)
+    testing.assertEq(fn0.paramNames[0], "src")
+    testing.assertEq(fn0.paramTypeNames.len(), 1)
+}
+fn testExtractPackageImportsCarriesHasBody() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"tc\",\"functions\":[\{\"name\":\"impl\",\"hasBody\":true\},\{\"name\":\"stub\",\"hasBody\":false\}]\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].functions.len(), 2)
+    testing.assert(got[0].functions[0].hasBody)
+    testing.assert(!got[0].functions[1].hasBody)
+}
+fn testExtractPackageImportsCarriesField() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"tc\",\"fields\":[\{\"owner\":\"Cfg\",\"name\":\"path\",\"typeName\":\"String\",\"exported\":true,\"hasDefault\":false\}]\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got[0].fields.len(), 1)
+    testing.assertEq(got[0].fields[0].owner, "Cfg")
+    testing.assertEq(got[0].fields[0].name, "path")
+    testing.assertEq(got[0].fields[0].typeName, "String")
+    testing.assert(got[0].fields[0].exported)
+}
+fn testExtractPackageImportsCarriesVariant() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"tc\",\"variants\":[\{\"owner\":\"Event\",\"name\":\"Click\",\"fieldTypes\":[\"Int\",\"Int\"]\}]\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got[0].variants.len(), 1)
+    testing.assertEq(got[0].variants[0].owner, "Event")
+    testing.assertEq(got[0].variants[0].name, "Click")
+    testing.assertEq(got[0].variants[0].fieldTypeNames.len(), 2)
+}
+fn testExtractPackageImportsCarriesAlias() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"tc\",\"aliases\":[\{\"name\":\"NodeId\",\"target\":\"Int\"\}]\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got[0].aliases.len(), 1)
+    testing.assertEq(got[0].aliases[0].name, "NodeId")
+    testing.assertEq(got[0].aliases[0].targetName, "Int")
+}
+fn testExtractPackageImportsCarriesTypeDecl() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"tc\",\"typeDecls\":[\{\"name\":\"User\",\"kind\":\"struct\",\"generics\":[]\}]\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got[0].typeDecls.len(), 1)
+    testing.assertEq(got[0].typeDecls[0].name, "User")
+    testing.assertEq(got[0].typeDecls[0].kind, "struct")
+}
+fn testExtractPackageImportsCarriesInterfaceExt() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"tc\",\"interfaceExts\":[\{\"owner\":\"User\",\"interfaceType\":\"Equal\"\}]\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got[0].interfaceExts.len(), 1)
+    testing.assertEq(got[0].interfaceExts[0].owner, "User")
+    testing.assertEq(got[0].interfaceExts[0].interfaceTypeName, "Equal")
+}
+fn testExtractPackageImportsCarriesRegisterAsIface() {
+    let body = "\{\"package\":\{\"files\":[],\"imports\":[\{\"alias\":\"tc\",\"registerAsIface\":[\"Hashable\",\"Ordered\"]\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got[0].registerAsIface.len(), 2)
+    testing.assertEq(got[0].registerAsIface[0], "Hashable")
+    testing.assertEq(got[0].registerAsIface[1], "Ordered")
+}
+fn testExtractPackageImportsRespectsSourceStringBoundary() {
+    let body = "\{\"package\":\{\"files\":[\{\"source\":\"// \\\"imports\\\":[]\\nfn main()\{\}\"\}],\"imports\":[\{\"alias\":\"tc\"\}]\}\}"
+    let got = frontExtractPackageImports(body)
+    testing.assertEq(got.len(), 1)
+    testing.assertEq(got[0].alias, "tc")
+}
+// An `"imports"` substring embedded inside an escaped JSON string
+// value (the Osty source body) must NOT be confused for the real
+// top-level `"imports"` key — the JSON-aware scanner tracks string
+// boundaries so the outer `imports` array wins.
+// =====================================================================
+// End-to-end install: cross-pkg method dispatch.
+// =====================================================================
+fn testCheckPackageToWireJsonResolvesAliasMemberCall() {
+    let body = "\{\"package\":\{\"files\":[\{\"path\":\"main.osty\",\"source\":\"fn main() \{ let _ = tc.checkSource(\\\"hi\\\") \}\"\}],\"imports\":[\{\"alias\":\"tc\",\"functions\":[\{\"name\":\"checkSource\",\"owner\":\"tc\",\"returnTypeRepr\":\{\"kind\":\"primitive\",\"name\":\"String\"\},\"paramNames\":[\"src\"],\"paramTypeReprs\":[\{\"kind\":\"primitive\",\"name\":\"String\"\}]\}]\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(!strings.contains(out, "\"code\":\"E0501\""))
+    testing.assert(!strings.contains(out, "\"code\":\"E0703\""))
+}
+// `tc.checkSource("hi")` would surface as E0703 (unknown method on
+// receiver) without the installed function surface. With the import
+// surface threaded in by `frontInstallImportSurfaces`, the call site
+// resolves and the wire output carries no E0501 / E0703.
+fn testCheckPackageToWireJsonResolvesAliasFieldAccess() {
+    let body = "\{\"package\":\{\"files\":[\{\"path\":\"main.osty\",\"source\":\"struct Cfg \{ path: String \}\\nfn open(c: Cfg) -> String \{ c.path \}\"\}],\"imports\":[\{\"alias\":\"tc\",\"fields\":[\{\"owner\":\"Cfg\",\"name\":\"path\",\"type\":\{\"kind\":\"primitive\",\"name\":\"String\"\},\"exported\":true\}]\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(!strings.contains(out, "\"code\":\"E0702\""))
+}
+// Struct fields exported through the import surface must satisfy
+// `c.path` field access. (The local struct decl is also present so
+// the test exercises the import-side registration explicitly — the
+// local decl alone would resolve without imports.)
+fn testCheckPackageToWireJsonInstallsImportAlias() {
+    let body = "\{\"package\":\{\"files\":[\{\"path\":\"main.osty\",\"source\":\"fn main() \{ let _ = tc.helper() \}\"\}],\"imports\":[\{\"alias\":\"tc\",\"functions\":[\{\"name\":\"helper\",\"owner\":\"tc\",\"returnTypeRepr\":\{\"kind\":\"unit\"\}\}]\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(!strings.contains(out, "\"code\":\"E0501\""))
+}
+// Without the alias binding, `tc` itself would not resolve and the
+// member-access lookup would never even be attempted —
+// `checkBind(env, "tc", ...)` is the gate that the install logic
+// must walk through.
+fn testCheckPackageToWireJsonWithoutImportsStillProducesE0501() {
+    let body = "\{\"package\":\{\"files\":[\{\"path\":\"main.osty\",\"source\":\"fn main() \{ let _ = tc.helper() \}\"\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(strings.contains(out, "\"diagnostics\":["))
+    testing.assert(strings.contains(out, "\"file\":\"main.osty\""))
+}
+// Negative control: when no imports are supplied, `tc` is
+// genuinely unresolved and the checker fires its normal
+// diagnostic. Confirms the install pipeline is the gate
+// distinguishing the two paths — the surface either resolves
+// (positive test above) or it produces a real diagnostic (this
+// test).
+fn testCheckPackageToWireJsonFnWithBodyMarked() {
+    let body = "\{\"package\":\{\"files\":[\{\"path\":\"main.osty\",\"source\":\"fn main() \{\}\"\}],\"imports\":[\{\"alias\":\"tc\",\"functions\":[\{\"name\":\"realImpl\",\"owner\":\"tc\",\"returnTypeRepr\":\{\"kind\":\"unit\"\},\"hasBody\":true\}]\}]\}\}"
+    let out = frontCheckPackageToWireJson(body)
+    testing.assert(!strings.contains(out, "\"code\":\"E0501\""))
+}

--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -284,22 +284,92 @@ pub fn frontExtractPackageFiles(packageJson: String) -> List<FrontPackageFile> {
     files
 }
 fn frontFindFilesArrayOpen(bs: List<Byte>, len: Int) -> Int {
+    let bounds = frontFindPackageObjectBounds(bs, len)
+    if bounds.start < 0 {
+        return -1
+    }
+    frontFindArrayOpenForKey(bs, bounds.start, bounds.end, "files")
+}
+/// FrontPackageBounds describes the half-open byte range that the
+/// `package` value spans inside its enclosing `{...}` braces. The
+/// `start` byte is the first byte AFTER the opening `{`; the `end`
+/// byte is the position OF the closing `}` (so `[start, end)` covers
+/// the object's interior content). Both values are -1 when the
+/// scanner could not find a top-level `"package": {...}` shape.
+pub struct FrontPackageBounds {
+    pub start: Int,
+    pub end: Int,
+}
+/// frontFindPackageObjectBounds locates the top-level `"package"`
+/// key inside the request body and returns the byte range covering
+/// the interior of its object value. Mirrors the Go-side
+/// `CheckRequest.Package` field decoding — only keys nested under
+/// `package` count as part of the package shape, so callers
+/// scanning for `files` / `imports` arrays should restrict their
+/// search to this range rather than the whole document.
+///
+/// Implementation: byte-by-byte scan with string-boundary tracking,
+/// matches `"package"` at any position outside a JSON string, then
+/// skips ws + `:` + ws to locate the opening `{` and uses
+/// `frontSkipJsonObject` to find the matching `}`. Returns `start =
+/// end = -1` when no top-level `"package":{...}` is present.
+fn frontFindPackageObjectBounds(bs: List<Byte>, len: Int) -> FrontPackageBounds {
     let mut i = 0
     for i < len {
         let b = bs[i].toInt()
         if b == 0x22 {
-            if frontMatchKeyBytes(bs, i, len, "files") {
-                let afterKey = i + 7
+            if frontMatchKeyBytes(bs, i, len, "package") {
+                let afterKey = i + 9
                 let colonAt = frontSkipAsciiWs(bs, afterKey, len)
                 if colonAt < len && bs[colonAt].toInt() == 0x3A {
                     let openAt = frontSkipAsciiWs(bs, colonAt + 1, len)
-                    if openAt < len && bs[openAt].toInt() == 0x5B {
-                        return openAt
+                    if openAt < len && bs[openAt].toInt() == 0x7B {
+                        let afterObject = frontSkipJsonObject(bs, openAt, len)
+                        return FrontPackageBounds {start: openAt + 1, end: afterObject - 1}
                     }
                 }
             }
             let stringEnd = frontSkipJsonString(bs, i, len)
             i = stringEnd
+            continue
+        }
+        i = i + 1
+    }
+    FrontPackageBounds {start: -1, end: -1}
+}
+/// frontFindArrayOpenForKey returns the position of the `[` opening
+/// the JSON array bound to `key` within the byte range `[start,
+/// end)`. The scan tracks string boundaries by calling
+/// `frontSkipJsonString` past every string and jumps past every
+/// nested object / array via `frontSkipJsonObject` / `frontSkipJsonArray`,
+/// so only direct children of the enclosing object can match.
+/// Returns -1 when no array-valued occurrence at the top level of
+/// the scanned range is found.
+fn frontFindArrayOpenForKey(bs: List<Byte>, start: Int, end: Int, key: String) -> Int {
+    let mut i = start
+    for i < end {
+        let b = bs[i].toInt()
+        if b == 0x22 {
+            if frontMatchKeyBytes(bs, i, end, key) {
+                let keyLen = key.bytes().len()
+                let afterKey = i + keyLen + 2
+                let colonAt = frontSkipAsciiWs(bs, afterKey, end)
+                if colonAt < end && bs[colonAt].toInt() == 0x3A {
+                    let openAt = frontSkipAsciiWs(bs, colonAt + 1, end)
+                    if openAt < end && bs[openAt].toInt() == 0x5B {
+                        return openAt
+                    }
+                }
+            }
+            i = frontSkipJsonString(bs, i, end)
+            continue
+        }
+        if b == 0x7B {
+            i = frontSkipJsonObject(bs, i, end)
+            continue
+        }
+        if b == 0x5B {
+            i = frontSkipJsonArray(bs, i, end)
             continue
         }
         i = i + 1

--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -71,11 +71,13 @@ pub fn frontCheckSourceToWireJson(source: String) -> String {
 /// extracts every file object inside `"files":[...]` (carrying
 /// `source` plus the per-file metadata `name` / `path` / `base` /
 /// `sourceFileId` from `PackageCheckFile`), concatenates the source
-/// bytes with a single `\n` separator, and runs the standard
-/// single-file check pipeline on the combined buffer. The
-/// combined-source approach gives multi-file callers package-level
-/// top-level scope for free — duplicate top-level decls across files
-/// correctly trigger E0501 / E0103 collisions just like the Go-side
+/// bytes with a single `\n` separator, runs the standard single-file
+/// check pipeline on the combined buffer, and additionally walks
+/// `"imports":[...]` to install each `PackageCheckImport` surface
+/// into the check env before elaboration. The combined-source
+/// approach gives multi-file callers package-level top-level scope
+/// for free — duplicate top-level decls across files correctly
+/// trigger E0501 / E0103 collisions just like the Go-side
 /// `selfhost.CheckPackageStructured`.
 ///
 /// Per-file token layout: a `FrontPackageFileTable` records each
@@ -90,31 +92,27 @@ pub fn frontCheckSourceToWireJson(source: String) -> String {
 /// `displayName` selection in `selfhostBuildPackageAst`) and a
 /// `sourceFileId` field when the request supplied one.
 ///
+/// Cross-package imports: every `PackageCheckImport` entry installs
+/// the import alias as a module-like named type binding, marks the
+/// alias on the check env so dotted access (`tc.foo()`) resolves,
+/// and registers every exported fn / field / variant / alias / type
+/// decl / interface extension / register-as-iface marker under that
+/// alias as owner. Mirrors `selfhostInstallImportSurfaces`
+/// (`internal/selfhost/package_adapter.go`) — see
+/// `toolchain/check_imports.osty` for the install logic.
+///
 /// Telemetry detail suffix mirrors the Go shape:
 /// `<file>:@L<line>:C<col>` when the owning file is known, falling
 /// back to `@L<line>:C<col>` for tokens whose owner cannot be
 /// resolved (degenerate stdin-style requests with empty `name` /
 /// `path` / `sourceFileId`).
-///
-/// Limitation relative to `selfhost.CheckPackageStructured` (Go-side
-/// production path, `internal/selfhost/package_adapter.go`):
-///
-///   - The `imports` array (`PackageCheckInput.Imports`, carrying
-///     cross-package surfaces — exported fns, fields, variants,
-///     type decls) is **not consumed**. References that need an
-///     installed import surface (typical `use std.io` / `use
-///     toolchain as tc`) will surface as E0501 unresolved-name
-///     diagnostics. Closing this requires a toolchain analogue of
-///     `selfhostInstallImportSurfaces` plus the full
-///     `PackageCheckImport` JSON decoder — explicitly out of scope
-///     for this landing (tracked as a separate batch in
-///     `SPEC_GAPS.md::cross-pkg-module-resolution`).
 pub fn frontCheckPackageToWireJson(packageJson: String) -> String {
     let files = frontExtractPackageFiles(packageJson)
+    let imports = frontExtractPackageImports(packageJson)
     let table = frontBuildPackageFileTable(files)
     let combined = table.combined
     let lexed = ostyLexSource(combined)
-    let result = frontendCheckLexedSourceStructured(lexed)
+    let result = frontendCheckLexedSourceWithImports(lexed, imports)
     frontCheckResultToWireJsonForLexedAndPackage(result, lexed, table)
 }
 /// frontExtractPackageFileSources is the legacy single-key extractor


### PR DESCRIPTION
## Summary

Closes PR #1966 limit **2** (cross-pkg imports in package mode). Mirrors the Go-side `internal/selfhost/package_adapter.go::selfhostInstallImportSurfaces` + `selfhostTypeReprToTy` + the `PackageCheckImport` wire shape from `internal/selfhost/api/package.go`.

Without this pipeline, multi-file requests carrying cross-package surfaces produced spurious E0501 unresolved-name / E0703 unknown-method / E0702 unknown-field diagnostics for every `tc.foo` / `std.io.bar` reference — see PR #1966.

### New module: `toolchain/check_imports.osty`

- **Per-surface struct shapes** (`FrontPackageImport`, `FrontPackageImportFn`, `FrontPackageImportField`, `FrontPackageImportVariant`, `FrontPackageImportAlias`, `FrontPackageImportType`, `FrontPackageImportInterfaceExt`, `FrontPackageImportGenericBound`) — direct mirrors of the `api.PackageCheck*` Go types.

- **Generic JSON value tree** (`FrontJsonValue` + `FrontJsonField`) with `frontParseJsonValueAt` recursing through strings / integers / booleans / nulls / arrays / objects. Accessor helpers (`frontJsonAsString` / `*AsInt` / `*AsBool` / `*AsArray` / `*AsObject` / `*AsStringList` / `*AsBoolList`) keep the typed decoders short.

- **Recursive `frontDecodeTypeReprValue`** matches `api.TypeRepr` JSON tags (`param_names` underscored form preserved). Per-surface decoders (`frontDecodeImportFn` / `*Field` / `*Variant` / `*Alias` / `*Type` / `*InterfaceExt` / `*GenericBound`) read fields by key off the value tree.

- **`frontExtractPackageImports`** locates `"imports":[...]` via the existing JSON-aware byte scanner (shared with `frontExtractPackageFiles`, so an `"imports"` substring inside an Osty source body cannot false-positive). Decodes each entry into a `FrontPackageImport`. Blank-alias entries are dropped.

- **`frontTypeReprToTy`** translates `FrontTypeRepr` → TyArena Int matching `selfhostTypeReprToTy` byte-for-byte (primitive lookup via `primKindFromName`, named generics through `args`, optional via `return`, tuple / fn via `args` (+ ret for fn), structured-or-fallback via the legacy string name when `kind` is blank).

- **`frontInstallImportSurfaces`** walks the decoded list in the Go-side order (interfaces → type decls → interface exts → aliases → fields → variants → fns). For each non-empty alias: binds it as a module-like named type, marks it as an import alias, registers each surface under that alias as owner. `hasBody:true` fns trigger `checkMarkFnHasBody` so the cross-pkg method dispatcher sees real implementations vs forward declarations. `frontImportFnParamNames` synthesises the `?`-prefix on trailing default params so `paramDefaultCount` recovers the count just like the Go side.

### Wiring

- `toolchain/check.osty` gains `frontendCheckLexedSourceWithImports` — interposes `frontInstallImportSurfaces` between `newElabCx` and `elabFile`. Matches the Go flow `cx := newElabCx(...); selfhostInstallImportSurfaces(cx.env, ...); elabFile(cx)`.

- `toolchain/check_json.osty::frontCheckPackageToWireJson` additionally extracts imports and routes through the new entry, so `tc.foo(...)` cross-package calls resolve instead of surfacing as E0501 / E0703 / E0702.

### Note on `SPEC_GAPS.md::cross-pkg-module-resolution`

That entry covers the deeper language-level `use <dep>.<module>` parsing gap inside the compiler frontend — broader than the wire-level installation closed here — and stays open.

### Tests

29 new focused tests under `toolchain/check_imports_test.osty`:

- 9 JSON value tree round-trips (string / int / negative int / bool / null / array / object / nested object / escape decoding)
- 5 TypeRepr decoder cases (primitive / optional / named generic / fn with paramNames / missing kind)
- 11 extractor cases (empty / no-key / alias-only / blank-alias drop / function / hasBody round-trip / field / variant / alias / typeDecl / interfaceExt / registerAsIface / source-substring isolation)
- 5 end-to-end install tests (alias-member call resolves, field access resolves, alias binding installed, no-imports negative control, hasBody marker round-trip)

## Test plan

- [x] `.bin/osty check toolchain/` — no new errors in `check_imports.osty` or its callers (4 pre-existing `inspect.osty` / `lint.osty` errors are from PR #1968's `Node` alias removal and unrelated to this PR)
- [x] `.bin/osty fmt --check` on all touched `.osty` files — clean
- [x] `go test ./internal/toolchain/ ./internal/mir/ ./internal/mirjson/ ./internal/selfhost/api/` — pass
- [x] `go vet ./internal/toolchain/ ./internal/selfhost/api/` — clean
- [ ] Osty-native `osty test toolchain/` runner — blocked by pre-existing `manifest_emit_test.osty:180` parse error per PR #1966 test plan, out of scope

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRYJBZ3Q5nLJQr5yaXsWXE)_