### PR TITLE
test: lock in cross-pkg interface boxing for Err construct (step 3 regression guard)

### DIFF
--- a/internal/backend/llvm_crosspkg_iface_box_test.go
+++ b/internal/backend/llvm_crosspkg_iface_box_test.go
@@ -1,0 +1,66 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestLLVMBackendBinaryCrossPkgInterfaceBoxingErrConstruct locks in
+// the cross-pkg interface boxing fix from PR #2007 (step 3/4 of
+// cross-pkg interface support). Before that PR the body-lowered
+// `error.new(msg)` body produced an assign-coercion error:
+//
+//	assign coercion `%error.BasicError` → `ptr` is not supported
+//	(dest `_return:Error`, src `error.BasicError`)
+//
+// because the destination MIR type (Error, a cross-pkg interface) was
+// lowered to opaque `ptr` via PR #2004's PascalCase fallback but the
+// LIR Proto assign path had no `Aggregate → Ptr` branch. The fix
+// GC-allocates the struct on the heap, copies the value in, and uses
+// the heap pointer as the interface value — sound for the
+// pattern-match-on-discriminant subset (`Err(_) -> …`).
+//
+// The Err arm of the match here exercises the boxed Error all the
+// way through: construct via `Err(error.new(...))`, box the
+// BasicError aggregate into the Error slot, embed in the
+// Result<Int, Error> Err variant, return, then destructure and
+// reach the Err arm via discriminant check. If any layer regresses
+// (boxing dropped, dest hint not propagated, GC root not bound)
+// the binary segfaults or links wrong.
+//
+// `err.message()` virtual dispatch is OUT of scope — that needs the
+// cross-pkg vtable injection (step 3.5) which is not yet
+// implemented. `Err(_)` here verifies the boxing prerequisite.
+func TestLLVMBackendBinaryCrossPkgInterfaceBoxingErrConstruct(t *testing.T) {
+	parallelClangBackendTest(t)
+	requireRealLLVMEmission(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.error
+
+fn make() -> Result<Int, Error> {
+    Err(error.new("oops"))
+}
+
+fn main() {
+    match make() {
+        Ok(v) -> println(v),
+        Err(_) -> println(-1),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := strings.TrimSpace(string(output)), "-1"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end binary regression test for the cross-pkg interface boxing fix landed in PR #2007 (step 3/4 of cross-pkg interface support). The existing test coverage from PR #2003 asserts at the IR level; this exercises the boxing through the full pipeline: body-lowering injection → Error type lowering → struct→ptr boxing → Result aggregate → match destructure → binary stdout.

If any layer regresses (boxing dropped, dest hint not propagated, GC root not bound) the binary segfaults or links wrong.

## What this guards

```osty
use std.error
fn make() -> Result<Int, Error> {
    Err(error.new("oops"))
}
fn main() {
    match make() {
        Ok(v) -> println(v),
        Err(_) -> println(-1),
    }
}
```

Expected stdout: `-1`

The Err arm exercises:
- body-lowering ON injects `error.new(msg) { BasicError { msg } }`
- PR #2004 lowers cross-pkg `Error` type as opaque `ptr`
- PR #2007 boxes the `BasicError` aggregate into the Error slot via `osty.gc.alloc_v1`
- boxed Error lands in `Err(...)` of `Result<Int, Error>`
- destructure reaches the Err arm via discriminant check

## Out of scope

`err.message()` virtual dispatch on the boxed Error needs cross-pkg vtable injection (step 3.5) which is still a remaining gap. `Err(_)` here verifies only the boxing prerequisite — the substantive PR #2007 fix.

## Test plan

- [x] `TestLLVMBackendBinaryCrossPkgInterfaceBoxingErrConstruct` passes (prints "-1", exit 0)
- [x] `go test -count=1 -short ./internal/backend/` clean, no regressions

## Why this scope

Step 3.5 (vtable injection) was attempted but requires changes across multiple layers (boxing shape from `ptr` → `{ptr, ptr}` iface aggregate, dispatch path rewrite at `lirTryLowerMirInterfaceCall`, MIR-side type recovery for interface method return types). Each is a non-trivial PR worth of work. Adding the regression test guards the boxing fix that DID land and prevents silent regression while the larger vtable work is queued.

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_