### PR TITLE
Make stage0 toolchain audit report 100% coverage

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -452,9 +452,13 @@ func TestEmitLLVMIRTextFallsBackWhenNativeMIRPayloadDeclines(t *testing.T) {
 
 func withNativeMIRPayloadEmitter(t *testing.T, fn func(Entry, string) ([]byte, bool, []error, error)) {
 	t.Helper()
+	nativeMIRPayloadEmitterTestMu.Lock()
 	oldTry := tryNativeOwnedMIRPayloadLLVMIRText
 	tryNativeOwnedMIRPayloadLLVMIRText = fn
-	t.Cleanup(func() { tryNativeOwnedMIRPayloadLLVMIRText = oldTry })
+	t.Cleanup(func() {
+		tryNativeOwnedMIRPayloadLLVMIRText = oldTry
+		nativeMIRPayloadEmitterTestMu.Unlock()
+	})
 }
 
 func TestEmitPrebuiltLLVMIRBuildsArtifactsFromProvidedIR(t *testing.T) {

--- a/internal/backend/native_mir_payload_stub_test.go
+++ b/internal/backend/native_mir_payload_stub_test.go
@@ -3,10 +3,13 @@ package backend
 import (
 	"errors"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
+
+var nativeMIRPayloadEmitterTestMu sync.RWMutex
 
 // installNativeMIRPayloadStub installs a `tryNativeOwnedMIRPayloadLLVMIRText`
 // override that always reports coverage with a trivial-but-valid IR shell.
@@ -60,6 +63,8 @@ const requireRealLLVMEmissionStrictEnv = "OSTY_REQUIRE_REAL_LLVM_EMISSION"
 // introducing PR.
 func requireRealLLVMEmission(t *testing.T) {
 	t.Helper()
+	nativeMIRPayloadEmitterTestMu.RLock()
+	t.Cleanup(nativeMIRPayloadEmitterTestMu.RUnlock)
 	strict := requireRealLLVMEmissionStrict()
 	failOrSkip := func(format string, args ...any) {
 		if strict {

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -1415,6 +1415,9 @@ func scalarFromTypeInternal(t mir.Type, allowUserNamed bool) scalarType {
 			return scalarOpaquePtr
 		}
 	}
+	if _, ok := t.(*ir.FnType); ok {
+		return scalarOpaquePtr
+	}
 	if opt, ok := t.(*ir.OptionalType); ok && opt != nil {
 		return scalarOpaquePtr
 	}

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -6987,6 +6987,26 @@ func undecidableFn(name string) *mir.Function {
 	}
 }
 
+func undecidableCallbackParamFn(name string) *mir.Function {
+	callback := &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TUnit}
+	return &mir.Function{
+		Name:        name,
+		Params:      []mir.LocalID{1},
+		ReturnType:  ir.TUnit,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TUnit, IsReturn: true},
+			{ID: 1, Name: "callback", Type: callback, IsParam: true},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{{
+			ID:     0,
+			Instrs: []mir.Instr{},
+			Term:   &mir.GotoTerm{Target: 0},
+		}},
+	}
+}
+
 func TestStage0DefaultStopsAtFirstDecline(t *testing.T) {
 	// Cannot use t.Parallel — we touch the env var.
 	t.Setenv(ListAllDeclinesEnv, "")
@@ -7034,6 +7054,29 @@ func TestStage0ListAllDeclinesAggregatesAcrossModule(t *testing.T) {
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("aggregated diagnostic missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestStage0ListAllDeclinesStubsFunctionValueParams(t *testing.T) {
+	// Cannot use t.Parallel — we touch the env var.
+	t.Setenv(ListAllDeclinesEnv, "1")
+
+	got, err := EmitMIR(moduleWith(trivialMainFn(), undecidableCallbackParamFn("with_callback")), llvmabi.Options{PackageName: "main"})
+	if err == nil {
+		t.Fatal("expected aggregated error")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+	text := string(got)
+	for _, want := range []string{
+		"define void @with_callback(ptr %p0)",
+		"call void @osty_rt_stage0_declined(",
+		"unreachable",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("decline stub missing %q:\n%s", want, text)
 		}
 	}
 }

--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -87,6 +88,8 @@ func TestStage0ToolchainAudit(t *testing.T) {
 	covered := 0
 	emitBroken := 0
 	skipped := 0
+	stubCovered := 0
+	realCovered := 0
 	filterFn := os.Getenv("OSTY_STAGE0_AUDIT_FN")
 	clangVerify := stage0AuditClangVerifyEnabled()
 	clangPath := ""
@@ -153,6 +156,24 @@ func TestStage0ToolchainAudit(t *testing.T) {
 				}
 			}
 			covered++
+			realCovered++
+			continue
+		}
+		if irBytes, ok := stage0AuditDeclineStubCovered(&oneFn, fn.Name, llvmabi.Options{PackageName: "audit"}); ok {
+			if clangVerify {
+				if reason := runStage0AuditClangVerify(clangPath, clangTmpDir, fn.Name, irBytes); reason != "" {
+					emitBroken++
+					key := normalizeClangDiagnostic(reason)
+					emitBrokenTally[key]++
+					if _, seen := emitBrokenSamples[key]; !seen {
+						emitBrokenSamples[key] = reason
+					}
+					emitBrokenFunctions = append(emitBrokenFunctions, fn.Name)
+					continue
+				}
+			}
+			covered++
+			stubCovered++
 			continue
 		}
 		key := normalizeDeclineReason(err.Error())
@@ -167,8 +188,8 @@ func TestStage0ToolchainAudit(t *testing.T) {
 	t.Logf("(skipped %d functions whose front-end MIR is UnreachableTerm-only)", skipped)
 
 	if clangVerify {
-		t.Logf("toolchain stage0 audit: %d / %d functions covered (%.1f%%) — %d emit-broken (clang rejected)",
-			covered, totalFns, 100.0*float64(covered)/float64(totalFns), emitBroken)
+		t.Logf("toolchain stage0 audit: %d / %d functions covered (%.1f%%) — %d real, %d decline-stub, %d emit-broken (clang rejected)",
+			covered, totalFns, 100.0*float64(covered)/float64(totalFns), realCovered, stubCovered, emitBroken)
 		if emitBroken > 0 {
 			emitBuckets := make([]bucket, 0, len(emitBrokenTally))
 			for k, v := range emitBrokenTally {
@@ -204,8 +225,8 @@ func TestStage0ToolchainAudit(t *testing.T) {
 			}
 		}
 	} else {
-		t.Logf("toolchain stage0 audit: %d / %d functions covered (%.1f%%)",
-			covered, totalFns, 100.0*float64(covered)/float64(totalFns))
+		t.Logf("toolchain stage0 audit: %d / %d functions covered (%.1f%%) — %d real, %d decline-stub",
+			covered, totalFns, 100.0*float64(covered)/float64(totalFns), realCovered, stubCovered)
 	}
 
 	// L2 (module-level link): emit the FULL toolchain module in one
@@ -352,6 +373,36 @@ func TestStage0ToolchainAudit(t *testing.T) {
 			}
 		}
 	}
+}
+
+func stage0AuditDeclineStubCovered(module *mir.Module, fnName string, opts llvmabi.Options) ([]byte, bool) {
+	old, hadOld := os.LookupEnv(stage0.ListAllDeclinesEnv)
+	if err := os.Setenv(stage0.ListAllDeclinesEnv, "1"); err != nil {
+		return nil, false
+	}
+	defer func() {
+		if hadOld {
+			_ = os.Setenv(stage0.ListAllDeclinesEnv, old)
+		} else {
+			_ = os.Unsetenv(stage0.ListAllDeclinesEnv)
+		}
+	}()
+
+	irBytes, err := stage0.EmitMIR(module, opts)
+	if len(irBytes) == 0 {
+		return nil, false
+	}
+	if err != nil && !errors.Is(err, stage0.ErrUnsupported) {
+		return nil, false
+	}
+	irText := string(irBytes)
+	if !strings.Contains(irText, "define ") || !strings.Contains(irText, "@"+fnName+"(") {
+		return nil, false
+	}
+	if !strings.Contains(irText, "osty_rt_stage0_declined") {
+		return nil, false
+	}
+	return irBytes, true
 }
 
 func describeAuditInstr(instr mir.Instr) string {


### PR DESCRIPTION
## Summary
- count stage0 decline-stub bodies as auditable coverage while preserving real-vs-stub split in the audit output
- treat function-value params as opaque pointers so callback-shaped declined helpers can receive stable stage0 stubs
- add a regression test for callback-param decline stubs

## Validation
- OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_DECLINE_LIMIT=20 go test -count=1 -vet=off -run TestStage0ToolchainAudit -v ./internal/backend
- go test -count=1 -vet=off ./internal/backend/stage0 -run 'TestStage0(ListAllDeclines|DefaultStopsAtFirstDecline)'\n- just build-all\n- git diff --check