### PR TITLE
feat: register cross-pkg interface methods in MIR signature table (step 3.5 part 1)

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -344,6 +344,44 @@ func (l *lowerer) collectSignatures() {
 				continue
 			}
 			l.interfaces[x.Name] = x
+			// Register interface methods in the method-signature
+			// table so `signatureForMethod(typeName, methodName)` for
+			// an interface receiver finds the method's real return
+			// type / param list instead of falling through to the
+			// bare-name path (`Error__message` mangled with no type
+			// info → MIR call site picks up whatever stale return-
+			// type the lowerer last propagated, which has surfaced as
+			// `declare i64 @Error__message(ptr)` even though the
+			// interface declares `-> String`).
+			//
+			// The mangled symbol stays `Iface__method` (e.g.
+			// `Error__message`); concrete-impl forwarding remains the
+			// job of cross-pkg vtable injection (step 3.5 follow-up).
+			// What this fixes: the call-site signature has accurate
+			// types so cross-pkg call lowering declares the right
+			// shape and the synthesised forwarder (when it lands) can
+			// match.
+			for _, m := range x.Methods {
+				if m == nil || m.Name == "" {
+					continue
+				}
+				sig := &fnSignature{
+					ir:      m,
+					owner:   x.Name,
+					symbol:  mangleMethodSymbol(x.Name, m.Name),
+					params:  m.Params,
+					retType: m.Return,
+				}
+				key := methodKey(x.Name, m.Name)
+				// Don't shadow a concrete-impl method already
+				// registered with the same key (defensive — interface
+				// names are nominal and shouldn't collide with struct
+				// / enum names, but cross-pkg layout suffix matching
+				// could theoretically introduce overlap).
+				if _, exists := l.methods[key]; !exists {
+					l.methods[key] = sig
+				}
+			}
 		case *ir.LetDecl:
 			l.globals[x.Name] = x
 		case *ir.UseDecl:


### PR DESCRIPTION
## Summary

Register cross-pkg interface methods in MIR's method signature table. Previously the `InterfaceDecl` case in the MIR lowerer only stored the decl in `l.interfaces` and skipped `l.methods` registration entirely — so `signatureForMethod("Error", "message")` returned nil and the call site picked up whatever stale type the lowerer last propagated.

## What this enables

Interface method dispatch now has accurate signature info available via `signatureForMethod`. This is the FIRST of two pieces needed for proper cross-pkg interface method calls:

1. ✅ **This PR**: signature registration (return type / params accessible)
2. ⏳ **Remaining**: forwarder synthesis (`@Error__message` → `@BasicError__message`) and vtable definition emission

## Limits

This alone does NOT fix the keychain end-to-end `err.message()` link failure. The dispatch path at `lowerMethodCallInto` uses `mc.T` (set during checker/IR lowering) for the FnRef return type — NOT `signatureForMethod`. The forwarder needs landing AND mc.T propagation needs a separate fix.

Why land this alone: it's a real fix that propagates correct type info, and the follow-up forwarder synthesis depends on having the signature table populated to know what shape to emit.

## Test plan

- [x] `go test -count=1 -short ./internal/mir/ ./internal/backend/ ./internal/ir/` clean, no regressions
- [x] Signature registration triggered for std.error.Error and similar stdlib interfaces (verified manually)
- [x] Defensive: doesn't overwrite existing concrete-impl entries

## Out of scope

- Cross-pkg vtable definition emission (`@osty.vtable.BasicError__Error`)
- `Error__message` forwarder synthesis at LIR Proto module emission
- mc.T propagation fix at the dispatch site

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_