### PR TITLE
feat: requireRealLLVMEmission strict-env mode + CI step (closes gate hole)

### DIFF
--- a/.github/workflows/fresh-clone-source-bootstrap.yml
+++ b/.github/workflows/fresh-clone-source-bootstrap.yml
@@ -169,3 +169,25 @@ jobs:
           set -euo pipefail
           cd "$RUNNER_TEMP/scratch/osty"
           ./.bin/osty check examples/calc 2>&1 | tee "$RUNNER_TEMP/check.log"
+
+      - name: Run strict-mode backend tests against the bootstrapped osty-self
+        # Reviewer-flagged gap from PR #1998: 88 backend tests use
+        # `requireRealLLVMEmission`, which SKIPs when osty-self isn't
+        # cached. CI runs from a fresh clone with no osty-self until
+        # this workflow builds one — so the gated tests silently
+        # skipped in every PR's run, hiding any MIR-direct regression
+        # until manual users hit it.
+        #
+        # With osty-self now in cache (post-bootstrap above), set
+        # OSTY_REQUIRE_REAL_LLVM_EMISSION=1 to flip the gate from
+        # skip-on-missing to fail-on-missing AND actually run the
+        # tests against the bootstrapped artifact. Any
+        # `requireRealLLVMEmission`-gated test that fails surfaces
+        # as a CI failure on the introducing PR — same contract as
+        # the install-self gate this workflow already provides.
+        env:
+          OSTY_REQUIRE_REAL_LLVM_EMISSION: "1"
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/scratch/osty"
+          go test -count=1 -short ./internal/backend/ 2>&1 | tee "$RUNNER_TEMP/strict-backend.log"

--- a/internal/backend/native_mir_payload_stub_test.go
+++ b/internal/backend/native_mir_payload_stub_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/osty/osty/internal/toolchain/selfhostcache"
@@ -30,6 +31,18 @@ func installNativeMIRPayloadDeclineStub(t *testing.T) {
 	})
 }
 
+// requireRealLLVMEmissionStrictEnv is the env var that flips
+// `requireRealLLVMEmission` from skip-on-missing to fail-on-missing.
+// CI / preflight bootstrap scripts should set this AFTER ensuring
+// osty-self is built (e.g. after `just bootstrap` succeeds) so any
+// regression in the MIR-direct emit path surfaces as a test failure
+// instead of an invisible skip.
+//
+// Without this env var, local dev runs continue to see clean skips
+// when osty-self isn't cached — preserves the fresh-clone-friendly
+// behavior `t.Skip` was added for in PR #1975.
+const requireRealLLVMEmissionStrictEnv = "OSTY_REQUIRE_REAL_LLVM_EMISSION"
+
 // requireRealLLVMEmission skips the test unless an `osty-self` binary is
 // reachable through `selfhostcache.ResolveBinary` — the same lookup the
 // LIR Proto subprocess uses at runtime (env override → in-tree build →
@@ -37,16 +50,46 @@ func installNativeMIRPayloadDeclineStub(t *testing.T) {
 // `osty-native-lirproto`, which forks `osty-self lir-proto-lower`; without
 // that artifact the subprocess declines and tests that assert specific
 // runtime symbols or optimisations cannot succeed.
+//
+// When `OSTY_REQUIRE_REAL_LLVM_EMISSION=1` is set (CI mode), the same
+// missing-artifact condition FAILS the test instead of skipping. This
+// closes the gate hole reviewer-flagged after PR #1998's silent
+// regression: tests with no osty-self skipped silently in CI, hiding
+// the regression that broke the bootstrap until manual users hit it.
+// With the strict env var set, CI catches MIR-direct breakage on the
+// introducing PR.
 func requireRealLLVMEmission(t *testing.T) {
 	t.Helper()
+	strict := requireRealLLVMEmissionStrict()
+	failOrSkip := func(format string, args ...any) {
+		if strict {
+			t.Fatalf(format, args...)
+		} else {
+			t.Skipf(format, args...)
+		}
+	}
 	root, err := selfhostcache.LocateProjectRoot(".")
 	if err != nil {
-		t.Skipf("requires osty-self artifact (locate project root: %v)", err)
+		failOrSkip("requires osty-self artifact (locate project root: %v)", err)
+		return
 	}
 	if _, _, err := selfhostcache.ResolveBinary(root); err != nil {
 		if errors.Is(err, selfhostcache.ErrNotCached) {
-			t.Skip("requires osty-self artifact (run `osty build toolchain/`); LIR Proto subprocess otherwise declines")
+			if strict {
+				t.Fatal("requires osty-self artifact (run `osty build toolchain/`); LIR Proto subprocess otherwise declines")
+			} else {
+				t.Skip("requires osty-self artifact (run `osty build toolchain/`); LIR Proto subprocess otherwise declines")
+			}
+			return
 		}
-		t.Skipf("requires osty-self artifact (resolve: %v)", err)
+		failOrSkip("requires osty-self artifact (resolve: %v)", err)
 	}
+}
+
+func requireRealLLVMEmissionStrict() bool {
+	switch os.Getenv(requireRealLLVMEmissionStrictEnv) {
+	case "1", "true", "TRUE", "yes", "YES", "on", "ON":
+		return true
+	}
+	return false
 }

--- a/internal/backend/require_real_llvm_strict_test.go
+++ b/internal/backend/require_real_llvm_strict_test.go
@@ -1,0 +1,52 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRequireRealLLVMEmissionStrictEnvOff confirms the default
+// behavior: when OSTY_REQUIRE_REAL_LLVM_EMISSION is unset (the
+// local-dev case), requireRealLLVMEmission still SKIPs when
+// osty-self is unreachable. Without this guarantee, every fresh
+// clone would fail the gated tests before the user has a chance
+// to run `osty build toolchain/`.
+func TestRequireRealLLVMEmissionStrictEnvOff(t *testing.T) {
+	t.Setenv(requireRealLLVMEmissionStrictEnv, "")
+	if requireRealLLVMEmissionStrict() {
+		t.Fatal("strict() returned true with env unset")
+	}
+}
+
+// TestRequireRealLLVMEmissionStrictEnvOn flips the env var and
+// confirms strict mode activates. CI workflows that bootstrap
+// osty-self before running tests should set this to FAIL on
+// missing artifact instead of silently skipping — the gate hole
+// reviewer-flagged after PR #1998's regression hid for 14 PRs.
+func TestRequireRealLLVMEmissionStrictEnvOn(t *testing.T) {
+	for _, val := range []string{"1", "true", "TRUE", "yes", "YES", "on", "ON"} {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv(requireRealLLVMEmissionStrictEnv, val)
+			if !requireRealLLVMEmissionStrict() {
+				t.Fatalf("strict() returned false for env %q", val)
+			}
+		})
+	}
+}
+
+// TestRequireRealLLVMEmissionStrictEnvIgnoresOtherValues confirms
+// arbitrary non-truthy values DON'T activate strict mode, so a
+// stray export of `OSTY_REQUIRE_REAL_LLVM_EMISSION=0` or
+// `=false` won't accidentally make tests skip when they should fail.
+// Mirrors the asymmetry in Go's `strconv.ParseBool` but limited to
+// the explicit accept-list above for stability.
+func TestRequireRealLLVMEmissionStrictEnvIgnoresOtherValues(t *testing.T) {
+	for _, val := range []string{"0", "false", "no", "off", "anything", " 1 "} {
+		t.Run(strings.TrimSpace(val), func(t *testing.T) {
+			t.Setenv(requireRealLLVMEmissionStrictEnv, val)
+			if requireRealLLVMEmissionStrict() {
+				t.Fatalf("strict() returned true for non-truthy env %q", val)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Reviewer-flagged followup. PR #2015 closed half the CI gate hole (install-self path). This PR closes the rest: 88 backend tests that use `requireRealLLVMEmission` silently SKIPed in CI because osty-self isn't cached on a fresh clone — exactly the shape of #1998's regression slipping through #1992's gate for 14 PRs.

## Two pieces

### 1. `OSTY_REQUIRE_REAL_LLVM_EMISSION=1` strict-env mode

Flips `requireRealLLVMEmission` from skip-on-missing to fail-on-missing. Without the var set, local dev runs continue to see clean skips when osty-self isn't cached (PR #1975's contract preserved).

### 2. CI workflow step

`fresh-clone-source-bootstrap.yml` now runs `go test -short ./internal/backend/` with strict env AFTER bootstrap succeeds. Every `requireRealLLVMEmission`-gated test that fails surfaces as a CI failure on the introducing PR.

## Trade-off

`-short` excludes heavy clang-link binary tests (`parallelClangBackendTest` → `requireClangForBackendTest` skips on `testing.Short()`). The canonical `Map.update` test is one such — it would catch the closure-arg-drop bug documented in #2017 but takes a clang link to do so. Catching IR-emit-only regressions via `-short` is the right first cut.

## Unit tests

- `TestRequireRealLLVMEmissionStrictEnvOff`: env unset → strict mode off (existing skip behavior preserved)
- `TestRequireRealLLVMEmissionStrictEnvOn`: `1`/`true`/`TRUE`/`yes`/`YES`/`on`/`ON` all activate strict mode
- `TestRequireRealLLVMEmissionStrictEnvIgnoresOtherValues`: arbitrary values (`0`/`false`/`no`/`off`/`"anything"`) don't accidentally activate strict mode

## Test plan

- [x] `OSTY_REQUIRE_REAL_LLVM_EMISSION=1 go test -count=1 -short ./internal/backend/` clean (all 88 gated tests pass under strict — baseline restored, future regressions get caught)
- [x] `go test -count=1 -short ./internal/backend/` (no env) clean
- [x] Unit tests pass

## Why this matters

The gate hole reviewer flagged after #1998 was structural. PR #2015 closed half (install-self path). This PR closes the rest (gated backend tests). With both landed, any future PR that breaks MIR-direct emit or install-self under default env fails CI on the introducing PR instead of silently masking for weeks.

https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9D4fG6CyEFmWv9TSxGgm)_