### PR TITLE
docs: FIXME for Map.update closure-arg-drop root cause + Layer-2 gap

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -311,6 +311,42 @@ func (l *lowerer) collectSignatures() {
 			}
 			l.structs[x.Name] = x
 			for _, m := range x.Methods {
+				// FIXME(method-sig-self-mismatch): m.Params does NOT
+				// include the receiver — `lowerFnDecl` parses
+				// `mut self` into a separate `Recv` field and drops
+				// it from Params, keeping only ReceiverMut as a
+				// bool. The MIR fn-definition path (`newFunction`
+				// at the `asMethod` branch, ~line 724-733)
+				// synthesizes a self param so the emitted MIR fn
+				// has [self, ...], but the SIG TABLE here registers
+				// raw m.Params (NO self). That off-by-one plus
+				// `methodCallSig`'s "drop first" assumption silently
+				// drops the LAST arg at every method-call site whose
+				// method has >0 source params.
+				//
+				// Concrete trigger: `Map<String,Int>.update(k,
+				// |n| ...)` registers sig.params=[key, f] (2).
+				// methodCallSig → [f] (1). orderArgs(2 args, 1
+				// slot) → [key] (closure dropped). MIR emits a
+				// 2-arg call to a 3-param def → LIR Proto rejects
+				// with "direct call argument count mismatch".
+				//
+				// The correct sig fix is to prepend a synthesized
+				// self param here (mirroring newFunction's
+				// asMethod branch). That fix has been verified in
+				// isolation on the minimal repro — but unmasks a
+				// Layer-2 type-confusion bug in some downstream
+				// call lowering (`osty_rt_list_get_i64` gets
+				// called with a String key where i64 index is
+				// expected, producing "ptr but expected 'i64'" at
+				// clang). The Layer-2 bug is hidden today because
+				// this drop bails the call earlier.
+				//
+				// Production workaround: PR #2013 inlined the
+				// toolchain's Map.update call sites. User code
+				// that calls Map.update with a closure still hits
+				// the drop. A real fix needs both this sig fix AND
+				// the Layer-2 type-confusion fix landing together.
 				sig := &fnSignature{
 					ir:      m,
 					owner:   x.Name,


### PR DESCRIPTION
## Summary

Documentation-only PR — FIXME comment in `internal/mir/lower.go` explaining the root cause of the `Map.update` closure-arg-drop bug that PR #2013 worked around. Pure docs change so the next attempt at the real fix doesn't re-discover the same chain.

## Why this is just a comment (not a fix)

Investigation found the root cause:

1. `lowerFnDecl` parses `mut self` into `fn.Recv` (separate field), drops it from `fn.Params`. Only `ReceiverMut` bool survives.
2. The MIR fn-definition path (`newFunction` `asMethod` branch) **synthesizes** a self param so the emitted MIR fn has `[self, ...]`.
3. The SIG TABLE at `lower.go:312-321` (StructDecl) and `lower.go:355-365` (EnumDecl) registers **raw** `m.Params` (NO self).
4. `methodCallSig` (`lower.go:9166`) assumes self is at index 0 and drops it. For sigs registered without self, this drops a real param.

End-effect for `Map<String,Int>.update(k, |n| (n ?? 0) + 1)`:
- sig.params = [key, f] (2)
- methodCallSig → [f] (1)
- orderArgs(2 args, 1 slot) → [key] (closure dropped silently)
- MIR emits 2-arg call to 3-param def → LIR Proto rejects: `"direct call argument count mismatch"`

The naive sig fix (prepend a synthesized self param at registration) was tested in isolation on the minimal repro. It resolves the "argument count mismatch" but **unmasks a Layer-2 type-confusion bug** in some downstream call lowering:

```
'%tN' defined with type 'ptr' but expected 'i64'
   call i64 @osty_rt_list_get_i64(ptr ..., i64 %tN)
```

Layer-2 is hidden today because the off-by-one drops the LAST arg before lowering proceeds further. Shipping the sig fix alone breaks `install-self` self-build (`main.ll:117404` style errors deep in toolchain IR).

## What this PR delivers

- Detailed FIXME comment in `mir/lower.go` at the StructDecl sig registration site (line 313)
- Documents the off-by-one + downstream Layer-2 + PR #2013 workaround status
- Saves the next person ~30 minutes of bisection

No behavior change. Tests still pass.

## Test plan

- [x] `go test -count=1 -short ./internal/mir/ ./internal/backend/ ./internal/ir/` clean
- [x] Clean rebuild + `install-self` still succeeds (no code change)

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_