### PR TITLE
fix: unblock install-self default env (#1998 Map.update regression workaround)

### DIFF
--- a/toolchain/check_json.osty
+++ b/toolchain/check_json.osty
@@ -964,13 +964,30 @@ fn frontWireBuildTelemetry(diags: List<CheckDiagnostic>, m: FrontWireMapper) -> 
             continue
         }
         let bucket = frontWireDiagBucket(d)
-        byContext.update(bucket, |n| (n ?? 0) + 1)
+        // Inlined `byContext.update(bucket, |n| (n ?? 0) + 1)`.
+        // Map.update with a closure arg currently drops the closure
+        // operand at MIR generation (the `__update` symbol gets a 2-
+        // arg declare instead of the 3-arg form the body emits → link
+        // fails with `undefined symbol: _ZTSN4main3MapISslEE__update`).
+        // The bug surfaces only at toolchain selfhost build time —
+        // the canonical Map.update test in
+        // `internal/backend/llvm_closure_coalesce_test.go` reproduces
+        // it locally but skips in CI via `requireRealLLVMEmission`,
+        // hiding the regression introduced by PR #1998
+        // (`OSTY_STDLIB_BODY_LOWER=1` default flip). Until the
+        // closure-arg-drop bug is fixed at the MIR-lower layer,
+        // inline the increment so toolchain selfhost build works under
+        // default env. The semantic is identical to the closure form.
+        let currentBucket = byContext.get(bucket) ?? 0
+        byContext.insert(bucket, currentBucket + 1)
         let detail = frontWireDiagDetail(d, m)
         if detail == "" {
             continue
         }
         let mut bucketDetails = details.get(bucket) ?? {:}
-        bucketDetails.update(detail, |n| (n ?? 0) + 1)
+        // Same workaround as the byContext.update above.
+        let currentDetail = bucketDetails.get(detail) ?? 0
+        bucketDetails.insert(detail, currentDetail + 1)
         details.insert(bucket, bucketDetails)
     }
     FrontWireTelemetry {byContext, details}


### PR DESCRIPTION
## Summary

Reviewer-flagged P0: PR #1998 flipped `OSTY_STDLIB_BODY_LOWER` default to ON. That exposed a latent `Map<String, Int>.update` lowering bug — the closure arg is dropped at MIR generation. **install-self fails under the default env** since #1998 merged.

## Reproduction

```sh
$ env -u OSTY_SELF_BIN OSTY_SELF_REGISTRY_OFFLINE=1 \
        OSTY_STAGE0_FALLBACK=1 ./.bin/osty install-self
...
ld.lld: error: undefined symbol: _ZTSN4main3MapISslEE__update
>>> referenced by main.ll (frontWireBuildTelemetry)
```

The existing canonical test `TestLLVMBackendBinaryRunsMapUpdateCanonicalPattern` reproduces this locally but **skips in CI** via `requireRealLLVMEmission` (no osty-self cached) → CI gate didn't catch it.

## Root cause (not fixed in this PR)

`mir_lower.osty` method-call dispatch for `Map.update` drops the closure operand:

```osty
fn main() {
    let mut counts: Map<String, Int> = {:}
    counts.update("a", |n: Int?| (n ?? 0) + 1)
    println(counts.len())
}
```

MIR dump shows the call emitted with 2 args (self + key) instead of 3 (self + key + closure). The closure is silently discarded.

## Pragmatic fix (this PR)

Inline both `frontWireBuildTelemetry` Map.update call sites as `get + insert`. Semantic-identical (the closures have no captures, fixed delta 1):

- `byContext.update(bucket, |n| (n ?? 0) + 1)` → `let cur = byContext.get(bucket) ?? 0; byContext.insert(bucket, cur + 1)`
- `bucketDetails.update(detail, |n| (n ?? 0) + 1)` → same shape

Just enough to restore install-self. The underlying MIR closure-arg-drop bug needs separate follow-up work.

## Test plan

- [x] `env -u OSTY_SELF_BIN OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_STAGE0_FALLBACK=1 ./.bin/osty install-self` succeeds under **default env** (no `OSTY_STDLIB_BODY_LOWER=0` override)
- [x] Clean rebuild from scratch: `rm -rf .osty/cache/self-host toolchain/.osty .osty/toolchain && install-self` succeeds
- [x] `go test -count=1 -short ./internal/...` clean, no regressions

## Out of scope (follow-up work)

1. **The actual MIR closure-arg-drop bug** — `mirLowerMethodCallUser` → `mirLowerOrderCallArgs` (or the `methodSigs` registration path) somewhere strips the fn-typed parameter for Map.update. Same shape may affect other stdlib methods with `fn` params.

2. **CI gate hardening** — `requireRealLLVMEmission`-skipping tests silently hide regressions during the install-self build phase. The reviewer correctly flagged that the CI gate from #1992 didn't catch its first real test.

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_