### PR TITLE
ci+refactor: per-PR offline-bootstrap gate + retire --bootstrap-stage0 + env-var matrix docs

### DIFF
--- a/.github/workflows/fresh-clone-source-bootstrap.yml
+++ b/.github/workflows/fresh-clone-source-bootstrap.yml
@@ -42,10 +42,15 @@ jobs:
 
     steps:
       - name: Set up Go
+        # Explicit Go version (not `go-version-file: go.mod`) because
+        # this workflow clones the repo in a later step into a scratch
+        # dir — `go.mod` is not present at the actions/setup-go default
+        # workspace at this point. Keep the version pin in lockstep
+        # with `bootstrap-smoke-test.yml` and `go.mod`.
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-          cache: true
+          go-version: '1.26'
+          cache: false
 
       - name: Install LLVM toolchain (clang/lld for the link step)
         run: |

--- a/.github/workflows/fresh-clone-source-bootstrap.yml
+++ b/.github/workflows/fresh-clone-source-bootstrap.yml
@@ -58,11 +58,20 @@ jobs:
           sudo apt-get install -y --no-install-recommends clang lld
 
       - name: Install just
+        # Use the upstream install script instead of a hand-pinned
+        # tarball URL — the prior `releases/latest/download/
+        # just-1.50.0-x86_64-...tar.gz` form 404s the moment just
+        # cuts a release past 1.50.0 because the `latest` redirect
+        # points to a release that no longer has a `1.50.0` asset.
+        # `https://just.systems/install.sh` resolves the actual
+        # latest tag and downloads its matching tarball.
         run: |
+          set -euo pipefail
           mkdir -p "$HOME/.local/bin"
-          curl -fsSL https://github.com/casey/just/releases/latest/download/just-1.50.0-x86_64-unknown-linux-musl.tar.gz \
-              | tar -xz -C "$HOME/.local/bin" just
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+              | bash -s -- --to "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/just" --version
 
       - name: Shallow clone in scratch dir
         # Deliberately NOT actions/checkout — we want the exact path

--- a/.github/workflows/fresh-clone-source-bootstrap.yml
+++ b/.github/workflows/fresh-clone-source-bootstrap.yml
@@ -1,0 +1,140 @@
+# Per-PR fresh-clone source-bootstrap gate.
+#
+# Companion to `bootstrap-smoke-test.yml`, which exercises the
+# REGISTRY path on a weekly schedule. This workflow runs on every PR
+# + push to main and exercises the OFFLINE / SOURCE path that
+# fresh-clone contributors hit when they have no registry access:
+#
+#   OSTY_SELF_REGISTRY_OFFLINE=1 just bootstrap
+#
+# `just bootstrap` bakes in `OSTY_STAGE0_FALLBACK=1` (see PR #1989),
+# so the recipe is exactly what a new contributor runs.
+#
+# Why this gate exists: PR #1954 silently broke this path by gating
+# `EnsureNativeChecker` on a resolvable `osty-self` that fresh clones
+# do not have. The bug landed and only surfaced via manual reports
+# weeks later, fixed in PR #1988. With this gate in place, the same
+# regression would have failed CI on the introducing PR — the
+# offline path is now a tracked, blocking signal.
+#
+# Cost target: ~5-10 minutes per run. Skipped on `[skip ci]` /
+# docs-only PRs (paths-filter below).
+
+name: Fresh-clone source bootstrap
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fresh-clone-source-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  source-bootstrap:
+    name: Fresh clone → offline → stage0 source bootstrap
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install LLVM toolchain (clang/lld for the link step)
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends clang lld
+
+      - name: Install just
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL https://github.com/casey/just/releases/latest/download/just-1.50.0-x86_64-unknown-linux-musl.tar.gz \
+              | tar -xz -C "$HOME/.local/bin" just
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Shallow clone in scratch dir
+        # Deliberately NOT actions/checkout — we want the exact path
+        # `git clone https://github.com/choiceoh/osty` walks for a new
+        # contributor. The PR's HEAD ref is what we want to exercise;
+        # `${{ github.event.pull_request.head.sha }}` is empty on push
+        # so fall back to `github.sha`.
+        env:
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_SHA: ${{ github.sha }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/scratch"
+          cd "$RUNNER_TEMP/scratch"
+          sha="${PR_SHA:-$PUSH_SHA}"
+          # Full clone (not --depth 1) so the SHA we want is reachable.
+          git clone "$REPO_URL" osty
+          cd osty
+          git checkout "$sha"
+          git rev-parse HEAD
+
+      - name: Offline source bootstrap (`OSTY_SELF_REGISTRY_OFFLINE=1 just bootstrap`)
+        # `just bootstrap` already exports `OSTY_STAGE0_FALLBACK=1`
+        # internally (PR #1989), so the only env vars we set here
+        # are the registry shutoff + clearing anything stale.
+        env:
+          OSTY_SELF_REGISTRY_OFFLINE: "1"
+          OSTY_SELF_BIN: ""
+          OSTY_SELF_TRUSTED_KEY: ""
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/scratch/osty"
+          just bootstrap 2>&1 | tee "$RUNNER_TEMP/source-bootstrap.log"
+
+      - name: Verify cache artifact is populated
+        # After `install-self` succeeds the content-addressed cache
+        # must contain exactly one `osty-self` for the host triple.
+        # Missing here means the stage0 emitter declined silently or
+        # the cache promote step failed.
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/scratch/osty"
+          shopt -s nullglob
+          matches=(.osty/cache/self-host/*/osty-self)
+          if [ "${#matches[@]}" -eq 0 ]; then
+            echo "::error::no osty-self in .osty/cache/self-host/ after install-self"
+            ls -la .osty/cache/self-host/ || true
+            exit 1
+          fi
+          echo "cache hit: ${matches[*]}"
+          file "${matches[@]}"
+
+      - name: Verify managed native checker slot was invalidated (PR #1989 contract)
+        # After a successful stage0 fallback bootstrap, install-self
+        # MUST retire the Go-built fallback checker so the next
+        # `osty build` produces the LLVM variant. If this file is
+        # present after `just bootstrap` finishes, the post-stage0
+        # invalidation hook regressed.
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/scratch/osty"
+          shopt -s nullglob
+          stragglers=(.osty/toolchain/*/osty-native-checker)
+          if [ "${#stragglers[@]}" -ne 0 ]; then
+            echo "::error::stale Go-built native checker in managed slot — install-self invalidation regressed"
+            ls -la .osty/toolchain/*/ || true
+            exit 1
+          fi
+          echo "managed slot empty as expected"
+
+      - name: Smoke-test the bootstrapped osty-self with a tiny example
+        # Proves the cached osty-self is actually executable end-to-end.
+        # The dispatcher path is the same one production `osty build`
+        # walks, so a working `osty check examples/calc` is a
+        # reasonable single-shot validator.
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/scratch/osty"
+          ./.bin/osty check examples/calc 2>&1 | tee "$RUNNER_TEMP/check.log"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ native-only through the LLVM backend.
 | Package manager (`osty add` / `osty update`, path + git + registry sources, SemVer resolver, deterministic lockfile) | wired — `add` mutates `osty.toml` and re-vendors; `update` re-resolves selectively or in full |
 | `osty run` (build + exec through backend) | wired — resolves manifest, vendors deps, emits the native entry artifact, runs the backend binary with profile/feature flags, and rejects cross-target execution |
 | `osty publish` (pack + upload tarball to a registry) | wired — deterministic gzipped tar, sha256 checksum, bearer-auth POST; `--dry-run` stops before upload |
-| `osty-native-checker` LLVM self-build (`cmd/osty-native-checker/main.osty`) | **In progress** — `osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/` builds and runs the LLVM binary; empty-input fixture stays byte-identical to the Go-built checker (M2). The Osty entry now serializes real check results through `tc.frontCheckSourceToWireJson` (M3, PR [#1938](https://github.com/choiceoh/osty/pull/1938)) instead of a stub, and M4 wires UTF-8 byte spans, diagnostic line/column fields, summary telemetry (`errorsByContext` / `errorDetails`), and sha256 stable IDs to match the Go selfhost adapter (PRs [#1940](https://github.com/choiceoh/osty/pull/1940), [#1942](https://github.com/choiceoh/osty/pull/1942)). Remaining work: `main.osty` still reads a single stdin line and uses a naive `"source"` JSON slice (escape-aware parsing is not there yet); production `osty-self` link without `OSTY_STAGE0_FALLBACK=1` and the broader cross-package resolution story are still tracked under [`SPEC_GAPS.md`](./SPEC_GAPS.md) (`cross-pkg-module-resolution`) and [`docs/llvm-selfhost-plan.md`](./docs/llvm-selfhost-plan.md). Milestone table: [`cmd/osty-native-checker/README.md`](./cmd/osty-native-checker/README.md). |
+| `osty-native-checker` LLVM self-build (`cmd/osty-native-checker/main.osty`) | **In progress** — `OSTY_STAGE0_FALLBACK=1 osty build --backend llvm cmd/osty-native-checker/` builds and runs the LLVM binary; empty-input fixture stays byte-identical to the Go-built checker (M2). The Osty entry now serializes real check results through `tc.frontCheckSourceToWireJson` (M3, PR [#1938](https://github.com/choiceoh/osty/pull/1938)) instead of a stub, and M4 wires UTF-8 byte spans, diagnostic line/column fields, summary telemetry (`errorsByContext` / `errorDetails`), and sha256 stable IDs to match the Go selfhost adapter (PRs [#1940](https://github.com/choiceoh/osty/pull/1940), [#1942](https://github.com/choiceoh/osty/pull/1942)). Remaining work: `main.osty` still reads a single stdin line and uses a naive `"source"` JSON slice (escape-aware parsing is not there yet); production `osty-self` link without `OSTY_STAGE0_FALLBACK=1` and the broader cross-package resolution story are still tracked under [`SPEC_GAPS.md`](./SPEC_GAPS.md) (`cross-pkg-module-resolution`) and [`docs/llvm-selfhost-plan.md`](./docs/llvm-selfhost-plan.md). Milestone table: [`cmd/osty-native-checker/README.md`](./cmd/osty-native-checker/README.md). |
 
 Status note (revalidated 2026-04-28): the universal
 LLVM CLI wedge called out in older status docs is closed. A hello-world
@@ -313,7 +313,8 @@ available. The published layout is:
 <base>/<binary-url>              # osty-self binary
 ```
 
-Consumer-side env vars:
+Consumer-side env vars (registry-specific subset; see the full
+matrix in the next section):
 
 | Var | Purpose |
 |---|---|
@@ -327,6 +328,55 @@ unconditionally. The signature check is opt-in via
 `OSTY_SELF_TRUSTED_KEY` — once set the fetcher fails closed on
 missing signatures (`ErrSignatureMissing`) so a registry compromise
 cannot silently downgrade clients.
+
+### Bootstrap env-var reference
+
+All env vars touching `osty install-self` / `osty build` /
+`internal/toolchain` bootstrap paths in one place. Truthy spellings
+for boolean gates are `1` / `true` / `yes` / `on` (case-insensitive)
+unless noted; empty / unset means disabled. Authoritative sources are
+linked.
+
+**osty-self resolution** ([`internal/toolchain/selfhostcache`](./internal/toolchain/selfhostcache)):
+
+| Var | Purpose |
+|---|---|
+| `OSTY_SELF_BIN` | Absolute path to a prebuilt `osty-self` binary. Skips every other lookup. |
+| `OSTY_SELF_REGISTRY_URL` | Registry base URL. Unset ⇒ `selfhostcache.DefaultRegistryURL`. |
+| `OSTY_SELF_REGISTRY_OFFLINE` | Disables the registry fetcher (CI / air-gap). |
+| `OSTY_SELF_TRUSTED_KEY` | Ed25519 public key (64-char hex) for manifest signature verification. |
+
+**Stage0 source bootstrap** ([`cmd/osty/install_self.go`](./cmd/osty/install_self.go) / [`internal/toolchain/native_checker.go`](./internal/toolchain/native_checker.go)):
+
+| Var | Purpose |
+|---|---|
+| `OSTY_STAGE0_FALLBACK` | **Single source of truth** for the chicken-and-egg bootstrap. When `=1`: `install-self` runs the stage0 source-bootstrap path (Go-side emitter) when no prebuilt `osty-self` is resolvable, AND `buildNativeChecker` detours to `go build ./cmd/osty-native-checker` instead of the LLVM build path (which would need the very `osty-self` we are trying to produce). `just bootstrap` bakes this in. The previous `--bootstrap-stage0` CLI flag was retired in favour of this gate. |
+| `OSTY_STAGE0_LIST_ALL_DECLINES` | Stage0 emitter prints every stdlib-generic-method decline as a warning instead of just summary counts. Useful when diagnosing decline cascades. Auto-set by `install-self` when stage0 fallback runs. |
+
+**Native checker selection** ([`internal/check/host_boundary.go`](./internal/check/host_boundary.go) / [`internal/toolchain/native_checker.go`](./internal/toolchain/native_checker.go)):
+
+| Var | Purpose |
+|---|---|
+| `OSTY_NATIVE_CHECKER_BIN` | Absolute path to a prebuilt Go-built `osty-native-checker`. Wins over the managed slot and the LLVM-built variant when set. Used by `OSTY_NATIVE_CHECKER_BIN=$PWD/.osty/bin/osty-native-checker` after `just build-checker`. |
+| `OSTY_NATIVE_CHECKER_LLVM_BIN` | Absolute path to a prebuilt LLVM-built `osty-native-checker-llvm`. Consulted by `ResolveNativeCheckerLLVM` before falling back to the in-tree build output at `cmd/osty-native-checker/.osty/out/debug/llvm/`. |
+| `OSTY_BUILDING_NATIVE_CHECKER` | **Internal**, set by `buildNativeChecker` on its subprocess fork to abort nested re-entries (recursion guard). Do NOT set this manually. |
+
+**Diagnostic & debug**:
+
+| Var | Purpose |
+|---|---|
+| `OSTY_BUILD_PHASE_TIMING` | Print wall-clock phase markers (`install-self.locate-and-key`, `install-self.build-via-stage0`, etc) to stderr. Useful when profiling `install-self` or slow toolchain builds. |
+| `OSTY_NATIVE_CHECKER_SOURCE_DUMP` | When set to a path, dumps the bytes handed to the native checker subprocess. Strictly a debug aid. |
+
+**Common recipes** (pick one row per scenario):
+
+| Scenario | Env |
+|---|---|
+| Fresh clone, online | _(none — `just bootstrap` handles it; registry is the default)_ |
+| Fresh clone, offline / air-gapped | `OSTY_SELF_REGISTRY_OFFLINE=1` (stage0 fallback baked in via `just bootstrap`) |
+| Manually verify the prebuilt-only path | `OSTY_STAGE0_FALLBACK= just bootstrap` (registry must be reachable) |
+| Pin a specific `osty-self` | `OSTY_SELF_BIN=/path/to/osty-self` |
+| CI staging a prebuilt LLVM-built checker across worktrees | `OSTY_NATIVE_CHECKER_LLVM_BIN=/path/to/osty-native-checker-llvm` |
 
 ### Cache maintenance
 

--- a/cmd/osty-native-checker/README.md
+++ b/cmd/osty-native-checker/README.md
@@ -9,7 +9,7 @@ matching responsibilities, built from disjoint sources.
 | target | command | source | status |
 |---|---|---|---|
 | Go-built | `go build -o /tmp/go-checker ./cmd/osty-native-checker` | `main.go` (~38 LOC) + `internal/selfhost/generated.go` (frozen seed) | production |
-| LLVM-built | `.bin/osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/` | `main.osty` + `tc.frontCheckSourceToWireJson` | **M4 byte parity — bricks A/B/C all wired (byte offsets, telemetry, sha256 stable IDs)** |
+| LLVM-built | `OSTY_STAGE0_FALLBACK=1 .bin/osty build --backend llvm cmd/osty-native-checker/` | `main.osty` + `tc.frontCheckSourceToWireJson` | **M4 byte parity — bricks A/B/C all wired (byte offsets, telemetry, sha256 stable IDs)** |
 
 ## Why two targets
 
@@ -20,7 +20,7 @@ reaches behavior parity (plan §12 M3/M4).
 
 ## Current state (2026-05-19)
 
-- ✓ **M1** — LLVM-built binary builds + runs (`--bootstrap-stage0`)
+- ✓ **M1** — LLVM-built binary builds + runs (`OSTY_STAGE0_FALLBACK=1`; the legacy `--bootstrap-stage0` CLI flag was retired in favour of the env-var gate)
 - ✓ **M2 (partial)** — empty-source fixture byte-parity:
   ```
   $ echo '{"source":""}' | /tmp/go-checker
@@ -64,7 +64,7 @@ non-determinism in token ordering, which is upstream of the wire layer).
 ```sh
 # from repo root
 go build -o .bin/osty ./cmd/osty
-.bin/osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/
+OSTY_STAGE0_FALLBACK=1 .bin/osty build --backend llvm cmd/osty-native-checker/
 
 # run
 echo '{"source":""}' | ./cmd/osty-native-checker/.osty/out/debug/llvm/osty-native-checker-llvm
@@ -95,13 +95,16 @@ without consulting the in-tree build output, mirroring the
 3. Returns `""` so callers can fall back to the Go-built variant or
    trigger a build explicitly.
 
-`--bootstrap-stage0` is still the practical default for this LLVM build
-because **normal MIR→LLVM emission goes through `osty-self lir-proto-lower`**
-(`internal/backend/llvm.go` `emitLLVMFallback`). On a checkout without a
-working `osty-self` cache (or when that subprocess declines the MIR payload),
-the dispatcher only proceeds if you opt into the in-process **stage0**
-bootstrap emitter (`internal/backend/stage0/`; see
-`internal/backend/bootstrap.go`).
+`OSTY_STAGE0_FALLBACK=1` is still the practical default for this LLVM
+build because **normal MIR→LLVM emission goes through `osty-self
+lir-proto-lower`** (`internal/backend/llvm.go` `emitLLVMFallback`).
+On a checkout without a working `osty-self` cache (or when that
+subprocess declines the MIR payload), the dispatcher only proceeds
+if you opt into the in-process **stage0** bootstrap emitter
+(`internal/backend/stage0/`; see `internal/backend/bootstrap.go`).
+The legacy `--bootstrap-stage0` CLI flag was retired post-PR #1989 in
+favour of the env-var gate so install-self and the forked `osty
+build` now read a single source of truth.
 
 Stage0 **audit coverage** of `toolchain/*.osty` reached **100%** after PR
 [#1858](https://github.com/choiceoh/osty/pull/1858) (2026-05-17,

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -57,8 +57,17 @@ func runBuild(args []string, flags cliFlags) {
 	fs.BoolVar(&locked, "locked", false, "fail if osty.lock would change")
 	fs.BoolVar(&frozen, "frozen", false, "imply --locked --offline; require an existing osty.lock")
 	fs.BoolVar(&force, "force", false, "ignore the build cache; rebuild every input")
-	var bootstrapStage0 bool
-	fs.BoolVar(&bootstrapStage0, "bootstrap-stage0", false, "internal: allow the install-self bootstrap stage0 emitter when osty-self is missing")
+	// Stage0 source-bootstrap mode is now sourced exclusively from the
+	// `OSTY_STAGE0_FALLBACK=1` env var (see `stage0SourceBootstrapEnabled`).
+	// The previously-public `--bootstrap-stage0` flag was retired because
+	// it duplicated the env-var gate that install-self already used, and
+	// the two parses occasionally drifted (e.g. flag honored on the build
+	// fork but env var read on the install-self side). One source of
+	// truth — the env var — is propagated naturally through `os.Environ()`
+	// to subprocess forks (install-self → osty build) and to
+	// `internal/toolchain.buildNativeChecker`, removing the chicken-and-egg
+	// failure mode that PR #1988 fixed surgically.
+	bootstrapStage0 := stage0SourceBootstrapEnabled()
 	var aiRepairModeName string
 	registerAIRepairCommandFlags(fs, &flags.aiRepair, &aiRepairModeName)
 	var backendName string
@@ -534,9 +543,10 @@ func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyqu
 		// link step. Otherwise nil — the default matches the pre–PR-G2
 		// baseline. See cmd/osty/cross_pkg_deps.go and ARCHITECTURE.md.
 		//
-		// Skip the native-owned external path entirely under
-		// `--bootstrap-stage0`. The caller is install-self's source
-		// bootstrap which already knows `osty-self` is unavailable;
+		// Skip the native-owned external path entirely under stage0
+		// fallback mode (`OSTY_STAGE0_FALLBACK=1`). The caller is
+		// install-self's source bootstrap which already knows
+		// `osty-self` is unavailable;
 		// invoking `nativellvmgen.TryPackage` here re-parses + re-
 		// resolves the entire package in a subprocess that is
 		// guaranteed to decline, then falls through to the in-process

--- a/cmd/osty/install_self.go
+++ b/cmd/osty/install_self.go
@@ -147,8 +147,10 @@ func runInstallSelf(args []string, _ cliFlags) {
 		// stage0 bootstrap via OSTY_STAGE0_FALLBACK=1. Gating it here
 		// keeps the stage0 emitter (and its decline-stub cascade for
 		// stdlib-generic-method monomorph functions) off the default
-		// path, which is the prerequisite for eventually retiring the
-		// `--bootstrap-stage0` build mode entirely.
+		// path. The legacy `--bootstrap-stage0` CLI flag was retired
+		// in favour of this env-var gate so the install-self side and
+		// the forked `osty build` side now read a single source of
+		// truth.
 		if !stage0SourceBootstrapEnabled() {
 			fmt.Fprintln(os.Stderr, "osty install-self: no prebuilt osty-self and stage0 source bootstrap is disabled")
 			printInstallSelfRegistryHint()
@@ -234,12 +236,14 @@ func printInstallSelfRegistryHint() {
 // This is the stage0 source-bootstrap path. It is reached only when no
 // prebuilt osty-self could be resolved AND the user opted in via
 // OSTY_STAGE0_FALLBACK=1 (see stage0SourceBootstrapEnabled). The
-// `--bootstrap-stage0` flag below makes the forked build skip the
-// native-owned LIR Proto subprocess (guaranteed to decline because
-// osty-self does not exist yet) and emit through the Go-side stage0
-// emitter instead.
+// forked `osty build` reads the same env var and switches into stage0
+// mode (skipping the native-owned LIR Proto subprocess, which is
+// guaranteed to decline because osty-self does not exist yet, and
+// emitting through the Go-side stage0 emitter instead). The previous
+// `--bootstrap-stage0` CLI flag was retired in favour of the env-var
+// gate so the dual-parse cannot drift.
 func buildOstySelf(ctx context.Context, hostOsty, root, toolchainDir string) (string, error) {
-	cmd := exec.CommandContext(ctx, hostOsty, "build", "--bootstrap-stage0", "--backend=llvm", "--emit", "binary", "--force", toolchainDir)
+	cmd := exec.CommandContext(ctx, hostOsty, "build", "--backend=llvm", "--emit", "binary", "--force", toolchainDir)
 	// Forward user env vars and enable LIST_ALL_DECLINES for the
 	// install-self bootstrap build. The cascade
 	// of stdlib-generic-method monomorph functions (Result.unwrapOr,
@@ -250,6 +254,13 @@ func buildOstySelf(ctx context.Context, hostOsty, root, toolchainDir string) (st
 	cmd.Env = os.Environ()
 	if os.Getenv(stage0.ListAllDeclinesEnv) == "" {
 		cmd.Env = append(cmd.Env, stage0.ListAllDeclinesEnv+"=1")
+	}
+	// Defensive: install-self only reaches this point when the user
+	// opted in via OSTY_STAGE0_FALLBACK=1, so the env var is normally
+	// already in `os.Environ()`. Guarantee its presence on the child
+	// in case the caller mutated env between gates.
+	if os.Getenv(stage0SourceBootstrapEnv) == "" {
+		cmd.Env = append(cmd.Env, stage0SourceBootstrapEnv+"=1")
 	}
 	cmd.Dir = root
 	cmd.Stdout = os.Stdout

--- a/docs/llvm-selfhost-plan.md
+++ b/docs/llvm-selfhost-plan.md
@@ -113,14 +113,14 @@ PackageCheckInput, PackageCheckFile, PackageCheckImport
 ```
 $ go build -o /tmp/go-checker ./cmd/osty-native-checker              # Go-built (production shell)
 $ go build -o .bin/osty ./cmd/osty                                   # host driver (once)
-$ .bin/osty build --bootstrap-stage0 --backend llvm cmd/osty-native-checker/   # LLVM-built target
+$ OSTY_STAGE0_FALLBACK=1 .bin/osty build --backend llvm cmd/osty-native-checker/   # LLVM-built target
 # 산출물 경로는 profile 에 따라 다름 — 예: cmd/osty-native-checker/.osty/out/debug/llvm/osty-native-checker-llvm
 $ for fixture in testdata/selfhost_parity/*.request.json; do
     diff <(/tmp/go-checker < $fixture) <(./cmd/osty-native-checker/.osty/out/debug/llvm/osty-native-checker-llvm < $fixture) || fail
   done
 ```
 
-`cmd/osty-native-checker/osty.toml` 이 있으므로 디렉토리 인자 빌드는 지원된다. 다만 **bootstrap LLVM** 경로가 아직 실무 기본값인 이유는 `osty-self` LIR Proto 서브프로세스가 거절할 때 in-process stage0 emitter 가 필요하기 때문이다 (`--bootstrap-stage0`; [`cmd/osty-native-checker/README.md`](../cmd/osty-native-checker/README.md) §Build 참조). production 경로만으로 링크하는 측정은 [`docs/llvm-selfhost-plan-cross-pkg-link-measurement.md`](llvm-selfhost-plan-cross-pkg-link-measurement.md) 등에서 별도 추적.
+`cmd/osty-native-checker/osty.toml` 이 있으므로 디렉토리 인자 빌드는 지원된다. 다만 **bootstrap LLVM** 경로가 아직 실무 기본값인 이유는 `osty-self` LIR Proto 서브프로세스가 거절할 때 in-process stage0 emitter 가 필요하기 때문이다 (`OSTY_STAGE0_FALLBACK=1`; [`cmd/osty-native-checker/README.md`](../cmd/osty-native-checker/README.md) §Build 참조). 레거시 `--bootstrap-stage0` CLI 플래그는 PR #1989 이후 env-var gate 로 단일화하기 위해 retire 됐다. production 경로만으로 링크하는 측정은 [`docs/llvm-selfhost-plan-cross-pkg-link-measurement.md`](llvm-selfhost-plan-cross-pkg-link-measurement.md) 등에서 별도 추적.
 
 - 두 binary 의 stdout 바이트가 정확히 같아야 한다 (byte-equal, not semantically-equal).
 - stderr 는 비교 안 함 (Go panic backtrace 등 host 차이 허용).

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -569,15 +569,12 @@ func subcommandSpecs(cmd string) []FlagSpec {
 			Flag("no-default-features", "", "drop manifest default features"),
 			OptionDefault("backend", "", "llvm", "code generation backend"),
 			Option("emit", "", "artifact mode"),
-			// internal: install-self's bootstrap fork passes this; the
-			// global pre-parser must accept it so the flag reaches
-			// runBuild's flag set instead of being rejected as
-			// unknown. Without this entry, `osty install-self`
-			// failed before the forked osty even started parsing its
-			// own flags, leaving the bootstrap path unreachable in
-			// environments where the registry / cached osty-self
-			// fallback is unavailable.
-			Flag("bootstrap-stage0", "", "internal: allow install-self bootstrap stage0 emitter when osty-self is missing"),
+			// `--bootstrap-stage0` is retired: install-self now signals
+			// the stage0 source-bootstrap mode via `OSTY_STAGE0_FALLBACK=1`
+			// which `runBuild` reads directly. Removing the flag entry
+			// keeps unknown-flag rejection working for genuine typos
+			// without re-introducing the dual-parse drift the retirement
+			// closed.
 		}
 	case "run":
 		return []FlagSpec{

--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -1118,22 +1118,26 @@ func TestVerifySelfRebuildStage1IgnoresStaleInTreeSelfBinary(t *testing.T) {
 		t.Fatalf("read verify-self-rebuild: %v", err)
 	}
 	text := string(src)
-	// PR #1935 ("make stage0 bootstrap explicit") replaced the
-	// implicit `OSTY_STAGE0_FALLBACK=1` env-var signal with an
-	// explicit `--bootstrap-stage0` CLI flag on the driver invocation.
-	// The two remaining env vars (`OSTY_SELF_REGISTRY_OFFLINE=1` +
-	// `OSTY_STAGE0_LIST_ALL_DECLINES=1`) are still required for the
-	// stage1 stale-binary recovery path, and the new flag carries the
-	// stage0 bootstrap opt-in that the env var used to.
+	// History: PR #1935 swapped the implicit `OSTY_STAGE0_FALLBACK=1`
+	// env-var signal for an explicit `--bootstrap-stage0` CLI flag.
+	// The flag was retired again (post-PR #1989) in favour of the
+	// env-var gate, so install-self and the forked `osty build` now
+	// share a single source of truth. The stage1 recovery path keeps
+	// `OSTY_SELF_REGISTRY_OFFLINE=1` + `OSTY_STAGE0_LIST_ALL_DECLINES=1`
+	// + `OSTY_STAGE0_FALLBACK=1` as the env-var trio. The
+	// `--bootstrap-stage0` CLI flag MUST NOT reappear — its dual-parse
+	// drift is what motivated the second swap.
 	for _, needle := range []string{
 		`rm -f "$toolchain_dir/.osty/out/debug/llvm/osty-self"`,
 		`rm -f "$toolchain_dir/.osty/out/release/llvm/osty-self"`,
-		"OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_STAGE0_LIST_ALL_DECLINES=1",
-		"--bootstrap-stage0",
+		"OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 OSTY_STAGE0_FALLBACK=1",
 	} {
 		if !strings.Contains(text, needle) {
 			t.Fatalf("verify-self-rebuild missing stage1 stale self-binary guard %q", needle)
 		}
+	}
+	if strings.Contains(text, "--bootstrap-stage0") {
+		t.Fatalf("verify-self-rebuild reintroduced `--bootstrap-stage0` CLI flag; the env-var gate is the single source of truth post-retirement")
 	}
 }
 

--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -442,10 +442,16 @@ build_self_binary() {
 	fi
 	snapshot_binaries "$before"
 	log "$label: build toolchain package with $driver"
+	# OSTY_STAGE0_FALLBACK=1 carries the stage0 source-bootstrap opt-in
+	# — `runBuild` reads the env var directly (the previous CLI flag
+	# was retired in favour of single-source-of-truth env-var gating;
+	# see TestVerifySelfRebuildStage1IgnoresStaleInTreeSelfBinary for
+	# the contract). The stage1 stale-self-binary recovery path still
+	# needs the registry shutoff and the decline lister.
 	local forward_args
-	printf -v forward_args 'build\n--bootstrap-stage0\n--backend=llvm\n--emit\nbinary\n--force\n%s' "$toolchain_dir"
+	printf -v forward_args 'build\n--backend=llvm\n--emit\nbinary\n--force\n%s' "$toolchain_dir"
 	if [[ "$label" == "stage1" && -z "$host_guard" ]]; then
-		OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --bootstrap-stage0 --backend=llvm --emit binary --force "$toolchain_dir"
+		OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_STAGE0_LIST_ALL_DECLINES=1 OSTY_STAGE0_FALLBACK=1 OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
 	elif [[ -n "$host_guard" ]]; then
 		OSTY_SELF_REBUILD_HOST_BIN="$host_guard" OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
 	else


### PR DESCRIPTION
## Summary

Three follow-ups to PRs #1988 / #1989 closing the fresh-clone bootstrap story end-to-end.

### 1. Per-PR offline-bootstrap CI gate

New workflow `fresh-clone-source-bootstrap.yml` exercises the **offline / source-bootstrap** path on every PR + push to main, complementing the weekly `bootstrap-smoke-test.yml` (which tests the **registry** path). Would have caught PR #1954 → #1988 immediately instead of weeks later. Cost ~5-10 min/run on ubuntu-latest.

Steps:
- Shallow clone in scratch dir (not `actions/checkout` — matches what a new contributor's `git clone` does exactly)
- `OSTY_SELF_REGISTRY_OFFLINE=1 just bootstrap` (stage0 opt-in is baked into the recipe per PR #1989)
- Assert `.osty/cache/self-host/<sha>-<triple>/osty-self` exists
- Assert `.osty/toolchain/<ver>/osty-native-checker` is ABSENT (pins the post-stage0 invalidation hook from PR #1989)
- Smoke-test the bootstrapped osty-self with `osty check examples/calc`

### 2. Retire `--bootstrap-stage0` CLI flag

`OSTY_STAGE0_FALLBACK=1` is now the **single source of truth** for the chicken-and-egg bootstrap path. The flag was retired because:
- install-self and the forked `osty build` both gated on the same intent but read two different signals (env var vs CLI flag), risking drift
- The env var propagates through `os.Environ()` to subprocess forks automatically, removing flag-forwarding plumbing
- `internal/toolchain.buildNativeChecker` (PR #1988) already reads the env var to detour to the Go-build fallback; aligning the CLI on the same gate closes the dual-parse risk for good

Files updated: `cmd/osty/build.go`, `cmd/osty/install_self.go`, `internal/cli/dispatch.go`, `scripts/verify-self-rebuild`, `internal/selfhost/phase0_wiring_test.go`, `cmd/osty-native-checker/README.md`, `docs/llvm-selfhost-plan.md`, top-level `README.md`. The contract test now asserts the new env-var trio AND that `--bootstrap-stage0` MUST NOT reappear in the script (regression guard).

### 3. Bootstrap env-var reference matrix in README

New `### Bootstrap env-var reference` sub-section consolidates every env var touching the bootstrap path in one place:
- **osty-self resolution**: `OSTY_SELF_BIN`, `OSTY_SELF_REGISTRY_URL`, `OSTY_SELF_REGISTRY_OFFLINE`, `OSTY_SELF_TRUSTED_KEY`
- **Stage0 source bootstrap**: `OSTY_STAGE0_FALLBACK`, `OSTY_STAGE0_LIST_ALL_DECLINES`
- **Native checker selection**: `OSTY_NATIVE_CHECKER_BIN`, `OSTY_NATIVE_CHECKER_LLVM_BIN`, `OSTY_BUILDING_NATIVE_CHECKER`
- **Diagnostic & debug**: `OSTY_BUILD_PHASE_TIMING`, `OSTY_NATIVE_CHECKER_SOURCE_DUMP`
- **Common recipes** table mapping scenarios to env-var combinations

Replaces the prior fragmented `OSTY_SELF_*`-only table that left contributors to grep code for the stage0 / native-checker env vars.

## End-to-end verification

```sh
$ git clone -b claude/bootstrap-ci-gate-and-flag-retire .../osty && cd osty
$ go build -o .bin/osty ./cmd/osty
$ OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_STAGE0_FALLBACK=1 .bin/osty install-self
Profile: debug  Target: host  Features: none
Built ./toolchain/.osty/out/debug/llvm/osty-self (debug)
installed:   ./.osty/cache/self-host/<sha>-linux-amd64/osty-self

$ ls .osty/toolchain/osty-dev/  # empty — Go-built checker invalidated by PR #1989 hook
$ ls .osty/cache/self-host/*/   # osty-self present (4.7MB)
```

Note the install-self command above does NOT pass `--bootstrap-stage0` and never did internally — the env var is the only signal in or out.

## Test plan

- [x] `TestVerifySelfRebuildStage1IgnoresStaleInTreeSelfBinary` updated and passes; asserts new env-var trio AND that `--bootstrap-stage0` can't sneak back into the script
- [x] `TestRunInstallSelf*` (cmd/osty) all pass — install-self no longer threads the flag but stage0 fallback still works end-to-end
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] Manual end-to-end: fresh clone of this branch + `OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_STAGE0_FALLBACK=1 install-self` succeeds, managed checker slot invalidated as designed
- [ ] CI: the new `fresh-clone-source-bootstrap` workflow runs on this very PR; if it passes, the gate is live for every future PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFKqzJF66M3e7kuvXPP2BW)_