### PR TITLE
fix: map UntypedInt/UntypedFloat to concrete int/float mangling codes

### DIFF
--- a/internal/ir/monomorph_snapshot.go
+++ b/internal/ir/monomorph_snapshot.go
@@ -74,7 +74,14 @@ func NewMonomorphTypeRequest(pkg, typeName string, typeArgCodes []string) *Monom
 
 // Osty: toolchain/monomorph.osty:37:5
 func MonomorphPrimCode(name string) string {
-	if name == "Int" {
+	if name == "Int" || name == "UntypedInt" {
+		// `UntypedInt` is the literal-default placeholder the checker
+		// emits when a numeric literal's type hasn't been pinned to a
+		// concrete int kind yet (e.g. `R` resolves to `UntypedInt`
+		// when `flatMap(|x| [x, x])` unifies `R` against the list
+		// literal's element type). Defaulting to `l` (Int) matches the
+		// Osty checker's UntypedInt-to-Int promotion at value-position
+		// boundaries and keeps the mangled symbol clang-acceptable.
 		return "l"
 	}
 	if name == "Int8" {
@@ -104,7 +111,9 @@ func MonomorphPrimCode(name string) string {
 	if name == "Byte" {
 		return "h"
 	}
-	if name == "Float" {
+	if name == "Float" || name == "UntypedFloat" {
+		// `UntypedFloat` mirrors `UntypedInt`: a float-literal default
+		// when the checker has not pinned a concrete float kind.
 		return "d"
 	}
 	if name == "Float32" {


### PR DESCRIPTION
## Summary

monomorph mangling 테이블 `MonomorphPrimCode`가 `UntypedInt`/`UntypedFloat` (체커가 numeric literal의 구체 타입을 확정하기 전에 쓰는 placeholder)을 인식 못 해서, 그 placeholder가 specialization mangle에 그대로 `?`로 흘러들어가 clang이 `expected '(' in call`로 거부했습니다.

## Fix

`UntypedInt` → `l` (Int), `UntypedFloat` → `d` (Float64)로 매핑. 체커가 value-position 경계에서 untyped numeric을 concrete로 promote하는 것과 동일한 규칙. unifier가 concrete int를 핀하지 못한 어떤 자리든 mangled 심볼이 clang-acceptable해집니다.

## Test plan

- [x] `go build` — clean
- [ ] CI Go 스위트

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_