### PR TITLE
feat: populate MIR tuple layouts so LIR Proto can lower tuple aggregates

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -155,7 +155,83 @@ func (l *lowerer) run() {
 	l.buildLayouts()
 	l.emitDeclarations()
 	l.emitScript()
+	l.collectTupleLayouts()
 }
+
+// collectTupleLayouts populates Layouts.Tuples from every tuple type
+// reachable through the lowered functions' locals. Tuples are structural
+// (never declared), so buildLayouts — which only walks declared structs
+// / enums / interfaces — leaves the table empty; the LIR Proto backend
+// then rejects every tuple aggregate with "has no MIR layout". Walking
+// the final locals (params, temporaries, return slots) registers a
+// layout keyed by the canonical `(A, B)` type string, recursing so
+// nested tuples (`(Int, (Int, T))`) are covered too.
+func (l *lowerer) collectTupleLayouts() {
+	if l.out == nil || l.out.Layouts == nil {
+		return
+	}
+	var visit func(t Type)
+	visit = func(t Type) {
+		tt, ok := t.(*ir.TupleType)
+		if !ok || tt == nil {
+			return
+		}
+		for _, e := range tt.Elems {
+			visit(e)
+		}
+		key := tt.String()
+		if key == "" {
+			return
+		}
+		if _, dup := l.out.Layouts.Tuples[key]; dup {
+			return
+		}
+		tl := &TupleLayout{Key: key, Mangled: mangleTupleName(tt)}
+		for i, e := range tt.Elems {
+			tl.Fields = append(tl.Fields, FieldLayout{
+				Index: i,
+				Name:  fmt.Sprintf("_%d", i),
+				Type:  e,
+			})
+		}
+		l.out.Layouts.Tuples[key] = tl
+	}
+	for _, fn := range l.out.Functions {
+		if fn == nil {
+			continue
+		}
+		for i := range fn.Locals {
+			visit(fn.Locals[i].Type)
+		}
+	}
+}
+
+// mangleTupleName builds an LLVM-safe nominal name for a tuple type.
+// The canonical `(A, B)` key carries parens/spaces that an unquoted
+// LLVM `%name` identifier rejects, so each element's type string is
+// sanitized to `[A-Za-z0-9_]` and joined under a `Tuple.` prefix —
+// e.g. `(Int, Int)` → `Tuple.Int.Int`.
+func mangleTupleName(tt *ir.TupleType) string {
+	var b strings.Builder
+	b.WriteString("Tuple")
+	for _, e := range tt.Elems {
+		b.WriteByte('.')
+		s := "Unit"
+		if e != nil {
+			s = e.String()
+		}
+		for _, r := range s {
+			switch {
+			case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+				b.WriteRune(r)
+			default:
+				b.WriteByte('_')
+			}
+		}
+	}
+	return b.String()
+}
+
 
 // ==== pass 1: signatures + layouts ====
 


### PR DESCRIPTION
## Summary

`internal/mir`의 `buildLayouts`는 선언된 struct/enum/interface만 순회합니다. tuple은 구조적 타입이라 선언되지 않으므로 `Layouts.Tuples`가 항상 비어 있었고, LIR Proto 백엔드는 모든 tuple aggregate를 `tuple aggregate type (A, B) has no MIR layout`으로 거부했습니다.

영향: plain `(Int, Int)` 생성, 그리고 tuple을 반환하는 stdlib combinator(`enumerate` → `List<(Int, T)>`, `partition` → `(List<T>, List<T>)`)가 전부 decline.

## Fix

`collectTupleLayouts`가 함수 lowering 후 실행되어, lowered 함수들의 local에서 도달 가능한 모든 tuple 타입에 대해 `TupleLayout`을 등록합니다 (중첩 tuple 재귀 포함):

- **Key**: canonical `(A, B)` 타입 문자열 — LIR Proto가 비교하는 MIR JSON type text와 일치.
- **Mangled**: LLVM-safe 이름. unquoted LLVM `%name` 식별자는 괄호·공백을 못 담으므로 `mangleTupleName`이 각 element 타입을 `[A-Za-z0-9_]`로 sanitize하고 `Tuple.` prefix를 붙임 (`(Int, Int)` → `Tuple.Int.Int`).

MIR JSON 인코더와 osty-self 디코더는 이미 tuple layout을 round-trip합니다 — producer 측만 빠져 있었습니다.

## Verification (source-bootstrap osty-self + LLVM 18)

- plain tuple: `(3, 7)` 생성 + `t.0 + t.1` projection → `10` ✓
- `OSTY_STDLIB_BODY_LOWER=1`에서 `enumerate` → `3`, `partition` → `2`/`1` ✓
- 회귀 확인: `take`/`drop`/`sorted`/`concat`/`appended`/`map`/`filter`/`fold` 모두 정상

## Test plan

- [x] `go vet ./internal/mir/` — clean
- [x] source-bootstrap osty-self로 plain tuple + enumerate + partition E2E 검증
- [x] tuple 미사용 메서드 회귀 없음 확인
- [ ] CI Go 스위트

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_