### PR TITLE
perf: pool heap-fallback bump-block buffers (compound on PR #1974)

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -9495,6 +9495,184 @@ int main(void) {
 	}
 }
 
+// TestRuntimeGCHeapPoolRecyclesHeapBumpBlocks locks the heap-fallback
+// bump-block pool landing: when the arena is exhausted (or forced
+// via the test-only `osty_gc_debug_force_heap_fallback_set`), bump
+// blocks `calloc` their data buffers from libc instead of carving
+// from the arena. Pre-pool, every released heap-backed block
+// `free`'d its buffer back to libc — glibc's allocator does not
+// reliably return those pages to the OS, so peak anon-RSS during a
+// long-running osty-self lowering would grow roughly linearly in
+// total heap-fallback churn. The pool recycles the buffer: a
+// released same-size buffer comes back memzero'd on the next
+// heap-fallback alloc, avoiding both the libc free/calloc cycle
+// and the calloc first-touch zero-fill cost.
+//
+// The test forces two consecutive heap-fallback allocations, drops
+// the first root, collects (releasing the block — its data buffer
+// should land in the pool), then allocates again. The third alloc
+// should consume the pooled buffer (`take_total > 0`) and the pool
+// stats should show one push + one take.
+func TestRuntimeGCHeapPoolRecyclesHeapBumpBlocks(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "heap_pool_harness.c")
+	binaryPath := filepath.Join(dir, "heap_pool_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+void osty_gc_debug_collect(void);
+void osty_gc_debug_force_heap_fallback_set(int64_t count);
+int64_t osty_gc_debug_heap_pool_push_total(void);
+int64_t osty_gc_debug_heap_pool_take_total(void);
+int64_t osty_gc_debug_heap_pool_count(void);
+
+int main(void) {
+    /* Phase 1: force one heap-fallback alloc, release, collect.
+     * The released block's data buffer should land in the heap
+     * pool. */
+    int64_t push_before = osty_gc_debug_heap_pool_push_total();
+    int64_t take_before = osty_gc_debug_heap_pool_take_total();
+
+    osty_gc_debug_force_heap_fallback_set(1);
+    void *first = osty_gc_alloc_v1(7, 32, "first-heap");
+    osty_gc_root_bind_v1(first);
+    osty_gc_root_release_v1(first);
+    osty_gc_debug_collect();
+
+    int64_t push_after_first = osty_gc_debug_heap_pool_push_total();
+    int64_t pool_count_after_first = osty_gc_debug_heap_pool_count();
+    printf("pool_push_happened:%d\n", push_after_first > push_before);
+    printf("pool_count_after_release:%d\n", pool_count_after_first > 0 ? 1 : 0);
+
+    /* Phase 2: force another heap fallback. The new bump block's
+     * data buffer should come from the pool (matching size),
+     * draining the pool entry. */
+    osty_gc_debug_force_heap_fallback_set(1);
+    void *second = osty_gc_alloc_v1(7, 32, "second-heap");
+    osty_gc_root_bind_v1(second);
+
+    int64_t take_after_second = osty_gc_debug_heap_pool_take_total();
+    int64_t pool_count_after_second = osty_gc_debug_heap_pool_count();
+    printf("pool_take_happened:%d\n", take_after_second > take_before);
+    printf("pool_drained:%d\n", pool_count_after_second < pool_count_after_first ? 1 : 0);
+
+    osty_gc_root_release_v1(second);
+    osty_gc_debug_collect();
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	want := strings.Join([]string{
+		"pool_push_happened:1",       // released heap block was pooled, not freed
+		"pool_count_after_release:1", // pool depth incremented
+		"pool_take_happened:1",       // next heap-fallback alloc consumed a pooled buffer
+		"pool_drained:1",             // pool depth decremented
+		"",
+	}, "\n")
+	if got := string(runOutput); got != want {
+		t.Fatalf("heap pool harness output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestRuntimeGCHeapPoolHonoursDisabledCap pins the pool's escape
+// hatch: setting `OSTY_GC_HEAP_POOL_CAP_BYTES=0` (the env override)
+// disables the pool entirely — pushes are rejected, releases fall
+// through to libc `free` exactly like the pre-pool behaviour. The
+// option exists so callers debugging memory regressions can A/B the
+// pool quickly without rebuilding the runtime.
+func TestRuntimeGCHeapPoolHonoursDisabledCap(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "heap_pool_disabled_harness.c")
+	binaryPath := filepath.Join(dir, "heap_pool_disabled_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#define _POSIX_C_SOURCE 200809L
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+void osty_gc_debug_collect(void);
+void osty_gc_debug_force_heap_fallback_set(int64_t count);
+int64_t osty_gc_debug_heap_pool_push_total(void);
+int64_t osty_gc_debug_heap_pool_count(void);
+
+int main(void) {
+    /* Disable the pool via the env-override path before any
+     * allocation primes it. */
+    setenv("OSTY_GC_HEAP_POOL_CAP_BYTES", "0", 1);
+
+    int64_t push_before = osty_gc_debug_heap_pool_push_total();
+    osty_gc_debug_force_heap_fallback_set(1);
+    void *first = osty_gc_alloc_v1(7, 32, "first-heap");
+    osty_gc_root_bind_v1(first);
+    osty_gc_root_release_v1(first);
+    osty_gc_debug_collect();
+    int64_t push_after = osty_gc_debug_heap_pool_push_total();
+    int64_t pool_count_after = osty_gc_debug_heap_pool_count();
+    printf("pool_push_suppressed:%d\n", push_after == push_before ? 1 : 0);
+    printf("pool_empty:%d\n", pool_count_after == 0 ? 1 : 0);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	want := strings.Join([]string{
+		"pool_push_suppressed:1",
+		"pool_empty:1",
+		"",
+	}, "\n")
+	if got := string(runOutput); got != want {
+		t.Fatalf("heap pool disabled harness output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
 // TestRuntimeGCArenaFreeListRecyclesBumpBlockRanges locks the arena
 // free-list landing: a workload that allocates an object, drops the
 // root, and collects (sweeping the only bump block) must surface a

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1420,6 +1420,138 @@ static void *osty_gc_arena_free_take(size_t bytes, size_t align) {
   return NULL;
 }
 
+/* Heap-fallback bump-block pool. The arena free-list above keeps
+ * arena-backed blocks within the 4 GiB reservation. When peak live
+ * working set exceeds 4 GiB (toolchain test bundles, large
+ * `lir-proto-lower` MIR JSONs) the bump allocator falls through to
+ * `calloc` in `osty_gc_bump_block_new`'s second branch — those
+ * blocks used to be unconditionally `free`'d on release. glibc's
+ * allocator does not always release the underlying physical pages
+ * back to the OS even after `free`, but more importantly each
+ * release / calloc cycle thrashes anon-RSS while the kernel decides
+ * whether to reclaim. Pooling the data buffer + memzeroing it on
+ * reuse keeps the heap working set steady and avoids the calloc
+ * fast-path's zero-fill cost on warm churn.
+ *
+ * Pool shape: simple LIFO sorted by exact `total_bytes` match.
+ * Most heap-fallback blocks share the default 64 KiB +
+ * `OSTY_GC_SIZE_CLASS_ALIGN` shape so an exact-size LIFO has a
+ * near-100% hit rate without sweep / coalesce overhead. Pool
+ * capacity is capped (`OSTY_GC_HEAP_POOL_CAP_BYTES`) at 64 MiB by
+ * default to bound the worst-case retained-heap-pool footprint —
+ * overflow on push falls back to `free`. The cap can be raised via
+ * `OSTY_GC_HEAP_POOL_CAP_BYTES` env override; setting it to 0
+ * disables the pool entirely (restoring the pre-pool `free`-on-
+ * release behaviour).
+ *
+ * The pool node header lives in the freed buffer's first
+ * `sizeof(osty_gc_heap_pool_node)` bytes (same trick as the arena
+ * free-list). The header carries both `total_bytes` (entire raw
+ * `data_alloc` byte length, including the alignment slack the
+ * allocator over-reserves) so a future take can return it intact,
+ * and `next` for the LIFO link.
+ */
+typedef struct osty_gc_heap_pool_node {
+  struct osty_gc_heap_pool_node *next;
+  size_t total_bytes;
+} osty_gc_heap_pool_node;
+
+static osty_gc_heap_pool_node *osty_gc_heap_pool_head = NULL;
+static int64_t osty_gc_heap_pool_count = 0;
+static int64_t osty_gc_heap_pool_bytes = 0;
+static int64_t osty_gc_heap_pool_push_total = 0;
+static int64_t osty_gc_heap_pool_take_total = 0;
+static int64_t osty_gc_heap_pool_take_bytes_total = 0;
+static int64_t osty_gc_heap_pool_overflow_free_total = 0;
+static int64_t osty_gc_heap_pool_cap_bytes = (int64_t)(64 * 1024 * 1024);
+static bool osty_gc_heap_pool_cap_loaded = false;
+
+static int64_t osty_gc_heap_pool_cap_bytes_now(void) {
+  const char *value;
+  char *end = NULL;
+  long long parsed;
+
+  if (osty_gc_heap_pool_cap_loaded) {
+    return osty_gc_heap_pool_cap_bytes;
+  }
+  osty_gc_heap_pool_cap_loaded = true;
+  value = getenv("OSTY_GC_HEAP_POOL_CAP_BYTES");
+  if (value == NULL || value[0] == '\0') {
+    return osty_gc_heap_pool_cap_bytes;
+  }
+  parsed = strtoll(value, &end, 10);
+  if (end == value || (end != NULL && *end != '\0') || parsed < 0) {
+    osty_rt_abort("invalid OSTY_GC_HEAP_POOL_CAP_BYTES");
+  }
+  osty_gc_heap_pool_cap_bytes = (int64_t)parsed;
+  return osty_gc_heap_pool_cap_bytes;
+}
+
+/* Push `data_alloc` onto the heap pool. Returns true when accepted;
+ * false means the caller must `free(data_alloc)` itself (pool full
+ * / disabled / size too small to hold the node header). */
+static bool osty_gc_heap_pool_push(void *data_alloc, size_t total_bytes) {
+  osty_gc_heap_pool_node *node;
+  int64_t cap;
+
+  if (data_alloc == NULL || total_bytes < sizeof(osty_gc_heap_pool_node)) {
+    return false;
+  }
+  cap = osty_gc_heap_pool_cap_bytes_now();
+  if (cap == 0) {
+    return false;
+  }
+  if (total_bytes > (size_t)INT64_MAX) {
+    osty_rt_abort("GC heap-pool total bytes overflow");
+  }
+  if (osty_gc_heap_pool_bytes + (int64_t)total_bytes > cap) {
+    osty_gc_heap_pool_overflow_free_total += 1;
+    return false;
+  }
+  node = (osty_gc_heap_pool_node *)data_alloc;
+  node->total_bytes = total_bytes;
+  node->next = osty_gc_heap_pool_head;
+  osty_gc_heap_pool_head = node;
+  osty_gc_heap_pool_count += 1;
+  osty_gc_heap_pool_bytes += (int64_t)total_bytes;
+  osty_gc_heap_pool_push_total += 1;
+  return true;
+}
+
+/* Take a pooled buffer of exactly `total_bytes` and memzero its
+ * contents to mimic `calloc`. Returns NULL when no match exists in
+ * the pool (caller falls through to `calloc`). First-fit on exact
+ * size match keeps the per-take cost O(pool depth); pool depth is
+ * bounded by `OSTY_GC_HEAP_POOL_CAP_BYTES / OSTY_GC_BUMP_BLOCK_BYTES`
+ * so in practice this is sublinear in lifetime allocation count. */
+static void *osty_gc_heap_pool_take(size_t total_bytes) {
+  osty_gc_heap_pool_node *prev = NULL;
+  osty_gc_heap_pool_node *cur = osty_gc_heap_pool_head;
+
+  if (osty_gc_heap_pool_cap_bytes_now() == 0) {
+    return NULL;
+  }
+  while (cur != NULL) {
+    if (cur->total_bytes == total_bytes) {
+      osty_gc_heap_pool_node *next = cur->next;
+      if (prev != NULL) {
+        prev->next = next;
+      } else {
+        osty_gc_heap_pool_head = next;
+      }
+      osty_gc_heap_pool_count -= 1;
+      osty_gc_heap_pool_bytes -= (int64_t)total_bytes;
+      osty_gc_heap_pool_take_total += 1;
+      osty_gc_heap_pool_take_bytes_total += (int64_t)total_bytes;
+      memset(cur, 0, total_bytes);
+      return cur;
+    }
+    prev = cur;
+    cur = cur->next;
+  }
+  return NULL;
+}
+
 static void osty_gc_arena_init(void) {
   if (osty_gc_arena_base != NULL || osty_gc_arena_init_failed) {
     return;
@@ -1446,12 +1578,27 @@ static void osty_gc_arena_init(void) {
   osty_gc_arena_end = osty_gc_arena_base + OSTY_GC_ARENA_BYTES;
 }
 
+/* Force the next N arena_alloc calls to return NULL so the bump-
+ * block allocator falls through to its heap-fallback branch. Used
+ * by `TestRuntimeGCHeapPoolRecyclesHeapBumpBlocks` to exercise the
+ * heap-pool reuse path without first having to push the arena
+ * cursor past the 4 GiB cap (which is impractical inside a unit
+ * test). Production code never decrements this counter. */
+static int64_t osty_gc_debug_force_heap_fallback_remaining = 0;
+void osty_gc_debug_force_heap_fallback_set(int64_t count) {
+  osty_gc_debug_force_heap_fallback_remaining = count;
+}
+
 static void *osty_gc_arena_alloc(size_t bytes, size_t align) {
   uintptr_t cur;
   uintptr_t aligned;
   uintptr_t next;
   void *recycled;
 
+  if (osty_gc_debug_force_heap_fallback_remaining > 0) {
+    osty_gc_debug_force_heap_fallback_remaining -= 1;
+    return NULL;
+  }
   if (osty_gc_arena_base == NULL) {
     osty_gc_arena_init();
     if (osty_gc_arena_base == NULL) {
@@ -3424,13 +3571,23 @@ osty_gc_bump_block_new(size_t min_size, osty_gc_bump_block **blocks_head,
   } else {
     /* Arena init failed or exhausted — fall back to heap. The
      * data region is owned by `data_alloc` (the unaligned
-     * calloc'd base) so `osty_gc_bump_block_release` can free
-     * it later. The lookup fast path won't help these blocks
+     * pointer to the raw allocation) so `osty_gc_bump_block_release`
+     * can recycle it (via `osty_gc_heap_pool_push`) or free it
+     * later. The lookup fast path won't help these blocks
      * (outside the arena range) but the hash-based lookup
-     * still works for them. */
+     * still works for them.
+     *
+     * Recycle path: a previously released same-size buffer is
+     * consulted via `osty_gc_heap_pool_take` first. On a hit the
+     * buffer comes back memzero'd (caller no longer pays the
+     * `calloc` first-touch zero-fill on warm churn).
+     */
     size_t total_bytes = block_size + OSTY_GC_SIZE_CLASS_ALIGN;
-    unsigned char *raw = (unsigned char *)calloc(1, total_bytes);
+    unsigned char *raw = (unsigned char *)osty_gc_heap_pool_take(total_bytes);
     uintptr_t aligned;
+    if (raw == NULL) {
+      raw = (unsigned char *)calloc(1, total_bytes);
+    }
     if (raw == NULL) {
       free(block);
       osty_rt_abort("out of memory (gc bump block data)");
@@ -3586,7 +3743,11 @@ static void osty_gc_bump_block_release(osty_gc_bump_block *target,
   /* Reclaim the payload region. Two cases:
    *   1. Heap-backed (`data_alloc != NULL`) — arena_init had failed
    *      or the arena was exhausted at the time of allocation, so
-   *      the data region came from `calloc`. Return it via `free`.
+   *      the data region came from `calloc`. Push onto the heap
+   *      pool when it has capacity (caller pays no `calloc` zero-
+   *      fill on the next same-size alloc); fall through to `free`
+   *      when the pool is disabled, full, or the total length is
+   *      too small to host the pool's intrusive node header.
    *   2. Arena-backed (`data_alloc == NULL`) — push the range onto
    *      the arena free-list so subsequent `osty_gc_arena_alloc`
    *      calls can hand it out again. Pre-recycle behaviour leaked
@@ -3597,7 +3758,14 @@ static void osty_gc_bump_block_release(osty_gc_bump_block *target,
    *      release path.
    */
   if (block->data_alloc != NULL) {
-    free(block->data_alloc);
+    /* total_bytes mirrors the `block_size + OSTY_GC_SIZE_CLASS_ALIGN`
+     * total the heap-fallback branch of `osty_gc_bump_block_new`
+     * reserved. The pool indexes by exact `total_bytes` so the
+     * same-size shape lines up on every reuse. */
+    size_t total_bytes = (size_t)block->size + (size_t)OSTY_GC_SIZE_CLASS_ALIGN;
+    if (!osty_gc_heap_pool_push(block->data_alloc, total_bytes)) {
+      free(block->data_alloc);
+    }
   } else if (block->data != NULL && block->size > 0) {
     osty_gc_arena_free_push(block->data, block->size);
   }
@@ -21705,6 +21873,31 @@ int64_t osty_gc_debug_arena_free_take_total(void) {
 }
 int64_t osty_gc_debug_arena_free_take_bytes_total(void) {
   return osty_gc_arena_free_take_bytes_total;
+}
+
+/* Heap-fallback bump-block pool debug helpers. The pool intercepts
+ * `osty_gc_bump_block_release` for heap-backed blocks: instead of
+ * `free`-ing the data buffer back to libc, it caches the buffer for
+ * the next same-size heap-fallback allocation. Lets tests assert
+ * the pool is hit (no calloc/free churn) and the cap is honoured
+ * (no unbounded retention). */
+int64_t osty_gc_debug_heap_pool_count(void) {
+  return osty_gc_heap_pool_count;
+}
+int64_t osty_gc_debug_heap_pool_bytes(void) {
+  return osty_gc_heap_pool_bytes;
+}
+int64_t osty_gc_debug_heap_pool_push_total(void) {
+  return osty_gc_heap_pool_push_total;
+}
+int64_t osty_gc_debug_heap_pool_take_total(void) {
+  return osty_gc_heap_pool_take_total;
+}
+int64_t osty_gc_debug_heap_pool_take_bytes_total(void) {
+  return osty_gc_heap_pool_take_bytes_total;
+}
+int64_t osty_gc_debug_heap_pool_overflow_free_total(void) {
+  return osty_gc_heap_pool_overflow_free_total;
 }
 
 int64_t osty_gc_debug_survivor_bump_block_count(void) {


### PR DESCRIPTION
## Summary

PR #1974 의 후속. **Arena** free-list 가 4 GiB mmap arena 내 reuse 를 cover, 본 PR 은 **heap fallback** 경로의 churn 을 잡음.

PR #1974 가 released bump block 의 data range 를 arena free-list 로 push → arena 내 working set 이 4 GiB 에 들면 peak-VM 안정. 4 GiB 초과 시 `osty_gc_bump_block_new` 의 heap fallback 으로 spillover — 매번 libc `calloc`/`free` cycle, glibc 의 free-page-return 정책에 묶여 cumulative heap-fallback alloc 카운트에 비례해 anon-RSS 가 자람 (steady-state live 가 flat 이어도).

## What this changes

`internal/backend/runtime/osty_runtime.c`:

1. **`osty_gc_heap_pool_*` helpers** — released heap-backed bump-block data buffer 의 intrusive LIFO. Exact `total_bytes` 매칭. Pool node header 가 buffer 자체에 lives → 추가 메모리 0. Default block size 64 KiB 가 dominant 이므로 push/take 가 exact match.

2. **`osty_gc_bump_block_new` heap fallback** — `osty_gc_heap_pool_take(total_bytes)` 를 `calloc` 보다 먼저. Hit 시 buffer 가 memzero'd (calloc 시맨틱 매칭, bump 할당자가 zero-init 가정). Miss 시 기존 `calloc` 으로 fallthrough.

3. **`osty_gc_bump_block_release` heap branch** — `free(data_alloc)` 대신 `osty_gc_heap_pool_push`. Overflow (`OSTY_GC_HEAP_POOL_CAP_BYTES` 도달) 시 push 가 false 반환, caller 가 기존대로 `free`. Default cap 64 MiB — worst-case retained-pool footprint bounded.

4. **Env-override `OSTY_GC_HEAP_POOL_CAP_BYTES`** — retained pool 바이트 cap. `0` 으로 pool 완전 비활성화 → 재빌드 없이 with-pool vs without-pool A/B profiling 가능. 다른 GC tunable (`OSTY_GC_THRESHOLD_BYTES` 등) env-knob 컨벤션 그대로.

5. **`osty_gc_debug_heap_pool_*` accessors** (6종) — `_count` / `_bytes` (현재 depth/byte footprint), `_push_total` / `_take_total` / `_take_bytes_total` (lifetime), `_overflow_free_total` (cap 으로 인한 push reject).

6. **Test-only `osty_gc_debug_force_heap_fallback_set(N)`** — 다음 `N` 번 `osty_gc_arena_alloc` 가 NULL 반환 → bump allocator 가 heap path 로 fallthrough. C harness 가 unit test 내에서 arena cursor 를 4 GiB 까지 밀지 않고도 pool exercise 가능. Production code 는 counter 건드리지 않음 → hot path 의 zero-cost branch.

## Memory impact

PR #1974 와 compound: arena free-list 가 reuse 를 4 GiB 안에 유지, 본 PR 은 그 외 spillover 를 cheap 하게. 4 GiB 초과 live working set 워크로드 (`osty test toolchain/` bundles, 큰 `lir-proto-lower` MIR JSON) 에서 직접적 benefit.

`lint.osty` 는 arena alone 으로 충분 → PR #1974 의 3 GiB peak 변동 없음. `osty install-self` end-to-end 동일.

`osty test toolchain/` bundle 이 8 GiB+ working set 으로 여전히 OOM — 본 PR + #1974 모두 합쳐도 부족. Test bundle granularity 작업이 필요한 별도 batch (본 PR scope 밖).

## Test plan

- [x] `TestRuntimeGCHeapPoolRecyclesHeapBumpBlocks` — force-heap-fallback 으로 두 alloc, 첫 release 가 pool push, 두 번째 alloc 이 pool take, depth 일관성 assert. 통과.
- [x] `TestRuntimeGCHeapPoolHonoursDisabledCap` — `OSTY_GC_HEAP_POOL_CAP_BYTES=0` 에서 alloc+release 후 pool 이 비어있음 assert (pre-pool `free`-on-release 동등). 통과.
- [x] 기존 `TestRuntimeGCArenaFreeListRecyclesBumpBlockRanges` (PR #1974) 통과 — 변경 없음.
- [x] `go test -short ./internal/backend/ ./internal/mir/` — 전 회귀 통과.
- [x] `osty install-self` (PR #1972 cherry-pick 후) end-to-end — clean.

## Dependency note

End-to-end `osty install-self` 검증은 PR #1972 (.node → .nodeId stragglers) merge 후 가능 — toolchain 의 `inspect.osty` / `lint.osty` 가 그 fix 없이는 type-check 실패 (본 PR 과 무관한 별도 fix).


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2YbnUpRw682ooUP91JSsk)_