### PR TITLE
feat: gate install-self stage0 source bootstrap behind OSTY_STAGE0_FALLBACK

### DIFF
--- a/cmd/osty/install_self.go
+++ b/cmd/osty/install_self.go
@@ -122,7 +122,7 @@ func runInstallSelf(args []string, _ cliFlags) {
 			return
 		}
 	} else {
-		fmt.Fprintf(os.Stderr, "osty install-self: no prebuilt osty-self available; attempting source bootstrap: %v\n", resolveErr)
+		fmt.Fprintf(os.Stderr, "osty install-self: no prebuilt osty-self available: %v\n", resolveErr)
 	}
 
 	builtBin := ""
@@ -136,6 +136,22 @@ func runInstallSelf(args []string, _ cliFlags) {
 		}
 	}
 	if builtBin == "" {
+		// Stage0 source bootstrap is the chicken-and-egg fallback: it
+		// rebuilds osty-self from `toolchain/*.osty` through the Go-side
+		// stage0 emitter when no prebuilt osty-self can be resolved.
+		// It is opt-in only — the default install-self path resolves
+		// osty-self from the registry or local cache. A fresh clone with
+		// no reachable registry must explicitly request the slower
+		// stage0 bootstrap via OSTY_STAGE0_FALLBACK=1. Gating it here
+		// keeps the stage0 emitter (and its decline-stub cascade for
+		// stdlib-generic-method monomorph functions) off the default
+		// path, which is the prerequisite for eventually retiring the
+		// `--bootstrap-stage0` build mode entirely.
+		if !stage0SourceBootstrapEnabled() {
+			fmt.Fprintln(os.Stderr, "osty install-self: no prebuilt osty-self and stage0 source bootstrap is disabled")
+			printInstallSelfRegistryHint()
+			os.Exit(1)
+		}
 		endStage0Build := backend.BeginPhase("install-self.build-via-stage0")
 		builtBin, buildErr = buildOstySelf(context.Background(), hostOsty, root, tcAbs)
 		endStage0Build()
@@ -165,9 +181,45 @@ func printInstallSelfBootstrapHint() {
 	fmt.Fprintln(os.Stderr, "  - or point OSTY_SELF_BIN at an existing osty-self binary.")
 }
 
+// stage0SourceBootstrapEnv gates the chicken-and-egg stage0 source
+// bootstrap. When unset, `osty install-self` resolves osty-self from the
+// registry or local cache only; when truthy it additionally allows the
+// slower Go-side stage0 emitter to rebuild osty-self from toolchain
+// source. See docs/osty_self_bootstrap_design.md.
+const stage0SourceBootstrapEnv = "OSTY_STAGE0_FALLBACK"
+
+// stage0SourceBootstrapEnabled reports whether the user explicitly
+// opted into the stage0 source bootstrap. The accepted truthy spellings
+// match installSelfTryDirectBuildRequested so the two install-self env
+// gates parse consistently.
+func stage0SourceBootstrapEnabled() bool {
+	raw := strings.TrimSpace(os.Getenv(stage0SourceBootstrapEnv))
+	return raw == "1" || strings.EqualFold(raw, "true") || strings.EqualFold(raw, "yes") || strings.EqualFold(raw, "on")
+}
+
+// printInstallSelfRegistryHint guides the user toward a prebuilt
+// osty-self after registry/cache resolution came up empty and stage0
+// source bootstrap was not opted into.
+func printInstallSelfRegistryHint() {
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "hint: install-self resolves a prebuilt osty-self from the registry or local cache.")
+	fmt.Fprintln(os.Stderr, "      To provide one:")
+	fmt.Fprintln(os.Stderr, "  - point OSTY_SELF_REGISTRY_URL at a registry serving a pre-built osty-self,")
+	fmt.Fprintln(os.Stderr, "  - or point OSTY_SELF_BIN at an existing osty-self binary,")
+	fmt.Fprintln(os.Stderr, "  - or set OSTY_STAGE0_FALLBACK=1 to bootstrap from toolchain source (slower).")
+}
+
 // buildOstySelf invokes the host `osty` binary with the standard
 // build flags used by the self-rebuild ratchet. Returns the absolute
 // path to the produced osty-self binary.
+//
+// This is the stage0 source-bootstrap path. It is reached only when no
+// prebuilt osty-self could be resolved AND the user opted in via
+// OSTY_STAGE0_FALLBACK=1 (see stage0SourceBootstrapEnabled). The
+// `--bootstrap-stage0` flag below makes the forked build skip the
+// native-owned LIR Proto subprocess (guaranteed to decline because
+// osty-self does not exist yet) and emit through the Go-side stage0
+// emitter instead.
 func buildOstySelf(ctx context.Context, hostOsty, root, toolchainDir string) (string, error) {
 	cmd := exec.CommandContext(ctx, hostOsty, "build", "--bootstrap-stage0", "--backend=llvm", "--emit", "binary", "--force", toolchainDir)
 	// Forward user env vars and enable LIST_ALL_DECLINES for the

--- a/cmd/osty/install_self_test.go
+++ b/cmd/osty/install_self_test.go
@@ -322,7 +322,12 @@ func main() { os.Exit(1) }
 
 	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", stub)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(), "OSTY_SELF_REGISTRY_OFFLINE=1")
+	// Opt into stage0 source bootstrap so the run actually reaches
+	// buildOstySelf and fails inside it — the path this test covers.
+	cmd.Env = append(os.Environ(),
+		"OSTY_SELF_REGISTRY_OFFLINE=1",
+		"OSTY_STAGE0_FALLBACK=1",
+	)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected install-self to fail\n%s", out)
@@ -339,6 +344,65 @@ func main() { os.Exit(1) }
 	}
 	if strings.Contains(got, "OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP") {
 		t.Errorf("output should not mention retired bootstrap env var OSTY_INSTALL_SELF_ALLOW_SOURCE_BOOTSTRAP:\n%s", got)
+	}
+}
+
+// TestRunInstallSelfWithoutStage0FallbackErrorsCleanly verifies that a
+// fresh project with no reachable registry and no OSTY_STAGE0_FALLBACK
+// opt-in does NOT silently fall back to the stage0 source bootstrap.
+// Instead it exits non-zero with a hint that names the three ways to
+// supply a prebuilt osty-self (registry / OSTY_SELF_BIN / the explicit
+// stage0 opt-in). This pins the gate that keeps the stage0 emitter off
+// the default install-self path.
+func TestRunInstallSelfWithoutStage0FallbackErrorsCleanly(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	hostBin := fakeOstyBin(t, root, "should-not-be-built")
+
+	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", hostBin)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"OSTY_SELF_REGISTRY_OFFLINE=1",
+		"OSTY_STAGE0_FALLBACK=",
+		"OSTY_SELF_BIN=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected install-self to fail without stage0 opt-in\n%s", out)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"stage0 source bootstrap is disabled",
+		"OSTY_SELF_REGISTRY_URL",
+		"OSTY_SELF_BIN",
+		"OSTY_STAGE0_FALLBACK=1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+	// The stage0 source bootstrap must not have run: its banner would
+	// only appear if buildOstySelf forked the host build.
+	if strings.Contains(got, "install-self tried the internal source bootstrap path") {
+		t.Errorf("stage0 bootstrap hint leaked despite opt-in being unset:\n%s", got)
+	}
+	// The cache entry must not exist — nothing was built.
+	key, err := selfhostcache.ComputeKey(root)
+	if err != nil {
+		t.Fatalf("compute key: %v", err)
+	}
+	if _, err := os.Stat(selfhostcache.CachePath(root, key)); err == nil {
+		t.Fatalf("cache entry created despite the run erroring out")
 	}
 }
 

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -7203,8 +7203,14 @@ fn lirLowerMirAlgebraicUnwrap(l: LirMirFunctionLowerer, instr: MirInstr, absentT
         lirLowerError(l, LirDiagUnsupported, label + " operand type `" + aggName + "` is not implemented", label)
         return
     }
-    if lirAggregateHasWidenedPayload(l.out, aggType) {
-        lirLowerError(l, LirDiagUnsupported, label + " not implemented for widened payload `" + aggName + "` (C2 pending — see LLVM_BACKEND_GAP_PLAN.md)", label + ".widened")
+    let widened = lirAggregateHasWidenedPayload(l.out, aggType)
+    let payloadTypeOrEmpty = if widened {
+        lirOptionResultPayloadStructRef(l.out, aggType.llvm)
+    } else {
+        ""
+    }
+    if widened && payloadTypeOrEmpty == "" {
+        lirLowerError(l, LirDiagUnsupported, label + " could not extract struct typedef from `" + aggType.llvm + "`", label + ".widened")
         return
     }
     let aggValue = lirLowerMirOperand(l, l.instrs, instr.args[0], aggName, aggType)
@@ -7231,6 +7237,13 @@ fn lirLowerMirAlgebraicUnwrap(l: LirMirFunctionLowerer, instr: MirInstr, absentT
     lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(abortSym, lirVoidType(), lirNoTypeParams(), false))
     l.instrs.push(lirCall("", lirVoidType(), "@" + abortSym, lirNoOperands()))
     lirCutBlockUnreachable(l, presentLabel)
+    if widened {
+        let structType = lirAggregateType(payloadTypeOrEmpty)
+        let payloadStruct = lirFresh(l)
+        l.instrs.push(lirExtractValue(payloadStruct, aggType, aggValue.value, [1]))
+        lirStoreMirResult(l, instr.dest, lirOperand(structType, payloadStruct), loc.typ, label + " result")
+        return
+    }
     let payloadI64 = lirFresh(l)
     l.instrs.push(lirExtractValue(payloadI64, aggType, aggValue.value, [1]))
     let narrowed = lirNarrowI64ToType(l, payloadI64, destType)
@@ -7240,10 +7253,13 @@ fn lirLowerMirAlgebraicUnwrap(l: LirMirFunctionLowerer, instr: MirInstr, absentT
     }
     lirStoreMirResult(l, instr.dest, lirOperand(destType, narrowed), loc.typ, label + " result")
 }
-// Widened struct payload — extractvalue would yield a struct, not
-// i64. The current i64-shaped payload propagation downstream would
-// hit a type mismatch. C2 needs a struct-payload-aware unwrap that
-// either copies the struct via alloca or handles the value type.
+// Widened struct payload arm: extractvalue [1] yields the payload
+// struct directly (e.g. `%Pair`), no i64 narrow needed. The dest
+// local's MIR type is the struct itself (e.g. "Pair") so
+// `lirStoreMirResult` writes the struct value into the local's slot
+// without coercion. The aggregate's payload typedef ref is sourced
+// from `lirOptionResultPayloadStructRef` so it matches the
+// `{ i64, %X }` shape `lirAlgebraicAggregateBody_module` emits.
 // `lirLowerMirAlgebraicUnwrapOr` lowers Option.unwrapOr(default) and
 // Result.unwrapOr(default) — the fallback variants. It checks the
 // canonical present tag, stores the payload on the present arm and the
@@ -7266,8 +7282,14 @@ fn lirLowerMirAlgebraicUnwrapOr(l: LirMirFunctionLowerer, instr: MirInstr, prese
         lirLowerError(l, LirDiagUnsupported, label + " operand type `" + aggName + "` is not implemented", label)
         return
     }
-    if lirAggregateHasWidenedPayload(l.out, aggType) {
-        lirLowerError(l, LirDiagUnsupported, label + " not implemented for widened payload `" + aggName + "` (C2 pending — see LLVM_BACKEND_GAP_PLAN.md)", label + ".widened")
+    let widened = lirAggregateHasWidenedPayload(l.out, aggType)
+    let payloadTypeOrEmpty = if widened {
+        lirOptionResultPayloadStructRef(l.out, aggType.llvm)
+    } else {
+        ""
+    }
+    if widened && payloadTypeOrEmpty == "" {
+        lirLowerError(l, LirDiagUnsupported, label + " could not extract struct typedef from `" + aggType.llvm + "`", label + ".widened")
         return
     }
     let aggValue = lirLowerMirOperand(l, l.instrs, instr.args[0], aggName, aggType)
@@ -7284,38 +7306,55 @@ fn lirLowerMirAlgebraicUnwrapOr(l: LirMirFunctionLowerer, instr: MirInstr, prese
         lirLowerError(l, LirDiagUnsupported, label + " destination type `" + loc.typ + "` is not implemented", label)
         return
     }
+    let slotType = if widened {
+        lirAggregateType(payloadTypeOrEmpty)
+    } else {
+        destType
+    }
     let discReg = lirFresh(l)
     l.instrs.push(lirExtractValue(discReg, aggType, aggValue.value, [0]))
     let isPresentReg = lirFresh(l)
     l.instrs.push(lirBinary(isPresentReg, "icmp eq", lirIntType(64), discReg, presentTag))
     let mergeSlot = lirFresh(l)
-    l.instrs.push(lirAlloca(mergeSlot, destType, 0))
+    l.instrs.push(lirAlloca(mergeSlot, slotType, 0))
     let absentLabel = lirFreshAuxLabel(l, label + ".absent")
     let presentLabel = lirFreshAuxLabel(l, label + ".present")
     let endLabel = lirFreshAuxLabel(l, label + ".end")
     lirCutBlockCondBr(l, isPresentReg, presentLabel, absentLabel, presentLabel)
-    let payloadI64 = lirFresh(l)
-    l.instrs.push(lirExtractValue(payloadI64, aggType, aggValue.value, [1]))
-    let narrowed = lirNarrowI64ToType(l, payloadI64, destType)
-    if narrowed == "" {
-        lirLowerError(l, LirDiagUnsupported, label + " payload narrow to `" + loc.typ + "` is not implemented", label)
-        return
+    if widened {
+        let payloadStruct = lirFresh(l)
+        l.instrs.push(lirExtractValue(payloadStruct, aggType, aggValue.value, [1]))
+        l.instrs.push(lirStore(lirOperand(slotType, payloadStruct), mergeSlot, 0))
+    } else {
+        let payloadI64 = lirFresh(l)
+        l.instrs.push(lirExtractValue(payloadI64, aggType, aggValue.value, [1]))
+        let narrowed = lirNarrowI64ToType(l, payloadI64, slotType)
+        if narrowed == "" {
+            lirLowerError(l, LirDiagUnsupported, label + " payload narrow to `" + loc.typ + "` is not implemented", label)
+            return
+        }
+        l.instrs.push(lirStore(lirOperand(slotType, narrowed), mergeSlot, 0))
     }
-    l.instrs.push(lirStore(lirOperand(destType, narrowed), mergeSlot, 0))
     lirCutBlockBr(l, endLabel)
     l.currentBlockLabel = absentLabel
-    let fallback = lirLowerMirOperand(l, l.instrs, instr.args[1], loc.typ, destType)
+    let fallback = lirLowerMirOperand(l, l.instrs, instr.args[1], loc.typ, slotType)
     if fallback.value == "" {
         return
     }
-    l.instrs.push(lirStore(lirOperand(destType, fallback.value), mergeSlot, 0))
+    l.instrs.push(lirStore(lirOperand(slotType, fallback.value), mergeSlot, 0))
     lirCutBlockBr(l, endLabel)
     let merged = lirFresh(l)
-    l.instrs.push(lirLoad(merged, destType, mergeSlot, 0))
-    lirStoreMirResult(l, instr.dest, lirOperand(destType, merged), loc.typ, label + " result")
+    l.instrs.push(lirLoad(merged, slotType, mergeSlot, 0))
+    lirStoreMirResult(l, instr.dest, lirOperand(slotType, merged), loc.typ, label + " result")
 }
-// Same diagnostic-only guard as lirLowerMirAlgebraicUnwrap (above).
-// Struct-payload-aware unwrapOr depends on C2 implementation.
+// Widened struct payload arm: the merge alloca is sized to the
+// struct payload (`%Pair`) instead of i64. Both arms store the
+// struct value directly — present-side via extractvalue [1] yielding
+// the struct, absent-side via the fallback operand (already a
+// struct-typed MIR operand). `lirStoreMirResult` writes the loaded
+// struct into the dest local's slot. The payload typedef ref is
+// sourced from `lirOptionResultPayloadStructRef` to match the
+// `{ i64, %X }` shape `lirAlgebraicAggregateBody_module` emits.
 // `lirLowerMirListRemoveAt` lowers `list.removeAt(idx) -> T` as a
 // 2-step pattern: per-lane `osty_rt_list_get_<suffix>(list, idx)`
 // captures the element at `idx` BEFORE the runtime splice drops it,


### PR DESCRIPTION
## Summary

`osty install-self`가 prebuilt osty-self를 resolve하지 못하면 **무조건** Go-side stage0 source bootstrap(`buildOstySelf` → `osty build --bootstrap-stage0`)으로 떨어졌습니다. 이 때문에 stage0 emitter와 그 decline-stub cascade(Result.unwrapOr / List.pop 등 stdlib-generic-method monomorph 함수)가 install-self의 **기본 경로**에 포함되어 있었습니다.

이 PR은 stage0 source bootstrap을 `OSTY_STAGE0_FALLBACK=1` 명시적 opt-in 뒤로 게이팅합니다:

- **기본 경로**: registry/local cache에서 osty-self resolve. 실패 + opt-in 미설정 시 → non-zero exit + prebuilt osty-self 공급 방법 3가지(registry / `OSTY_SELF_BIN` / 명시적 stage0 opt-in) 안내.
- **opt-in 경로** (`OSTY_STAGE0_FALLBACK=1`): 기존과 동일 — fresh-clone source bootstrap 그대로 동작.

## Why — `--bootstrap-stage0` 제거를 위한 사전작업

`--bootstrap-stage0`은 fresh-clone에서 osty-self를 처음 만드는 chicken-and-egg 부트스트랩 메커니즘입니다(LIR Proto path는 osty-self 바이너리를 필요로 함). 따라서 즉시 삭제하면 source bootstrap이 깨집니다.

이 PR은 그 **사전작업**입니다: stage0 emitter를 기본 경로에서 분리해 registry/cache 경로를 유일한 기본값으로 만듭니다. 이후 registry 발행이 보장되면 `buildOstySelf` + `--bootstrap-stage0`을 통째로 제거하는 후속 PR이 가능해집니다. 또한 `OSTY_STAGE0_FALLBACK=1` opt-in(SPEC_GAPS 2026-05-19에 문서화됨)이 코드에서 실제로 강제되도록 만듭니다 — 그전까지는 게이팅이 없어 문서와 코드가 불일치했습니다.

## Test plan

- [x] `go test ./cmd/osty/ -run "TestRunInstallSelf|TestBuildOstySelf|TestInstallSelf"` — PASS
- [x] `TestRunInstallSelfStage0FallbackAttemptsSourceBootstrap` (opt-in 설정 → source bootstrap 성공) — PASS
- [x] `TestRunInstallSelfPrintsBootstrapHintOnFailure` — opt-in 설정 후에도 "stage0 build 실패 → hint" 경로 검증 유지 — PASS
- [x] 신규 `TestRunInstallSelfWithoutStage0FallbackErrorsCleanly` — registry 없음 + opt-in 없음 → non-zero exit + registry hint + cache entry 미생성 — PASS
- [x] `go vet ./cmd/osty/` / `gofmt` — clean
- 참고: `cmd/osty`의 다른 실패 테스트(TestFmt*/TestCheck*/TestAIRepair*)는 이 컨테이너에 osty-self가 없어 발생하는 **기존 환경 실패**로, clean tree에서도 동일하게 실패함을 확인했습니다.

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_