### PR TITLE
fix: more List combinators lower through LIR Proto (reduce/windowed/first/last/find/chunked/zip)

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -232,7 +232,6 @@ func mangleTupleName(tt *ir.TupleType) string {
 	return b.String()
 }
 
-
 // ==== pass 1: signatures + layouts ====
 
 func (l *lowerer) collectSignatures() {

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4447,7 +4447,28 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 		for i, e := range x.Elems {
 			fields[i] = bs.lowerExprAsOperand(e)
 		}
-		return &AggregateRV{Kind: AggTuple, Fields: fields, T: x.T}
+		tt := x.T
+		// A tuple literal's type is always `(typeof e0, typeof e1, ...)`.
+		// The selfhost checker can poison `x.T` to a non-tuple shape
+		// inside an injected generic stdlib body (`List.zip` builds
+		// `(self[i], other[i])` and the literal came back typed `Int`).
+		// Reconstruct from the lowered element operands so the tuple
+		// AggregateRV carries a layout-resolvable `(A, B)` type.
+		if _, ok := tt.(*ir.TupleType); !ok {
+			elems := make([]ir.Type, len(fields))
+			recovered := true
+			for i, op := range fields {
+				if op == nil || op.Type() == nil || isPoisonType(op.Type()) {
+					recovered = false
+					break
+				}
+				elems[i] = op.Type()
+			}
+			if recovered {
+				tt = &ir.TupleType{Elems: elems}
+			}
+		}
+		return &AggregateRV{Kind: AggTuple, Fields: fields, T: tt}
 	case *ir.ListLit:
 		lt := hint
 		if lt == nil || isPoisonType(lt) {

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -201,7 +201,13 @@ pub struct List<T> {
         }
         let mut start = 0
         for start + size <= n {
-            out.push(self.drop(start).take(size))
+            let mut window: List<T> = []
+            let mut j = start
+            for j < start + size {
+                window.push(self[j])
+                j = j + 1
+            }
+            out.push(window)
             start = start + step
         }
         out
@@ -229,19 +235,13 @@ pub struct List<T> {
         if self.isEmpty() {
             return None
         }
-        let mut first: T? = None
-        let mut tail: List<T> = []
-        let mut seenFirst = false
-        for item in self {
-            if !seenFirst {
-                first = Some(item)
-                seenFirst = true
-            } else {
-                tail.push(item)
-            }
+        let mut acc = self[0]
+        let mut i = 1
+        for i < self.len() {
+            acc = f(acc, self[i])
+            i = i + 1
         }
-        let acc = first.unwrap()
-        Some(tail.fold(acc, f))
+        Some(acc)
     }
 
     /// Running left fold — returns every intermediate accumulator.

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -262,7 +262,8 @@ pub struct List<T> {
     ///
     ///     [1, 2, 3].scan(0, |a, x| a + x) == [0, 1, 3, 6]
     pub fn scan<A>(self, init: A, f: fn(A, T) -> A) -> List<A> {
-        let mut out: List<A> = [init]
+        let mut out: List<A> = []
+        out.push(init)
         let mut acc = init
         for item in self {
             acc = f(acc, item)

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -179,16 +179,18 @@ pub struct List<T> {
             process.abort("List.chunked: size must be positive, got {size}")
         }
         let mut out: List<List<T>> = []
-        let mut bucket: List<T> = []
-        for item in self {
-            bucket.push(item)
-            if bucket.len() >= size {
-                out.push(bucket)
-                bucket = []
+        let n = self.len()
+        let mut start = 0
+        for start < n {
+            let mut bucket: List<T> = []
+            let limit = if start + size < n { start + size } else { n }
+            let mut j = start
+            for j < limit {
+                bucket.push(self[j])
+                j = j + 1
             }
-        }
-        if !bucket.isEmpty() {
             out.push(bucket)
+            start = start + size
         }
         out
     }

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -15,10 +15,18 @@ pub struct List<T> {
         self.len() == 0
     }
     pub fn first(self) -> T? {
-        self.get(0)
+        if self.isEmpty() {
+            None
+        } else {
+            Some(self[0])
+        }
     }
     pub fn last(self) -> T? {
-        self.get(self.len() - 1)
+        if self.isEmpty() {
+            None
+        } else {
+            Some(self[self.len() - 1])
+        }
     }
     pub fn get(self, index: Int) -> T?
 
@@ -27,10 +35,12 @@ pub struct List<T> {
     }
     pub fn indexOf(self, item: T) -> Int?
     pub fn find(self, pred: fn(T) -> Bool) -> T? {
-        for item in self {
-            if pred(item) {
-                return Some(item)
+        let mut i = 0
+        for i < self.len() {
+            if pred(self[i]) {
+                return Some(self[i])
             }
+            i = i + 1
         }
         None
     }


### PR DESCRIPTION
## Summary

`OSTY_STDLIB_BODY_LOWER=1`에서 더 많은 `List` combinator가 LIR Proto path로 end-to-end 동작하게 합니다. source-bootstrap osty-self + LLVM 18 환경에서 메서드별로 실측·수정했습니다.

## 근본 원인

selfhost 체커는 generic stdlib 메서드 본문에서 **owning 타입 변수 `T`가 관여하는 특정 식**을 타입 추론하지 못해 `<error>`로 poison합니다. 그 poison이 주입된 MIR로 흘러 잘못된 codegen/decline을 유발합니다. 두 갈래로 대응했습니다 — (A) `collections.osty`를 poison을 유발하지 않는 동등 형태로 재작성, (B) tuple-literal 타입을 element operand에서 복구.

## 수정 (5 commits)

**`collections.osty` 재작성** — nested generic 호출/형태 회피, 동작 동일:
- `reduce` — `tail.fold(acc,f)` (nested generic call) → in-place index fold.
- `windowed` — `self.drop(start).take(size)` (nested generic calls) → 인라인 window 빌드.
- `first`/`last` — `self.get(i)` (generic-return 메서드 호출) → `if isEmpty { None } else { Some(self[i]) }`. (poison 시 dest 없는 `intrinsic list_get` + `unreachable` → SIGTRAP였음)
- `find` — `for item in self` → index loop.
- `chunked` — loop 밖 `bucket` + `bucket = []` 재할당 → per-iteration 신규 `bucket` + index loop.

**`internal/mir/lower.go`** — `TupleLit` 타입이 `TupleType`이 아니면(`zip`의 `(self[i],other[i])`가 `Int`로 poison) 이미 lowering된 element operand들로부터 `(A, B)` 재구성.

## Verification (source-bootstrap osty-self + LLVM 18, `OSTY_STDLIB_BODY_LOWER=1`)

`[4,1,3,2]` 기준 11개 호출 전수 실행:
```
map.fold=20  filter=2  reduce=10  first=4  last=2
enumerate=4  chunked=2  windowed=3  zip=4  sorted=4  take=2
```
`zip` 요소 접근(`pair.0+pair.1` → 11/22/33)·plain tuple 회귀 없음.

## Scope

이번 PR로 동작하는 `List` combinator: `map`·`filter`·`fold`·`reduce`·`first`·`last`·`find`·`enumerate`·`partition`·`chunked`·`windowed`·`zip` + `take`/`drop`/`sorted`/`concat`/`appended`.

남은 `scan`(closure-param 추론)·`flatMap`(`E0700`)·`groupBy`(`Map` 백엔드)는 frozen seed 체커 레벨 버그로, 별도 trajectory입니다.

## Test plan

- [x] `go build ./internal/mir/ ./cmd/osty/` · `go vet` · `gofmt` — clean
- [x] `osty check internal/stdlib/modules/collections.osty` — 변경분 신규 에러 0
- [x] source-bootstrap osty-self로 11개 combinator E2E 실행 검증
- [ ] CI Go 스위트

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_