### PR TITLE
feat: wrap bare fn pointers as closure env when used as fn-typed values

### DIFF
--- a/.github/workflows/fresh-clone-source-bootstrap.yml
+++ b/.github/workflows/fresh-clone-source-bootstrap.yml
@@ -17,8 +17,10 @@
 # regression would have failed CI on the introducing PR — the
 # offline path is now a tracked, blocking signal.
 #
-# Cost target: ~5-10 minutes per run. Skipped on `[skip ci]` /
-# docs-only PRs (paths-filter below).
+# Cost target: ~5-10 minutes per run. Runs on every PR — no
+# paths filter is applied, because a "docs-only" PR can still
+# touch installer scripts or just-recipes that the bootstrap
+# walks, and the bootstrap is cheap enough to keep universal.
 
 name: Fresh-clone source bootstrap
 
@@ -79,7 +81,16 @@ jobs:
         # contributor. The PR's HEAD ref is what we want to exercise;
         # `${{ github.event.pull_request.head.sha }}` is empty on push
         # so fall back to `github.sha`.
+        #
+        # Fork PR handling: when a PR is opened from a fork, the
+        # head SHA points to a commit that exists only in the fork.
+        # Cloning the BASE repo and then `git checkout <fork-sha>`
+        # fails because the object isn't reachable. Fetching the
+        # GitHub-synthesized `refs/pull/<N>/head` ref makes the
+        # head commit available in the base clone, so the checkout
+        # works identically for same-repo and fork PRs.
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
           PUSH_SHA: ${{ github.sha }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
@@ -91,7 +102,13 @@ jobs:
           # Full clone (not --depth 1) so the SHA we want is reachable.
           git clone "$REPO_URL" osty
           cd osty
-          git checkout "$sha"
+          if [ -n "${PR_NUMBER:-}" ]; then
+            # Fetch the PR head ref so fork-PR commits become reachable.
+            git fetch origin "refs/pull/${PR_NUMBER}/head:pr-head"
+            git checkout "$sha"
+          else
+            git checkout "$sha"
+          fi
           git rev-parse HEAD
 
       - name: Offline source bootstrap (`OSTY_SELF_REGISTRY_OFFLINE=1 just bootstrap`)

--- a/cmd/osty/install_self.go
+++ b/cmd/osty/install_self.go
@@ -200,8 +200,18 @@ func runInstallSelf(args []string, _ cliFlags) {
 	// surface the failure as a warning, not a hard error, because the
 	// install itself succeeded.
 	if tookStage0Path {
-		if err := toolchain.InvalidateManagedNativeChecker(root); err != nil {
-			fmt.Fprintf(os.Stderr, "osty install-self: warning: failed to invalidate stage0 native checker slot (next build will keep the Go-built variant): %v\n", err)
+		// Sweep ALL version-stamped slots, not just the current
+		// process's. `--osty-bin <other-host>` runs install-self
+		// through a different binary whose toolchain version stamp
+		// resolves to a sibling `.osty/toolchain/<other-version>/`
+		// subdirectory. Pre-PR #1999 `InvalidateManagedNativeChecker`
+		// only cleared the current process's slot, so subsequent
+		// builds with the host that ran install-self stayed pinned to
+		// their own Go-built fallback. The broad sweep is safe
+		// because the install just produced a fresh osty-self, so
+		// any cached checker for any version is now obsolete.
+		if err := toolchain.InvalidateAllManagedNativeCheckers(root); err != nil {
+			fmt.Fprintf(os.Stderr, "osty install-self: warning: failed to invalidate stage0 native checker slot(s) (next build may keep the Go-built variant): %v\n", err)
 		}
 	}
 	fmt.Printf("installed:   %s\n", cachedPath)

--- a/cmd/osty/install_self.go
+++ b/cmd/osty/install_self.go
@@ -152,7 +152,23 @@ func runInstallSelf(args []string, _ cliFlags) {
 		// the forked `osty build` side now read a single source of
 		// truth.
 		if !stage0SourceBootstrapEnabled() {
-			fmt.Fprintln(os.Stderr, "osty install-self: no prebuilt osty-self and stage0 source bootstrap is disabled")
+			// Two code paths reach this branch with builtBin still
+			// empty: (a) prebuilt resolution failed (`resolveErr != nil`)
+			// and we never ran the selfhost rebuild; (b) `--force` was
+			// passed, prebuilt resolution succeeded, but the selfhost
+			// rebuild on lines 132-138 set `buildErr` and left builtBin
+			// empty. Surface the actual failure cause instead of always
+			// reporting "no prebuilt" — that wording misleads users
+			// debugging a force-rebuild failure into chasing registry
+			// problems they do not have.
+			switch {
+			case resolveErr == nil && buildErr != nil:
+				fmt.Fprintf(os.Stderr, "osty install-self: selfhost build failed and stage0 source bootstrap is disabled: %v\n", buildErr)
+			case resolveErr != nil:
+				fmt.Fprintln(os.Stderr, "osty install-self: no prebuilt osty-self and stage0 source bootstrap is disabled")
+			default:
+				fmt.Fprintln(os.Stderr, "osty install-self: unable to produce osty-self and stage0 source bootstrap is disabled")
+			}
 			printInstallSelfRegistryHint()
 			os.Exit(1)
 		}

--- a/cmd/osty/install_self_test.go
+++ b/cmd/osty/install_self_test.go
@@ -12,6 +12,35 @@ import (
 	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
 
+// installSelfTestEnv returns the parent environment with the
+// caller-listed keys stripped, plus the overrides appended. Use
+// instead of `append(os.Environ(), "KEY=VAL")` for subprocess
+// invocations that need to *override* env values: duplicate keys are
+// allowed in `os.Environ()` form and child `getenv` typically returns
+// the FIRST match, so an unfiltered append silently loses the
+// override when the parent shell already exported the same key. Tests
+// that depend on `OSTY_STAGE0_FALLBACK` / `OSTY_SELF_BIN` semantics
+// MUST go through this helper so the harness is hermetic across the
+// dev shells engineers actually run them in.
+func installSelfTestEnv(t *testing.T, overrides ...string) []string {
+	t.Helper()
+	strip := map[string]bool{}
+	for _, kv := range overrides {
+		if eq := strings.IndexByte(kv, '='); eq > 0 {
+			strip[kv[:eq]] = true
+		}
+	}
+	parent := os.Environ()
+	out := make([]string, 0, len(parent)+len(overrides))
+	for _, kv := range parent {
+		if eq := strings.IndexByte(kv, '='); eq > 0 && strip[kv[:eq]] {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, overrides...)
+}
+
 // TestInstallSelfUsageMessage exercises the helper that some future
 // help-text generator will consult. Cheap correctness check that the
 // usage string mentions the canonical flags.
@@ -325,7 +354,7 @@ func main() { os.Exit(1) }
 	cmd.Dir = root
 	// Opt into stage0 source bootstrap so the run actually reaches
 	// buildOstySelf and fails inside it — the path this test covers.
-	cmd.Env = append(os.Environ(),
+	cmd.Env = installSelfTestEnv(t,
 		"OSTY_SELF_REGISTRY_OFFLINE=1",
 		"OSTY_STAGE0_FALLBACK=1",
 	)
@@ -372,7 +401,7 @@ func TestRunInstallSelfWithoutStage0FallbackErrorsCleanly(t *testing.T) {
 
 	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", hostBin)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(),
+	cmd.Env = installSelfTestEnv(t,
 		"OSTY_SELF_REGISTRY_OFFLINE=1",
 		"OSTY_STAGE0_FALLBACK=",
 		"OSTY_SELF_BIN=",
@@ -424,7 +453,7 @@ func TestRunInstallSelfStage0FallbackAttemptsSourceBootstrap(t *testing.T) {
 
 	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", hostBin)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(),
+	cmd.Env = installSelfTestEnv(t,
 		"OSTY_STAGE0_FALLBACK=1",
 		"OSTY_SELF_REGISTRY_OFFLINE=1",
 	)
@@ -484,7 +513,7 @@ func TestRunInstallSelfStage0FallbackInvalidatesNativeCheckerSlot(t *testing.T) 
 
 	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", hostBin)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(),
+	cmd.Env = installSelfTestEnv(t,
 		"OSTY_STAGE0_FALLBACK=1",
 		"OSTY_SELF_REGISTRY_OFFLINE=1",
 	)
@@ -535,7 +564,7 @@ func TestRunInstallSelfWithResolvedSelfDoesNotInvalidateNativeCheckerSlot(t *tes
 
 	cmd := exec.Command(ostyBin, "install-self")
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(),
+	cmd.Env = installSelfTestEnv(t,
 		"OSTY_SELF_BIN="+prebuilt,
 		"OSTY_SELF_REGISTRY_OFFLINE=1",
 		"OSTY_STAGE0_FALLBACK=",
@@ -572,7 +601,7 @@ func TestRunInstallSelfForceUsesResolvedSelfhostWithoutStage0Fallback(t *testing
 
 	cmd := exec.Command(ostyBin, "install-self", "--force", "--osty-bin", hostBin)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(),
+	cmd.Env = installSelfTestEnv(t,
 		"OSTY_SELF_BIN="+selfBin,
 		"OSTY_STAGE0_FALLBACK=",
 		"OSTY_STAGE0_LIST_ALL_DECLINES=",
@@ -636,7 +665,7 @@ func TestRunInstallSelfForceUsesStaleLocalSelfhostWithoutStage0Fallback(t *testi
 
 	cmd := exec.Command(ostyBin, "install-self", "--force", "--osty-bin", hostBin)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(),
+	cmd.Env = installSelfTestEnv(t,
 		"OSTY_STAGE0_FALLBACK=",
 		"OSTY_STAGE0_LIST_ALL_DECLINES=",
 		"OSTY_SELF_BIN=",

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -109,24 +109,12 @@ func main() {
 	// the first check (cheap when none happens, e.g. for `osty fmt`).
 	check.UseManagedSubprocessChecker(".")
 
-	// Propagate the resolved checker path to subprocesses
-	// (`osty-native-llvmgen`, `osty-native-lirproto`) via
-	// `OSTY_NATIVE_CHECKER_BIN`. Without this the subprocesses run
-	// their own `toolchain.EnsureNativeChecker` starting from the
-	// emitted package's temp-dir, which has no managed-slot binary —
-	// the check phase returns empty, IR lowering loses generic type
-	// info, and monomorph mangles unresolved type vars as `?` (breaks
-	// clang on shapes like `xs.flatMap(|x| [x, x])`).
-	//
-	// Probe-only: read the managed slot if it already exists, but
-	// never trigger a build here. Pre-PR #1999 this called
-	// `EnsureNativeChecker(".")` unconditionally, which fired
-	// `installNativeChecker` (a full LLVM build of the checker) the
-	// first time any user ran `osty fmt` / `osty --help` / etc. —
-	// commands that have no business waiting on a checker build. Now
-	// cold-cache cheap commands stay cheap; the codegen subprocess
-	// path still builds-on-demand inside its own `EnsureNativeChecker`
-	// call when it actually needs the checker.
+	// Probe (cheap) the managed checker slot first and propagate via
+	// `OSTY_NATIVE_CHECKER_BIN` if already cached. If empty, defer the
+	// decision until after subcommand parsing — only commands that
+	// actually need the checker (build / check / run) should pay for
+	// `EnsureNativeChecker`. Commands like `osty fmt` / `osty --help`
+	// stay cheap on cold caches.
 	if os.Getenv("OSTY_NATIVE_CHECKER_BIN") == "" {
 		if path := toolchain.ProbeManagedNativeChecker("."); path != "" {
 			_ = os.Setenv("OSTY_NATIVE_CHECKER_BIN", path)
@@ -145,6 +133,26 @@ func main() {
 	flags := convertFlags(parsed.Flags)
 	cmd := parsed.Name
 	args := append([]string{cmd}, parsed.RawRest...)
+	// Eager-build the managed checker for subcommands that will spawn
+	// codegen subprocesses (`osty-native-llvmgen`, `osty-native-lirproto`)
+	// so child processes inherit a working `OSTY_NATIVE_CHECKER_BIN`
+	// override. Without this, the subprocesses each run their own
+	// `EnsureNativeChecker` from a temp dir, which has no managed slot
+	// — the check phase returns empty, IR lowering loses generic type
+	// info, and monomorph mangles unresolved type vars as `?` (breaks
+	// clang on shapes like `xs.flatMap(|x| [x, x])`).
+	//
+	// Restricted to commands that actually drive codegen — `fmt`,
+	// `--help`, `install-self`, etc. don't spawn the codegen
+	// subprocess chain and so don't need the eager build. The probe-
+	// only path above (line 116-122) already propagates the env when
+	// the slot is already populated, so this only fires on cold cache
+	// for the codegen-driving subcommands.
+	if os.Getenv("OSTY_NATIVE_CHECKER_BIN") == "" && commandSpawnsCodegenSubprocesses(cmd) {
+		if path, err := toolchain.EnsureNativeChecker("."); err == nil && path != "" {
+			_ = os.Setenv("OSTY_NATIVE_CHECKER_BIN", path)
+		}
+	}
 	// fmt has its own flag parser because --check/--write only make
 	// sense in that subcommand. Most front-end subcommands take exactly
 	// one file path as their second positional arg.
@@ -1266,6 +1274,30 @@ func printScopeNode(s *resolve.Scope, depth int) {
 	for _, child := range s.Children() {
 		printScopeNode(child, depth+1)
 	}
+}
+
+// commandSpawnsCodegenSubprocesses reports whether the subcommand
+// will fork `osty-native-llvmgen` or `osty-native-lirproto` during
+// its execution. These subprocesses each need a managed native
+// checker for typechecking the package they emit; without an
+// inherited `OSTY_NATIVE_CHECKER_BIN`, each one re-enters
+// `EnsureNativeChecker` from its own temp dir, walks up to find
+// the project root, and either spawns the LLVM build subprocess
+// (slow) or relies on the recursion-guard Go shell (correctness-
+// degraded). Eager-resolving from the outer process amortises the
+// build into one place and propagates the env down to every child.
+//
+// Subcommands that don't spawn codegen (`osty fmt`, `osty --help`,
+// `osty install-self`, etc.) skip the eager resolve so cold-cache
+// invocations stay cheap. The probe-only path at the top of `main`
+// still propagates the env when the slot is already populated, so
+// repeat invocations of cheap commands never trigger a build.
+func commandSpawnsCodegenSubprocesses(cmd string) bool {
+	switch cmd {
+	case "build", "check", "typecheck", "run", "gen", "test", "bench":
+		return true
+	}
+	return false
 }
 
 func usage() {

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -116,10 +116,19 @@ func main() {
 	// emitted package's temp-dir, which has no managed-slot binary —
 	// the check phase returns empty, IR lowering loses generic type
 	// info, and monomorph mangles unresolved type vars as `?` (breaks
-	// clang on shapes like `xs.flatMap(|x| [x, x])`). Resolve eagerly
-	// here so child processes inherit a working override.
+	// clang on shapes like `xs.flatMap(|x| [x, x])`).
+	//
+	// Probe-only: read the managed slot if it already exists, but
+	// never trigger a build here. Pre-PR #1999 this called
+	// `EnsureNativeChecker(".")` unconditionally, which fired
+	// `installNativeChecker` (a full LLVM build of the checker) the
+	// first time any user ran `osty fmt` / `osty --help` / etc. —
+	// commands that have no business waiting on a checker build. Now
+	// cold-cache cheap commands stay cheap; the codegen subprocess
+	// path still builds-on-demand inside its own `EnsureNativeChecker`
+	// call when it actually needs the checker.
 	if os.Getenv("OSTY_NATIVE_CHECKER_BIN") == "" {
-		if path, err := toolchain.EnsureNativeChecker("."); err == nil && path != "" {
+		if path := toolchain.ProbeManagedNativeChecker("."); path != "" {
 			_ = os.Setenv("OSTY_NATIVE_CHECKER_BIN", path)
 		}
 	}

--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -24,9 +24,14 @@ var ErrMIRCoverageIncomplete = errors.New("backend: MIR coverage incomplete")
 //
 // Default: ON. The pipeline reached PR3-C steady state in PR #1997
 // (flatMap end-to-end), so the rollout gate is flipped — bodied
-// stdlib methods (`xs.map(...)`, `xs.flatMap(...)`, etc.) now monomorphize
-// out of `toolchain/`-authored sources in the default build instead of
-// falling through to a runtime intrinsic that does not exist.
+// stdlib methods now monomorphize out of `toolchain/`-authored
+// sources in the default build. Most common combinators
+// (`map`, `filter`, `len`) already had `osty_rt_list_*` runtime
+// intrinsics covering them in OFF mode; the ones that did NOT and
+// would fall through with "no such symbol" at link time
+// (`flatMap`, `scan`, `chunked`, `windowed`, `zip`, …) are what
+// gated this flip. With injection ON those bodies are emitted out
+// of `internal/stdlib/modules/collections.osty`.
 //
 // Escape hatch: `OSTY_STDLIB_BODY_LOWER=0` (or `off` / `false`) still
 // disables injection so regression bisection and the install-self

--- a/internal/backend/entry_inject_test.go
+++ b/internal/backend/entry_inject_test.go
@@ -37,7 +37,20 @@ func TestStdlibBodyLoweringEnabledDefaultOn(t *testing.T) {
 	// this test in a shell that exports `OSTY_STDLIB_BODY_LOWER=0`
 	// would make it fail, which is the correct behavior — "default"
 	// means unset.
+	//
+	// Save/restore the env so any caller that exports the flag (e.g.
+	// a developer running `go test` from a shell with the escape
+	// hatch set) sees their environment intact after this test; the
+	// pre-PR #1999 form dropped the value for the rest of the run.
+	prev, hadPrev := os.LookupEnv("OSTY_STDLIB_BODY_LOWER")
 	os.Unsetenv("OSTY_STDLIB_BODY_LOWER")
+	t.Cleanup(func() {
+		if hadPrev {
+			os.Setenv("OSTY_STDLIB_BODY_LOWER", prev)
+		} else {
+			os.Unsetenv("OSTY_STDLIB_BODY_LOWER")
+		}
+	})
 	if !stdlibBodyLoweringEnabled() {
 		t.Fatalf("unset env yields disabled, want enabled default (post-flip)")
 	}

--- a/internal/backend/stdlib_type_inject.go
+++ b/internal/backend/stdlib_type_inject.go
@@ -716,7 +716,12 @@ func keepBodiedMethods(methods []*ir.FnDecl) []*ir.FnDecl {
 	if len(methods) == 0 {
 		return methods
 	}
-	out := methods[:0]
+	// Allocate a fresh slice instead of compacting in place with
+	// `methods[:0]` so the filtered-out method decls are not held
+	// alive by the backing array, and so callers that retain a
+	// reference to `methods` (or reslice it later) cannot see the
+	// stripped entries reappear past `len(out)` via reslicing.
+	out := make([]*ir.FnDecl, 0, len(methods))
 	for _, m := range methods {
 		if m == nil {
 			continue

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -4611,6 +4611,12 @@ func recoverListHigherOrderReturn(listName string, elem Type, method string, arg
 
 // flatMapElemFromArg extracts the element type R of `List<R>` from a
 // `flatMap` argument's closure or named-fn return.
+//
+// Accepts only `List<R>` returns. `List<T>.flatMap` is declared as
+// `fn(T) -> List<R>`; an `Iter<R>` return would not type-check
+// against that signature, and silently re-typing a poisoned `Iter`
+// closure as if it were `List` would feed an invalid R into
+// monomorph and mask the underlying checker mismatch.
 func flatMapElemFromArg(e Expr) Type {
 	if e == nil {
 		return nil
@@ -4639,7 +4645,7 @@ func flatMapElemFromArg(e Expr) Type {
 	if t == nil {
 		return nil
 	}
-	if nt, ok := t.(*NamedType); ok && nt != nil && (nt.Name == "List" || nt.Name == "Iter") && len(nt.Args) >= 1 {
+	if nt, ok := t.(*NamedType); ok && nt != nil && nt.Name == "List" && len(nt.Args) >= 1 {
 		if r := nt.Args[0]; r != nil && r != ErrTypeVal && !hasPoisonedTypeArg(r) && !containsTypeVar(r) {
 			return r
 		}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2,6 +2,7 @@ package mir
 
 import (
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"strconv"
@@ -170,15 +171,9 @@ func (l *lowerer) collectTupleLayouts() {
 	if l.out == nil || l.out.Layouts == nil {
 		return
 	}
+	seen := map[string]bool{}
 	var visit func(t Type)
-	visit = func(t Type) {
-		tt, ok := t.(*ir.TupleType)
-		if !ok || tt == nil {
-			return
-		}
-		for _, e := range tt.Elems {
-			visit(e)
-		}
+	registerTuple := func(tt *ir.TupleType) {
 		key := tt.String()
 		if key == "" {
 			return
@@ -196,6 +191,50 @@ func (l *lowerer) collectTupleLayouts() {
 		}
 		l.out.Layouts.Tuples[key] = tl
 	}
+	visit = func(t Type) {
+		if t == nil {
+			return
+		}
+		// `seen` guards against unbounded recursion through self-
+		// referential types (e.g. linked-list `Cons<T>`) and avoids
+		// repeated work on shapes that appear in many locals.
+		key := t.String()
+		if key != "" {
+			if seen[key] {
+				return
+			}
+			seen[key] = true
+		}
+		switch tt := t.(type) {
+		case *ir.TupleType:
+			if tt != nil {
+				for _, e := range tt.Elems {
+					visit(e)
+				}
+				registerTuple(tt)
+			}
+		case *ir.NamedType:
+			// `List<(Int, Int)>`, `Option<(A, B)>`, `Map<K, (A, B)>`
+			// etc. carry tuples in their args. The reviewer concern
+			// (PR #1982 P1) was that a top-level-only check left
+			// these unregistered and LIR Proto then rejected the
+			// tuple aggregate at the use site.
+			if tt != nil {
+				for _, a := range tt.Args {
+					visit(a)
+				}
+			}
+		case *ir.FnType:
+			// Function signatures can also surface tuples in params
+			// or return types (e.g. `fn(Int) -> (A, B)`).
+			if tt != nil {
+				for _, p := range tt.Params {
+					visit(p)
+				}
+				visit(tt.Return)
+			}
+		}
+	}
 	for _, fn := range l.out.Functions {
 		if fn == nil {
 			continue
@@ -211,9 +250,22 @@ func (l *lowerer) collectTupleLayouts() {
 // LLVM `%name` identifier rejects, so each element's type string is
 // sanitized to `[A-Za-z0-9_]` and joined under a `Tuple.` prefix —
 // e.g. `(Int, Int)` → `Tuple.Int.Int`.
+//
+// Suffix-disambiguator: a pure sanitize-and-join is lossy
+// (`pkg.B` and `pkg_B` collapse to the same `pkg_B`), and
+// `lirModuleDeclareTypeDef` deduplicates typedefs by name — without
+// disambiguation a second tuple layout sharing the sanitized name
+// would silently bind to the wrong aggregate shape. A 64-bit FNV
+// hash of the canonical type-string key (paren/space/etc all
+// preserved) appended as a `_X<16hex>` suffix makes the mapping
+// injective while keeping the human-readable prefix.
 func mangleTupleName(tt *ir.TupleType) string {
 	var b strings.Builder
 	b.WriteString("Tuple")
+	key := ""
+	if tt != nil {
+		key = tt.String()
+	}
 	for _, e := range tt.Elems {
 		b.WriteByte('.')
 		s := "Unit"
@@ -229,6 +281,9 @@ func mangleTupleName(tt *ir.TupleType) string {
 			}
 		}
 	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	fmt.Fprintf(&b, "_X%016x", h.Sum64())
 	return b.String()
 }
 

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -35,10 +35,12 @@ pub struct List<T> {
     }
     pub fn indexOf(self, item: T) -> Int?
     pub fn find(self, pred: fn(T) -> Bool) -> T? {
+        let n = self.len()
         let mut i = 0
-        for i < self.len() {
-            if pred(self[i]) {
-                return Some(self[i])
+        for i < n {
+            let item = self[i]
+            if pred(item) {
+                return Some(item)
             }
             i = i + 1
         }
@@ -247,9 +249,10 @@ pub struct List<T> {
         if self.isEmpty() {
             return None
         }
+        let n = self.len()
         let mut acc = self[0]
         let mut i = 1
-        for i < self.len() {
+        for i < n {
             acc = f(acc, self[i])
             i = i + 1
         }
@@ -277,11 +280,13 @@ pub struct List<T> {
     /// sub-lists.
     pub fn flatMap<R>(self, f: fn(T) -> List<R>) -> List<R> {
         let mut out: List<R> = []
+        let n = self.len()
         let mut i = 0
-        for i < self.len() {
+        for i < n {
             let inner = f(self[i])
+            let m = inner.len()
             let mut j = 0
-            for j < inner.len() {
+            for j < m {
                 out.push(inner[j])
                 j = j + 1
             }

--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -121,25 +121,6 @@ func ManagedNativeCheckerPath(projectRoot string) string {
 	return filepath.Join(projectRoot, toolchainDirName, Version(), NativeCheckerBinaryName())
 }
 
-// recursionFallbackCheckerPath returns the slot the recursion-guard
-// detour writes its Go-built shell to during a nested
-// `osty build --backend llvm cmd/osty-native-checker/` invocation.
-//
-// The recursion case (`OSTY_BUILDING_NATIVE_CHECKER=1`) needs a
-// checker so the subprocess's own frontend can typecheck the checker
-// source — but writing the Go shell to the canonical managed slot
-// makes it persist past the subprocess: if the outer LLVM build
-// fails, the next `EnsureNativeChecker` call finds the cached Go
-// shell, short-circuits on `fileExists(path)`, and silently downgrades
-// the production checker to the Go fallback. Routing the fallback to
-// a sibling path keeps the canonical slot empty until a real LLVM
-// build promotes its artifact there, so failed LLVM builds surface
-// as the expected "managed slot still empty → retry the build"
-// behavior on the next call instead of an undetectable downgrade.
-func recursionFallbackCheckerPath(projectRoot string) string {
-	return filepath.Join(projectRoot, toolchainDirName, Version(), NativeCheckerBinaryName()+".recursion-fallback")
-}
-
 // InvalidateManagedNativeChecker deletes the cached managed checker
 // artifact (if present) so the next `EnsureNativeChecker` call rebuilds
 // it from scratch. Used by `osty install-self` to retire a Go-built
@@ -158,53 +139,6 @@ func InvalidateManagedNativeChecker(projectRoot string) error {
 		return fmt.Errorf("invalidate managed native checker %s: %w", path, err)
 	}
 	return nil
-}
-
-// InvalidateAllManagedNativeCheckers removes every cached
-// native-checker artifact under `<projectRoot>/<toolchainDirName>/*/`.
-// Use after `install-self` produces a new `osty-self` so that any
-// `--osty-bin <other-host>` invocation (which pins a different
-// toolchain version stamp under a sibling subdirectory) also picks
-// up the LLVM-built variant on its next build, rather than continuing
-// to serve a stale Go-built fallback from its own slot.
-//
-// `InvalidateManagedNativeChecker(projectRoot)` only touches the
-// current process's `Version()` slot — sufficient when the install
-// runs from the same host that subsequent builds use, but pre-PR
-// #1999 it silently left a stale fallback in any other version slot
-// the project had accumulated (typical when devs switch between two
-// `osty` builds during bootstrap iteration).
-//
-// Best-effort: a missing tree returns nil; per-entry remove errors
-// are collected into a joined error so the caller can warn but the
-// loop processes every slot.
-func InvalidateAllManagedNativeCheckers(projectRoot string) error {
-	toolchainDir := filepath.Join(projectRoot, toolchainDirName)
-	entries, err := os.ReadDir(toolchainDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("scan managed toolchain dir %s: %w", toolchainDir, err)
-	}
-	var errs []error
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		slot := filepath.Join(toolchainDir, e.Name(), NativeCheckerBinaryName())
-		if err := os.Remove(slot); err != nil && !os.IsNotExist(err) {
-			errs = append(errs, fmt.Errorf("invalidate %s: %w", slot, err))
-		}
-		// Also clear the recursion-fallback slot — if a previous
-		// build crashed mid-way, the fallback could persist and
-		// the next subprocess would prefer it over rebuilding.
-		fallback := filepath.Join(toolchainDir, e.Name(), NativeCheckerBinaryName()+".recursion-fallback")
-		if err := os.Remove(fallback); err != nil && !os.IsNotExist(err) {
-			errs = append(errs, fmt.Errorf("invalidate %s: %w", fallback, err))
-		}
-	}
-	return errors.Join(errs...)
 }
 
 // ManagedNativeCheckerLLVMPath returns the conventional location
@@ -284,18 +218,6 @@ func EnsureNativeChecker(start string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// Recursion-guard detour: when we are the LLVM-build subprocess
-	// spawned by an outer EnsureNativeChecker, prefer the sibling
-	// "recursion-fallback" slot the subprocess wrote into. This keeps
-	// the canonical managed slot untouched until the outer LLVM build
-	// produces a real artifact, so a failed LLVM build does not leak
-	// the Go shell into the persistent cache.
-	if os.Getenv(RecursionGuardEnv) == "1" {
-		fallback := recursionFallbackCheckerPath(root)
-		if fileExists(fallback) {
-			return fallback, nil
-		}
-	}
 	path := ManagedNativeCheckerPath(root)
 	if fileExists(path) {
 		return path, nil
@@ -304,11 +226,6 @@ func EnsureNativeChecker(start string) (string, error) {
 	nativeCheckerBuildMu.Lock()
 	defer nativeCheckerBuildMu.Unlock()
 
-	if os.Getenv(RecursionGuardEnv) == "1" {
-		if fallback := recursionFallbackCheckerPath(root); fileExists(fallback) {
-			return fallback, nil
-		}
-	}
 	if fileExists(path) {
 		return path, nil
 	}
@@ -317,14 +234,6 @@ func EnsureNativeChecker(start string) (string, error) {
 	}
 	if err := installNativeChecker(path); err != nil {
 		return "", err
-	}
-	if os.Getenv(RecursionGuardEnv) == "1" {
-		// In the recursion case installNativeChecker wrote the Go
-		// shell to the recursion-fallback slot, not `path`. Return
-		// that slot so the caller's frontend has a usable checker.
-		if fallback := recursionFallbackCheckerPath(root); fileExists(fallback) {
-			return fallback, nil
-		}
 	}
 	return path, nil
 }
@@ -340,10 +249,10 @@ func defaultManagedProjectRoot(start string) (string, error) {
 	return root, nil
 }
 
-// ProbeManagedNativeChecker returns the path of the managed
-// native-checker artifact if it already exists, or empty if none is
-// cached. Probe-only: does NOT trigger a build. Use this from CLI
-// entry points that need to propagate `OSTY_NATIVE_CHECKER_BIN` to
+// ProbeManagedNativeChecker returns the managed native-checker path
+// if it already exists, or "" if no build has populated the slot yet.
+// Probe-only: does NOT trigger a build. Use this from CLI entry
+// points that need to propagate `OSTY_NATIVE_CHECKER_BIN` to
 // subprocesses without paying for an LLVM build on cold caches —
 // `EnsureNativeChecker` fires the full build path and is wrong for
 // cheap commands like `osty fmt` / `osty --help`.
@@ -360,6 +269,46 @@ func ProbeManagedNativeChecker(start string) string {
 		return ""
 	}
 	return path
+}
+
+// InvalidateAllManagedNativeCheckers removes every cached
+// native-checker artifact under `<projectRoot>/<toolchainDirName>/*/`.
+// Use after `install-self` produces a new `osty-self` so that any
+// `--osty-bin <other-host>` invocation (which pins a different
+// toolchain version stamp under a sibling subdirectory) also picks
+// up the LLVM-built variant on its next build, rather than continuing
+// to serve a stale Go-built fallback from its own slot.
+//
+// `InvalidateManagedNativeChecker(projectRoot)` only touches the
+// current process's `Version()` slot — sufficient when the install
+// runs from the same host that subsequent builds use, but pre-PR
+// #1999 it silently left a stale fallback in any other version slot
+// the project had accumulated (typical when devs switch between two
+// `osty` builds during bootstrap iteration).
+//
+// Best-effort: a missing tree returns nil; per-entry remove errors
+// are collected into a joined error so the caller can warn but the
+// loop processes every slot.
+func InvalidateAllManagedNativeCheckers(projectRoot string) error {
+	toolchainDir := filepath.Join(projectRoot, toolchainDirName)
+	entries, err := os.ReadDir(toolchainDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("scan managed toolchain dir %s: %w", toolchainDir, err)
+	}
+	var errs []error
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		slot := filepath.Join(toolchainDir, e.Name(), NativeCheckerBinaryName())
+		if err := os.Remove(slot); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("invalidate %s: %w", slot, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func defaultSourceRepoRoot() (string, error) {
@@ -428,37 +377,7 @@ func buildNativeChecker(dest string) error {
 	// to `internal/selfhost/generated.go` and has no `osty-self`
 	// dependency — sufficient to typecheck `toolchain/*.osty` and
 	// `cmd/osty-native-checker/main.osty` so the build can complete.
-	if stage0FallbackEnabled() {
-		// Stage0 opt-in: caller explicitly wants the Go shell in the
-		// production slot for the duration of the install-self
-		// bootstrap. The install-self flow invalidates the slot via
-		// `InvalidateManagedNativeChecker` once `osty-self` becomes
-		// resolvable, so this Go shell is intentionally transient.
-		return buildNativeCheckerViaGo(root, dest)
-	}
-	if os.Getenv(RecursionGuardEnv) == "1" {
-		// Recursion detour: route the Go shell to a sibling
-		// "recursion-fallback" slot instead of the canonical managed
-		// slot. The outer LLVM build that spawned us has not finished
-		// yet — if it later fails, the Go shell here would otherwise
-		// remain in the canonical slot and silently downgrade every
-		// subsequent `osty check`/`osty build` to the Go fallback,
-		// hiding the LLVM build failure. The fallback slot is only
-		// visible to subprocesses running under `RecursionGuardEnv`
-		// (see `EnsureNativeChecker`); outside the recursion the
-		// canonical slot stays empty until a real LLVM artifact is
-		// promoted into it.
-		mgrRoot, err := managedProjectRootFunc(".")
-		if err == nil {
-			fallback := recursionFallbackCheckerPath(mgrRoot)
-			if dirErr := os.MkdirAll(filepath.Dir(fallback), 0o755); dirErr == nil {
-				return buildNativeCheckerViaGo(root, fallback)
-			}
-		}
-		// On the rare path where we can't compute the managed root,
-		// fall back to the original behavior — the recursion guard
-		// still prevents an infinite loop, and the failure mode is
-		// the pre-fix one rather than a worse mis-resolution.
+	if stage0FallbackEnabled() || os.Getenv(RecursionGuardEnv) == "1" {
 		return buildNativeCheckerViaGo(root, dest)
 	}
 	if err := verifyOstySelfCached(root); err != nil {

--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -121,6 +121,25 @@ func ManagedNativeCheckerPath(projectRoot string) string {
 	return filepath.Join(projectRoot, toolchainDirName, Version(), NativeCheckerBinaryName())
 }
 
+// recursionFallbackCheckerPath returns the slot the recursion-guard
+// detour writes its Go-built shell to during a nested
+// `osty build --backend llvm cmd/osty-native-checker/` invocation.
+//
+// The recursion case (`OSTY_BUILDING_NATIVE_CHECKER=1`) needs a
+// checker so the subprocess's own frontend can typecheck the checker
+// source — but writing the Go shell to the canonical managed slot
+// makes it persist past the subprocess: if the outer LLVM build
+// fails, the next `EnsureNativeChecker` call finds the cached Go
+// shell, short-circuits on `fileExists(path)`, and silently downgrades
+// the production checker to the Go fallback. Routing the fallback to
+// a sibling path keeps the canonical slot empty until a real LLVM
+// build promotes its artifact there, so failed LLVM builds surface
+// as the expected "managed slot still empty → retry the build"
+// behavior on the next call instead of an undetectable downgrade.
+func recursionFallbackCheckerPath(projectRoot string) string {
+	return filepath.Join(projectRoot, toolchainDirName, Version(), NativeCheckerBinaryName()+".recursion-fallback")
+}
+
 // InvalidateManagedNativeChecker deletes the cached managed checker
 // artifact (if present) so the next `EnsureNativeChecker` call rebuilds
 // it from scratch. Used by `osty install-self` to retire a Go-built
@@ -218,6 +237,18 @@ func EnsureNativeChecker(start string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Recursion-guard detour: when we are the LLVM-build subprocess
+	// spawned by an outer EnsureNativeChecker, prefer the sibling
+	// "recursion-fallback" slot the subprocess wrote into. This keeps
+	// the canonical managed slot untouched until the outer LLVM build
+	// produces a real artifact, so a failed LLVM build does not leak
+	// the Go shell into the persistent cache.
+	if os.Getenv(RecursionGuardEnv) == "1" {
+		fallback := recursionFallbackCheckerPath(root)
+		if fileExists(fallback) {
+			return fallback, nil
+		}
+	}
 	path := ManagedNativeCheckerPath(root)
 	if fileExists(path) {
 		return path, nil
@@ -226,6 +257,11 @@ func EnsureNativeChecker(start string) (string, error) {
 	nativeCheckerBuildMu.Lock()
 	defer nativeCheckerBuildMu.Unlock()
 
+	if os.Getenv(RecursionGuardEnv) == "1" {
+		if fallback := recursionFallbackCheckerPath(root); fileExists(fallback) {
+			return fallback, nil
+		}
+	}
 	if fileExists(path) {
 		return path, nil
 	}
@@ -234,6 +270,14 @@ func EnsureNativeChecker(start string) (string, error) {
 	}
 	if err := installNativeChecker(path); err != nil {
 		return "", err
+	}
+	if os.Getenv(RecursionGuardEnv) == "1" {
+		// In the recursion case installNativeChecker wrote the Go
+		// shell to the recursion-fallback slot, not `path`. Return
+		// that slot so the caller's frontend has a usable checker.
+		if fallback := recursionFallbackCheckerPath(root); fileExists(fallback) {
+			return fallback, nil
+		}
 	}
 	return path, nil
 }
@@ -247,6 +291,28 @@ func defaultManagedProjectRoot(start string) (string, error) {
 		return "", fmt.Errorf("resolve managed toolchain root: %w", err)
 	}
 	return root, nil
+}
+
+// ProbeManagedNativeChecker returns the path of the managed
+// native-checker artifact if it already exists, or empty if none is
+// cached. Probe-only: does NOT trigger a build. Use this from CLI
+// entry points that need to propagate `OSTY_NATIVE_CHECKER_BIN` to
+// subprocesses without paying for an LLVM build on cold caches —
+// `EnsureNativeChecker` fires the full build path and is wrong for
+// cheap commands like `osty fmt` / `osty --help`.
+func ProbeManagedNativeChecker(start string) string {
+	root, err := managedProjectRootFunc(start)
+	if err != nil {
+		return ""
+	}
+	path := ManagedNativeCheckerPath(root)
+	if path == "" {
+		return ""
+	}
+	if !fileExists(path) {
+		return ""
+	}
+	return path
 }
 
 func defaultSourceRepoRoot() (string, error) {
@@ -315,7 +381,37 @@ func buildNativeChecker(dest string) error {
 	// to `internal/selfhost/generated.go` and has no `osty-self`
 	// dependency — sufficient to typecheck `toolchain/*.osty` and
 	// `cmd/osty-native-checker/main.osty` so the build can complete.
-	if stage0FallbackEnabled() || os.Getenv(RecursionGuardEnv) == "1" {
+	if stage0FallbackEnabled() {
+		// Stage0 opt-in: caller explicitly wants the Go shell in the
+		// production slot for the duration of the install-self
+		// bootstrap. The install-self flow invalidates the slot via
+		// `InvalidateManagedNativeChecker` once `osty-self` becomes
+		// resolvable, so this Go shell is intentionally transient.
+		return buildNativeCheckerViaGo(root, dest)
+	}
+	if os.Getenv(RecursionGuardEnv) == "1" {
+		// Recursion detour: route the Go shell to a sibling
+		// "recursion-fallback" slot instead of the canonical managed
+		// slot. The outer LLVM build that spawned us has not finished
+		// yet — if it later fails, the Go shell here would otherwise
+		// remain in the canonical slot and silently downgrade every
+		// subsequent `osty check`/`osty build` to the Go fallback,
+		// hiding the LLVM build failure. The fallback slot is only
+		// visible to subprocesses running under `RecursionGuardEnv`
+		// (see `EnsureNativeChecker`); outside the recursion the
+		// canonical slot stays empty until a real LLVM artifact is
+		// promoted into it.
+		mgrRoot, err := managedProjectRootFunc(".")
+		if err == nil {
+			fallback := recursionFallbackCheckerPath(mgrRoot)
+			if dirErr := os.MkdirAll(filepath.Dir(fallback), 0o755); dirErr == nil {
+				return buildNativeCheckerViaGo(root, fallback)
+			}
+		}
+		// On the rare path where we can't compute the managed root,
+		// fall back to the original behavior — the recursion guard
+		// still prevents an infinite loop, and the failure mode is
+		// the pre-fix one rather than a worse mis-resolution.
 		return buildNativeCheckerViaGo(root, dest)
 	}
 	if err := verifyOstySelfCached(root); err != nil {

--- a/internal/toolchain/native_checker.go
+++ b/internal/toolchain/native_checker.go
@@ -160,6 +160,53 @@ func InvalidateManagedNativeChecker(projectRoot string) error {
 	return nil
 }
 
+// InvalidateAllManagedNativeCheckers removes every cached
+// native-checker artifact under `<projectRoot>/<toolchainDirName>/*/`.
+// Use after `install-self` produces a new `osty-self` so that any
+// `--osty-bin <other-host>` invocation (which pins a different
+// toolchain version stamp under a sibling subdirectory) also picks
+// up the LLVM-built variant on its next build, rather than continuing
+// to serve a stale Go-built fallback from its own slot.
+//
+// `InvalidateManagedNativeChecker(projectRoot)` only touches the
+// current process's `Version()` slot — sufficient when the install
+// runs from the same host that subsequent builds use, but pre-PR
+// #1999 it silently left a stale fallback in any other version slot
+// the project had accumulated (typical when devs switch between two
+// `osty` builds during bootstrap iteration).
+//
+// Best-effort: a missing tree returns nil; per-entry remove errors
+// are collected into a joined error so the caller can warn but the
+// loop processes every slot.
+func InvalidateAllManagedNativeCheckers(projectRoot string) error {
+	toolchainDir := filepath.Join(projectRoot, toolchainDirName)
+	entries, err := os.ReadDir(toolchainDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("scan managed toolchain dir %s: %w", toolchainDir, err)
+	}
+	var errs []error
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		slot := filepath.Join(toolchainDir, e.Name(), NativeCheckerBinaryName())
+		if err := os.Remove(slot); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("invalidate %s: %w", slot, err))
+		}
+		// Also clear the recursion-fallback slot — if a previous
+		// build crashed mid-way, the fallback could persist and
+		// the next subprocess would prefer it over rebuilding.
+		fallback := filepath.Join(toolchainDir, e.Name(), NativeCheckerBinaryName()+".recursion-fallback")
+		if err := os.Remove(fallback); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("invalidate %s: %w", fallback, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
 // ManagedNativeCheckerLLVMPath returns the conventional location
 // `osty build --backend llvm cmd/osty-native-checker/` writes its
 // artifact to (`<project>/cmd/osty-native-checker/.osty/out/{debug,release}/llvm/osty-native-checker-llvm`).

--- a/internal/toolchain/native_checker_test.go
+++ b/internal/toolchain/native_checker_test.go
@@ -134,11 +134,6 @@ func TestBuildNativeCheckerRecursionGuardDetoursToGoBuild(t *testing.T) {
 	// is the one being exercised, not the stage0 branch.
 	t.Setenv(Stage0FallbackEnv, "")
 	sourceRepoRootFunc = func() (string, error) { return root, nil }
-	// Route managed-project-root resolution at `root` too so the
-	// recursion-fallback slot lands under our temp dir.
-	oldManagedRoot := managedProjectRootFunc
-	managedProjectRootFunc = func(string) (string, error) { return root, nil }
-	t.Cleanup(func() { managedProjectRootFunc = oldManagedRoot })
 	verifyCalls := 0
 	verifyOstySelfCached = func(string) error {
 		verifyCalls++
@@ -159,20 +154,12 @@ func TestBuildNativeCheckerRecursionGuardDetoursToGoBuild(t *testing.T) {
 	if goBuildCalls != 1 {
 		t.Fatalf("goBuildNativeChecker calls = %d, want 1", goBuildCalls)
 	}
-	// Post-PR #1999: the recursion-guard detour writes to the sibling
-	// fallback slot under the managed root, NOT to dest. This keeps
-	// the canonical slot empty until a real LLVM build succeeds, so
-	// a later failure does not leak the Go shell into the cache.
-	fallback := recursionFallbackCheckerPath(root)
-	body, err := os.ReadFile(fallback)
+	body, err := os.ReadFile(dest)
 	if err != nil {
-		t.Fatalf("read recursion-fallback slot %s: %v", fallback, err)
+		t.Fatalf("read managed dest: %v", err)
 	}
 	if string(body) != "recursion-guard go-built checker" {
-		t.Fatalf("recursion-fallback body = %q, want recursion-guard go-built checker", body)
-	}
-	if _, err := os.Stat(dest); !os.IsNotExist(err) {
-		t.Fatalf("canonical dest %s should not exist under recursion guard, got err=%v", dest, err)
+		t.Fatalf("managed dest body = %q, want recursion-guard go-built checker", body)
 	}
 }
 

--- a/internal/toolchain/native_checker_test.go
+++ b/internal/toolchain/native_checker_test.go
@@ -134,6 +134,11 @@ func TestBuildNativeCheckerRecursionGuardDetoursToGoBuild(t *testing.T) {
 	// is the one being exercised, not the stage0 branch.
 	t.Setenv(Stage0FallbackEnv, "")
 	sourceRepoRootFunc = func() (string, error) { return root, nil }
+	// Route managed-project-root resolution at `root` too so the
+	// recursion-fallback slot lands under our temp dir.
+	oldManagedRoot := managedProjectRootFunc
+	managedProjectRootFunc = func(string) (string, error) { return root, nil }
+	t.Cleanup(func() { managedProjectRootFunc = oldManagedRoot })
 	verifyCalls := 0
 	verifyOstySelfCached = func(string) error {
 		verifyCalls++
@@ -154,12 +159,20 @@ func TestBuildNativeCheckerRecursionGuardDetoursToGoBuild(t *testing.T) {
 	if goBuildCalls != 1 {
 		t.Fatalf("goBuildNativeChecker calls = %d, want 1", goBuildCalls)
 	}
-	body, err := os.ReadFile(dest)
+	// Post-PR #1999: the recursion-guard detour writes to the sibling
+	// fallback slot under the managed root, NOT to dest. This keeps
+	// the canonical slot empty until a real LLVM build succeeds, so
+	// a later failure does not leak the Go shell into the cache.
+	fallback := recursionFallbackCheckerPath(root)
+	body, err := os.ReadFile(fallback)
 	if err != nil {
-		t.Fatalf("read managed dest: %v", err)
+		t.Fatalf("read recursion-fallback slot %s: %v", fallback, err)
 	}
 	if string(body) != "recursion-guard go-built checker" {
-		t.Fatalf("managed dest body = %q, want recursion-guard go-built checker", body)
+		t.Fatalf("recursion-fallback body = %q, want recursion-guard go-built checker", body)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("canonical dest %s should not exist under recursion guard, got err=%v", dest, err)
 	}
 }
 

--- a/justfile
+++ b/justfile
@@ -68,7 +68,14 @@ bootstrap: build-all
     # working until the conflict between `builtinNonGenericMethods` +
     # `RewriteStdlibMethodCallsites` is resolved at the IR layer; user
     # `osty build` continues to get the default-on path.
-    OSTY_STAGE0_FALLBACK=1 OSTY_STDLIB_BODY_LOWER=0 {{bin}} install-self
+    #
+    # Both env vars use the `${VAR:-1}` / `${VAR:-0}` form so a caller
+    # can override on the command line — for example,
+    # `OSTY_STAGE0_FALLBACK= just bootstrap` to verify the prebuilt-only
+    # path that the comment block above advertises. Hard-coding the
+    # values would silently override caller intent and make that
+    # documented contract impossible.
+    OSTY_STAGE0_FALLBACK="${OSTY_STAGE0_FALLBACK:-1}" OSTY_STDLIB_BODY_LOWER="${OSTY_STDLIB_BODY_LOWER:-0}" {{bin}} install-self
 
 # cache-self prints the canonical .osty/cache/self-host/<sha>-<triple>/
 # osty-self path for the current toolchain SHA + host triple. With

--- a/matrix_retest/iter_groupby/iter_groupby_test.osty
+++ b/matrix_retest/iter_groupby/iter_groupby_test.osty
@@ -5,5 +5,16 @@ use std.testing
 fn testListGroupByClosure() {
     let xs = [1, 2, 3, 4]
     let groups = xs.groupBy(|x| x % 2)
+    // Bucket-count-only would false-PASS for any 2-bucket
+    // result (e.g. one bucket per element). Assert per-key
+    // contents: odd → [1, 3], even → [2, 4].
     testing.assertEq(groups.len(), 2)
+    let odd = groups.getOr(1, [])
+    testing.assertEq(odd.len(), 2)
+    testing.assertEq(odd[0], 1)
+    testing.assertEq(odd[1], 3)
+    let even = groups.getOr(0, [])
+    testing.assertEq(even.len(), 2)
+    testing.assertEq(even[0], 2)
+    testing.assertEq(even[1], 4)
 }

--- a/matrix_retest/iter_map/iter_map_test.osty
+++ b/matrix_retest/iter_map/iter_map_test.osty
@@ -7,5 +7,13 @@ use std.testing
 fn testListMapClosure() {
     let xs = [1, 2, 3, 4]
     let doubled = xs.map(|x| x * 2)
+    // Length-only assertion is false-PASS prone: a broken
+    // implementation that preserves length while emitting wrong
+    // values would still pass. Assert every element so the test
+    // actually verifies the closure was applied.
     testing.assertEq(doubled.len(), 4)
+    testing.assertEq(doubled[0], 2)
+    testing.assertEq(doubled[1], 4)
+    testing.assertEq(doubled[2], 6)
+    testing.assertEq(doubled[3], 8)
 }

--- a/matrix_retest/iter_scan/iter_scan_test.osty
+++ b/matrix_retest/iter_scan/iter_scan_test.osty
@@ -5,5 +5,12 @@ use std.testing
 fn testListScanClosure() {
     let xs = [4, 1, 3, 2]
     let prefix = xs.scan(0, |a, x| a + x)
+    // Length-only check would false-PASS for any 5-element
+    // list. Assert the prefix sums: 0, 0+4, +1, +3, +2 = 0,4,5,8,10
     testing.assertEq(prefix.len(), 5)
+    testing.assertEq(prefix[0], 0)
+    testing.assertEq(prefix[1], 4)
+    testing.assertEq(prefix[2], 5)
+    testing.assertEq(prefix[3], 8)
+    testing.assertEq(prefix[4], 10)
 }

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -592,6 +592,7 @@ pub struct LirModule {
     pub runtimeDecls: LirRuntimeDecls,
     pub stringPool: LirStringPool,
     pub metadata: List<String>,
+    pub thunkSymbols: List<String>,
 }
 pub fn lirModule(packageName: String, sourcePath: String, target: String) -> LirModule {
     let stringPoolEntries: List<LirStringGlobal> = []
@@ -603,8 +604,9 @@ pub fn lirModuleWithStringPoolEntries(packageName: String, sourcePath: String, t
     let functions: List<LirFunction> = []
     let renderedFunctions: List<String> = []
     let metadata: List<String> = []
+    let thunkSymbols: List<String> = []
     let stringPool = LirStringPool {entries: stringPoolEntries}
-    LirModule {packageName, sourcePath, target, typeDefs, globals, functions, renderedFunctions, runtimeDecls: lirRuntimeDecls(), stringPool, metadata}
+    LirModule {packageName, sourcePath, target, typeDefs, globals, functions, renderedFunctions, runtimeDecls: lirRuntimeDecls(), stringPool, metadata, thunkSymbols}
 }
 // ====================================================================
 // Diagnostics and lowerer shell
@@ -8824,7 +8826,7 @@ fn lirLowerMirOperand(l: LirMirFunctionLowerer, instrs: List<LirInstr>, op: MirO
             return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: "null"}
         }
         if kind == MirConstFn {
-            return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: "@" + c.fnSymbol}
+            return lirEmitBareFnAsClosure(l, instrs, c.fnSymbol)
         }
         lirLowerError(l, LirDiagUnsupported, "unsupported MIR const kind `" + mirConstKindName(kind) + "`", "const." + mirConstKindName(kind))
         return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
@@ -8975,6 +8977,144 @@ fn lirLowerMirIndexProjectionIndex(l: LirMirFunctionLowerer, instrs: List<LirIns
     return lirOperand(lirIntType(64), lirIntToString(proj.indexConst))
 }
 
+// lirClosureThunkName mirrors `mirThunkName` in `toolchain/mir_generator.osty`.
+// Distinct prefix so the closure-env value cannot collide with the
+// underlying user function symbol.
+fn lirClosureThunkName(symbol: String) -> String {
+    "__osty_closure_thunk_" + symbol
+}
+
+// lirRenderBareFnThunk builds the `define private` block that adapts
+// a bare top-level fn (`@<symbol>`) into the uniform closure ABI
+// `RET (ptr %env, T0 %arg0, T1 %arg1, ...)`. The env is unused;
+// captures live elsewhere when the value comes from an actual
+// closure literal. For a bare fn there are no captures, so the
+// thunk just forwards its non-env params to the underlying call.
+fn lirRenderBareFnThunk(symbol: String, retType: LirType, paramTypes: List<LirType>) -> String {
+    let thunk = lirClosureThunkName(symbol)
+    let mut header: List<String> = ["ptr %env"]
+    let mut callArgs: List<String> = []
+    let mut i = 0
+    for pt in paramTypes {
+        let ptStr = lirTypeString(pt)
+        header.push(ptStr + " %arg" + lirIntToString(i))
+        callArgs.push(ptStr + " %arg" + lirIntToString(i))
+        i = i + 1
+    }
+    let retStr = lirRenderTypeOrVoid(retType)
+    let mut lines: List<String> = []
+    lines.push("define private " + retStr + " @" + thunk + "(" + strings.join(header, ", ") + ") \{")
+    lines.push("entry:")
+    if lirTypeIsVoid(retType) {
+        lines.push("  call void @" + symbol + "(" + strings.join(callArgs, ", ") + ")")
+        lines.push("  ret void")
+    } else {
+        lines.push("  %ret = call " + retStr + " @" + symbol + "(" + strings.join(callArgs, ", ") + ")")
+        lines.push("  ret " + retStr + " %ret")
+    }
+    lines.push("\}")
+    strings.join(lines, "\n")
+}
+
+// lirEnsureBareFnThunk lazily registers the closure-adapter thunk
+// for `symbol`. Re-entry with the same symbol is a no-op so multiple
+// `intToStr`-shaped values across a module share one thunk
+// definition.
+//
+// Returns `true` when a thunk for `symbol` exists after the call
+// (either pre-existing or just emitted); `false` only when the
+// caller can't generate one (the wrapped fn's signature is opaque),
+// in which case the caller should fall back to the raw fn-pointer
+// shape and skip closure wrapping.
+fn lirEnsureBareFnThunk(l: LirMirFunctionLowerer, symbol: String) -> Bool {
+    if listContainsString(l.out.thunkSymbols, symbol) {
+        return true
+    }
+    let mut foundIdx = -1
+    let mut i = 0
+    for fn_ in l.mirModule.functions {
+        if (fn_.exportSymbol != "" && fn_.exportSymbol == symbol) || fn_.name == symbol {
+            foundIdx = i
+        }
+        i = i + 1
+    }
+    if foundIdx < 0 {
+        return false
+    }
+    let target = l.mirModule.functions[foundIdx]
+    // Skip closure-body lifted fns: they already take an env as their
+    // first parameter (`ClosureEnv` / `ClosureEnv.<tag>...`) and the
+    // closure-allocation MIR lowering elsewhere stores the bare
+    // `@<symbol>` pointer (NOT a thunk wrapper) into slot 0 of the
+    // env struct. Wrapping such a fn again would build a 2-level
+    // closure: the original env stores the wrap-env ptr instead of
+    // the fn ptr, and the call site dereferences the wrap-env as if
+    // it were a fn pointer → segfault.
+    if target.params.len() > 0 {
+        let firstParamId = target.params[0]
+        let firstParamLocal = mirFunctionLocal(target, firstParamId)
+        if firstParamLocal.id >= 0 {
+            let firstParamTyp = firstParamLocal.typ
+            if firstParamTyp == "ClosureEnv" || strings.startsWith(firstParamTyp, "ClosureEnv.") {
+                return false
+            }
+        }
+    }
+    let retType = lirLowerMirType(l, target.returnType)
+    let mut paramTypes: List<LirType> = []
+    for paramId in target.params {
+        let loc = mirFunctionLocal(target, paramId)
+        if loc.id < 0 {
+            return false
+        }
+        let pt = lirLowerMirType(l, loc.typ)
+        if pt.className == LirTypeUnknown && pt.llvm == "" {
+            return false
+        }
+        paramTypes.push(pt)
+    }
+    let rendered = lirRenderBareFnThunk(symbol, retType, paramTypes)
+    l.out.renderedFunctions.push(rendered)
+    l.out.thunkSymbols.push(symbol)
+    true
+}
+
+// lirEmitBareFnAsClosure wraps a `@<symbol>` bare-fn address into a
+// closure-env value the uniform call ABI can consume. Allocates a
+// 0-capture `osty_rt_closure_env`, stores the closure thunk pointer
+// into the env's `fn_ptr` slot (offset 0), and returns the env
+// pointer.
+//
+// Pre-PR #2001 `MirConstFn` lowered to the raw fn address `@<sym>`,
+// which the callee then dereferenced as a closure env (`load ptr,
+// ptr %env` followed by an indirect call). For a bare fn that's a
+// read of the first 8 bytes of the function's machine code reinterpreted
+// as a pointer — undefined behavior that crashed at runtime. Wrapping
+// the bare fn here makes the value structurally identical to a
+// closure literal, so the existing closure call ABI Just Works.
+fn lirEmitBareFnAsClosure(l: LirMirFunctionLowerer, instrs: List<LirInstr>, fnSymbol: String) -> LirOperand {
+    let ptrType = lirPtrType()
+    if !lirEnsureBareFnThunk(l, fnSymbol) {
+        // Signature opaque: fall back to the raw fn-ptr shape.
+        // External / intrinsic fn refs end up here. Callees that
+        // genuinely need closure shape would have been routed
+        // through a regular closure literal, not a bare fn const.
+        return LirOperand {typ: ptrType, value: "@" + fnSymbol}
+    }
+    let symbol = "osty.rt.closure_env_alloc_v2"
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, ptrType, [lirIntType(64), ptrType, lirIntType(64)], false))
+    let envName = lirFresh(l)
+    let siteSymbol = lirStringEntriesInternKnown(l.stringPoolEntries, "bare-fn:" + fnSymbol, lirCStringEncodeSelfhostSafe("bare-fn:" + fnSymbol), lirStringByteLenWithNul("bare-fn:" + fnSymbol))
+    instrs.push(lirCall(envName, ptrType, "@" + symbol, [
+        lirOperand(lirIntType(64), "0"),
+        lirOperand(ptrType, siteSymbol),
+        lirOperand(lirIntType(64), "0"),
+    ]))
+    let thunkPtrOperand = LirOperand {typ: ptrType, value: "@" + lirClosureThunkName(fnSymbol)}
+    instrs.push(lirStore(thunkPtrOperand, envName, 8))
+    LirOperand {typ: ptrType, value: envName}
+}
+
 fn lirLowerMirConst(l: LirMirFunctionLowerer, c: MirConst, hintName: String, hint: LirType) -> LirOperand {
     let kind = c.kind
     if kind == MirConstInt {
@@ -9014,7 +9154,7 @@ fn lirLowerMirConst(l: LirMirFunctionLowerer, c: MirConst, hintName: String, hin
         return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: "null"}
     }
     if kind == MirConstFn {
-        return LirOperand {typ: LirType {llvm: "ptr", className: LirTypePtr}, value: "@" + c.fnSymbol}
+        return lirEmitBareFnAsClosure(l, l.instrs, c.fnSymbol)
     }
     lirLowerError(l, LirDiagUnsupported, "unsupported MIR const kind `" + mirConstKindName(kind) + "`", "const." + mirConstKindName(kind))
     LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -5391,23 +5391,45 @@ fn lirLowerMirStringIsEmpty(l: LirMirFunctionLowerer, instr: MirInstr) {
 // `emitStringConcatN`. ConcatN exists so a `"a" + b + c` site allocates one
 // fresh String instead of N-1 intermediate String buffers.
 fn lirLowerMirStringConcat(l: LirMirFunctionLowerer, instr: MirInstr) {
-    if instr.args.len() < 2 {
-        lirLowerError(l, LirDiagInvalidInput, "string.concat expects at least two arguments", "string.concat")
-        return
-    }
-    if instr.args.len() == 2 {
-        lirLowerMirStringRuntimeCall(l, instr, mirRtStringSymbol("Concat"), lirPtrType(), [lirPtrType(), lirPtrType()], "string.concat")
+    if instr.args.len() < 1 {
+        lirLowerError(l, LirDiagInvalidInput, "string.concat expects at least one argument", "string.concat")
         return
     }
     let mut parts: List<LirOperand> = []
     for arg in instr.args {
-        let mut value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, lirPtrType())
+        // String interpolation: `"v={n}"` arrives here with the
+        // interpolated expressions already lowered as MIR operands
+        // typed with their natural shape (Int, Float, Bool, Char,
+        // Byte, …). The runtime ConcatN takes an array of `ptr`
+        // (each pointing to a C string), so non-String parts must be
+        // CONVERTED to their decimal / textual representation before
+        // the array store — not bit-cast / inttoptr'd, which would
+        // store the raw value as a pointer address and either
+        // miscompile (`store ptr 42, ptr %slot`) or crash at runtime.
+        //
+        // We pick the to_string runtime helper from `arg.typ`
+        // (the MIR-level type spelling) rather than from the LIR
+        // operand's type, because for constants the LIR operand
+        // inherits the hint we pass to `lirLowerMirOperand` — passing
+        // `lirPtrType()` here makes `lirHintOrDefaultIntType` return
+        // ptr-typed operand `LirOperand{typ: ptr, value: "42"}` and
+        // the `className != LirTypePtr` check below misses the
+        // conversion site entirely. The MIR type is the source of
+        // truth, so we lower the operand with NO hint (zero LirType)
+        // and let the conversion decide based on `arg.typ`.
+        let mut value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, LirType {llvm: "", className: LirTypeUnknown})
         if value.value == "" {
             return
         }
-        if value.typ.className != LirTypePtr {
+        if !lirStringEq(arg.typ, "String") && value.typ.className != LirTypePtr {
             let ptrType = lirPtrType()
-            if value.typ.className == LirTypeUnknown {
+            let toStringSym = lirRuntimeToStringSymbolForType(value.typ)
+            if toStringSym != "" {
+                lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeToStringDecl(toStringSym, value.typ))
+                let convDest = lirFresh(l)
+                l.instrs.push(lirCall(convDest, lirPtrType(), "@" + toStringSym, [value]))
+                value = LirOperand {typ: ptrType, value: convDest}
+            } else if value.typ.className == LirTypeUnknown {
                 value = LirOperand {typ: ptrType, value: value.value}
             } else {
                 let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, ptrType, lirPrimitiveTypeIsUnsigned(arg.typ))
@@ -5421,6 +5443,37 @@ fn lirLowerMirStringConcat(l: LirMirFunctionLowerer, instr: MirInstr) {
             }
         }
         parts.push(lirOperand(lirPtrType(), value.value))
+    }
+    // 1-arg path: `"{n}"` (a string literal that is a single
+    // interpolation with no surrounding text). The conversion to
+    // String already happened in the loop above, so the only thing
+    // left is to bind the result to the destination — no runtime
+    // call needed. Pre-PR #2000 the MIR emitter still emitted a
+    // string.concat for this shape and the LIR Proto rejected it
+    // ("string.concat expects at least two arguments"), which
+    // blocked helper functions like `fn intToStr(n: Int) -> String
+    // { "{n}" }`.
+    if parts.len() == 1 {
+        if instr.hasDest {
+            lirStoreMirResult(l, instr.dest, parts[0], "String", "string.concat result")
+        }
+        return
+    }
+    // 2-arg fast path: avoid the [N x ptr] alloca for the common
+    // `a + b` / `"x{y}"` shape and call `osty_rt_strings_Concat`
+    // directly. Both Concat and ConcatN have the same observable
+    // semantics; Concat is one runtime hop cheaper. Conversion of
+    // non-String parts has already happened in the loop above, so
+    // both branches feed the runtime fully-converted ptrs.
+    if parts.len() == 2 {
+        let symbol = mirRtStringSymbol("Concat")
+        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirPtrType(), [lirPtrType(), lirPtrType()], false))
+        let dest = lirFresh(l)
+        l.instrs.push(lirCall(dest, lirPtrType(), "@" + symbol, parts))
+        if instr.hasDest {
+            lirStoreMirResult(l, instr.dest, lirOperand(lirPtrType(), dest), "String", "string.concat result")
+        }
+        return
     }
     let count = parts.len()
     let countText = lirIntToString(count)

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -9058,7 +9058,12 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
     // function type never needs a structural LLVM spelling. Mirrors
     // `mir_generator.osty`'s builtin-container map where `ClosureEnv`
     // already lowers to `ptr`.
-    if strings.startsWith(name, "ClosureEnv") || strings.startsWith(name, "fn(") {
+    // Exact match for the builtin `ClosureEnv` type name. A
+    // `startsWith` form would also pointer-erase user-defined types
+    // like `ClosureEnvState` / `ClosureEnvStats`, which `mir_generator`
+    // / `onb_abi` already treat with `==`. `fn(` is a structural
+    // function-value spelling and is correct as a prefix match.
+    if name == "ClosureEnv" || strings.startsWith(name, "fn(") {
         return LirType {llvm: "ptr", className: LirTypePtr}
     }
     for layout in l.mirModule.layouts.interfaces {

--- a/toolchain/monomorph.osty
+++ b/toolchain/monomorph.osty
@@ -41,7 +41,16 @@ pub struct MonomorphTypeRequest {
 /// encodings; Osty's canonical `Int` is platform-independent i64 and
 /// maps to `l` (C `long`) to distinguish it from explicit `Int64` (`x`).
 pub fn monomorphPrimCode(name: String) -> String {
-    if name == "Int" {
+    // `UntypedInt` / `UntypedFloat` are the literal-default placeholders
+    // the checker emits when a numeric literal flows into a position
+    // that has not pinned a concrete int / float kind yet (e.g. `R`
+    // resolves to `UntypedInt` for `xs.scan(0, |a, b| a + b)`). The Go-
+    // side snapshot maps them to `l` / `d` so `?` never reaches the
+    // Itanium mangler — see `internal/ir/monomorph_snapshot.go`. Keep
+    // this Osty table in lockstep, otherwise the selfhost path (which
+    // calls `monomorphPrimCode` here from `monomorph_pass.osty`) still
+    // emits `?` mangled codes that clang rejects at link time.
+    if name == "Int" || name == "UntypedInt" {
         return "l"
     }
     if name == "Int8" {
@@ -71,7 +80,7 @@ pub fn monomorphPrimCode(name: String) -> String {
     if name == "Byte" {
         return "h"
     }
-    if name == "Float" {
+    if name == "Float" || name == "UntypedFloat" {
         return "d"
     }
     if name == "Float32" {


### PR DESCRIPTION
## Summary

Long-standing bare-fn-as-closure ABI gap fixed. `applyTwice(intToStr)` and similar patterns (free fn passed where `fn(T) -> R` is expected) used to segfault because the callee's uniform closure ABI dereferenced the bare fn address as if it were a closure env. The fix wraps every `MirConstFn` in a closure env (with a lazily-generated thunk in slot 0) so its structural shape matches what a closure literal produces.

## Mechanism

At each `MirConstFn` lowering site (`toolchain/lir_proto.osty`):

```llvm
%env = call ptr @osty.rt.closure_env_alloc_v2(i64 0, ptr @site, i64 0)
store ptr @__osty_closure_thunk_<symbol>, ptr %env
```

Module-level (one per unique fn symbol, deduped via `LirModule.thunkSymbols`):

```llvm
define private RET @__osty_closure_thunk_<symbol>(ptr %env, T0 %arg0, ...) {
entry:
  %ret = call RET @<symbol>(T0 %arg0, ...)
  ret RET %ret
}
```

Now the callee's `load ptr, ptr %env` → `call ptr %fn_ptr(env, args)` lands on the thunk, which forwards (ignoring env) to the actual fn.

## Skip path for closure bodies

Lifted closure-body fns (`main__closure1`) already take `ClosureEnv` as their first parameter and the closure-alloc site stores `@<symbol>` (not a thunk) directly into env slot 0. Double-wrapping would build a 2-level closure where the original env stores a wrap-env ptr instead of a fn ptr → segfault. `lirEnsureBareFnThunk` detects this by inspecting `target.params[0].typ` and returns false (callers fall through to raw fn-ptr shape).

## Test plan

- [x] `/tmp/smoke`: `applyTwice(intToStr)` → "1-2", `applyTwice(double)` → "2-4", `applyTwice(neg)` → "-1--2"
- [x] Multiple bare fns in one call: `compose(inc, sq, 3)` → 10
- [x] Closure path unchanged: `applyTwice(|n| "v={n}")` → "v=1-v=2"
- [x] All cases exit 0 (clean termination)
- [x] `TestLLVMBackendEmitApplyTwiceInterp` still passes
- [x] `go test -count=1 -short ./internal/{mir,ir,check,backend}/` — only the 3 pre-existing PR #1998-era backend failures remain (unrelated to this change)
- [x] osty-self rebuilt 3× during iteration, no regression

## Out of scope

- External / intrinsic fn refs (where the wrapped fn isn't a defined `MirFunction` in the module) fall through to the raw `@<symbol>` shape via `lirEnsureBareFnThunk` returning false. Currently works because external fn refs go through direct-call `FnRef` sites or get passed to call sites that handle bare ptrs.
- The `STRING_INTERP_RESOLVE_GAP.md` Day 4 architectural fix (Go-side astbridge consumes arena children) is still blocked on `generated.go` regeneration — orthogonal to this PR.

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_