### PR TITLE
fix: remove just-bootstrap body-lower mask so CI gate exercises default env

### DIFF
--- a/justfile
+++ b/justfile
@@ -57,25 +57,27 @@ build-all: build build-checker build-lirproto
 # triggers. Override on the command line (`OSTY_STAGE0_FALLBACK= just
 # bootstrap`) when you want to verify the prebuilt-only path instead.
 bootstrap: build-all
-    # `OSTY_STDLIB_BODY_LOWER=0` is the escape hatch from PR #1998's
-    # default-on flip. The stage0 source bootstrap path is sensitive to
-    # bodied stdlib injection because the toolchain itself calls into
-    # bodied methods (e.g. `Map<String, Int>.update`) whose injected
-    # form collides with the builtin-receiver dispatcher's intrinsic
-    # path — the symbol falls through to `mangleMethodSymbol(typeName,
-    # method)` (`_ZTSN…MapISslEE__update`) without a matching `define`.
-    # Disabling injection here keeps the existing bootstrap shape
-    # working until the conflict between `builtinNonGenericMethods` +
-    # `RewriteStdlibMethodCallsites` is resolved at the IR layer; user
-    # `osty build` continues to get the default-on path.
+    # PR #2013 inlined the `Map<String, Int>.update` toolchain call
+    # sites that previously needed `OSTY_STDLIB_BODY_LOWER=0` to
+    # dodge the closure-arg-drop bug introduced by PR #1998's
+    # default-on flip. `install-self` now works under the default
+    # env, so the bootstrap recipe exercises the same path
+    # production `osty build` walks.
     #
-    # Both env vars use the `${VAR:-1}` / `${VAR:-0}` form so a caller
-    # can override on the command line — for example,
-    # `OSTY_STAGE0_FALLBACK= just bootstrap` to verify the prebuilt-only
-    # path that the comment block above advertises. Hard-coding the
-    # values would silently override caller intent and make that
-    # documented contract impossible.
-    OSTY_STAGE0_FALLBACK="${OSTY_STAGE0_FALLBACK:-1}" OSTY_STDLIB_BODY_LOWER="${OSTY_STDLIB_BODY_LOWER:-0}" {{bin}} install-self
+    # If you hit a fresh stdlib-body lowering regression while
+    # extending this recipe, set `OSTY_STDLIB_BODY_LOWER=0 just
+    # bootstrap` from the shell as the escape hatch — same
+    # contract as before, just no longer the default. Removing the
+    # default workaround means the CI gate
+    # (`fresh-clone-source-bootstrap.yml`) now actually catches
+    # regressions that need body-lowering ON to surface, which is
+    # what reviewer feedback flagged after PR #1998 silently
+    # bypassed the gate for an entire 14-PR cycle.
+    #
+    # `OSTY_STAGE0_FALLBACK="${VAR:-1}"` stays as documented above —
+    # it's the chicken-and-egg fix from PR #1989 and is independent
+    # of the body-lowering flip.
+    OSTY_STAGE0_FALLBACK="${OSTY_STAGE0_FALLBACK:-1}" {{bin}} install-self
 
 # cache-self prints the canonical .osty/cache/self-host/<sha>-<triple>/
 # osty-self path for the current toolchain SHA + host triple. With


### PR DESCRIPTION
## Summary

Reviewer-flagged CI gate hole: the `fresh-clone-source-bootstrap.yml` gate (PR #1992) was meant to catch fresh-clone install-self regressions on every PR. After PR #1998 flipped `OSTY_STDLIB_BODY_LOWER` default to ON, the toolchain self-build broke under the default env — **but the gate kept passing because `just bootstrap` itself baked in `OSTY_STDLIB_BODY_LOWER=0` as the documented workaround**.

End-effect: PR #1998 introduced a regression that the gate designed to catch this exact class of bug silently masked for 14 PRs (#1998 → #2011).

The reviewer caught this:
> "CI gate (#1992) 가 첫 실전 fail. 가능한 원인:
> - CI gate 가 BODY_LOWER 환경을 따로 안 검증 (default flip 자체는 통과)"

## What this PR does

PR #2013 inlined the two toolchain `Map<String, Int>.update` call sites whose closure-arg-drop bug was the real blocker for default-ON `install-self`. With that fixed, the workaround in `just bootstrap` is no longer needed and **actively harmful** — it keeps the gate from exercising the same path production `osty build` walks.

Remove `OSTY_STDLIB_BODY_LOWER="${VAR:-0}"` from `just bootstrap`. `OSTY_STAGE0_FALLBACK="${VAR:-1}"` stays (PR #1989 chicken-and-egg, independent).

Escape-hatch contract preserved: callers hitting a fresh body-lowering regression can still `OSTY_STDLIB_BODY_LOWER=0 just bootstrap` from the shell.

## Test plan

- [x] CI-equivalent env (`OSTY_SELF_REGISTRY_OFFLINE=1 OSTY_SELF_TRUSTED_KEY="" OSTY_STAGE0_FALLBACK=1 ./.bin/osty install-self`) succeeds end-to-end without the BODY_LOWER override
- [x] Clean rebuild from scratch: install-self succeeds, cache artifact populated as the gate's "Verify cache artifact" step expects
- [x] `go test -count=1 -short ./internal/...` clean

## Why this matters

Without this, any future PR that flips a default behind a body-lowering wall will repeat the exact same silent-mask pattern. The gate's value proposition is "catch regressions on the introducing PR" — that fails the moment the gate runs the workaround instead of the default.

This is the structural follow-up to PR #2013 (which fixed the symptom). PR #2013 alone leaves the gate hole in place; this PR closes it.

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_