### PR TITLE
fix: partial flatMap unblock infrastructure (recovery + typeargs + body rewrite)

### DIFF
--- a/internal/backend/stdlib_type_inject.go
+++ b/internal/backend/stdlib_type_inject.go
@@ -679,12 +679,54 @@ func cloneStdlibTypeDecl(key stdlibTypeKey, d ir.Decl, moduleTypes map[string]bo
 		if shouldQualifyStdlibTypeName(key.Module, x.Name, moduleTypes) {
 			x.Name = qualifiedStdlibTypeName(key.Module, x.Name)
 		}
+		// Builtin reference types (`Map<K,V>`, `Set<T>`, …) route their
+		// primitive operations through runtime intrinsics — `Map.get` /
+		// `Map.insert` / `Map.clear` / `Set.insert` / etc. carry no
+		// `.osty` body. When monomorph specializes the type, those
+		// bodyless methods produce empty `_ZTS…<Type>__<method>` fn
+		// decls that the LIR Proto backend rejects with "no blocks".
+		// Strip them from the injected clone so monomorph never sees
+		// them; call sites still resolve via the `check_env.osty`
+		// registry and the MIR lowerer's intrinsic dispatch.
+		if isBuiltinReferenceType(x.Name) {
+			x.Methods = keepBodiedMethods(x.Methods)
+		}
 	case *ir.EnumDecl:
 		if shouldQualifyStdlibTypeName(key.Module, x.Name, moduleTypes) {
 			x.Name = qualifiedStdlibTypeName(key.Module, x.Name)
 		}
 	}
 	return cp
+}
+
+// isBuiltinReferenceType reports whether name is a pointer-shaped
+// builtin generic whose primitive operations are runtime intrinsics
+// rather than bodied Osty methods. Used by `cloneStdlibTypeDecl` to
+// drop bodyless method declarations so monomorph does not emit empty
+// `_ZTS…__<method>` fn decls.
+func isBuiltinReferenceType(name string) bool {
+	switch name {
+	case "Map", "Set":
+		return true
+	}
+	return false
+}
+
+func keepBodiedMethods(methods []*ir.FnDecl) []*ir.FnDecl {
+	if len(methods) == 0 {
+		return methods
+	}
+	out := methods[:0]
+	for _, m := range methods {
+		if m == nil {
+			continue
+		}
+		if m.Body == nil {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 func qualifyStdlibDeclTypes(d ir.Decl, module string, moduleTypes map[string]bool) {

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -4327,7 +4327,7 @@ func (l *lowerer) backfillClosureArgsFromMethodCall(mc *MethodCall) {
 	// stdlib higher-order method table the closure backfill
 	// uses, so chained `map/filter/andThen/...` chains lower
 	// without their middle nodes being marked as ErrType.
-	if mc.T == nil || mc.T == ErrTypeVal {
+	if mc.T == nil || mc.T == ErrTypeVal || containsClosureResultSentinel(mc.T) {
 		if recovered := recoverHigherOrderMethodReturnType(recvT, mc.Name, mc.Args); recovered != nil {
 			mc.T = recovered
 		}
@@ -4339,6 +4339,28 @@ func (l *lowerer) backfillClosureArgsFromMethodCall(mc *MethodCall) {
 	if mc.Name == "flatMap" && mc.T != nil && mc.T != ErrTypeVal {
 		fillFlatMapTypeArgs(mc, recvT)
 	}
+}
+
+// containsClosureResultSentinel reports whether t carries the
+// `?closure_result` placeholder the AST-side surface-shape recovery
+// inserts when `xs.map(fn) / xs.flatMap(fn)` cannot resolve the
+// closure return at parse time. The sentinel is a NamedType, not a
+// TypeVar or ErrType, so the usual recovery conditions miss it.
+func containsClosureResultSentinel(t Type) bool {
+	if t == nil {
+		return false
+	}
+	if nt, ok := t.(*NamedType); ok && nt != nil {
+		if nt.Name == "?closure_result" {
+			return true
+		}
+		for _, a := range nt.Args {
+			if containsClosureResultSentinel(a) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // fillFlatMapTypeArgs sets `mc.TypeArgs = [T, R]` for a flatMap call

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -4646,7 +4646,12 @@ func refineExpectedFromOtherArgs(expected *FnType, recvT Type, method string, ar
 		return
 	}
 	if nt, ok := recvT.(*NamedType); ok && nt != nil && (nt.Name == "List" || nt.Name == "Iter") {
-		if method == "fold" && closureIdx == 1 && len(args) == 2 && len(expected.Params) >= 1 {
+		if (method == "fold" || method == "scan") && closureIdx == 1 && len(args) == 2 && len(expected.Params) >= 1 {
+			// `fold<A>(init: A, fn(A, T) -> A) -> A` and
+			// `scan<A>(init: A, fn(A, T) -> A) -> List<A>` share
+			// the closure shape — fill `A` from the init arg's
+			// concrete type so the closure's first param +
+			// return resolve before backfill.
 			if expected.Params[0] == nil {
 				if initT := safeExprType(args[0].Value); initT != ErrTypeVal {
 					expected.Params[0] = initT
@@ -4747,9 +4752,11 @@ func expectedClosureFnTypeForList(elem Type, method string, argIdx, argCount int
 		if argIdx == 0 && argCount == 1 {
 			return &FnType{Params: []Type{elem}}
 		}
-	case "filter", "any", "all", "forEach":
+	case "filter", "any", "all", "forEach", "find", "partition":
 		// `filter(fn(T) -> Bool) -> List<T>`, similar shape for
-		// the others.
+		// the others. `find(fn(T) -> Bool) -> T?` and
+		// `partition(fn(T) -> Bool) -> (List<T>, List<T>)` share
+		// the predicate shape.
 		if argIdx == 0 && argCount == 1 {
 			ret := TBool
 			if method == "forEach" {
@@ -4757,11 +4764,13 @@ func expectedClosureFnTypeForList(elem Type, method string, argIdx, argCount int
 			}
 			return &FnType{Params: []Type{elem}, Return: ret}
 		}
-	case "fold":
-		// `fold<A>(init: A, f: fn(A, T) -> A) -> A` — closure is
-		// the second arg. A is derivable from the init arg —
-		// callers thread it via `expectedClosureFnTypeForBuiltinAtArg`
-		// which has access to the full MethodCall arg list.
+	case "fold", "scan":
+		// `fold<A>(init: A, f: fn(A, T) -> A) -> A` and
+		// `scan<A>(init: A, f: fn(A, T) -> A) -> List<A>` share
+		// the closure shape — only the return wrapping differs.
+		// `A` is derivable from the init arg —
+		// `expectedClosureFnTypeForBuiltinAtArg` patches it from
+		// the surrounding args.
 		if argIdx == 1 && argCount == 2 {
 			return &FnType{Params: []Type{nil, elem}}
 		}
@@ -4769,6 +4778,19 @@ func expectedClosureFnTypeForList(elem Type, method string, argIdx, argCount int
 		// `reduce(fn(T, T) -> T) -> T?`.
 		if argIdx == 0 && argCount == 1 {
 			return &FnType{Params: []Type{elem, elem}, Return: elem}
+		}
+	case "flatMap":
+		// `flatMap<R>(fn(T) -> List<R>) -> List<R>` — R is not
+		// known here; backfillClosure leaves Return nil and only
+		// fills the param slot, matching how `map` is handled.
+		if argIdx == 0 && argCount == 1 {
+			return &FnType{Params: []Type{elem}}
+		}
+	case "groupBy":
+		// `groupBy<K>(key: fn(T) -> K) -> Map<K, List<T>>` — K is
+		// not known here; like `map`, leave Return nil.
+		if argIdx == 0 && argCount == 1 {
+			return &FnType{Params: []Type{elem}}
 		}
 	}
 	return nil

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -4332,6 +4332,52 @@ func (l *lowerer) backfillClosureArgsFromMethodCall(mc *MethodCall) {
 			mc.T = recovered
 		}
 	}
+	// flatMap-specific: when the checker leaves TypeArgs empty or
+	// poisoned, monomorph mangles `R` as `?` and clang rejects the
+	// `_Z…flatMapIl?E…` symbol. Derive `[T, R]` from the receiver +
+	// recovered return so monomorph specializes.
+	if mc.Name == "flatMap" && mc.T != nil && mc.T != ErrTypeVal {
+		fillFlatMapTypeArgs(mc, recvT)
+	}
+}
+
+// fillFlatMapTypeArgs sets `mc.TypeArgs = [T, R]` for a flatMap call
+// when the recovered return type carries a concrete element. Other
+// methods are intentionally left alone — broader fill triggers
+// monomorph regressions on scan/groupBy.
+func fillFlatMapTypeArgs(mc *MethodCall, recvT Type) {
+	if mc == nil || mc.T == nil {
+		return
+	}
+	nt, ok := mc.T.(*NamedType)
+	if !ok || nt == nil || nt.Name != "List" || len(nt.Args) < 1 {
+		return
+	}
+	r := nt.Args[0]
+	if r == nil || r == ErrTypeVal || hasPoisonedTypeArg(r) || containsTypeVar(r) {
+		return
+	}
+	rNt, ok2 := recvT.(*NamedType)
+	if !ok2 || rNt == nil || !rNt.Builtin || len(rNt.Args) < 1 {
+		return
+	}
+	t := rNt.Args[0]
+	if t == nil || t == ErrTypeVal || hasPoisonedTypeArg(t) || containsTypeVar(t) {
+		return
+	}
+	if len(mc.TypeArgs) > 0 {
+		clean := true
+		for _, ta := range mc.TypeArgs {
+			if ta == nil || ta == ErrTypeVal || hasPoisonedTypeArg(ta) || containsTypeVar(ta) {
+				clean = false
+				break
+			}
+		}
+		if clean {
+			return
+		}
+	}
+	mc.TypeArgs = []Type{t, r}
 }
 
 // recoverHigherOrderMethodReturnType derives the return type of
@@ -4522,10 +4568,52 @@ func recoverListHigherOrderReturn(listName string, elem Type, method string, arg
 			pair := &TupleType{Elems: []Type{elem, elem}}
 			return &NamedType{Name: listName, Args: []Type{pair}, Builtin: true}
 		}
+	case "flatMap":
+		if len(args) == 1 {
+			if r := flatMapElemFromArg(args[0].Value); r != nil {
+				return &NamedType{Name: listName, Args: []Type{r}, Builtin: true}
+			}
+		}
 	case "len":
 		return TInt
 	case "isEmpty":
 		return TBool
+	}
+	return nil
+}
+
+// flatMapElemFromArg extracts the element type R of `List<R>` from a
+// `flatMap` argument's closure or named-fn return.
+func flatMapElemFromArg(e Expr) Type {
+	if e == nil {
+		return nil
+	}
+	t := closureReturnType(e)
+	if t == nil {
+		if et := e.Type(); et != nil {
+			if ft, ok := et.(*FnType); ok && ft != nil && ft.Return != nil {
+				t = ft.Return
+			}
+		}
+	}
+	// Closure body inference fallback: when the checker left the
+	// closure's recorded return type poisoned (`<error>`), walk the
+	// AST body of a closure literal and pull a recoverable list type
+	// from its tail expression.
+	if t == nil || t == ErrTypeVal {
+		if cl, ok := e.(*Closure); ok && cl != nil && cl.Body != nil && cl.Body.Result != nil {
+			if bt := cl.Body.Result.Type(); bt != nil && bt != ErrTypeVal {
+				t = bt
+			}
+		}
+	}
+	if t == nil {
+		return nil
+	}
+	if nt, ok := t.(*NamedType); ok && nt != nil && (nt.Name == "List" || nt.Name == "Iter") && len(nt.Args) >= 1 {
+		if r := nt.Args[0]; r != nil && r != ErrTypeVal && !hasPoisonedTypeArg(r) {
+			return r
+		}
 	}
 	return nil
 }

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -232,7 +232,6 @@ func mangleTupleName(tt *ir.TupleType) string {
 	return b.String()
 }
 
-
 // ==== pass 1: signatures + layouts ====
 
 func (l *lowerer) collectSignatures() {

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4447,7 +4447,28 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 		for i, e := range x.Elems {
 			fields[i] = bs.lowerExprAsOperand(e)
 		}
-		return &AggregateRV{Kind: AggTuple, Fields: fields, T: x.T}
+		tt := x.T
+		// A tuple literal's type is always `(typeof e0, typeof e1, ...)`.
+		// The selfhost checker can poison `x.T` to a non-tuple shape
+		// inside an injected generic stdlib body (`List.zip` builds
+		// `(self[i], other[i])` and the literal came back typed `Int`).
+		// Reconstruct from the lowered element operands so the tuple
+		// AggregateRV carries a layout-resolvable `(A, B)` type.
+		if _, ok := tt.(*ir.TupleType); !ok {
+			elems := make([]ir.Type, len(fields))
+			recovered := true
+			for i, op := range fields {
+				if op == nil || op.Type() == nil || isPoisonType(op.Type()) {
+					recovered = false
+					break
+				}
+				elems[i] = op.Type()
+			}
+			if recovered {
+				tt = &ir.TupleType{Elems: elems}
+			}
+		}
+		return &AggregateRV{Kind: AggTuple, Fields: fields, T: tt}
 	case *ir.ListLit:
 		lt := hint
 		if lt == nil || isPoisonType(lt) {

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -201,7 +201,13 @@ pub struct List<T> {
         }
         let mut start = 0
         for start + size <= n {
-            out.push(self.drop(start).take(size))
+            let mut window: List<T> = []
+            let mut j = start
+            for j < start + size {
+                window.push(self[j])
+                j = j + 1
+            }
+            out.push(window)
             start = start + step
         }
         out
@@ -229,19 +235,13 @@ pub struct List<T> {
         if self.isEmpty() {
             return None
         }
-        let mut first: T? = None
-        let mut tail: List<T> = []
-        let mut seenFirst = false
-        for item in self {
-            if !seenFirst {
-                first = Some(item)
-                seenFirst = true
-            } else {
-                tail.push(item)
-            }
+        let mut acc = self[0]
+        let mut i = 1
+        for i < self.len() {
+            acc = f(acc, self[i])
+            i = i + 1
         }
-        let acc = first.unwrap()
-        Some(tail.fold(acc, f))
+        Some(acc)
     }
 
     /// Running left fold — returns every intermediate accumulator.

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -262,7 +262,8 @@ pub struct List<T> {
     ///
     ///     [1, 2, 3].scan(0, |a, x| a + x) == [0, 1, 3, 6]
     pub fn scan<A>(self, init: A, f: fn(A, T) -> A) -> List<A> {
-        let mut out: List<A> = [init]
+        let mut out: List<A> = []
+        out.push(init)
         let mut acc = init
         for item in self {
             acc = f(acc, item)

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -277,10 +277,15 @@ pub struct List<T> {
     /// sub-lists.
     pub fn flatMap<R>(self, f: fn(T) -> List<R>) -> List<R> {
         let mut out: List<R> = []
-        for item in self {
-            for r in f(item) {
-                out.push(r)
+        let mut i = 0
+        for i < self.len() {
+            let inner = f(self[i])
+            let mut j = 0
+            for j < inner.len() {
+                out.push(inner[j])
+                j = j + 1
             }
+            i = i + 1
         }
         out
     }

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -179,16 +179,18 @@ pub struct List<T> {
             process.abort("List.chunked: size must be positive, got {size}")
         }
         let mut out: List<List<T>> = []
-        let mut bucket: List<T> = []
-        for item in self {
-            bucket.push(item)
-            if bucket.len() >= size {
-                out.push(bucket)
-                bucket = []
+        let n = self.len()
+        let mut start = 0
+        for start < n {
+            let mut bucket: List<T> = []
+            let limit = if start + size < n { start + size } else { n }
+            let mut j = start
+            for j < limit {
+                bucket.push(self[j])
+                j = j + 1
             }
-        }
-        if !bucket.isEmpty() {
             out.push(bucket)
+            start = start + size
         }
         out
     }

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -15,10 +15,18 @@ pub struct List<T> {
         self.len() == 0
     }
     pub fn first(self) -> T? {
-        self.get(0)
+        if self.isEmpty() {
+            None
+        } else {
+            Some(self[0])
+        }
     }
     pub fn last(self) -> T? {
-        self.get(self.len() - 1)
+        if self.isEmpty() {
+            None
+        } else {
+            Some(self[self.len() - 1])
+        }
     }
     pub fn get(self, index: Int) -> T?
 
@@ -27,10 +35,12 @@ pub struct List<T> {
     }
     pub fn indexOf(self, item: T) -> Int?
     pub fn find(self, pred: fn(T) -> Bool) -> T? {
-        for item in self {
-            if pred(item) {
-                return Some(item)
+        let mut i = 0
+        for i < self.len() {
+            if pred(self[i]) {
+                return Some(self[i])
             }
+            i = i + 1
         }
         None
     }

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2425,11 +2425,29 @@ fn lirAlgebraicAggregateBody_module(out: LirModule, mir: MirModule, name: String
     if payloadInner == "" {
         return lirBraced("i64, i64")
     }
+    // Builtin-source structs (`List<T>` / `Map<K,V>` / `Set<T>`
+    // monomorph specializations carrying `builtinSource != ""`) are
+    // pointer-shaped at the LLVM ABI — embedding their struct typedef
+    // as the Option/Result payload leaves the aggregate unsized
+    // because the underlying runtime struct has no LLVM body.
+    // Default to the i64 payload path (caller ptrtoint's the ptr).
+    if lirMirStructIsBuiltinSource(mir, payloadInner) {
+        return lirBraced("i64, i64")
+    }
     let structRef = lirMirStructTypeRefByName(mir, payloadInner)
     if structRef == "" {
         return lirBraced("i64, i64")
     }
     lirBraced("i64, " + structRef)
+}
+
+fn lirMirStructIsBuiltinSource(mir: MirModule, name: String) -> Bool {
+    for layout in mir.layouts.structs {
+        if lirMirStructLayoutMatches(layout, name) {
+            return layout.builtinSource != ""
+        }
+    }
+    false
 }
 // Ensure the struct typedef is forward-declared at the top of the
 // module so this Option<S> typedef can reference it. The composite
@@ -5127,6 +5145,18 @@ fn lirEmitAlgebraicStruct(l: LirMirFunctionLowerer, aggType: LirType, disc: Int,
     value
 }
 fn lirEmitOptionNone(l: LirMirFunctionLowerer, optType: LirType) -> String {
+    // Widened-payload `Option<V>` (V is a struct / pointer-shaped
+    // composite — common for `Map<K, V>::get` returning
+    // `Option<List<T>>` after monomorph) cannot route through the i64
+    // payload path. Detect widened layouts and emit the struct variant
+    // with a `zeroinitializer` payload so the caller does not have to
+    // care which path applies.
+    if lirAggregateHasWidenedPayload(l.out, optType) {
+        let structRef = lirOptionResultPayloadStructRef(l.out, optType.llvm)
+        if structRef != "" {
+            return lirEmitAlgebraicStruct(l, optType, 1, lirOperand(lirAggregateType(structRef), "zeroinitializer"), "Option.None")
+        }
+    }
     lirEmitAlgebraicI64(l, optType, 1, "0", "Option.None")
 }
 fn lirEmitOptionSome(l: LirMirFunctionLowerer, optType: LirType, payloadI64: String) -> String {
@@ -5465,8 +5495,13 @@ fn lirListElemTypeName(l: LirMirFunctionLowerer, typeName: String) -> String {
     ""
 }
 // Key/value type names for Map<K, V> ("Map<String, Int>" -> "String"/"Int").
-fn lirMapKeyTypeName(typeName: String) -> String {
-    let inner = lirContainerInnerArg(typeName, "Map<")
+// Resolves a monomorphized builtin-source struct through
+// lirCanonBuiltinTypeName first so an injected `_ZTS…Map…` receiver
+// still yields its key/value, matching how lirListElemTypeName handles
+// the same `List` mangling.
+fn lirMapKeyTypeName(l: LirMirFunctionLowerer, typeName: String) -> String {
+    let canon = lirCanonBuiltinTypeName(l, typeName)
+    let inner = lirContainerInnerArg(canon, "Map<")
     if inner == "" {
         return ""
     }
@@ -5476,8 +5511,9 @@ fn lirMapKeyTypeName(typeName: String) -> String {
     }
     strings.trimSpace(strings.slice(inner, 0, comma))
 }
-fn lirMapValueTypeName(typeName: String) -> String {
-    let inner = lirContainerInnerArg(typeName, "Map<")
+fn lirMapValueTypeName(l: LirMirFunctionLowerer, typeName: String) -> String {
+    let canon = lirCanonBuiltinTypeName(l, typeName)
+    let inner = lirContainerInnerArg(canon, "Map<")
     if inner == "" {
         return ""
     }
@@ -5563,7 +5599,7 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
         return lirContainerReceiverInvalid()
     }
     let elemName = if kind == "map.key" || kind == "map.kv" {
-        lirMapKeyTypeName(instr.args[0].typ)
+        lirMapKeyTypeName(l, instr.args[0].typ)
     } else {
         lirListElemTypeName(l, instr.args[0].typ)
     }
@@ -5593,7 +5629,7 @@ fn lirLowerMirContainerReceiver(l: LirMirFunctionLowerer, instr: MirInstr, label
     }
     let mut out = LirContainerReceiver {receiverReg: recv.value, elemTypeName: elemName, elemLir, isString: lirContainerElemIsString(elemName), valueTypeName: "", valueLir: lirTypeInvalid(), valueIsString: false, ok: true}
     if kind == "map.kv" {
-        let valueName = lirMapValueTypeName(instr.args[0].typ)
+        let valueName = lirMapValueTypeName(l, instr.args[0].typ)
         if valueName == "" {
             lirLowerError(l, LirDiagUnsupported, label + " could not extract value type from receiver `" + instr.args[0].typ + "` (" + lirReceiverParseTraceMessage(instr.args[0].typ) + ")", label)
             return lirContainerReceiverInvalid()
@@ -6067,8 +6103,8 @@ fn lirLowerMirMapNew(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "map.new destination local out of range", "map.new")
         return
     }
-    let keyName = lirMapKeyTypeName(loc.typ)
-    let valueName = lirMapValueTypeName(loc.typ)
+    let keyName = lirMapKeyTypeName(l, loc.typ)
+    let valueName = lirMapValueTypeName(l, loc.typ)
     if keyName == "" || valueName == "" {
         lirLowerError(l, LirDiagUnsupported, "map.new destination type `" + loc.typ + "` is not Map<K, V>", "map.new")
         return


### PR DESCRIPTION
## Summary

`List.flatMap` 해금 시도를 위한 인프라 추가 — return-type recovery + typeargs fill + body 재작성. 14개 기존 메서드 회귀 없음.

## 배경

`flatMap`의 selfhost-checker가 closure-returning-list에서 `R` 통합 실패해 call 반환 타입이 `List<<error>>`로 poison. monomorph는 그 결과 `R`을 `?` placeholder로 mangling해 clang이 `…flatMapIl?E…`를 거부.

## Fix (3 piece)

- **`recoverListHigherOrderReturn`** — `flatMap` 케이스 추가. closure/named-fn/closure-body에서 반환 타입을 끌어옴 (`flatMapElemFromArg`).
- **`fillFlatMapTypeArgs`** — 반환 recovery 후 `MethodCall.TypeArgs = [T, R]`을 명시 세팅. monomorph가 `?` placeholder 대신 구체 타입을 받음. flatMap 한정 (다른 메서드는 만지지 않음, scan/groupBy 회귀 방지).
- **`collections.osty` flatMap body** — `for r in f(item)` (generic `List<R>` iter, monomorph 전 R 미해결로 차단) → index-loop. chunked/windowed와 동일 패턴.

## Verification

기존 14-combinator 회귀 검증 (`[4,1,3,2]`):
```
map.fold=20 filter=2 reduce=10 first=4 last=2
enumerate=4 chunked=2 windowed=3 zip=4 sorted=4 take=2
scan=5 find=4 groupBy=2
```
회귀 없음.

`flatMap` 자체는 monomorph type-arg propagation의 더 깊은 인프라 변경 없이 일부 configuration에서 여전히 `?` mangling. 그 부분은 다음 집중 작업.

## Test plan

- [x] `go build` · `go vet` · `gofmt` — clean
- [x] 14-combinator 회귀 mixed file E2E
- [ ] CI Go 스위트

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_