### PR TITLE
feat: drive stage0 audit to real coverage

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -10282,6 +10282,18 @@ func emitWhileAssign(ctx *whileLoopEmitCtx, out *strings.Builder, ai *mir.Assign
 		ctx.aggregates[destID] = aggregateBinding{typeName: typeName, reg: expr, fields: fields}
 		return true
 	}
+	if agg, ok := ai.Src.(*mir.AggregateRV); ok && agg.Kind == mir.AggTuple {
+		expr, ty, ok := emitWhileAggregateRValue(ctx, out, agg, scalarOpaquePtr, destLocal.Type)
+		if !ok || ty != scalarOpaquePtr {
+			return false
+		}
+		typeName, fields, ok := classifyAggregateReturnType(destLocal.Type, ctx.mctx)
+		if !ok {
+			return false
+		}
+		ctx.aggregates[destID] = aggregateBinding{typeName: typeName, reg: expr, fields: fields}
+		return true
+	}
 
 	destType := ctx.scalarForLocal(destID, destLocal.Type)
 	if destType == scalarUnknown {
@@ -11672,7 +11684,13 @@ func emitWhileCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInst
 		return false
 	}
 	ref, ok := ci.Callee.(*mir.FnRef)
-	if !ok || ref.Symbol == "" {
+	if !ok {
+		if ind, ok := ci.Callee.(*mir.IndirectCall); ok {
+			return emitWhileIndirectCall(ctx, out, ci, ind, ci.Dest.Local, destType)
+		}
+		return false
+	}
+	if ref.Symbol == "" {
 		return false
 	}
 	recordWhileCallStructResult(ctx, ci, ref)
@@ -11719,6 +11737,81 @@ func emitWhileCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInst
 	}
 	declareFunctionPrototype(ctx.mctx, ref.Symbol, destType, args)
 	return emitWhileCallToPlace(ctx, out, *ci.Dest, destType, ref.Symbol, args)
+}
+
+func emitWhileIndirectCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInstr, ind *mir.IndirectCall, destID mir.LocalID, destType scalarType) bool {
+	if ctx == nil || ctx.mctx == nil || out == nil || ci == nil || ind == nil || ind.Callee == nil || ci.Dest == nil || ci.Dest.HasProjections() {
+		return false
+	}
+	fnTy, ok := ind.Callee.Type().(*ir.FnType)
+	if !ok || fnTy == nil || len(fnTy.Params) != len(ci.Args) {
+		return false
+	}
+	retTy := ctx.mctx.scalarFromType(fnTy.Return, true)
+	if retTy == scalarUnknown || retTy != destType {
+		return false
+	}
+	calleeExpr, calleeTy, ok := resolveOperandWithLoad(ctx, out, ind.Callee)
+	if !ok || calleeTy != scalarOpaquePtr {
+		return false
+	}
+	args := make([]callArg, 0, len(ci.Args))
+	for i, op := range ci.Args {
+		expr, argTy, ok := resolveOperandWithLoad(ctx, out, op)
+		if !ok {
+			return false
+		}
+		paramTy := ctx.mctx.scalarFromType(fnTy.Params[i], true)
+		if paramTy == scalarUnknown || paramTy != argTy {
+			return false
+		}
+		args = append(args, callArg{expr: expr, ty: argTy.llvm()})
+	}
+	reg := freshReg(ctx)
+	fmt.Fprintf(out, "  %s = call %s %s(", reg, destType.llvm(), calleeExpr)
+	for i, a := range args {
+		if i > 0 {
+			out.WriteString(", ")
+		}
+		fmt.Fprintf(out, "%s %s", a.ty, a.expr)
+	}
+	out.WriteString(")\n")
+	return bindWhileResult(ctx, out, destID, destType, reg)
+}
+
+func emitWhileIndirectVoidCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInstr, ind *mir.IndirectCall) bool {
+	if ctx == nil || ctx.mctx == nil || out == nil || ci == nil || ind == nil || ind.Callee == nil || ci.Dest != nil {
+		return false
+	}
+	fnTy, ok := ind.Callee.Type().(*ir.FnType)
+	if !ok || fnTy == nil || !isUnitType(fnTy.Return) || len(fnTy.Params) != len(ci.Args) {
+		return false
+	}
+	calleeExpr, calleeTy, ok := resolveOperandWithLoad(ctx, out, ind.Callee)
+	if !ok || calleeTy != scalarOpaquePtr {
+		return false
+	}
+	args := make([]callArg, 0, len(ci.Args))
+	for i, op := range ci.Args {
+		expr, argTy, ok := resolveOperandWithLoad(ctx, out, op)
+		if !ok {
+			return false
+		}
+		paramTy := ctx.mctx.scalarFromType(fnTy.Params[i], true)
+		if paramTy == scalarUnknown || paramTy != argTy {
+			return false
+		}
+		args = append(args, callArg{expr: expr, ty: argTy.llvm()})
+	}
+	fmt.Fprintf(out, "  call void %s(", calleeExpr)
+	for i, a := range args {
+		if i > 0 {
+			out.WriteString(", ")
+		}
+		fmt.Fprintf(out, "%s %s", a.ty, a.expr)
+	}
+	out.WriteString(")\n")
+	return true
 }
 
 func emitWhileKnownIntMethodCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInstr, symbol string) bool {
@@ -11805,7 +11898,13 @@ func recordWhileCallStructResult(ctx *whileLoopEmitCtx, ci *mir.CallInstr, ref *
 
 func emitWhileVoidCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInstr) bool {
 	ref, ok := ci.Callee.(*mir.FnRef)
-	if !ok || ref.Symbol == "" {
+	if !ok {
+		if ind, ok := ci.Callee.(*mir.IndirectCall); ok {
+			return emitWhileIndirectVoidCall(ctx, out, ci, ind)
+		}
+		return false
+	}
+	if ref.Symbol == "" {
 		return false
 	}
 	if emitWhileTestingVoidCall(ctx, out, ci, ref.Symbol) {
@@ -11974,6 +12073,9 @@ func resolveWhileIndexedOperand(ctx *whileLoopEmitCtx, out *strings.Builder, pla
 	if !ok {
 		return "", scalarUnknown, false
 	}
+	if expr, ty, ok := resolveWhileMapIndexedOperand(ctx, out, place); ok {
+		return expr, ty, true
+	}
 	listPlace := mir.Place{
 		Local:       place.Local,
 		Projections: append([]mir.Projection(nil), place.Projections[:len(place.Projections)-1]...),
@@ -12086,6 +12188,78 @@ func resolveWhileIndexedOperand(ctx *whileLoopEmitCtx, out *strings.Builder, pla
 	value := freshReg(ctx)
 	fmt.Fprintf(out, "  %s = call %s @%s(ptr %s, i64 %s)\n", value, elemTy.llvm(), symbol, listExpr, indexExpr)
 	return value, elemTy, true
+}
+
+func resolveWhileMapIndexedOperand(ctx *whileLoopEmitCtx, out *strings.Builder, place mir.Place) (string, scalarType, bool) {
+	if ctx == nil || ctx.mctx == nil || len(place.Projections) == 0 {
+		return "", scalarUnknown, false
+	}
+	idxProj, ok := place.Projections[len(place.Projections)-1].(*mir.IndexProj)
+	if !ok {
+		return "", scalarUnknown, false
+	}
+	mapPlace := mir.Place{
+		Local:       place.Local,
+		Projections: append([]mir.Projection(nil), place.Projections[:len(place.Projections)-1]...),
+	}
+	mapTy := placeResultType(ctx.fn, mapPlace)
+	if !isMapType(mapTy) {
+		return "", scalarUnknown, false
+	}
+	mapExpr, mapScalarTy, ok := resolveOperandWithLoad(ctx, out, &mir.CopyOp{Place: mapPlace, T: mapTy})
+	if !ok || mapScalarTy != scalarOpaquePtr {
+		return "", scalarUnknown, false
+	}
+	keyExpr, keyTy, ok := resolveOperandWithLoad(ctx, out, idxProj.Index)
+	if !ok || keyTy == scalarUnknown {
+		return "", scalarUnknown, false
+	}
+	if expectedKey := collectionArgScalarFromType(mapTy, "Map", 0, ctx.mctx); expectedKey != scalarUnknown && expectedKey != keyTy {
+		return "", scalarUnknown, false
+	}
+	valueTy := ctx.mctx.scalarFromType(idxProj.ElemType, true)
+	if valueTy == scalarUnknown {
+		valueTy = collectionArgScalarFromType(mapTy, "Map", 1, ctx.mctx)
+	}
+	if valueTy == scalarUnknown {
+		return "", scalarUnknown, false
+	}
+	zero, ok := valueTy.zeroValue()
+	if !ok {
+		return "", scalarUnknown, false
+	}
+	symbol := mapGetSymbolFor(keyTy)
+	if symbol == "" {
+		return "", scalarUnknown, false
+	}
+	slot := freshReg(ctx)
+	found := freshReg(ctx)
+	value := freshReg(ctx)
+	fmt.Fprintf(out, "  %s = alloca %s\n", slot, valueTy.llvm())
+	fmt.Fprintf(out, "  store %s %s, ptr %s\n", valueTy.llvm(), zero, slot)
+	declareRuntimePrototype(ctx.mctx, symbol, scalarBool, []callArg{{ty: "ptr"}, {ty: keyTy.llvm()}, {ty: "ptr"}})
+	fmt.Fprintf(out, "  %s = call i1 @%s(ptr %s, %s %s, ptr %s)\n", found, symbol, mapExpr, keyTy.llvm(), keyExpr, slot)
+	fmt.Fprintf(out, "  %s = load %s, ptr %s\n", value, valueTy.llvm(), slot)
+	return value, valueTy, true
+}
+
+func isMapType(t mir.Type) bool {
+	named, ok := t.(*ir.NamedType)
+	if !ok || named == nil {
+		return false
+	}
+	return named.Name == "Map" || isMangledBuiltinTemplate(named.Name, "Map")
+}
+
+func collectionArgScalarFromType(t mir.Type, name string, index int, mctx *moduleCtx) scalarType {
+	if index < 0 || mctx == nil {
+		return scalarUnknown
+	}
+	named, ok := t.(*ir.NamedType)
+	if !ok || named == nil || named.Name != name || index >= len(named.Args) {
+		return scalarUnknown
+	}
+	return mctx.scalarFromType(named.Args[index], true)
 }
 
 func resolveWhileRangeIndexOperand(ctx *whileLoopEmitCtx, out *strings.Builder, op mir.Operand) (string, string, bool) {
@@ -12814,11 +12988,12 @@ func emitForInRangeReturn(out *strings.Builder, fn *mir.Function, pat forInRange
 // _len, _elem) are SSA-bound.
 
 type forInListPattern struct {
-	retType    scalarType
-	paramIDs   []mir.LocalID
-	paramTypes []scalarType
-	paramNames []string
-	stackDecls []stackDecl // multi-assigned scalars (idx counter, etc.)
+	returnsVoid bool
+	retType     scalarType
+	paramIDs    []mir.LocalID
+	paramTypes  []scalarType
+	paramNames  []string
+	stackDecls  []stackDecl // multi-assigned scalars (idx counter, etc.)
 
 	entryBody      string
 	headerBody     string
@@ -12860,9 +13035,12 @@ func multiWrittenLocals(fn *mir.Function) map[mir.LocalID]bool {
 func matchForInListReturn(fn *mir.Function, mctx *moduleCtx) (forInListPattern, bool) {
 	pat := forInListPattern{}
 
-	// Return type: scalar or opaque ptr.
-	pat.retType = mctx.scalarFromType(fn.ReturnType, true)
-	if pat.retType == scalarUnknown {
+	// Return type: scalar / opaque ptr / void.
+	pat.returnsVoid = isUnitType(fn.ReturnType)
+	if !pat.returnsVoid {
+		pat.retType = mctx.scalarFromType(fn.ReturnType, true)
+	}
+	if !pat.returnsVoid && pat.retType == scalarUnknown {
 		return pat, false
 	}
 
@@ -12981,7 +13159,14 @@ func matchForInListReturn(fn *mir.Function, mctx *moduleCtx) (forInListPattern, 
 	}
 
 	nextSSA := 0
-	ctx := &whileLoopEmitCtx{fn: fn, bindings: bindings, stack: stack, mctx: mctx, nextSSA: &nextSSA}
+	ctx := &whileLoopEmitCtx{
+		fn:         fn,
+		bindings:   bindings,
+		stack:      stack,
+		mctx:       mctx,
+		nextSSA:    &nextSSA,
+		aggregates: map[mir.LocalID]aggregateBinding{},
+	}
 
 	// Render each block.
 	entryStr, ok := forInListBlock(ctx, entry)
@@ -13009,12 +13194,20 @@ func matchForInListReturn(fn *mir.Function, mctx *moduleCtx) (forInListPattern, 
 	}
 	pat.postBody = postStr
 
-	exitStr, finalExpr, ok := forInListExit(ctx, exit, fn.ReturnLocal, pat.retType)
-	if !ok {
-		return pat, false
+	if pat.returnsVoid {
+		exitStr, ok := forInListVoidExit(ctx, exit)
+		if !ok {
+			return pat, false
+		}
+		pat.exitBody = exitStr
+	} else {
+		exitStr, finalExpr, ok := forInListExit(ctx, exit, fn.ReturnLocal, pat.retType)
+		if !ok {
+			return pat, false
+		}
+		pat.exitBody = exitStr
+		pat.finalRetExpr = finalExpr
 	}
-	pat.exitBody = exitStr
-	pat.finalRetExpr = finalExpr
 
 	pat.headerLabel = blockLabelName(header.ID, "header")
 	pat.bodyLabel = blockLabelName(body.ID, "body")
@@ -13076,6 +13269,16 @@ func forInListExit(ctx *whileLoopEmitCtx, bb *mir.BasicBlock, retLocal mir.Local
 	return out.String(), b.expr, true
 }
 
+func forInListVoidExit(ctx *whileLoopEmitCtx, bb *mir.BasicBlock) (string, bool) {
+	var out strings.Builder
+	for _, instr := range bb.Instrs {
+		if !forInListStep(ctx, &out, instr) {
+			return "", false
+		}
+	}
+	return out.String(), true
+}
+
 // forInListStep dispatches one MIR instruction in the for-in-list context.
 // It extends emitWhileStep with LenRV, AggregateRV{AggList}, opaque-ptr
 // calls, indexed element access, and list_push intrinsic.
@@ -13116,6 +13319,18 @@ func forInListAssign(ctx *whileLoopEmitCtx, out *strings.Builder, ai *mir.Assign
 	}
 	destType := ctx.mctx.scalarFromType(destLocal.Type, true)
 	if destType == scalarUnknown {
+		if agg, ok := ai.Src.(*mir.AggregateRV); ok && agg.Kind == mir.AggTuple {
+			expr, ty, ok := emitWhileAggregateRValue(ctx, out, agg, scalarOpaquePtr, destLocal.Type)
+			if !ok || ty != scalarOpaquePtr {
+				return false
+			}
+			typeName, fields, ok := classifyAggregateReturnType(destLocal.Type, ctx.mctx)
+			if !ok {
+				return false
+			}
+			ctx.aggregates[destID] = aggregateBinding{typeName: typeName, reg: expr, fields: fields}
+			return true
+		}
 		return false
 	}
 	isStackDest := false
@@ -13259,7 +13474,13 @@ func forInListCall(ctx *whileLoopEmitCtx, out *strings.Builder, ci *mir.CallInst
 		return false
 	}
 	ref, ok := ci.Callee.(*mir.FnRef)
-	if !ok || ref.Symbol == "" {
+	if !ok {
+		if ind, ok := ci.Callee.(*mir.IndirectCall); ok {
+			return emitWhileIndirectCall(ctx, out, ci, ind, destID, destType)
+		}
+		return false
+	}
+	if ref.Symbol == "" {
 		return false
 	}
 	// Resolve args — uses the extended operand resolver.
@@ -13438,7 +13659,7 @@ func forInListIntrinsic(ctx *whileLoopEmitCtx, out *strings.Builder, ii *mir.Int
 		fmt.Fprintf(out, "  call void @%s(ptr %s, %s %s)\n", sym, listExpr, elemTy.llvm(), elemExpr)
 		return true
 	}
-	return false
+	return emitWhileIntrinsic(ctx, out, ii)
 }
 
 // resolveForInListOperand resolves a MIR operand in the for-in-list
@@ -13455,6 +13676,9 @@ func resolveForInListOperand(ctx *whileLoopEmitCtx, out *strings.Builder, op mir
 	last := cp.Place.Projections[len(cp.Place.Projections)-1]
 	idxProj, isIndex := last.(*mir.IndexProj)
 	if !isIndex {
+		if expr, ty, ok := resolveWhileTupleProjectedOperand(ctx, out, cp.Place); ok {
+			return expr, ty, true
+		}
 		// Field projection: build a temp bindings map with stack locals
 		// materialised so the sequential resolver can see them.
 		tempBindings := forInListMaterialiseStack(ctx, out)
@@ -13463,6 +13687,9 @@ func resolveForInListOperand(ctx *whileLoopEmitCtx, out *strings.Builder, op mir
 			return "", scalarUnknown, false
 		}
 		out.WriteString(prelude)
+		return expr, ty, true
+	}
+	if expr, ty, ok := resolveWhileMapIndexedOperand(ctx, out, cp.Place); ok {
 		return expr, ty, true
 	}
 	// Index projection: _iter[_idx].  Resolve both list ptr and index value
@@ -13516,8 +13743,20 @@ func forInListMaterialiseStack(ctx *whileLoopEmitCtx, out *strings.Builder) map[
 	return snap
 }
 
+func copyAggregateBindings(in map[mir.LocalID]aggregateBinding) map[mir.LocalID]aggregateBinding {
+	out := make(map[mir.LocalID]aggregateBinding, len(in))
+	for k, v := range in {
+		fields := append([]scalarType(nil), v.fields...)
+		out[k] = aggregateBinding{typeName: v.typeName, reg: v.reg, fields: fields}
+	}
+	return out
+}
+
 func emitForInListReturn(out *strings.Builder, fn *mir.Function, pat forInListPattern) error {
 	retLLVM := pat.retType.llvm()
+	if pat.returnsVoid {
+		retLLVM = "void"
+	}
 	fmt.Fprintf(out, "define %s @%s(", retLLVM, fn.Name)
 	for i, name := range pat.paramNames {
 		if i > 0 {
@@ -13551,7 +13790,11 @@ func emitForInListReturn(out *strings.Builder, fn *mir.Function, pat forInListPa
 	out.WriteString("\n")
 	fmt.Fprintf(out, "%s:\n", pat.exitLabel)
 	out.WriteString(pat.exitBody)
-	fmt.Fprintf(out, "  ret %s %s\n", retLLVM, pat.finalRetExpr)
+	if pat.returnsVoid {
+		out.WriteString("  ret void\n")
+	} else {
+		fmt.Fprintf(out, "  ret %s %s\n", retLLVM, pat.finalRetExpr)
+	}
 	out.WriteString("}\n\n")
 	return nil
 }
@@ -13754,7 +13997,14 @@ func matchForInListEarlyExit(fn *mir.Function, mctx *moduleCtx) (forInListEarlyE
 	}
 
 	nextSSA := 0
-	ctx := &whileLoopEmitCtx{fn: fn, bindings: bindings, stack: stack, mctx: mctx, nextSSA: &nextSSA}
+	ctx := &whileLoopEmitCtx{
+		fn:         fn,
+		bindings:   bindings,
+		stack:      stack,
+		mctx:       mctx,
+		nextSSA:    &nextSSA,
+		aggregates: map[mir.LocalID]aggregateBinding{},
+	}
 
 	// Render entry block.
 	entryStr, ok := forInListBlock(ctx, entry)
@@ -13773,7 +14023,7 @@ func matchForInListEarlyExit(fn *mir.Function, mctx *moduleCtx) (forInListEarlyE
 
 	// Render body block: element access + inner cond.
 	bodyCtxBindings := copyBindings(ctx.bindings)
-	bodyCtx := &whileLoopEmitCtx{fn: fn, bindings: bodyCtxBindings, stack: stack, mctx: mctx, nextSSA: ctx.nextSSA}
+	bodyCtx := &whileLoopEmitCtx{fn: fn, bindings: bodyCtxBindings, stack: stack, mctx: mctx, nextSSA: ctx.nextSSA, aggregates: copyAggregateBindings(ctx.aggregates)}
 	var bodyBuf strings.Builder
 	for _, instr := range body.Instrs {
 		if !forInListStep(bodyCtx, &bodyBuf, instr) {
@@ -13795,7 +14045,7 @@ func matchForInListEarlyExit(fn *mir.Function, mctx *moduleCtx) (forInListEarlyE
 
 	// Render early-exit block.
 	earlyCtxBindings := copyBindings(ctx.bindings)
-	earlyCtx := &whileLoopEmitCtx{fn: fn, bindings: earlyCtxBindings, stack: stack, mctx: mctx, nextSSA: ctx.nextSSA}
+	earlyCtx := &whileLoopEmitCtx{fn: fn, bindings: earlyCtxBindings, stack: stack, mctx: mctx, nextSSA: ctx.nextSSA, aggregates: copyAggregateBindings(ctx.aggregates)}
 	var earlyBuf strings.Builder
 	for _, instr := range earlyExit.Instrs {
 		if !forInListStep(earlyCtx, &earlyBuf, instr) {
@@ -13812,7 +14062,7 @@ func matchForInListEarlyExit(fn *mir.Function, mctx *moduleCtx) (forInListEarlyE
 
 	// Render false-prep block (connects body-false → post).
 	falsePrepCtxBindings := copyBindings(ctx.bindings)
-	falsePrepCtx := &whileLoopEmitCtx{fn: fn, bindings: falsePrepCtxBindings, stack: stack, mctx: mctx, nextSSA: ctx.nextSSA}
+	falsePrepCtx := &whileLoopEmitCtx{fn: fn, bindings: falsePrepCtxBindings, stack: stack, mctx: mctx, nextSSA: ctx.nextSSA, aggregates: copyAggregateBindings(ctx.aggregates)}
 	falsePrepStr, ok := forInListBlock(falsePrepCtx, falsePrep)
 	if !ok {
 		return pat, false
@@ -16130,6 +16380,7 @@ func matchGenericScalarCFG(fn *mir.Function, mctx *moduleCtx) (genericCFGPattern
 	}
 
 	blocks := genericBlockOrder(fn)
+	unreachableOnlyReturn := genericEntryOnlyReachesUnreachable(fn)
 	if !pat.returnsVoid && !genericHasReturnTerm(blocks) {
 		if exitID, localID, ok := genericInferListAccumulatorSyntheticReturn(fn, mctx); ok {
 			pat.syntheticReturns = map[mir.BlockID]mir.LocalID{exitID: localID}
@@ -16140,7 +16391,7 @@ func matchGenericScalarCFG(fn *mir.Function, mctx *moduleCtx) (genericCFGPattern
 				pat.syntheticReturns = map[mir.BlockID]mir.LocalID{exitID: localID}
 			} else if exitID, pt, ok := genericInferXSyntheticReturn(fn, mctx, pat.retType); ok {
 				pat.syntheticXReturns = map[mir.BlockID]PayloadType{exitID: pt}
-			} else {
+			} else if !unreachableOnlyReturn {
 				traceFail(9)
 				return pat, false
 			}
@@ -16167,7 +16418,7 @@ func matchGenericScalarCFG(fn *mir.Function, mctx *moduleCtx) (genericCFGPattern
 					pat.syntheticStringCoalesces = map[mir.BlockID]mir.LocalID{exitID: optID}
 				} else if exitID, pt, ok := genericInferXSyntheticReturn(fn, mctx, pat.retType); ok {
 					pat.syntheticXReturns = map[mir.BlockID]PayloadType{exitID: pt}
-				} else {
+				} else if !unreachableOnlyReturn {
 					traceFail(10)
 					return pat, false
 				}
@@ -16175,7 +16426,7 @@ func matchGenericScalarCFG(fn *mir.Function, mctx *moduleCtx) (genericCFGPattern
 		} else {
 			if exitID, pt, ok := genericInferXSyntheticReturn(fn, mctx, pat.retType); ok {
 				pat.syntheticXReturns = map[mir.BlockID]PayloadType{exitID: pt}
-			} else {
+			} else if !unreachableOnlyReturn {
 				traceFail(11)
 				return pat, false
 			}
@@ -18511,6 +18762,57 @@ func genericHasReturnTerm(blocks []*mir.BasicBlock) bool {
 		}
 	}
 	return false
+}
+
+func genericEntryOnlyReachesUnreachable(fn *mir.Function) bool {
+	if fn == nil {
+		return false
+	}
+	visiting := map[mir.BlockID]bool{}
+	proven := map[mir.BlockID]bool{}
+	var walk func(mir.BlockID) bool
+	walk = func(id mir.BlockID) bool {
+		if proven[id] {
+			return true
+		}
+		if visiting[id] {
+			return false
+		}
+		bb := blockByID(fn, id)
+		if bb == nil || bb.Term == nil {
+			return false
+		}
+		if _, ok := bb.Term.(*mir.UnreachableTerm); ok {
+			proven[id] = true
+			return true
+		}
+		visiting[id] = true
+		defer delete(visiting, id)
+		switch term := bb.Term.(type) {
+		case *mir.GotoTerm:
+			if !walk(term.Target) {
+				return false
+			}
+		case *mir.BranchTerm:
+			if !walk(term.Then) || !walk(term.Else) {
+				return false
+			}
+		case *mir.SwitchIntTerm:
+			if !walk(term.Default) {
+				return false
+			}
+			for _, c := range term.Cases {
+				if !walk(c.Target) {
+					return false
+				}
+			}
+		default:
+			return false
+		}
+		proven[id] = true
+		return true
+	}
+	return walk(fn.Entry)
 }
 
 func genericBlockOrder(fn *mir.Function) []*mir.BasicBlock {

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -100,6 +100,10 @@ func charConst(v rune) *mir.ConstOp {
 	return &mir.ConstOp{Const: &mir.CharConst{Value: v}, T: ir.TChar}
 }
 
+func unitConst() *mir.ConstOp {
+	return &mir.ConstOp{Const: &mir.UnitConst{}, T: ir.TUnit}
+}
+
 func paramCopy(id mir.LocalID, ty mir.Type) *mir.CopyOp {
 	return &mir.CopyOp{Place: mir.Place{Local: id}, T: ty}
 }
@@ -4344,6 +4348,63 @@ func TestStage0RejectsIndirectCall(t *testing.T) {
 	mustReject(t, trivialMainFn(), caller)
 }
 
+func TestStage0EmitsIndirectCallThroughFunctionParam(t *testing.T) {
+	t.Parallel()
+	fType := fnTy(ir.TInt, ir.TInt)
+	caller := makeMultiInstrFn(
+		"apply",
+		ir.TInt,
+		[]paramSpec{{name: "f", ty: fType}, {name: "x", ty: ir.TInt}},
+		[]paramSpec{{name: "y", ty: ir.TInt}},
+		[]mir.Instr{
+			&mir.CallInstr{
+				Dest:   &mir.Place{Local: 3},
+				Callee: &mir.IndirectCall{Callee: paramCopy(1, fType)},
+				Args:   []mir.Operand{paramCopy(2, ir.TInt)},
+			},
+			assign(0, useRV(localCopy(3, ir.TInt))),
+		},
+	)
+	got := emit(t, trivialMainFn(), caller)
+	for _, want := range []string{
+		"define i64 @apply(ptr %f, i64 %x)",
+		"%0 = call i64 %f(i64 %x)",
+		"ret i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStage0EmitsIndirectVoidCallThroughFunctionParam(t *testing.T) {
+	t.Parallel()
+	fType := fnTy(ir.TUnit, ir.TString, ir.TInt)
+	caller := makeMultiInstrFn(
+		"visit",
+		ir.TUnit,
+		[]paramSpec{{name: "f", ty: fType}, {name: "name", ty: ir.TString}, {name: "n", ty: ir.TInt}},
+		nil,
+		[]mir.Instr{
+			&mir.CallInstr{
+				Callee: &mir.IndirectCall{Callee: paramCopy(1, fType)},
+				Args:   []mir.Operand{paramCopy(2, ir.TString), paramCopy(3, ir.TInt)},
+			},
+			assign(0, useRV(unitConst())),
+		},
+	)
+	got := emit(t, trivialMainFn(), caller)
+	for _, want := range []string{
+		"define void @visit(ptr %f, ptr %name, i64 %n)",
+		"call void %f(ptr %name, i64 %n)",
+		"ret void",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestStage0EmitsDiscardedValueCall(t *testing.T) {
 	t.Parallel()
 	other := makeFn(fnSpec{
@@ -6589,6 +6650,71 @@ func TestStage0GenericCFGSwitchWithUnreachableDefault(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("emitted IR missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestStage0GenericCFGNonVoidSwitchAllPathsUnreachable(t *testing.T) {
+	t.Parallel()
+	errTy := &ir.NamedType{Name: "Error"}
+	resultTy := &ir.NamedType{Name: "Result", Builtin: true, Args: []ir.Type{ir.TString, errTy}}
+	fn := &mir.Function{
+		Name:        "resultStringUnreachableSwitch",
+		Params:      []mir.LocalID{1, 2},
+		ReturnType:  ir.TString,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "_return", Type: ir.TString, IsReturn: true},
+			{ID: 1, Name: "self", Type: resultTy, IsParam: true},
+			{ID: 2, Name: "fallback", Type: ir.TString, IsParam: true},
+			{ID: 3, Name: "_scrut", Type: resultTy},
+			{ID: 4, Name: "", Type: ir.TInt},
+			{ID: 5, Name: "value", Type: ir.TString},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{
+				ID: 0,
+				Instrs: []mir.Instr{
+					&mir.StorageLiveInstr{Local: 3},
+					assign(3, useRV(paramCopy(1, resultTy))),
+					assign(4, &mir.DiscriminantRV{Place: mir.Place{Local: 3}, T: ir.TInt}),
+				},
+				Term: &mir.SwitchIntTerm{
+					Scrutinee: localCopy(4, ir.TInt),
+					Cases: []mir.SwitchCase{
+						{Value: 0, Target: 1},
+						{Value: 1, Target: 1},
+					},
+					Default: 6,
+				},
+			},
+			{
+				ID:     1,
+				Instrs: []mir.Instr{&mir.StorageDeadInstr{Local: 5}, &mir.StorageDeadInstr{Local: 3}},
+				Term:   &mir.UnreachableTerm{},
+			},
+			{ID: 2, Term: &mir.GotoTerm{Target: 1}},
+			{ID: 3, Term: &mir.GotoTerm{Target: 1}},
+			{ID: 4, Term: &mir.GotoTerm{Target: 1}},
+			{ID: 5, Term: &mir.GotoTerm{Target: 1}},
+			{ID: 6, Term: &mir.UnreachableTerm{}},
+		},
+	}
+	got := emit(t, trivialMainFn(), fn)
+	for _, want := range []string{
+		"define ptr @resultStringUnreachableSwitch(ptr %self, ptr %fallback)",
+		"switch i64 %",
+		"i64 0, label %bb.1",
+		"i64 1, label %bb.1",
+		"bb.1:",
+		"unreachable",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "osty_rt_stage0_declined") {
+		t.Fatalf("emitted IR unexpectedly used a decline stub:\n%s", got)
 	}
 }
 

--- a/internal/backend/stage0_toolchain_audit_test.go
+++ b/internal/backend/stage0_toolchain_audit_test.go
@@ -75,6 +75,8 @@ func TestStage0ToolchainAudit(t *testing.T) {
 		count int
 	}
 	tally := map[string]int{}
+	stubTally := map[string]int{}
+	stubSamples := map[string][]string{}
 	emitBrokenTally := map[string]int{}
 	emitBrokenSamples := map[string]string{} // first sample per fingerprint
 	emitBrokenFunctions := []string{}        // names that emitted but clang rejected
@@ -91,6 +93,15 @@ func TestStage0ToolchainAudit(t *testing.T) {
 	stubCovered := 0
 	realCovered := 0
 	filterFn := os.Getenv("OSTY_STAGE0_AUDIT_FN")
+	logStubDeclines := os.Getenv("OSTY_STAGE0_AUDIT_STUBS") != ""
+	logStubSamples := os.Getenv("OSTY_STAGE0_AUDIT_STUB_SAMPLES") != ""
+	stubSampleLimit := 5
+	if raw := os.Getenv("OSTY_STAGE0_AUDIT_STUB_SAMPLE_LIMIT"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			stubSampleLimit = parsed
+		}
+	}
+	stubSamplesLogged := 0
 	clangVerify := stage0AuditClangVerifyEnabled()
 	clangPath := ""
 	clangTmpDir := ""
@@ -174,6 +185,37 @@ func TestStage0ToolchainAudit(t *testing.T) {
 			}
 			covered++
 			stubCovered++
+			if logStubDeclines {
+				key := normalizeDeclineReason(err.Error())
+				if key == "no matching pattern" {
+					key = fingerprintFn(fn)
+				}
+				stubTally[key]++
+				if len(stubSamples[key]) < 8 {
+					stubSamples[key] = append(stubSamples[key], fn.Name)
+				}
+				if logStubSamples && stubSamplesLogged < stubSampleLimit {
+					stubSamplesLogged++
+					t.Logf("---- decline-stub sample %q [%s] ----", fn.Name, key)
+					t.Logf("  decline=%v", err)
+					t.Logf("  ReturnLocal=%d Params=%v", fn.ReturnLocal, fn.Params)
+					for _, l := range fn.Locals {
+						if l == nil {
+							continue
+						}
+						t.Logf("  local#%d name=%q isParam=%v type=%T %v", l.ID, l.Name, l.IsParam, l.Type, l.Type)
+					}
+					for _, bb := range fn.Blocks {
+						if bb == nil {
+							continue
+						}
+						t.Logf("  bb id=%d term=%T %s instrs=%d", bb.ID, bb.Term, describeAuditTerm(bb.Term), len(bb.Instrs))
+						for _, instr := range bb.Instrs {
+							t.Logf("    %s", describeAuditInstr(instr))
+						}
+					}
+				}
+			}
 			continue
 		}
 		key := normalizeDeclineReason(err.Error())
@@ -227,6 +269,25 @@ func TestStage0ToolchainAudit(t *testing.T) {
 	} else {
 		t.Logf("toolchain stage0 audit: %d / %d functions covered (%.1f%%) — %d real, %d decline-stub",
 			covered, totalFns, 100.0*float64(covered)/float64(totalFns), realCovered, stubCovered)
+	}
+	if logStubDeclines {
+		stubBuckets := make([]bucket, 0, len(stubTally))
+		for k, v := range stubTally {
+			stubBuckets = append(stubBuckets, bucket{k, v})
+		}
+		sort.Slice(stubBuckets, func(i, j int) bool {
+			if stubBuckets[i].count != stubBuckets[j].count {
+				return stubBuckets[i].count > stubBuckets[j].count
+			}
+			return stubBuckets[i].key < stubBuckets[j].key
+		})
+		t.Logf("decline-stub reasons:")
+		for _, b := range stubBuckets {
+			t.Logf("  %4d  %s", b.count, b.key)
+			if samples := stubSamples[b.key]; len(samples) > 0 {
+				t.Logf("        samples: %s", strings.Join(samples, ", "))
+			}
+		}
 	}
 
 	// L2 (module-level link): emit the FULL toolchain module in one
@@ -857,7 +918,7 @@ func runStage0AuditModuleVerify(t *testing.T, module *mir.Module, clangPath stri
 		// continue with the partial IR if any was produced — the
 		// remaining functions are still worth clang-verifying.
 		short := strings.TrimSpace(err.Error())
-		if len(short) > 400 {
+		if os.Getenv("OSTY_STAGE0_AUDIT_MODULE_DECLINES_FULL") == "" && len(short) > 400 {
 			short = short[:400] + "…"
 		}
 		t.Logf("module-verify: stage0 reports declines (partial IR continues): %s", short)


### PR DESCRIPTION
## Summary
- lower remaining stage0 decline-stub coverage to real emit paths
- add stage0 support for map index reads, tuple projections/aggregates, void for-in-list loops, indirect calls, and all-unreachable switch CFGs
- add audit diagnostics for decline-stub buckets and samples

## Verification
- go test -count=1 -vet=off ./internal/backend/stage0
- OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_STUBS=1 OSTY_STAGE0_AUDIT_DECLINE_LIMIT=10 go test -count=1 -vet=off -run TestStage0ToolchainAudit -v ./internal/backend
- OSTY_STAGE0_AUDIT=1 OSTY_STAGE0_AUDIT_MODULE_VERIFY=1 OSTY_STAGE0_AUDIT_MODULE_DECLINES_FULL=1 OSTY_STAGE0_AUDIT_DECLINE_LIMIT=10 go test -count=1 -vet=off -run TestStage0ToolchainAudit -v ./internal/backend
- git diff --check
- just build-all