### PR TITLE
fix: complete flatMap end-to-end under OSTY_STDLIB_BODY_LOWER=1

### DIFF
--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -34,6 +34,22 @@ func run(stdin io.Reader, stdout io.Writer) error {
 	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
 		return fmt.Errorf("decode llvmgen request: %w", err)
 	}
+	// Install the managed-subprocess checker so the in-process
+	// `check.PackageGraph` call inside `preparePackageEntry` resolves
+	// against the same Osty-native checker the host uses. Without this
+	// the default factory returns `(nil, "no native checker
+	// installed")`, every check call returns an empty Result, and IR
+	// lowering falls back to AST-only inference — which can leave
+	// generic method calls like `xs.flatMap(|x| [x, x])` with a
+	// `List<R>` return whose `R` is still a TyVar, surfacing as `?`
+	// in the monomorph-mangled symbol and breaking clang.
+	//
+	// The host (`cmd/osty/main.go`) exports `OSTY_NATIVE_CHECKER_BIN`
+	// before invoking us so the env-override branch wins; we still
+	// install the managed-subprocess factory as a defensive fallback
+	// when the env var is unset (e.g. an integration test invoking
+	// this binary directly).
+	check.UseManagedSubprocessChecker(".")
 	if req.MIR != nil {
 		return runMIRRequest(req, stdout)
 	}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -68,6 +68,7 @@ import (
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/stdlib"
 	"github.com/osty/osty/internal/token"
+	"github.com/osty/osty/internal/toolchain"
 	"github.com/osty/osty/internal/types"
 	"golang.org/x/term"
 )
@@ -107,6 +108,21 @@ func main() {
 	// wins and the production factory lazily resolves the managed binary on
 	// the first check (cheap when none happens, e.g. for `osty fmt`).
 	check.UseManagedSubprocessChecker(".")
+
+	// Propagate the resolved checker path to subprocesses
+	// (`osty-native-llvmgen`, `osty-native-lirproto`) via
+	// `OSTY_NATIVE_CHECKER_BIN`. Without this the subprocesses run
+	// their own `toolchain.EnsureNativeChecker` starting from the
+	// emitted package's temp-dir, which has no managed-slot binary —
+	// the check phase returns empty, IR lowering loses generic type
+	// info, and monomorph mangles unresolved type vars as `?` (breaks
+	// clang on shapes like `xs.flatMap(|x| [x, x])`). Resolve eagerly
+	// here so child processes inherit a working override.
+	if os.Getenv("OSTY_NATIVE_CHECKER_BIN") == "" {
+		if path, err := toolchain.EnsureNativeChecker("."); err == nil && path != "" {
+			_ = os.Setenv("OSTY_NATIVE_CHECKER_BIN", path)
+		}
+	}
 
 	parsed := clicmd.ParseArgs(os.Args[1:])
 	if !parsed.IsOk() {

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -4327,7 +4327,7 @@ func (l *lowerer) backfillClosureArgsFromMethodCall(mc *MethodCall) {
 	// stdlib higher-order method table the closure backfill
 	// uses, so chained `map/filter/andThen/...` chains lower
 	// without their middle nodes being marked as ErrType.
-	if mc.T == nil || mc.T == ErrTypeVal || containsClosureResultSentinel(mc.T) {
+	if mc.T == nil || mc.T == ErrTypeVal || containsClosureResultSentinel(mc.T) || containsTypeVar(mc.T) || hasPoisonedTypeArg(mc.T) {
 		if recovered := recoverHigherOrderMethodReturnType(recvT, mc.Name, mc.Args); recovered != nil {
 			mc.T = recovered
 		}
@@ -4363,10 +4363,15 @@ func containsClosureResultSentinel(t Type) bool {
 	return false
 }
 
-// fillFlatMapTypeArgs sets `mc.TypeArgs = [T, R]` for a flatMap call
-// when the recovered return type carries a concrete element. Other
-// methods are intentionally left alone — broader fill triggers
-// monomorph regressions on scan/groupBy.
+// fillFlatMapTypeArgs sets `mc.TypeArgs = [R]` for a flatMap call when
+// the recovered return type carries a concrete element. The convention
+// at the MethodCall stage is method-local TypeArgs only —
+// `RewriteStdlibMethodCallsites` prepends the receiver's owner args
+// when it rewrites the call into the injected free-fn shape, so
+// duplicating the owner T here pushes the arity to 3 vs the free fn's
+// [T, R] generics list and the monomorph request bails. Other methods
+// are intentionally left alone — broader fill triggers monomorph
+// regressions on scan/groupBy.
 func fillFlatMapTypeArgs(mc *MethodCall, recvT Type) {
 	if mc == nil || mc.T == nil {
 		return
@@ -4399,7 +4404,7 @@ func fillFlatMapTypeArgs(mc *MethodCall, recvT Type) {
 			return
 		}
 	}
-	mc.TypeArgs = []Type{t, r}
+	mc.TypeArgs = []Type{r}
 }
 
 // recoverHigherOrderMethodReturnType derives the return type of
@@ -4619,12 +4624,14 @@ func flatMapElemFromArg(e Expr) Type {
 		}
 	}
 	// Closure body inference fallback: when the checker left the
-	// closure's recorded return type poisoned (`<error>`), walk the
-	// AST body of a closure literal and pull a recoverable list type
-	// from its tail expression.
-	if t == nil || t == ErrTypeVal {
+	// closure's recorded return type poisoned (`<error>`), or carrying
+	// a residual TyVar that the outer unification never resolved, walk
+	// the AST body of a closure literal and pull a recoverable list
+	// type from its tail expression.
+	tNeedsFallback := t == nil || t == ErrTypeVal || hasPoisonedTypeArg(t) || containsTypeVar(t)
+	if tNeedsFallback {
 		if cl, ok := e.(*Closure); ok && cl != nil && cl.Body != nil && cl.Body.Result != nil {
-			if bt := cl.Body.Result.Type(); bt != nil && bt != ErrTypeVal {
+			if bt := cl.Body.Result.Type(); bt != nil && bt != ErrTypeVal && !hasPoisonedTypeArg(bt) && !containsTypeVar(bt) {
 				t = bt
 			}
 		}
@@ -4633,7 +4640,7 @@ func flatMapElemFromArg(e Expr) Type {
 		return nil
 	}
 	if nt, ok := t.(*NamedType); ok && nt != nil && (nt.Name == "List" || nt.Name == "Iter") && len(nt.Args) >= 1 {
-		if r := nt.Args[0]; r != nil && r != ErrTypeVal && !hasPoisonedTypeArg(r) {
+		if r := nt.Args[0]; r != nil && r != ErrTypeVal && !hasPoisonedTypeArg(r) && !containsTypeVar(r) {
 			return r
 		}
 	}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -43327,13 +43327,23 @@ func elabInferList(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 	// Osty: /tmp/selfhost_merged.osty:20390:5
 	elemTy := outerElem
 	_ = elemTy
+	// Surgical hand-edit (CLAUDE.md LLVM self-host critical-path exception):
+	// equivalent to toolchain/elab.osty `outerElemIsVar` branch. When the
+	// expected element type is a bare TyVar (e.g. flatMap's `List<R>` with R
+	// unbound), the lone `tyIsBad` check below would fall into elabCheck
+	// against the TyVar, which never binds R from the literal — leaving the
+	// monomorph mangler with `?` for R. Routing the first elem through
+	// elabInfer instead refines elemTy to the concrete element type so the
+	// outer unify can bind R. See toolchain/elab.osty:elabInferList.
+	outerElemIsVar := func() bool { _, ok := tyKindAt(tys, outerElem).(*TyKind_TkVar); return ok }()
+	_ = outerElemIsVar
 	// Osty: /tmp/selfhost_merged.osty:20391:5
 	i := 0
 	_ = i
 	// Osty: /tmp/selfhost_merged.osty:20392:5
 	for _, elemIdx := range elemIdxs {
 		// Osty: /tmp/selfhost_merged.osty:20393:9
-		if tyIsBad(tys, elemTy) && i == 0 {
+		if (tyIsBad(tys, elemTy) || outerElemIsVar) && i == 0 {
 			// Osty: /tmp/selfhost_merged.osty:20395:13
 			r := elabInfer(cx, elemIdx)
 			_ = r

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -2839,9 +2839,10 @@ fn elabInferList(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     }
     let mut coreElems: List<Int> = []
     let mut elemTy = outerElem
+    let outerElemIsVar = tyKindAt(tys, outerElem) == TkVar
     let mut i = 0
     for elemIdx in elemIdxs {
-        if tyIsBad(tys, elemTy) && i == 0 {
+        if (tyIsBad(tys, elemTy) || outerElemIsVar) && i == 0 {
             let r = elabInfer(cx, elemIdx)
             elemTy = r.ty
             coreElems.push(r.node)


### PR DESCRIPTION
## Summary

flatMap was the last List combinator emitting a monomorph symbol with `?` placeholders (`_Z…flatMapIl?E…PFN4osty4ListI?EElE…`) because the checker left the closure's `List<R>` return with R unresolved and the IR-side recovery never refined the call's TypeArgs to concrete types. Three layers were touched to close the loop:

1. **Checker (toolchain/elab.osty + surgical edit in internal/selfhost/generated.go)** — `elabInferList` now routes the first element through `elabInfer` when the outer expected element type is a bare TyVar (e.g. `List<TyVar(R)>` from a flatMap fn-shape). The prior `tyIsBad`-only branch forced a spurious `elabCheck` against the TyVar, which `checkExpectAssignable` rejects and leaves R unbound. The surgical generated.go edit pairs with the toolchain change per CLAUDE.md's LLVM self-host critical-path exception (single-PR equivalence, ~14 LOC additive branch only — relates to **E0701 closure-body assignability against unbound generic returns**, on the LLVM self-host plan's PR3-C surface-recovery trajectory).

2. **IR recovery (internal/ir/lower.go)** — `backfillClosureArgsFromMethodCall` extends the higher-order-method return-type recovery to fire when `mc.T` still carries a TyVar or poisoned arg, not just `nil`/`ErrType`/sentinel. `flatMapElemFromArg`'s closure-body fallback gains the same broadened trigger. `fillFlatMapTypeArgs` now sets `mc.TypeArgs = [R]` (method-local only) to match `RewriteStdlibMethodCallsites`'s convention of prepending the receiver's owner args; the prior `[T, R]` shape pushed the arity to 3 vs the injected free fn's `[T, R]` generics list and the monomorph request bailed.

3. **Subprocess checker propagation (cmd/osty/main.go + cmd/osty-native-llvmgen/main.go)** — host exports the resolved `OSTY_NATIVE_CHECKER_BIN` after `UseManagedSubprocessChecker` resolves it, and the llvmgen subprocess installs the managed-subprocess checker as a defensive fallback. Without this the subprocess invoked from `tryExternalPackageLLVMArtifacts` ran `check.PackageGraph` with no checker installed, IR lowering fell back to AST-only inference, and monomorph never saw concrete R.

## Test plan

- [x] `osty build /tmp/smoke` with `OSTY_STDLIB_BODY_LOWER=1` on `[4,1,3,2].flatMap(\|x\| [x, x]).len()` builds cleanly and outputs `8`.
- [x] 14-combinator regression suite: map.fold=20 filter=2 reduce=10 first=4 last=2 enumerate=4 chunked=2 windowed=3 zip=3 sorted=4 take=2 scan=5 find=4 flatMap=8.
- [x] Works without `OSTY_STAGE0_FALLBACK` (external `osty-native-llvmgen` path).
- [ ] `groupBy` remains broken with a pre-existing LIR Proto `multiple definition of local value` bug — separate issue, not introduced by this PR.

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_