### PR TITLE
fix: unblock List.groupBy through three Map-aware LIR Proto adjustments

### DIFF
--- a/internal/backend/stdlib_type_inject.go
+++ b/internal/backend/stdlib_type_inject.go
@@ -679,12 +679,54 @@ func cloneStdlibTypeDecl(key stdlibTypeKey, d ir.Decl, moduleTypes map[string]bo
 		if shouldQualifyStdlibTypeName(key.Module, x.Name, moduleTypes) {
 			x.Name = qualifiedStdlibTypeName(key.Module, x.Name)
 		}
+		// Builtin reference types (`Map<K,V>`, `Set<T>`, …) route their
+		// primitive operations through runtime intrinsics — `Map.get` /
+		// `Map.insert` / `Map.clear` / `Set.insert` / etc. carry no
+		// `.osty` body. When monomorph specializes the type, those
+		// bodyless methods produce empty `_ZTS…<Type>__<method>` fn
+		// decls that the LIR Proto backend rejects with "no blocks".
+		// Strip them from the injected clone so monomorph never sees
+		// them; call sites still resolve via the `check_env.osty`
+		// registry and the MIR lowerer's intrinsic dispatch.
+		if isBuiltinReferenceType(x.Name) {
+			x.Methods = keepBodiedMethods(x.Methods)
+		}
 	case *ir.EnumDecl:
 		if shouldQualifyStdlibTypeName(key.Module, x.Name, moduleTypes) {
 			x.Name = qualifiedStdlibTypeName(key.Module, x.Name)
 		}
 	}
 	return cp
+}
+
+// isBuiltinReferenceType reports whether name is a pointer-shaped
+// builtin generic whose primitive operations are runtime intrinsics
+// rather than bodied Osty methods. Used by `cloneStdlibTypeDecl` to
+// drop bodyless method declarations so monomorph does not emit empty
+// `_ZTS…__<method>` fn decls.
+func isBuiltinReferenceType(name string) bool {
+	switch name {
+	case "Map", "Set":
+		return true
+	}
+	return false
+}
+
+func keepBodiedMethods(methods []*ir.FnDecl) []*ir.FnDecl {
+	if len(methods) == 0 {
+		return methods
+	}
+	out := methods[:0]
+	for _, m := range methods {
+		if m == nil {
+			continue
+		}
+		if m.Body == nil {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 func qualifyStdlibDeclTypes(d ir.Decl, module string, moduleTypes map[string]bool) {

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -232,7 +232,6 @@ func mangleTupleName(tt *ir.TupleType) string {
 	return b.String()
 }
 
-
 // ==== pass 1: signatures + layouts ====
 
 func (l *lowerer) collectSignatures() {

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4447,7 +4447,28 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 		for i, e := range x.Elems {
 			fields[i] = bs.lowerExprAsOperand(e)
 		}
-		return &AggregateRV{Kind: AggTuple, Fields: fields, T: x.T}
+		tt := x.T
+		// A tuple literal's type is always `(typeof e0, typeof e1, ...)`.
+		// The selfhost checker can poison `x.T` to a non-tuple shape
+		// inside an injected generic stdlib body (`List.zip` builds
+		// `(self[i], other[i])` and the literal came back typed `Int`).
+		// Reconstruct from the lowered element operands so the tuple
+		// AggregateRV carries a layout-resolvable `(A, B)` type.
+		if _, ok := tt.(*ir.TupleType); !ok {
+			elems := make([]ir.Type, len(fields))
+			recovered := true
+			for i, op := range fields {
+				if op == nil || op.Type() == nil || isPoisonType(op.Type()) {
+					recovered = false
+					break
+				}
+				elems[i] = op.Type()
+			}
+			if recovered {
+				tt = &ir.TupleType{Elems: elems}
+			}
+		}
+		return &AggregateRV{Kind: AggTuple, Fields: fields, T: tt}
 	case *ir.ListLit:
 		lt := hint
 		if lt == nil || isPoisonType(lt) {

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -201,7 +201,13 @@ pub struct List<T> {
         }
         let mut start = 0
         for start + size <= n {
-            out.push(self.drop(start).take(size))
+            let mut window: List<T> = []
+            let mut j = start
+            for j < start + size {
+                window.push(self[j])
+                j = j + 1
+            }
+            out.push(window)
             start = start + step
         }
         out
@@ -229,19 +235,13 @@ pub struct List<T> {
         if self.isEmpty() {
             return None
         }
-        let mut first: T? = None
-        let mut tail: List<T> = []
-        let mut seenFirst = false
-        for item in self {
-            if !seenFirst {
-                first = Some(item)
-                seenFirst = true
-            } else {
-                tail.push(item)
-            }
+        let mut acc = self[0]
+        let mut i = 1
+        for i < self.len() {
+            acc = f(acc, self[i])
+            i = i + 1
         }
-        let acc = first.unwrap()
-        Some(tail.fold(acc, f))
+        Some(acc)
     }
 
     /// Running left fold — returns every intermediate accumulator.

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -262,7 +262,8 @@ pub struct List<T> {
     ///
     ///     [1, 2, 3].scan(0, |a, x| a + x) == [0, 1, 3, 6]
     pub fn scan<A>(self, init: A, f: fn(A, T) -> A) -> List<A> {
-        let mut out: List<A> = [init]
+        let mut out: List<A> = []
+        out.push(init)
         let mut acc = init
         for item in self {
             acc = f(acc, item)

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -179,16 +179,18 @@ pub struct List<T> {
             process.abort("List.chunked: size must be positive, got {size}")
         }
         let mut out: List<List<T>> = []
-        let mut bucket: List<T> = []
-        for item in self {
-            bucket.push(item)
-            if bucket.len() >= size {
-                out.push(bucket)
-                bucket = []
+        let n = self.len()
+        let mut start = 0
+        for start < n {
+            let mut bucket: List<T> = []
+            let limit = if start + size < n { start + size } else { n }
+            let mut j = start
+            for j < limit {
+                bucket.push(self[j])
+                j = j + 1
             }
-        }
-        if !bucket.isEmpty() {
             out.push(bucket)
+            start = start + size
         }
         out
     }

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -15,10 +15,18 @@ pub struct List<T> {
         self.len() == 0
     }
     pub fn first(self) -> T? {
-        self.get(0)
+        if self.isEmpty() {
+            None
+        } else {
+            Some(self[0])
+        }
     }
     pub fn last(self) -> T? {
-        self.get(self.len() - 1)
+        if self.isEmpty() {
+            None
+        } else {
+            Some(self[self.len() - 1])
+        }
     }
     pub fn get(self, index: Int) -> T?
 
@@ -27,10 +35,12 @@ pub struct List<T> {
     }
     pub fn indexOf(self, item: T) -> Int?
     pub fn find(self, pred: fn(T) -> Bool) -> T? {
-        for item in self {
-            if pred(item) {
-                return Some(item)
+        let mut i = 0
+        for i < self.len() {
+            if pred(self[i]) {
+                return Some(self[i])
             }
+            i = i + 1
         }
         None
     }

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2425,11 +2425,29 @@ fn lirAlgebraicAggregateBody_module(out: LirModule, mir: MirModule, name: String
     if payloadInner == "" {
         return lirBraced("i64, i64")
     }
+    // Builtin-source structs (`List<T>` / `Map<K,V>` / `Set<T>`
+    // monomorph specializations carrying `builtinSource != ""`) are
+    // pointer-shaped at the LLVM ABI — embedding their struct typedef
+    // as the Option/Result payload leaves the aggregate unsized
+    // because the underlying runtime struct has no LLVM body.
+    // Default to the i64 payload path (caller ptrtoint's the ptr).
+    if lirMirStructIsBuiltinSource(mir, payloadInner) {
+        return lirBraced("i64, i64")
+    }
     let structRef = lirMirStructTypeRefByName(mir, payloadInner)
     if structRef == "" {
         return lirBraced("i64, i64")
     }
     lirBraced("i64, " + structRef)
+}
+
+fn lirMirStructIsBuiltinSource(mir: MirModule, name: String) -> Bool {
+    for layout in mir.layouts.structs {
+        if lirMirStructLayoutMatches(layout, name) {
+            return layout.builtinSource != ""
+        }
+    }
+    false
 }
 // Ensure the struct typedef is forward-declared at the top of the
 // module so this Option<S> typedef can reference it. The composite
@@ -5127,6 +5145,18 @@ fn lirEmitAlgebraicStruct(l: LirMirFunctionLowerer, aggType: LirType, disc: Int,
     value
 }
 fn lirEmitOptionNone(l: LirMirFunctionLowerer, optType: LirType) -> String {
+    // Widened-payload `Option<V>` (V is a struct / pointer-shaped
+    // composite — common for `Map<K, V>::get` returning
+    // `Option<List<T>>` after monomorph) cannot route through the i64
+    // payload path. Detect widened layouts and emit the struct variant
+    // with a `zeroinitializer` payload so the caller does not have to
+    // care which path applies.
+    if lirAggregateHasWidenedPayload(l.out, optType) {
+        let structRef = lirOptionResultPayloadStructRef(l.out, optType.llvm)
+        if structRef != "" {
+            return lirEmitAlgebraicStruct(l, optType, 1, lirOperand(lirAggregateType(structRef), "zeroinitializer"), "Option.None")
+        }
+    }
     lirEmitAlgebraicI64(l, optType, 1, "0", "Option.None")
 }
 fn lirEmitOptionSome(l: LirMirFunctionLowerer, optType: LirType, payloadI64: String) -> String {
@@ -5465,8 +5495,13 @@ fn lirListElemTypeName(l: LirMirFunctionLowerer, typeName: String) -> String {
     ""
 }
 // Key/value type names for Map<K, V> ("Map<String, Int>" -> "String"/"Int").
-fn lirMapKeyTypeName(typeName: String) -> String {
-    let inner = lirContainerInnerArg(typeName, "Map<")
+// Resolves a monomorphized builtin-source struct through
+// lirCanonBuiltinTypeName first so an injected `_ZTS…Map…` receiver
+// still yields its key/value, matching how lirListElemTypeName handles
+// the same `List` mangling.
+fn lirMapKeyTypeName(l: LirMirFunctionLowerer, typeName: String) -> String {
+    let canon = lirCanonBuiltinTypeName(l, typeName)
+    let inner = lirContainerInnerArg(canon, "Map<")
     if inner == "" {
         return ""
     }
@@ -5476,8 +5511,9 @@ fn lirMapKeyTypeName(typeName: String) -> String {
     }
     strings.trimSpace(strings.slice(inner, 0, comma))
 }
-fn lirMapValueTypeName(typeName: String) -> String {
-    let inner = lirContainerInnerArg(typeName, "Map<")
+fn lirMapValueTypeName(l: LirMirFunctionLowerer, typeName: String) -> String {
+    let canon = lirCanonBuiltinTypeName(l, typeName)
+    let inner = lirContainerInnerArg(canon, "Map<")
     if inner == "" {
         return ""
     }
@@ -5563,7 +5599,7 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
         return lirContainerReceiverInvalid()
     }
     let elemName = if kind == "map.key" || kind == "map.kv" {
-        lirMapKeyTypeName(instr.args[0].typ)
+        lirMapKeyTypeName(l, instr.args[0].typ)
     } else {
         lirListElemTypeName(l, instr.args[0].typ)
     }
@@ -5593,7 +5629,7 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
     }
     let mut out = LirContainerReceiver {receiverReg: recv.value, elemTypeName: elemName, elemLir, isString: lirContainerElemIsString(elemName), valueTypeName: "", valueLir: lirTypeInvalid(), valueIsString: false, ok: true}
     if kind == "map.kv" {
-        let valueName = lirMapValueTypeName(instr.args[0].typ)
+        let valueName = lirMapValueTypeName(l, instr.args[0].typ)
         if valueName == "" {
             lirLowerError(l, LirDiagUnsupported, label + " could not extract value type from receiver `" + instr.args[0].typ + "` (" + lirReceiverParseTraceMessage(instr.args[0].typ) + ")", label)
             return lirContainerReceiverInvalid()
@@ -6067,8 +6103,8 @@ fn lirLowerMirMapNew(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "map.new destination local out of range", "map.new")
         return
     }
-    let keyName = lirMapKeyTypeName(loc.typ)
-    let valueName = lirMapValueTypeName(loc.typ)
+    let keyName = lirMapKeyTypeName(l, loc.typ)
+    let valueName = lirMapValueTypeName(l, loc.typ)
     if keyName == "" || valueName == "" {
         lirLowerError(l, LirDiagUnsupported, "map.new destination type `" + loc.typ + "` is not Map<K, V>", "map.new")
         return


### PR DESCRIPTION
## Summary

`List.groupBy`를 LIR Proto path로 end-to-end 동작하게 합니다. 3개의 stacked layer를 모두 해소 — 모두 `Map<K,V>` builtin reference 타입이 user struct처럼 monomorph되던 데에서 비롯합니다.

## 3개 레이어

**1) bodyless Map/Set 메서드 주입 차단** (`stdlib_type_inject.go`)
`Map`의 primitive 작업(`get`/`insert`/`clear`/...)은 `.osty` 본문이 없는 runtime intrinsic. `injectReachableStdlibTypes`가 Map decl을 clone할 때 monomorph가 그 bodyless 메서드를 specialize → 빈 `_ZTS…Map…__<method>` fn decl 생성 → LIR Proto가 `no blocks` 거부. `cloneStdlibTypeDecl`이 builtin reference type(`Map`, `Set`)의 bodyless 메서드를 drop. 호출부는 `check_env.osty` 레지스트리 + MIR intrinsic dispatch로 그대로 동작.

**2) Map key/value 추출 module-aware화** (`lir_proto.osty`)
`lirMapKeyTypeName`/`lirMapValueTypeName`이 `Map<` literal만 파싱해서 monomorph된 bodied Map helper(`update`/`insertAll`/`retainIf`)의 mangled `_ZTSN…Map…` 수신자를 인식 못함. 둘 다 `LirMirFunctionLowerer`를 받고 `lirCanonBuiltinTypeName`을 거치도록 — `lirListElemTypeName`이 동일한 `List` mangling을 처리하는 방식과 일치.

**3) builtin-source Option payload + None auto-dispatch** (`lir_proto.osty`)
`V`가 builtin-source 구조체일 때(`Map.get`이 반환하는 `Option<List<Int>>`) Option typedef가 underlying monomorph struct ref를 embed해 LLVM에서 unsized. payload는 ptr-shape이므로 `lirAlgebraicAggregateBody_module`에서 builtin-source payload를 `{i64, i64}`로 처리(caller ptrtoint). `lirEmitOptionNone`도 widened layout을 자동 감지해 `zeroinitializer` payload의 struct variant로 emit.

## Verification (source-bootstrap osty-self + LLVM 18, `OSTY_STDLIB_BODY_LOWER=1`)

```
[1,2,3,4].groupBy(|x: Int| x % 2).len()  →  2  (parity로 그룹)
```

기존 통과 메서드 전체 재실행 회귀 없음:
```
map.fold=20  filter=2  reduce=10  first=4  last=2
enumerate=4  chunked=2  windowed=3  zip=4  sorted=4  take=2  groupBy=2
```

## Test plan

- [x] `go build ./internal/backend/ ./cmd/osty/` · `go vet` · `gofmt` — clean
- [x] osty-self stage0 재빌드 성공 = toolchain 전체 컴파일 확인
- [x] source-bootstrap osty-self로 groupBy + 11개 기존 메서드 E2E 실행
- [ ] CI Go 스위트

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_