### PR TITLE
fix: bootstrap-smoke-test just URL + two stale local-env test failures

### DIFF
--- a/.github/workflows/bootstrap-smoke-test.yml
+++ b/.github/workflows/bootstrap-smoke-test.yml
@@ -50,11 +50,19 @@ jobs:
           go-version: '1.26'
 
       - name: Install just
+        # Use the upstream install script rather than a hand-pinned
+        # tarball URL: `releases/latest/download/just-1.50.0-...tar.gz`
+        # 404s the moment casey/just cuts a release past 1.50.0,
+        # because the `latest` redirect points at the new tag and the
+        # old asset stops existing there. Aligned with the per-PR
+        # `fresh-clone-source-bootstrap.yml` gate (PR #1992).
         run: |
-          curl -fsSL https://github.com/casey/just/releases/latest/download/just-1.50.0-x86_64-unknown-linux-musl.tar.gz \
-              | tar -xz -C "$HOME/.local/bin" just
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
           mkdir -p "$HOME/.local/bin"
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+              | bash -s -- --to "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/just" --version
 
       - name: Install LLVM toolchain (clang/lld for the link step)
         run: |

--- a/cmd/osty/main_subprocess_test.go
+++ b/cmd/osty/main_subprocess_test.go
@@ -14,6 +14,17 @@ import (
 // but main() never runs from inside `go test`, so we install it here.
 //
 // Part of the gate (b-hard) test migration tracked in SUBPROCESS_SWITCHOVER.md.
+//
+// Also exports `OSTY_NATIVE_CHECKER_BIN` to point at the same Go-built
+// checker so subprocess tests that exec `osty` directly (`runOstyCLI`
+// in airepair_test.go, the TestCheckCLI* family in check_cmd_test.go, …)
+// resolve the checker without re-entering the LLVM build path. Without
+// this every subprocess `osty check` in this package fails with
+// "managed native checker unavailable: LLVM-built osty-native-checker
+// requires a resolvable osty-self" on fresh worktrees post-PR #1954 —
+// the env-var precedence in `internal/check.defaultNativeChecker`
+// wins over the managed factory, so a single Setenv here unblocks
+// every subprocess test at once.
 func TestMain(m *testing.M) {
 	binPath, err := check.BuildSharedNativeCheckerForTests()
 	if err != nil {
@@ -21,5 +32,9 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	check.InstallSubprocessCheckerForPackageTests(binPath)
+	if err := os.Setenv("OSTY_NATIVE_CHECKER_BIN", binPath); err != nil {
+		fmt.Fprintf(os.Stderr, "cmd/osty TestMain: setenv OSTY_NATIVE_CHECKER_BIN: %v\n", err)
+		os.Exit(1)
+	}
 	os.Exit(m.Run())
 }

--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -970,7 +970,13 @@ func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 		"fn lirLowerMirAbort(l: LirMirFunctionLowerer, instr: MirInstr)",
 		"l.instrs.push(lirCallWithAttrs(\"\", lirVoidType(), \"@osty_rt_panic\", args, \"\", lirRuntimePanicAttrs()))",
 		"let fields: List<MirFieldLayout> = []",
-		"MirStructLayout {name: \"\", mangled: \"\", fields, size: 0, align: 0}",
+		// MirStructLayout sentinel — pin the empty-name + size:0
+		// prefix only. PR #1981 widened the struct with
+		// `builtinSource` / `builtinSourceArgs`; pinning the full
+		// field list would force this guard to churn every time the
+		// struct grows a new field. The "empty layout" semantic that
+		// `lirFindMirStructLayout` returns on miss is what matters.
+		"MirStructLayout {name: \"\", mangled: \"\", fields, size: 0, align: 0,",
 		"MirTupleLayout {key: \"\", mangled: \"\", fields}",
 		"return lirLowerMirStringRuntimeCall(l, instr, llvmSetRuntimeNewSymbol(), lirPtrType(), lirNoTypeParams(), \"set.new\")",
 		"l.instrs.push(lirCall(listReg, lirPtrType(), \"@\" + newSym, lirNoOperands()))",


### PR DESCRIPTION
## Summary

Three small unrelated fixes that share a common diagnosis path (noticed while watching PRs #1988/#1989/#1992 land):

### 1. `bootstrap-smoke-test.yml` — same pinned-tarball `just` URL bug

The weekly smoke test still uses the hand-pinned `releases/latest/download/just-1.50.0-x86_64-...tar.gz` URL that 404s once casey/just cuts a release past 1.50.0. PR #1992's per-PR gate hit the same bug live; this PR brings the sibling workflow into lockstep with the upstream `just.systems/install.sh` script + a `--version` smoke test. Without this, next Sunday's run would silently fail.

### 2. `TestLirProtoStage2SeedCoercionAndIndexStoreGuards` — stale struct-literal guard

The guard pinned the literal `MirStructLayout {name: "", mangled: "", fields, size: 0, align: 0}` shape. PR #1981 widened the struct with `builtinSource` / `builtinSourceArgs` fields, breaking the strict substring match (test fails on every checkout from main right now). Loosened the guard to pin the empty-name + size:0 prefix only — the empty-layout sentinel semantic that `lirFindMirStructLayout` returns on miss is what matters, not the full field list (which would force this guard to churn every time `MirStructLayout` grows a field).

### 3. `cmd/osty/TestCheckCLI*` family — subprocess can't find native checker

The subprocess tests in `cmd/osty/` exec `osty check ...` via `runOstyCLI`. The spawned subprocess re-enters `UseManagedSubprocessChecker` which needs `osty-self` to build the LLVM-built checker. On any fresh worktree without `osty install-self` having run, every `TestCheckCLI*` / `TestCheckWithAIRepair*` / `TestFmtRunsSemanticAIRepair*` etc fails with "managed native checker unavailable" — the same regression class PRs #1988/#1989/#1992 closed for `just bootstrap` but that bypassed the test path.

`TestMain` now exports `OSTY_NATIVE_CHECKER_BIN` pointing at the Go-built shared checker it already builds for the in-process factory, so every subprocess `osty check` resolves the checker via the env-override path that wins over the managed factory in `internal/check.defaultNativeChecker`.

## Test plan

- [x] `TestLirProtoStage2SeedCoercionAndIndexStoreGuards` — passes (was failing on main)
- [x] `TestCheckCLI*` / `TestCheckWithAIRepair*` / `TestFmtRunsSemanticAIRepair*` — all pass (were failing on main on any worktree without osty-self)
- [x] `go test ./cmd/osty/ -short` — full suite green
- [x] `go test ./internal/selfhost/ -short` — full suite green
- [x] `go vet ./...` clean
- [ ] CI: weekly bootstrap-smoke-test will exercise the new `just` install path on the next Sunday run (or via `workflow_dispatch`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFKqzJF66M3e7kuvXPP2BW)_