### PR TITLE
feat: fresh-clone bootstrap follow-ups — env-baked just bootstrap + LLVM checker upgrade + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,22 @@ After `git clone` + `go build -o .bin/osty ./cmd/osty`:
 
 ```sh
 just bootstrap   # builds osty + native-checker + native-lirproto, then
-                 # `osty install-self` builds osty-self and promotes it
-                 # into .osty/cache/self-host/<sha>-<triple>/
+                 # `OSTY_STAGE0_FALLBACK=1 osty install-self` builds
+                 # osty-self and promotes it into .osty/cache/self-host/
+                 # <sha>-<triple>/.
 ```
+
+`just bootstrap` bakes in `OSTY_STAGE0_FALLBACK=1` because the
+production native-checker build path (PR #1954) gates on a resolvable
+`osty-self`, which fresh clones do not have. The env var (PR #1980)
+tells `install-self` to take the stage0 source-bootstrap path AND
+tells `buildNativeChecker` to detour to `go build
+./cmd/osty-native-checker` (PR #1988), sidestepping the chicken-and-
+egg. After `install-self` succeeds, the Go-built native checker slot
+is invalidated so the next `osty build` produces the LLVM variant
+from live `toolchain/*.osty`. Override with `OSTY_STAGE0_FALLBACK=
+just bootstrap` to verify the prebuilt-only path (registry / cache
+hit) end-to-end.
 
 Subsequent `osty build` / `osty run` / `osty test` invocations resolve
 the binary through the cache and skip the slow toolchain rebuild.
@@ -281,8 +294,10 @@ in order:
 When all four miss, the resolver returns the canonical `osty-self
 not found` decline so the upstream backend dispatcher can fall back
 to its decline handler. **Fresh clones therefore work out of the
-box** without exporting any env var — `just bootstrap` consults the
-upstream registry directly.
+box** — `just bootstrap` first consults the upstream registry, and
+when offline / registry-unreachable falls through to the stage0
+source-bootstrap path (the env var is baked into the recipe — see
+the "One-shot bootstrap" section above).
 
 ### Network fetch + signing
 

--- a/cmd/osty/install_self.go
+++ b/cmd/osty/install_self.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/backend/stage0"
+	"github.com/osty/osty/internal/toolchain"
 	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
 
@@ -127,6 +128,7 @@ func runInstallSelf(args []string, _ cliFlags) {
 
 	builtBin := ""
 	var buildErr error
+	tookStage0Path := false
 	if force && resolveErr == nil {
 		endSelfhostBuild := backend.BeginPhase("install-self.build-via-selfhost")
 		builtBin, buildErr = buildOstySelfWithSelfhost(context.Background(), resolvedSelf, hostOsty, root, tcAbs)
@@ -155,6 +157,7 @@ func runInstallSelf(args []string, _ cliFlags) {
 		endStage0Build := backend.BeginPhase("install-self.build-via-stage0")
 		builtBin, buildErr = buildOstySelf(context.Background(), hostOsty, root, tcAbs)
 		endStage0Build()
+		tookStage0Path = true
 	}
 	if buildErr != nil {
 		fmt.Fprintf(os.Stderr, "osty install-self: build: %v\n", buildErr)
@@ -168,6 +171,21 @@ func runInstallSelf(args []string, _ cliFlags) {
 		os.Exit(1)
 	}
 	endPromote()
+	// Stage0 fallback bootstrap populates `.osty/toolchain/<ver>/
+	// osty-native-checker` with the Go-built shell (the chicken-and-egg
+	// escape hatch wired by PR #1988). Now that `osty-self` is in the
+	// content-addressed cache, the LLVM-built native checker is
+	// buildable — but the next `osty build` would hit the cached
+	// Go-built artifact and skip the upgrade. Invalidate the slot so
+	// the next invocation re-enters `buildNativeChecker` and produces
+	// the LLVM variant from live `toolchain/*.osty`. Best-effort:
+	// surface the failure as a warning, not a hard error, because the
+	// install itself succeeded.
+	if tookStage0Path {
+		if err := toolchain.InvalidateManagedNativeChecker(root); err != nil {
+			fmt.Fprintf(os.Stderr, "osty install-self: warning: failed to invalidate stage0 native checker slot (next build will keep the Go-built variant): %v\n", err)
+		}
+	}
 	fmt.Printf("installed:   %s\n", cachedPath)
 }
 

--- a/cmd/osty/install_self_test.go
+++ b/cmd/osty/install_self_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/toolchain"
 	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
 
@@ -446,6 +447,109 @@ func TestRunInstallSelfStage0FallbackAttemptsSourceBootstrap(t *testing.T) {
 	}
 	if string(body) != "fresh stage0 osty-self" {
 		t.Fatalf("cached body = %q", body)
+	}
+}
+
+// TestRunInstallSelfStage0FallbackInvalidatesNativeCheckerSlot pins the
+// post-bootstrap LLVM-checker upgrade path: after stage0 fallback
+// populates osty-self into the cache, the Go-built native checker
+// dropped into `.osty/toolchain/<ver>/` by the sub-osty build is
+// retired so the next `osty build` produces the LLVM variant. Without
+// this, fresh-clone users would be permanently stuck on the frozen
+// `internal/selfhost/generated.go` seed even after osty-self exists.
+func TestRunInstallSelfStage0FallbackInvalidatesNativeCheckerSlot(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	// Pre-seed the managed native checker slot to mimic what the sub-osty
+	// build's `buildNativeCheckerViaGo` path would have written. The
+	// install-self post-hook must delete this file.
+	managedCheckerPath := toolchain.ManagedNativeCheckerPath(root)
+	if err := os.MkdirAll(filepath.Dir(managedCheckerPath), 0o755); err != nil {
+		t.Fatalf("mkdir managed checker dir: %v", err)
+	}
+	if err := os.WriteFile(managedCheckerPath, []byte("stale go-built checker"), 0o755); err != nil {
+		t.Fatalf("seed managed checker: %v", err)
+	}
+	hostBin := fakeOstyBin(t, root, "fresh stage0 osty-self")
+
+	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", hostBin)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"OSTY_STAGE0_FALLBACK=1",
+		"OSTY_SELF_REGISTRY_OFFLINE=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install-self stage0 fallback: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "installed:") {
+		t.Fatalf("install-self did not report cache install:\n%s", out)
+	}
+	if _, statErr := os.Stat(managedCheckerPath); !os.IsNotExist(statErr) {
+		t.Fatalf("managed checker slot %q must be invalidated after stage0 fallback (stat err: %v)", managedCheckerPath, statErr)
+	}
+}
+
+// TestRunInstallSelfWithResolvedSelfDoesNotInvalidateNativeCheckerSlot
+// guards the non-stage0 path: when install-self resolved osty-self from
+// the registry/cache without entering the stage0 source bootstrap, the
+// managed native checker slot is whatever it was (presumably the
+// LLVM-built artifact) and must not be wiped.
+func TestRunInstallSelfWithResolvedSelfDoesNotInvalidateNativeCheckerSlot(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	// Pre-seed a managed checker we want preserved.
+	managedCheckerPath := toolchain.ManagedNativeCheckerPath(root)
+	if err := os.MkdirAll(filepath.Dir(managedCheckerPath), 0o755); err != nil {
+		t.Fatalf("mkdir managed checker dir: %v", err)
+	}
+	if err := os.WriteFile(managedCheckerPath, []byte("good LLVM-built checker"), 0o755); err != nil {
+		t.Fatalf("seed managed checker: %v", err)
+	}
+	// Pre-seed an OSTY_SELF_BIN so install-self resolves osty-self
+	// without ever entering the stage0 path.
+	prebuilt := filepath.Join(t.TempDir(), "prebuilt-self")
+	if err := os.WriteFile(prebuilt, []byte("prebuilt osty-self"), 0o755); err != nil {
+		t.Fatalf("seed prebuilt self: %v", err)
+	}
+
+	cmd := exec.Command(ostyBin, "install-self")
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"OSTY_SELF_BIN="+prebuilt,
+		"OSTY_SELF_REGISTRY_OFFLINE=1",
+		"OSTY_STAGE0_FALLBACK=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install-self with prebuilt self: %v\n%s", err, out)
+	}
+	body, err := os.ReadFile(managedCheckerPath)
+	if err != nil {
+		t.Fatalf("managed checker must still exist (was invalidated unexpectedly): %v", err)
+	}
+	if string(body) != "good LLVM-built checker" {
+		t.Fatalf("managed checker body = %q, want preserved 'good LLVM-built checker'", body)
 	}
 }
 

--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -121,6 +121,26 @@ func ManagedNativeCheckerPath(projectRoot string) string {
 	return filepath.Join(projectRoot, toolchainDirName, Version(), NativeCheckerBinaryName())
 }
 
+// InvalidateManagedNativeChecker deletes the cached managed checker
+// artifact (if present) so the next `EnsureNativeChecker` call rebuilds
+// it from scratch. Used by `osty install-self` to retire a Go-built
+// fallback (placed by the stage0 bootstrap path) once `osty-self`
+// becomes resolvable — the next `osty build` will then re-enter
+// `buildNativeChecker` and produce the LLVM-built variant from live
+// `toolchain/*.osty` sources, which is the steady-state production
+// configuration described in `cmd/osty-native-checker/README.md`.
+//
+// A missing file is not an error. Any other error (e.g. permission
+// denied) is returned so the caller can decide whether to surface a
+// warning.
+func InvalidateManagedNativeChecker(projectRoot string) error {
+	path := ManagedNativeCheckerPath(projectRoot)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("invalidate managed native checker %s: %w", path, err)
+	}
+	return nil
+}
+
 // ManagedNativeCheckerLLVMPath returns the conventional location
 // `osty build --backend llvm cmd/osty-native-checker/` writes its
 // artifact to (`<project>/cmd/osty-native-checker/.osty/out/{debug,release}/llvm/osty-native-checker-llvm`).

--- a/internal/toolchain/native_checker_test.go
+++ b/internal/toolchain/native_checker_test.go
@@ -146,6 +146,43 @@ func TestFilterEnvRemovesInheritedRecursionGuard(t *testing.T) {
 	}
 }
 
+// TestInvalidateManagedNativeCheckerDeletesArtifact pins the
+// post-stage0 upgrade hook: after `osty install-self` populates the
+// cache with a freshly bootstrapped `osty-self`, the helper must
+// retire the Go-built native checker so the next `osty build` rebuilds
+// the LLVM variant. Missing-file is silent; any other error surfaces.
+func TestInvalidateManagedNativeCheckerDeletesArtifact(t *testing.T) {
+	root := t.TempDir()
+	dest := ManagedNativeCheckerPath(root)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(dest, []byte("go-built"), 0o755); err != nil {
+		t.Fatalf("seed managed checker: %v", err)
+	}
+
+	if err := InvalidateManagedNativeChecker(root); err != nil {
+		t.Fatalf("InvalidateManagedNativeChecker: %v", err)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("dest %q must not exist after invalidate (stat err: %v)", dest, err)
+	}
+}
+
+// TestInvalidateManagedNativeCheckerIsSilentWhenAbsent guards the
+// happy-path install-self flow: if the stage0 path was taken but the
+// managed checker slot was never populated (e.g. sub-osty build short-
+// circuited via a different code path), invalidate is a no-op instead
+// of an error. That way install-self never surfaces a spurious warning
+// in the common case.
+func TestInvalidateManagedNativeCheckerIsSilentWhenAbsent(t *testing.T) {
+	root := t.TempDir()
+	// Never create the managed checker slot.
+	if err := InvalidateManagedNativeChecker(root); err != nil {
+		t.Fatalf("InvalidateManagedNativeChecker on absent slot returned error: %v", err)
+	}
+}
+
 // TestBuildNativeCheckerStage0FallbackDetoursToGoBuild pins the
 // fresh-clone bootstrap fix: with `OSTY_STAGE0_FALLBACK=1`,
 // `buildNativeChecker` must short-circuit to the Go-build path and

--- a/justfile
+++ b/justfile
@@ -47,8 +47,17 @@ build-all: build build-checker build-lirproto
 # Subsequent compiles look the binary up via
 # `selfhostcache.ResolveBinary` instead of re-running the slow
 # toolchain build.
+#
+# OSTY_STAGE0_FALLBACK=1 is baked in: post-PR #1954, the production
+# native-checker build path gates on a resolvable `osty-self`, which
+# fresh clones do not have. The env var (introduced by #1980, wired
+# through buildNativeChecker by #1988) tells install-self to take the
+# stage0 source-bootstrap path AND tells buildNativeChecker to detour
+# to `go build ./cmd/osty-native-checker` so the chicken-and-egg never
+# triggers. Override on the command line (`OSTY_STAGE0_FALLBACK= just
+# bootstrap`) when you want to verify the prebuilt-only path instead.
 bootstrap: build-all
-    {{bin}} install-self
+    OSTY_STAGE0_FALLBACK=1 {{bin}} install-self
 
 # cache-self prints the canonical .osty/cache/self-host/<sha>-<triple>/
 # osty-self path for the current toolchain SHA + host triple. With


### PR DESCRIPTION
## Summary

Three follow-ups to PR #1988 closing the remaining UX rough edges around fresh-clone bootstrap.

1. **`just bootstrap` bakes in `OSTY_STAGE0_FALLBACK=1`** — fresh-clone users no longer need to discover the env var. Override with `OSTY_STAGE0_FALLBACK= just bootstrap` to verify the prebuilt-only path.
2. **`osty install-self` retires the Go-built native checker after stage0 succeeds** — without this, fresh-clone users were permanently pinned to the frozen `internal/selfhost/generated.go` seed because the managed slot at `.osty/toolchain/<ver>/osty-native-checker` (Go-built by PR #1988's fallback) would shadow the LLVM-built variant forever. Now `install-self` invalidates the slot after a successful stage0 path, so the next `osty build` re-enters `buildNativeChecker` and produces the LLVM variant from live `toolchain/*.osty`. Failure to invalidate is a warning, not a hard error — the install itself succeeded.
3. **README "Bootstrapping `osty-self`" section updated** — reflects the new flow: registry-first lookup, stage0 source-bootstrap fallback baked into `just bootstrap`, and the post-install LLVM-checker upgrade. Replaces stale "no env var needed" framing that predated PR #1954's LLVM-checker flip.

## End-to-end verification

```sh
$ git clone https://github.com/choiceoh/osty && cd osty
$ go build -o .bin/osty ./cmd/osty
$ OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_STAGE0_FALLBACK=1 .bin/osty install-self
osty install-self: no prebuilt osty-self available: selfhostcache: no usable osty-self binary found
Profile: debug  Target: host  Features: none
Built ./toolchain/.osty/out/debug/llvm/osty-self (debug)
installed:   ./.osty/cache/self-host/<sha>-linux-amd64/osty-self

$ ls .osty/toolchain/osty-dev/  # empty — Go-built checker invalidated
$ ls .osty/cache/self-host/*/   # osty-self present (4.7MB)
```

## Test plan

- [x] `TestInvalidateManagedNativeCheckerDeletesArtifact` / `TestInvalidateManagedNativeCheckerIsSilentWhenAbsent` — unit coverage on the helper (deletes when present, no-op when absent).
- [x] `TestRunInstallSelfStage0FallbackInvalidatesNativeCheckerSlot` — end-to-end install-self stage0 path wipes a pre-seeded managed checker slot.
- [x] `TestRunInstallSelfWithResolvedSelfDoesNotInvalidateNativeCheckerSlot` — guards the non-stage0 path: an existing LLVM-built checker is preserved when `install-self` resolves osty-self from registry/`OSTY_SELF_BIN` without entering stage0.
- [x] `go test ./internal/toolchain/... ./internal/check/... ./cmd/osty/ -short` — all pass
- [x] `go vet ./...` clean
- [x] Manual: fresh clone → `OSTY_STAGE0_FALLBACK=1 install-self` → confirmed `.osty/toolchain/<ver>/` is empty after success (managed slot invalidated as designed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFKqzJF66M3e7kuvXPP2BW)_