### PR TITLE
fix: detour native-checker recursion guard to go-build path

### DIFF
--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -201,18 +201,19 @@ func ResolveNativeCheckerLLVM(projectRoot string) string {
 // clones do not yet have. This keeps `osty install-self` working
 // end-to-end on a fresh clone without forcing the user to manually
 // pre-stage a checker via `OSTY_NATIVE_CHECKER_BIN`.
+//
+// Recursion detour: when `OSTY_BUILDING_NATIVE_CHECKER=1` is set (we are
+// the `osty build --backend llvm cmd/osty-native-checker/` subprocess
+// trying to typecheck the checker's own source), `buildNativeChecker`
+// ALSO detours to the Go-build path. Without this the inner subprocess
+// errored out with a recursion-guard message and the post-install
+// chicken-and-egg "first `osty build` after `install-self` triggers a
+// fresh LLVM build of the native checker" path was broken (see PR #1995
+// CI gate failure). The detour produces a Go-built checker in the
+// managed slot just long enough for the inner subprocess to typecheck;
+// the outer process then overwrites the slot with the LLVM artifact it
+// just built, so the steady-state remains LLVM-built.
 func EnsureNativeChecker(start string) (string, error) {
-	if os.Getenv(RecursionGuardEnv) == "1" {
-		return "", fmt.Errorf(
-			"managed osty-native-checker build re-entered EnsureNativeChecker via %s=1; "+
-				"the LLVM build subprocess (`osty build --backend llvm cmd/osty-native-checker/`) "+
-				"depends on the same managed checker it is trying to produce. "+
-				"Pre-build the artifact, set OSTY_NATIVE_CHECKER_BIN to an existing binary, "+
-				"or set OSTY_STAGE0_FALLBACK=1 to bootstrap via the Go-built checker shell "+
-				"before triggering the managed path",
-			RecursionGuardEnv,
-		)
-	}
 	root, err := managedProjectRootFunc(start)
 	if err != nil {
 		return "", err
@@ -292,17 +293,29 @@ func buildNativeChecker(dest string) error {
 	if err != nil {
 		return err
 	}
-	// Stage0 source bootstrap: the user has explicitly opted into the
-	// chicken-and-egg `osty install-self` recovery path
-	// (`OSTY_STAGE0_FALLBACK=1`). No `osty-self` exists yet — that's
-	// what install-self is currently building — so the LLVM path
-	// cannot run. Build the Go-side native checker shell instead;
-	// it has no `osty-self` dependency (delegates straight to
-	// `internal/selfhost/generated.go`) and is sufficient to typecheck
-	// the toolchain during install-self. Once install-self completes
-	// the slot is cached, and post-bootstrap `osty build` invocations
-	// reuse it without re-entering this branch.
-	if stage0FallbackEnabled() {
+	// Two flavours of "LLVM path is unavailable, build the Go-side shell":
+	//
+	// 1. Stage0 source bootstrap (`OSTY_STAGE0_FALLBACK=1`): the user
+	//    explicitly opted into the install-self recovery path. No
+	//    `osty-self` exists yet — that's literally what install-self is
+	//    currently producing — so the LLVM path cannot run.
+	//
+	// 2. Recursion detour (`OSTY_BUILDING_NATIVE_CHECKER=1`): we are
+	//    the LLVM-build subprocess spawned by `buildNativeChecker`
+	//    itself, and now we need a checker to typecheck the checker's
+	//    own source. Spawning another LLVM-build subprocess would
+	//    loop forever. Build the Go-side shell into the managed slot
+	//    just long enough for our outer caller to read; that outer
+	//    caller (the original `osty check` / `osty build` that
+	//    triggered our existence) then overwrites the slot with the
+	//    LLVM artifact it produces from us, so the steady state remains
+	//    LLVM-built.
+	//
+	// Either flavour produces a Go-built shell that delegates straight
+	// to `internal/selfhost/generated.go` and has no `osty-self`
+	// dependency — sufficient to typecheck `toolchain/*.osty` and
+	// `cmd/osty-native-checker/main.osty` so the build can complete.
+	if stage0FallbackEnabled() || os.Getenv(RecursionGuardEnv) == "1" {
 		return buildNativeCheckerViaGo(root, dest)
 	}
 	if err := verifyOstySelfCached(root); err != nil {

--- a/internal/toolchain/native_checker_test.go
+++ b/internal/toolchain/native_checker_test.go
@@ -107,14 +107,59 @@ func TestInstallManagedBinaryReplacesExistingArtifactAfterRenameFailure(t *testi
 	}
 }
 
-func TestEnsureNativeCheckerReturnsRecursionGuardError(t *testing.T) {
+// TestBuildNativeCheckerRecursionGuardDetoursToGoBuild pins the
+// post-PR-1995 fix: when the LLVM build subprocess re-enters
+// `buildNativeChecker` (because it needs a checker to typecheck the
+// checker's own source), it MUST detour to the Go-build path instead
+// of erroring with a recursion-guard message. The previous behaviour
+// broke the first `osty check` / `osty build` after `osty install-self`
+// because the post-install invalidation hook (PR #1989) cleared the
+// managed slot, and the subsequent re-build hit the recursion guard
+// with no way to make progress.
+func TestBuildNativeCheckerRecursionGuardDetoursToGoBuild(t *testing.T) {
+	root := t.TempDir()
+	dest := filepath.Join(root, NativeCheckerBinaryName())
+
+	oldRepoRoot := sourceRepoRootFunc
+	oldVerify := verifyOstySelfCached
+	oldGoBuild := goBuildNativeChecker
+	t.Cleanup(func() {
+		sourceRepoRootFunc = oldRepoRoot
+		verifyOstySelfCached = oldVerify
+		goBuildNativeChecker = oldGoBuild
+	})
+
 	t.Setenv(RecursionGuardEnv, "1")
-	_, err := EnsureNativeChecker(".")
-	if err == nil {
-		t.Fatal("EnsureNativeChecker returned nil, want recursion guard error")
+	// Explicitly clear stage0 fallback so the recursion-guard branch
+	// is the one being exercised, not the stage0 branch.
+	t.Setenv(Stage0FallbackEnv, "")
+	sourceRepoRootFunc = func() (string, error) { return root, nil }
+	verifyCalls := 0
+	verifyOstySelfCached = func(string) error {
+		verifyCalls++
+		return errors.New("must not be called under recursion guard")
 	}
-	if !strings.Contains(err.Error(), RecursionGuardEnv) {
-		t.Fatalf("error %q does not mention %q", err, RecursionGuardEnv)
+	goBuildCalls := 0
+	goBuildNativeChecker = func(rootArg, outPath string) error {
+		goBuildCalls++
+		return os.WriteFile(outPath, []byte("recursion-guard go-built checker"), 0o755)
+	}
+
+	if err := buildNativeChecker(dest); err != nil {
+		t.Fatalf("buildNativeChecker under recursion guard: %v", err)
+	}
+	if verifyCalls != 0 {
+		t.Fatalf("verifyOstySelfCached called %d times under recursion guard, want 0", verifyCalls)
+	}
+	if goBuildCalls != 1 {
+		t.Fatalf("goBuildNativeChecker calls = %d, want 1", goBuildCalls)
+	}
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read managed dest: %v", err)
+	}
+	if string(body) != "recursion-guard go-built checker" {
+		t.Fatalf("managed dest body = %q, want recursion-guard go-built checker", body)
 	}
 }
 
@@ -203,6 +248,10 @@ func TestBuildNativeCheckerStage0FallbackDetoursToGoBuild(t *testing.T) {
 	})
 
 	t.Setenv(Stage0FallbackEnv, "1")
+	// Explicitly clear the recursion guard so the stage0 branch is
+	// the one being exercised (post-PR-1995 fix, both env vars
+	// independently trigger the Go-build path).
+	t.Setenv(RecursionGuardEnv, "")
 	sourceRepoRootFunc = func() (string, error) { return root, nil }
 	verifyCalls := 0
 	verifyOstySelfCached = func(string) error {
@@ -297,12 +346,14 @@ func TestBuildNativeCheckerFailsWhenOstySelfCacheMisses(t *testing.T) {
 		verifyOstySelfCached = oldVerify
 	})
 
-	// Explicitly clear the stage0 fallback gate — it would short-circuit
+	// Explicitly clear BOTH gates that would short-circuit
 	// `buildNativeChecker` to the Go-build path before the cache-miss
 	// check could fire, masking this regression test if the surrounding
 	// environment happened to leak `OSTY_STAGE0_FALLBACK=1` from an
-	// install-self invocation.
+	// install-self invocation OR `OSTY_BUILDING_NATIVE_CHECKER=1` from
+	// a nested subprocess.
 	t.Setenv(Stage0FallbackEnv, "")
+	t.Setenv(RecursionGuardEnv, "")
 	sourceRepoRootFunc = func() (string, error) { return root, nil }
 	verifyOstySelfCached = func(string) error {
 		return errors.New("osty-self not cached: run `osty install-self` first")


### PR DESCRIPTION
## Summary

Closes the **post-install-self** chicken-and-egg uncovered by PR #1995's CI gate.

### Symptom

After `osty install-self` succeeds (populating the cache and invalidating the managed Go-built checker slot per PR #1989), the first `osty check` / `osty build` triggers `EnsureNativeChecker` which spawns `osty build --backend llvm cmd/osty-native-checker/`. That subprocess needs to typecheck its own source, calls `EnsureNativeChecker` recursively, hits the recursion guard, and errors:

```
osty: check: managed native checker unavailable: build LLVM osty-native-checker: exit status 1
 (... type checking unavailable for package
  = note: managed native checker unavailable: managed osty-native-checker build re-entered EnsureNativeChecker via OSTY_BUILDING_NATIVE_CHECKER=1
   ...)
```

Result: every fresh-clone bootstrap left the user with a working `osty-self` but a broken native-checker rebuild path on the next command. Visible on PR #1995 CI gate logs.

### Fix

When `OSTY_BUILDING_NATIVE_CHECKER=1` is observed inside `buildNativeChecker`, detour to the Go-build path (same as the existing `OSTY_STAGE0_FALLBACK=1` fallback added by PR #1988). The Go-built shell has no `osty-self` dependency and doesn't spawn another `osty build`, so the recursion terminates cleanly. The outer caller (which is the original `osty build --backend llvm cmd/osty-native-checker/`) then overwrites the slot with the LLVM artifact it produces, so the steady-state remains LLVM-built.

Semantically identical to the stage0 fallback: the env var that triggers it is different, but the failure mode it addresses ("LLVM path needs something the LLVM path itself produces") is the same chicken-and-egg.

```go
if stage0FallbackEnabled() || os.Getenv(RecursionGuardEnv) == "1" {
    return buildNativeCheckerViaGo(root, dest)
}
```

## End-to-end verification

```sh
$ git clone -b claude/recursion-guard-go-build-detour .../osty && cd osty
$ go build -o .bin/osty ./cmd/osty
$ OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_STAGE0_FALLBACK=1 .bin/osty install-self
installed:   .osty/cache/self-host/<sha>-linux-amd64/osty-self

# This is the path that was broken; now it succeeds:
$ .bin/osty check examples/calc
# (exit 0, no output)
```

## Test plan

- [x] **Removed** `TestEnsureNativeCheckerReturnsRecursionGuardError` (asserted the now-deleted erroring behaviour).
- [x] **Added** `TestBuildNativeCheckerRecursionGuardDetoursToGoBuild` — pins that when `OSTY_BUILDING_NATIVE_CHECKER=1` is set, `verifyOstySelfCached` is NEVER called and `goBuildNativeChecker` IS called.
- [x] Existing `TestBuildNativeCheckerStage0FallbackDetoursToGoBuild` + `TestBuildNativeCheckerFailsWhenOstySelfCacheMisses` gained explicit `RecursionGuardEnv=""` clears so the new OR-branch can't mask either test under ambient env.
- [x] `go test ./internal/toolchain/...` — all pass.
- [x] Manual: fresh clone + `OSTY_STAGE0_FALLBACK=1 install-self` → subsequent `osty check examples/calc` exits 0 (was exit 1 before this PR).
- [ ] CI: this PR's own `Fresh clone → offline → stage0 source bootstrap` gate should now pass the previously-failing smoke-test step. After this merges, the gate also unblocks PR #1995 (which was held on the same failure).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFKqzJF66M3e7kuvXPP2BW)_