### PR TITLE
feat: cross-pkg interface boxing for struct→Error assign (step 3/4)

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3433,6 +3433,46 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
                         return
                     }
                     value = rebuilt
+                } else if value.typ.className == LirTypeAggregate && destType.className == LirTypePtr {
+                    // Cross-pkg interface boxing fallback (PR step 3).
+                    // Source is a real struct aggregate (e.g.
+                    // `BasicError { message }` from injected
+                    // `error.new` body), destination is `ptr` because
+                    // the destination's MIR type is a cross-pkg
+                    // interface (`Error`) lowered to opaque ptr via
+                    // the PR #2004 PascalCase fallback.
+                    //
+                    // No local vtable means we can't build the full
+                    // `{ptr data, ptr vtable}` iface aggregate. But
+                    // the working subset — pattern-match-on-
+                    // discriminant code like `Err(_) -> ...` — only
+                    // needs the destination slot to hold a valid ptr
+                    // representing the boxed value. Allocate the
+                    // struct on the GC heap, copy the value in, and
+                    // hand the heap pointer back as the interface
+                    // value. Mirrors `lirBoxInterfaceData` minus the
+                    // iface aggregate wrap.
+                    //
+                    // Soundness: any consumer that DOES call a
+                    // method on the boxed Error (e.g.
+                    // `err.message()`) will hit a missing-vtable
+                    // failure at LIR — see PR description's "Step
+                    // 3 — cross-pkg vtable injection" gap. The
+                    // boxing here is the prerequisite for that
+                    // future step.
+                    let allocSym = "osty.gc.alloc_v1"
+                    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(allocSym, lirPtrType(), [lirIntType(64), lirIntType(64), lirPtrType()], false))
+                    let sizeReg = lirEmitSizeOf(l, value.typ)
+                    let siteLabel = "mir.crosspkg.iface.box." + destLoc.typ
+                    let siteSym = lirStringEntriesInternKnown(l.stringPoolEntries, siteLabel, lirCStringEncodeSelfhostSafe(siteLabel), lirStringByteLenWithNul(siteLabel))
+                    let boxReg = lirFresh(l)
+                    l.instrs.push(lirCall(boxReg, lirPtrType(), "@" + allocSym, [
+                        lirOperand(lirIntType(64), "1"),
+                        lirOperand(lirIntType(64), sizeReg),
+                        lirOperand(lirPtrType(), siteSym),
+                    ]))
+                    l.instrs.push(lirStore(value, boxReg, 0))
+                    value = LirOperand {typ: destType, value: boxReg}
                 } else if lirTypeIsVoid(value.typ) && strings.startsWith(destLoc.name, "_") {
                     // Cross-pkg smoke-test convention: see sibling arm
                     // above (lirTypeIsVoid + `_`-prefix narrowing in


### PR DESCRIPTION
## Summary

Adds the missing assign-coercion branch for `Aggregate → Ptr`: when source is a real struct aggregate and destination is `ptr` (cross-pkg interface erased via PR #2004's opaque-ptr fallback), GC-allocate the struct on the heap, store the value, and use the heap pointer as the interface value.

## Mechanism

```osty
// std.error
pub fn new(message: String) -> Error {
    BasicError { message }
}
```

Lowers to MIR `let _return: Error = BasicError { message }`. Before this PR the assign coercion declined with `assign coercion %error.BasicError → ptr is not supported`. After this PR:

```llvm
%box = call ptr @osty.gc.alloc_v1(i64 1, i64 <sizeof BasicError>, ptr @<site-label>)
store %error.BasicError %value, ptr %box
; %box is the boxed Error value (ptr-shaped iface representation)
```

Mirrors `lirBoxInterfaceData` minus the full `{ptr data, ptr vtable}` iface aggregate (cross-pkg vtable injection is the next remaining gap).

## Verified end-to-end

```osty
use std.error
fn make() -> Result<Int, Error> {
    Err(error.new("oops"))
}
fn main() {
    match make() {
        Ok(v) -> println(v),
        Err(_) -> println(-1),
    }
}
```

```
$ osty build /tmp/errtest && errtest
-1
```

Pre-fix: emit declined. Post-fix: builds and runs.

## Test plan

- [x] `/tmp/errtest` (end-to-end Err(error.new("oops")) → match → println): emits, links, runs, prints `-1`
- [x] `go test -count=1 -short ./internal/mir/ ./internal/backend/ ./internal/ir/`: only the 3 pre-existing PR #2003-era backend failures remain, no regressions

## Out of scope (remaining ~2 of 4 steps)

Each is a separate PR-worth of work:

- **Cross-pkg interface vtable injection** (step 3.5): `@osty.vtable.BasicError__Error` symbol propagation for `err.message()` virtual dispatch. The boxing here is the prerequisite, not the full fix — `Err(_)` discriminant checks work, `Err(err) -> err.message()` still fails at link.

- **Cross-pkg init-globals ctor RENDER path** (step 4a): `lirRenderModule` is EITHER/OR between `m.renderedFunctions` (text) and `m.functions` (typed AST). The ctor pushed to typed AST is invisible when text wins. The clean fix (render ctor to text up-front) triggers severe selfhost-rebuild slowdown that needs deeper investigation.

- **`std.keychain.get → osty_rt_keychain_get` ABI adapter** (step 4b): runtime returns `osty_rt_os_string_result *` not the Osty aggregate `Result<String, Error>`. Needs an Osty-side wrapper or a new rewrite-with-adapter pathway.

Step progress: PR #2004 = 1.5/4. This PR adds another ~0.5 → **2 / 4**.

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_