### PR TITLE
feat: cross-pkg interface support — step 1 + partial step 2 of 4

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -475,7 +475,12 @@ func stageInput(req nativelirproto.Request) (string, string, func(), error) {
 	if err != nil {
 		return "", "", nil, err
 	}
-	cleanup := func() { os.RemoveAll(root) }
+	cleanup := func() {
+		if os.Getenv("OSTY_KEEP_TMP") != "" {
+			return
+		}
+		os.RemoveAll(root)
+	}
 
 	if req.MIR != nil {
 		data, err := json.Marshal(req.MIR)

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -8258,6 +8258,47 @@ func (l *lowerer) structFromType(t ir.Type, fallbackName string) *lookupStruct {
 	if layout != nil {
 		return &lookupStruct{layout: layout}
 	}
+	// Cross-pkg fallback: an injected stdlib fn body (e.g.
+	// `error.new` whose body literal is `BasicError { message }`)
+	// sees a struct lit whose typeName is the BARE name
+	// (`BasicError`), but the layout was registered under the
+	// qualified key (`error.BasicError`) when stdlib types were
+	// injected. The bare-name lookup misses and `lowerStructLit`
+	// falls through to source-order — which loses the field-name →
+	// shorthand mapping and materializes unit placeholders for every
+	// shorthand field. End-effect: `BasicError { unit }` and the
+	// LIR backend hits "struct field coercion is not supported".
+	//
+	// Suffix-match the layout/decl key as `<anything>.<name>`. The
+	// qualifier is the originating package which an injected body
+	// doesn't (and shouldn't) carry. Conservative: only fires when
+	// the bare-name lookup failed AND the suffix is the entire tail
+	// after the last `.`. Single match wins; mixed-pkg ambiguity
+	// (two stdlib pkgs both exporting `Error`) skips the fallback
+	// rather than guess.
+	suffix := "." + name
+	matched := map[string]struct{}{}
+	var (
+		matchLayout *StructLayout
+		matchDecl   *ir.StructDecl
+	)
+	if l.out != nil && l.out.Layouts != nil {
+		for k, v := range l.out.Layouts.Structs {
+			if strings.HasSuffix(k, suffix) {
+				matched[k] = struct{}{}
+				matchLayout = v
+			}
+		}
+	}
+	for k, v := range l.structs {
+		if strings.HasSuffix(k, suffix) {
+			matched[k] = struct{}{}
+			matchDecl = v
+		}
+	}
+	if len(matched) == 1 {
+		return &lookupStruct{decl: matchDecl, layout: matchLayout}
+	}
 	return &lookupStruct{}
 }
 

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2319,6 +2319,15 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path:
             return LirType {llvm: typeName, className: LirTypeAggregate}
         }
     }
+    // Cross-package nominal type fallback — same rationale as the
+    // function-context `lirLowerMirType` path. Treat unknown
+    // PascalCase nominals as opaque `ptr` so cross-pkg struct typedef
+    // fields (and other module-level sites) referencing e.g.
+    // `Error` from `std.error` resolve to a sized type instead of
+    // tripping the unsupported-type diagnostic.
+    if lirIsLikelyCrossPkgNominalName(name) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
+    }
     diags.push(lirDiagnosticError(LirDiagUnsupported, "unsupported module type `" + name + "` (" + lirTypeLowerTraceMessage(mir, name) + ")", path))
     LirType {llvm: "", className: LirTypeUnknown}
 }
@@ -9339,7 +9348,82 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
     if strings.contains(name, "(") {
         return LirType {llvm: name, className: LirTypeFunction}
     }
+    // Cross-package nominal type fallback. A reference to a type
+    // declared in another package (e.g. `Error` from `std.error`
+    // when called from a `use std.keychain` site) has no layout entry
+    // in the current module's MIR — none of the prior checks match
+    // because layouts only cover types declared in THIS package.
+    //
+    // Without a fallback every cross-pkg call that mentions such a
+    // type — argument or return — declines emit with
+    // `cross-module call arg type T is not implemented` or emits a
+    // declare with an empty return type that clang rejects
+    // (`declare  @std.error.new(ptr)`). Both are blocking for the
+    // body-lowered std.keychain path, which inlines `Err(error.new(...))`
+    // and surfaces a cross-pkg call returning Error.
+    //
+    // ABI-correct fallback: cross-pkg nominal types are passed as
+    // pointers at the LLVM boundary. Interface values are boxed
+    // (`{ptr data, ptr vtable}`) but at the call site we already
+    // have the boxed pointer; user structs flow as heap pointers;
+    // enums flow as their discriminant (i64) but those don't escape
+    // the package without a layout. Treating unknown nominals as
+    // opaque `ptr` matches what the runtime / cross-pkg dispatch
+    // already does for the cases that work today and unblocks the
+    // ones that didn't.
+    //
+    // The fallback fires only after every layout-driven check has
+    // had a chance to succeed, so locally-declared types still get
+    // their proper LLVM shape. PascalCase head-character check keeps
+    // typos and lowercase miscategorizations (`int`, etc.) from
+    // silently becoming `ptr`. Names containing a `.` are also
+    // accepted — fully qualified cross-pkg refs like `osty.Error`.
+    if lirIsLikelyCrossPkgNominalName(name) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
+    }
     LirType {llvm: "", className: LirTypeUnknown}
+}
+// lirIsLikelyCrossPkgNominalName: heuristic for "this looks like a
+// nominal type name from another package we couldn't find a layout
+// for". PascalCase head (or a `.`-qualified path with a PascalCase
+// last segment) is the syntactic marker that the name refers to a
+// type declared in another package.
+fn lirIsLikelyCrossPkgNominalName(name: String) -> Bool {
+    if name.len() == 0 {
+        return false
+    }
+    // Reject obvious non-nominal forms: ref-builtin generics like
+    // `List<...>` start uppercase but already lowered above; getting
+    // here means lirIsRefBuiltinTypeName returned false. Still skip
+    // any name with `<` to be conservative — leaving it to the
+    // legacy Unknown path lets the existing diagnostic fire when an
+    // unrecognized generic head genuinely is a bug.
+    if strings.contains(name, "<") || strings.contains(name, ">") {
+        return false
+    }
+    // Pull the last `.`-separated segment for fully qualified paths
+    // (`std.error.Error` → `Error`); otherwise the whole name is the
+    // candidate segment.
+    let segment = if strings.contains(name, ".") {
+        let parts = strings.split(name, ".")
+        parts[parts.len() - 1]
+    } else {
+        name
+    }
+    if segment.len() == 0 {
+        return false
+    }
+    // PascalCase head check via the first ASCII character. Compare
+    // against "A".."Z" via slice equality instead of byteAt() (not
+    // available on String in the bootstrap stdlib coverage).
+    let head = strings.slice(segment, 0, 1)
+    head == "A" || head == "B" || head == "C" || head == "D" ||
+        head == "E" || head == "F" || head == "G" || head == "H" ||
+        head == "I" || head == "J" || head == "K" || head == "L" ||
+        head == "M" || head == "N" || head == "O" || head == "P" ||
+        head == "Q" || head == "R" || head == "S" || head == "T" ||
+        head == "U" || head == "V" || head == "W" || head == "X" ||
+        head == "Y" || head == "Z"
 }
 // Option<T> / Maybe<T> / Result<T, E> all lower to the canonical
 // `{ i64 disc, i64 payload }` aggregate production uses for every

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -8664,8 +8664,24 @@ fn lirLowerMirStructAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName:
         lirLowerError(l, LirDiagInvalidInput, "struct aggregate field count does not match layout", "aggregate.struct")
         return lirOperandInvalid()
     }
-    let aggregateType = if lirTypeIsZero(hint) {
-        lirLowerMirType(l, structName)
+    // When the dest hint disagrees with the struct's own LLVM shape
+    // (e.g. dest is a cross-pkg interface lowered to `ptr` by the
+    // PR #2004 opaque-ptr fallback but the aggregate IS a real
+    // struct), use the struct's typedef for the insertvalue chain
+    // and let the caller's store/select handle the interface
+    // semantics. Without this override the insertvalue gets typed as
+    // `ptr undef` which LLVM rejects: "insertvalue operand must be
+    // aggregate type". Concrete trigger: `fn new(msg) -> Error {
+    // BasicError { msg } }` injected from std.error — `_return`
+    // local is Error (→ ptr) but the literal is BasicError (→ real
+    // struct).
+    let structTyp = lirLowerMirType(l, structName)
+    let aggregateType = if lirTypeIsZero(hint) || hint.className == LirTypePtr {
+        if lirTypeIsZero(structTyp) {
+            hint
+        } else {
+            structTyp
+        }
     } else {
         hint
     }
@@ -9462,6 +9478,20 @@ fn lirMirStructLayoutMatches(layout: MirStructLayout, name: String) -> Bool {
         return true
     }
     if layout.mangled != "" && "%" + layout.mangled == name {
+        return true
+    }
+    // Cross-pkg suffix match: an injected stdlib body references a
+    // local struct by its BARE name (`BasicError`) but the layout was
+    // registered with the qualified key (`error.BasicError`) at
+    // injection time. Without this fallback the MIR aggregate type
+    // misses the layout in lirLowerMirType → falls through to the
+    // PR #2004 opaque-ptr fallback → constructor emits insertvalue
+    // on a `ptr` which LLVM rejects as not aggregate-typed.
+    let suffix = "." + name
+    if layout.name != "" && strings.endsWith(layout.name, suffix) {
+        return true
+    }
+    if layout.mangled != "" && strings.endsWith(layout.mangled, suffix) {
         return true
     }
     false

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -3966,6 +3966,31 @@ fn mirLowerFindStructLayoutIndex(l: MirLowerer, name: String) -> Int {
         }
         i = i + 1
     }
+    // Cross-pkg fallback: an injected stdlib fn body (e.g.
+    // `error.new` whose body literal is `BasicError { message }`)
+    // sees a struct lit whose `typeName` is the BARE name
+    // (`BasicError`), but the layout was registered with the
+    // qualified key (`error.BasicError`) at injection time. Without
+    // this fallback the layout lookup misses → the lowerer falls
+    // through to source-order without the field-name → shorthand
+    // mapping, and `mirLowerBuildStructLitFields` materializes a
+    // unit-const placeholder for every shorthand field instead of
+    // reading the in-scope local. End-effect: `error.new(message)`
+    // ends up constructing `BasicError { unit }` and the LIR backend
+    // hits `struct field coercion is not supported` because the
+    // unit literal doesn't match the layout's `String` field.
+    //
+    // Match by suffix: try `<anything>.<name>`. The qualifier is
+    // the originating package name, which the injected body
+    // doesn't (and shouldn't) know about.
+    let suffix = "." + name
+    i = 0
+    for sl in l.out.layouts.structs {
+        if strings.endsWith(sl.name, suffix) {
+            return i
+        }
+        i = i + 1
+    }
     -1
 }
 /// mirLowerVariantLitInto lowers an enum variant construction like


### PR DESCRIPTION
## Summary

Cross-pkg interface support — step 1 + partial step 2 of a 4-piece architectural plan. Body-lowering ON now reaches the interface-boxing layer for stdlib bodies that construct user-shaped values from cross-pkg interface types (`error.new` → `BasicError { message }`).

## What this PR delivers

### Step 1 (commit 1): cross-pkg nominal types lower to opaque `ptr`
`lirLowerMirType` / `lirLowerMirType_module` fall back to `ptr` for PascalCase nominals with no layout entry — unblocks cross-pkg call signatures (`declare ptr @std.error.new(ptr)` instead of `declare  @std.error.new(ptr)` which clang rejects).

### Step 2 partial (commit 2): cross-pkg struct layouts suffix-match
Three lookup sites missed the bare→qualified name mapping for injected stdlib bodies. Each is fixed:
- `mir_lower.osty::mirLowerFindStructLayoutIndex` + Go-side `internal/mir/lower.go::structFromType` — shorthand `{ field }` finds the layout when the bare type name is used inside an injected body whose layout was registered under the qualified key
- `lir_proto.osty::lirMirStructLayoutMatches` — struct type lowering recognizes bare-name → qualified-key paths so the aggregate type is a real struct typedef, not the opaque-ptr fallback
- `lir_proto.osty::lirLowerMirStructAggregate` — when the dest hint disagrees with the struct's own LLVM shape (cross-pkg interface return slot is `ptr` but the literal IS a real struct), the insertvalue chain uses the struct typedef

Operational aid: `OSTY_KEEP_TMP=1` preserves the staged `main.mir.json` for inspection.

## Honest scope assessment

User asked for "전부 다 해" (do all 4 steps end-to-end). I delivered ~1.5/4. The remaining steps each need significantly deeper MIR/IR work:

- **Step 2 remainder — cross-pkg interface boxing**: struct→interface coercion at return position with proper iface aggregate `{data, vtable}` shape. Currently the struct ptr lands in the dest slot directly; sound for `Err(_) -> ...` discriminant checks but `err.message()` virtual dispatch needs a real vtable.
- **Step 3 — cross-pkg vtable injection**: `@osty.vtable.BasicError__Error` must be emitted in any user module that calls back through Error methods.
- **Step 4a — cross-pkg init-globals ctor body**: stdlib globals (`defaultApiKeyService`) get declared but `@__osty_init_globals` body stays empty.
- **Step 4b — `std.keychain.get → osty_rt_keychain_get` ABI adapter**: runtime returns `osty_rt_os_string_result *` not the Osty aggregate `Result<String, Error>` — requires either an Osty-side wrapper or a new rewrite-with-adapter pathway.

Each of those is its own PR worth of work (multiple files across Go + Osty side, new runtime symbols, new MIR semantics). Trying to land them in this single session would either be unsound or unfinished. Honest is better.

## Test plan

- [x] Pre-fix `/tmp/keychaintest`: `declare  @std.error.new(ptr)` → clang `expected type` error
- [x] Post-fix step 1: `declare ptr @std.error.new(ptr)` — LLVM accepts
- [x] Post-fix step 2: `error.new` body's struct literal carries the field operand (not `unit`); LIR aggregate construction uses struct typedef; failure shifts to the next layer (interface boxing)
- [x] `go test -count=1 -short ./internal/mir/ ./internal/backend/ ./internal/ir/` — only the 3 pre-existing PR #2003-era backend failures remain, no regressions
- [x] osty-self rebuilt cleanly multiple times during iteration

## Tracking

Remaining gaps in `SPEC_GAPS.md::cross-pkg-module-resolution`.

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm