### PR TITLE
feat: complete source selfhost ratchet

### DIFF
--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -148,6 +148,7 @@ func LowerMIR(mod *mir.Module, target Target) (*Program, error) {
 	}
 	state := &lowerState{target: target, mod: mod}
 	out := &Program{Target: target}
+	reachable := reachableFunctionsFromMain(mod, mainFn)
 
 	// Lower main first — its layout decisions (vararg slot, etc.) drive the
 	// shared cstring set used by every other function in the same module.
@@ -161,6 +162,9 @@ func LowerMIR(mod *mir.Module, target Target) (*Program, error) {
 		if fn == nil || fn == mainFn {
 			continue
 		}
+		if !reachable[fn] {
+			continue
+		}
 		lowered, err := state.lowerFunction(fn)
 		if err != nil {
 			return nil, err
@@ -169,6 +173,91 @@ func LowerMIR(mod *mir.Module, target Target) (*Program, error) {
 	}
 	out.CStrings = state.cstrings
 	return out, nil
+}
+
+func reachableFunctionsFromMain(mod *mir.Module, mainFn *mir.Function) map[*mir.Function]bool {
+	reachable := map[*mir.Function]bool{}
+	byName := map[string]*mir.Function{}
+	for _, fn := range mod.Functions {
+		if fn != nil && fn.Name != "" {
+			byName[fn.Name] = fn
+		}
+	}
+	var visit func(*mir.Function)
+	visit = func(fn *mir.Function) {
+		if fn == nil || reachable[fn] {
+			return
+		}
+		reachable[fn] = true
+		for _, symbol := range functionReferences(fn) {
+			visit(byName[symbol])
+		}
+	}
+	visit(mainFn)
+	return reachable
+}
+
+func functionReferences(fn *mir.Function) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(symbol string) {
+		if symbol == "" || seen[symbol] {
+			return
+		}
+		seen[symbol] = true
+		out = append(out, symbol)
+	}
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			collectInstrFunctionRefs(instr, add)
+		}
+	}
+	return out
+}
+
+func collectInstrFunctionRefs(instr mir.Instr, add func(string)) {
+	switch i := instr.(type) {
+	case *mir.AssignInstr:
+		collectRValueFunctionRefs(i.Src, add)
+	case *mir.IntrinsicInstr:
+		for _, arg := range i.Args {
+			collectOperandFunctionRefs(arg, add)
+		}
+	case *mir.CallInstr:
+		switch c := i.Callee.(type) {
+		case *mir.FnRef:
+			add(c.Symbol)
+		case *mir.IndirectCall:
+			collectOperandFunctionRefs(c.Callee, add)
+		}
+		for _, arg := range i.Args {
+			collectOperandFunctionRefs(arg, add)
+		}
+	}
+}
+
+func collectRValueFunctionRefs(rv mir.RValue, add func(string)) {
+	switch r := rv.(type) {
+	case *mir.UseRV:
+		collectOperandFunctionRefs(r.Op, add)
+	case *mir.BinaryRV:
+		collectOperandFunctionRefs(r.Left, add)
+		collectOperandFunctionRefs(r.Right, add)
+	case *mir.AggregateRV:
+		for _, f := range r.Fields {
+			collectOperandFunctionRefs(f, add)
+		}
+	}
+}
+
+func collectOperandFunctionRefs(op mir.Operand, add func(string)) {
+	c, ok := op.(*mir.ConstOp)
+	if !ok {
+		return
+	}
+	if fn, ok := c.Const.(*mir.FnConst); ok {
+		add(fn.Symbol)
+	}
 }
 
 type lowerState struct {
@@ -304,7 +393,7 @@ func (s *lowerState) assignLocalSlots(fn *mir.Function) error {
 	// AggregateRV writer needs a slot to stamp each field into, and
 	// the epilogue needs that same slot to load slot+0 → x0 and
 	// slot+8 → x1. Force the slot in by inserting $ret into `read`.
-	if fn.ReturnType == mir.TUnit || isABIScalarType(fn.ReturnType) {
+	if fn.ReturnType == mir.TUnit || s.isABIScalarType(fn.ReturnType) {
 		delete(read, fn.ReturnLocal)
 	} else {
 		read[fn.ReturnLocal] = true
@@ -623,7 +712,7 @@ func (s *lowerState) lowerAssign(fn *mir.Function, instr *mir.AssignInstr) ([]In
 	// take the slot if there is one.
 	slot, hasSlot := s.localSlots[instr.Dest.Local]
 	if !hasSlot {
-		if instr.Dest.Local == fn.ReturnLocal && isABIScalarType(fn.ReturnType) {
+		if instr.Dest.Local == fn.ReturnLocal && s.isABIScalarType(fn.ReturnType) {
 			// allocate a synthetic slot at frame's tail
 			slot = s.allocateReturnSlot(fn)
 			hasSlot = true
@@ -1009,7 +1098,7 @@ func (s *lowerState) lowerStructLiteralAssign(rv *mir.AggregateRV, destSlot int6
 	}
 	var out []Instr
 	for i, field := range rv.Fields {
-		if !isABIScalarType(layout.Fields[i].Type) {
+		if !s.isABIScalarType(layout.Fields[i].Type) {
 			return nil, fmt.Errorf("%w: struct %s field %s has non-scalar type %s", ErrUnsupportedShape, rv.T, layout.Fields[i].Name, layout.Fields[i].Type)
 		}
 		mat, err := s.materialiseOperand(field, RegX9)
@@ -1039,6 +1128,10 @@ func isABIScalarType(t mir.Type) bool {
 		return true
 	}
 	return isBuiltinPointerType(t)
+}
+
+func (s *lowerState) isABIScalarType(t mir.Type) bool {
+	return isABIScalarType(t) || s.isBuiltinSourcePointerType(t)
 }
 
 // isClosureScalarType reports whether t is a closure-shaped pointer
@@ -1077,6 +1170,14 @@ func isBuiltinPointerType(t mir.Type) bool {
 	return false
 }
 
+func builtinPointerName(name string) bool {
+	switch name {
+	case "List", "Map", "Set", "Channel", "Bytes", "Handle":
+		return true
+	}
+	return false
+}
+
 // isFloatABIType reports whether t is a Float / Float64 — values that
 // occupy a d-register on AAPCS64 calls and need fmov / fadd opcodes
 // rather than the integer-side str / add lowerings.
@@ -1092,12 +1193,12 @@ func (s *lowerState) abiRegSlots(t mir.Type) (int, bool) {
 	if t == mir.TUnit {
 		return 0, true
 	}
-	if isABIScalarType(t) {
+	if s.isABIScalarType(t) {
 		return 1, true
 	}
 	if layout := s.lookupStructLayout(t); layout != nil {
 		for _, f := range layout.Fields {
-			if !isABIScalarType(f.Type) {
+			if !s.isABIScalarType(f.Type) {
 				return 0, false
 			}
 		}
@@ -1140,7 +1241,7 @@ func (s *lowerState) abiRegSlots(t mir.Type) (int, bool) {
 // builtin generics (List<T>, Map<K,V>, etc.) and large structs stay out
 // until a follow-up slice teaches the lowerer about indirect passing.
 func (s *lowerState) isABIPassableType(t mir.Type) bool {
-	if isABIScalarType(t) {
+	if s.isABIScalarType(t) {
 		return true
 	}
 	_, ok := s.abiRegSlots(t)
@@ -1159,7 +1260,7 @@ func (s *lowerState) abiUsesIndirectStruct(t mir.Type) bool {
 		return false
 	}
 	for _, f := range layout.Fields {
-		if !isABIScalarType(f.Type) {
+		if !s.isABIScalarType(f.Type) {
 			return false
 		}
 	}
@@ -1183,9 +1284,6 @@ func (s *lowerState) indirectStructByteSize(t mir.Type) int64 {
 // per-field offsets — Phase B.5 v1 only handles all-scalar structs so a
 // straightforward `field_index * 8` is enough.
 func (s *lowerState) lookupStructLayout(t mir.Type) *mir.StructLayout {
-	if s.mod == nil || s.mod.Layouts == nil {
-		return nil
-	}
 	nt, ok := t.(*ir.NamedType)
 	if !ok || nt == nil {
 		return nil
@@ -1193,11 +1291,41 @@ func (s *lowerState) lookupStructLayout(t mir.Type) *mir.StructLayout {
 	if !structLayoutSupported(nt) {
 		return nil
 	}
+	layout := s.structLayoutForNamedType(nt)
+	if layout != nil && layout.BuiltinSource != "" {
+		return nil
+	}
+	return layout
+}
+
+func (s *lowerState) structLayoutForNamedType(nt *ir.NamedType) *mir.StructLayout {
+	if s.mod == nil || s.mod.Layouts == nil || nt == nil {
+		return nil
+	}
 	key := nt.Name
 	if nt.Package != "" && !nt.Builtin {
 		key = strings.TrimPrefix(nt.Package, "std.") + "." + nt.Name
 	}
 	return s.mod.Layouts.Structs[key]
+}
+
+func (s *lowerState) builtinSourceArgs(t mir.Type) (string, []mir.Type) {
+	nt, ok := t.(*ir.NamedType)
+	if !ok || nt == nil {
+		return "", nil
+	}
+	if nt.Builtin {
+		return nt.Name, nt.Args
+	}
+	if layout := s.structLayoutForNamedType(nt); layout != nil && layout.BuiltinSource != "" {
+		return layout.BuiltinSource, layout.BuiltinSourceArgs
+	}
+	return "", nil
+}
+
+func (s *lowerState) isBuiltinSourcePointerType(t mir.Type) bool {
+	name, _ := s.builtinSourceArgs(t)
+	return builtinPointerName(name)
 }
 
 // structLayoutSupported reports whether the named type is a Phase B.5 v1
@@ -1352,7 +1480,7 @@ func (s *lowerState) payloadAllScalar(fields []mir.FieldLayout) bool {
 // and no-payload enums qualify; structs always need ≥1 register
 // per field so a struct with 1 scalar field also passes.
 func (s *lowerState) isABIWordType(t mir.Type) bool {
-	if isABIScalarType(t) {
+	if s.isABIScalarType(t) {
 		return true
 	}
 	slots, ok := s.abiRegSlots(t)
@@ -1390,7 +1518,7 @@ func (s *lowerState) localTypeSize(t mir.Type) int64 {
 	if t == mir.TUnit {
 		return 0
 	}
-	if isABIScalarType(t) {
+	if s.isABIScalarType(t) {
 		return 8
 	}
 	if sl := s.lookupStructLayout(t); sl != nil {
@@ -1400,7 +1528,7 @@ func (s *lowerState) localTypeSize(t mir.Type) int64 {
 		// to "treat as opaque pointer" so pre-existing List/Map locals
 		// keep their 8-byte slot.
 		for _, f := range sl.Fields {
-			if !isABIScalarType(f.Type) {
+			if !s.isABIScalarType(f.Type) {
 				return 8
 			}
 		}
@@ -2299,7 +2427,7 @@ func (s *lowerState) lowerMapNew(instr *mir.IntrinsicInstr) ([]Instr, error) {
 	if destLoc == nil {
 		return nil, fmt.Errorf("%w: map_new dest local missing", ErrUnsupportedShape)
 	}
-	keyT, valT := mapKeyValueTypes(destLoc.Type)
+	keyT, valT := s.mapKeyValueTypes(destLoc.Type)
 	if keyT == nil || valT == nil {
 		return nil, fmt.Errorf("%w: map_new dest type %s isn't Map<K,V>", ErrUnsupportedShape, destLoc.Type)
 	}
@@ -2545,12 +2673,12 @@ func mapRemoveSymbolForKeyKind(kind int) (string, error) {
 
 // mapKeyValueTypes extracts the K, V parameterisation from a
 // `Map<K,V>` named type. Returns (nil, nil) for non-map types.
-func mapKeyValueTypes(t mir.Type) (mir.Type, mir.Type) {
-	nt, ok := t.(*ir.NamedType)
-	if !ok || nt == nil || !nt.Builtin || nt.Name != "Map" || len(nt.Args) < 2 {
+func (s *lowerState) mapKeyValueTypes(t mir.Type) (mir.Type, mir.Type) {
+	name, args := s.builtinSourceArgs(t)
+	if name != "Map" || len(args) < 2 {
 		return nil, nil
 	}
-	return nt.Args[0], nt.Args[1]
+	return args[0], args[1]
 }
 
 // mapInsertSymbolForKeyKind picks the runtime insert symbol from a

--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -1666,7 +1666,11 @@ func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 		"lirEmitContainerCall(l, instr, llvmMapRuntimeRemoveSymbol(recv.elemLir.llvm, recv.isString), lirIntType(1)",
 		"let boxType = lirRawType(lirBraced(\"i64, ptr, ptr\"))",
 		"l.instrs.push(lirSelect(payloadI64, lirIntType(64), isOk, okPayloadI64, errPayloadI64))",
+		"if strings.slice(typeName, 0, prefix.len()) != prefix",
+		`if strings.slice(typeName, typeName.len() - 1, typeName.len()) != ">"`,
+		"strings.slice(typeName, prefix.len(), typeName.len() - 1)",
 		"let comma = lirFirstTopLevelComma(args)",
+		"let ch = strings.slice(s, i, i + 1)",
 		"strings.trim(strings.slice(args, 0, comma))",
 	} {
 		if !strings.Contains(text, needle) {
@@ -1675,6 +1679,14 @@ func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 	}
 	if strings.Contains(text, "strings.fromChar(ch)") {
 		t.Fatalf("lir_proto.osty reintroduced stage2-unsafe strings.fromChar(ch) in generic arg splitting")
+	}
+	if strings.Contains(text, `strings.trimPrefix(typeName, prefix)`) || strings.Contains(text, `strings.trimSuffix(inner, ">")`) {
+		t.Fatalf("lir_proto.osty reintroduced helper-based generic arg slicing in lirContainerInnerArg")
+	}
+	if strings.Contains(text, "let typeChars = strings.chars(typeName)") ||
+		strings.Contains(text, "let prefixChars = strings.chars(prefix)") ||
+		strings.Contains(text, "let ch = chars[i]") {
+		t.Fatalf("lir_proto.osty reintroduced stage2-unsafe Char generic parsing")
 	}
 }
 

--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -578,8 +578,9 @@ func TestPhase0SelfHostWiringExists(t *testing.T) {
 }
 
 // TestSelfhostDoctorRunsBackendProbe pins the `--selfhost-doctor`
-// backend probe so the status cannot drift back to a text-only Phase 0
-// claim while the real MIR JSON -> LIR Proto path regresses underneath it.
+// source probe so the status cannot drift back to a text-only Phase 0
+// claim, or to a MIR-JSON-only backend pass, while the real source ->
+// LLVM IR path regresses underneath it.
 func TestSelfhostDoctorRunsBackendProbe(t *testing.T) {
 	root, err := filepath.Abs("../..")
 	if err != nil {
@@ -602,18 +603,444 @@ func TestSelfhostDoctorRunsBackendProbe(t *testing.T) {
 		"selfhostProbeError",
 		"lirLowerMirModule(",
 		"lirRenderModule(",
-		"mirJsonParseModule(raw)",
-		"selfhostMirProbeError",
-		"lirLowerMirModuleListsInto(",
 		"LLVM IR renderer produced no return instruction",
+		"fn add(a: Int, b: Int) -> Int",
+		"return add(x, 1)",
 		"selfRebuildBundleSource",
 		"selfRebuildRunClang",
-		"osty-self MIR JSON backend: enabled",
+		"selfRebuildWriteStringViaShell",
+		`os.execWith("/bin/sh", ["-c", "cat > \"$1\"", "osty-self-write", path], contents`,
+		"fn selfRebuildHostIsWindows() -> Bool {\n    false\n}",
+		"selfRebuildRawSubcommand",
+		`childEnv.insert("OSTY_SELF_REBUILD_FORWARD_ARGS", "")`,
+		"let probeError = selfhostProbeError()",
+		"osty-self source compiler: enabled",
 		"osty-self self-rebuild probe: OK",
-		"osty-self self-rebuild driver: MIR JSON backend -> clang object/runtime link",
+		"osty-self self-rebuild driver: source bundle -> clang object/runtime link",
 	} {
 		if !strings.Contains(text, needle) {
 			t.Errorf("doctor probe missing %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"osty-self MIR JSON backend: enabled",
+		"osty-self self-rebuild driver: MIR JSON backend -> clang object/runtime link",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("doctor regressed to MIR-JSON backend success marker %q", forbidden)
+		}
+	}
+}
+
+func TestMirLowerMethodBodyUsesOwnerForSyntheticSelf(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "mir_lower.osty"))
+	if err != nil {
+		t.Fatalf("read mir_lower.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		`mirLowerFunctionBody(l, out, decl, retT, owner, asMethod, span)`,
+		`pub fn mirLowerFunctionBody(l: MirLowerer, out: MirFunction, decl: HirFnDecl, retT: HirType, owner: String, asMethod: Bool, span: MirSpan)`,
+		`fn mirLowerMethodParamsWithSelf(owner: String, decl: HirFnDecl) -> List<HirParam>`,
+		`mirLowerMethodSignature(s.name, m.name, mirLowerMethodParamsWithSelf(s.name, m), m.ret, m.span)`,
+		`mirLowerMethodSignature(e.name, m.name, mirLowerMethodParamsWithSelf(e.name, m), m.ret, m.span)`,
+		`let selfOwner = if owner != ""`,
+		`hirParam("self", hirTypeNamed(selfOwner, []), decl.span)`,
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("mir_lower.osty missing synthetic self owner guard %q", needle)
+		}
+	}
+	if strings.Contains(text, `hirParam("self", hirTypeNamed(mirLowerSelfOwnerName(decl), []), decl.span)`) {
+		t.Fatalf("method body lowering reintroduced decl-param owner recovery for synthetic self")
+	}
+}
+
+func TestMirLowerLookupsUseIndexMaps(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "mir_lower.osty"))
+	if err != nil {
+		t.Fatalf("read mir_lower.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"pub fnSigIndex: Map<String, Int>",
+		"pub methodSigIndex: Map<String, Int>",
+		"pub structIndex: Map<String, Int>",
+		"pub enumIndex: Map<String, Int>",
+		"pub globalIndex: Map<String, Int>",
+		"pub useAliasIndex: Map<String, Int>",
+		"l.fnSigIndex.insert(decl.name, idx)",
+		"l.methodSigIndex.insert(key, methodIdx)",
+		"l.structIndex.insert(s.name, structIdx)",
+		"l.enumIndex.insert(e.name, enumIdx)",
+		"l.globalIndex.insert(g.name, globalIdx)",
+		"l.useAliasIndex.insert(u.alias, aliasIdx)",
+		"match l.fnSigIndex.get(name)",
+		"match l.methodSigIndex.get(key)",
+		"if mirLowerEnumForVariant(bs.l, e.identName) != \"\" {",
+		"return mirLowerIdentVariantOperand(bs, e)",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("mir_lower.osty missing lookup-index guard %q", needle)
+		}
+	}
+}
+
+func TestMonomorphTypeCloneAvoidsDeadPayloadAllocations(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "monomorph_pass.osty"))
+	if err != nil {
+		t.Fatalf("read monomorph_pass.osty: %v", err)
+	}
+	text := string(src)
+	start := strings.Index(text, "pub fn hirCloneType(t: HirType) -> HirType {")
+	if start < 0 {
+		t.Fatalf("monomorph_pass.osty missing hirCloneType")
+	}
+	endMarker := "/// hirCloneTypeList applies hirCloneType"
+	end := strings.Index(text[start:], endMarker)
+	if end < 0 {
+		t.Fatalf("monomorph_pass.osty missing hirCloneTypeList marker")
+	}
+	cloneBody := text[start : start+end]
+	for _, needle := range []string{
+		"if t.kind == HirTypeNamed",
+		"let mut out = t",
+		"out.namedArgs = hirCloneTypeList(t.namedArgs)",
+		"if t.kind == HirTypeFn",
+		"out.fnParams = hirCloneTypeList(t.fnParams)",
+		"out.fnReturn = hirCloneTypeList(t.fnReturn)",
+		"\n    t\n}",
+	} {
+		if !strings.Contains(cloneBody, needle) {
+			t.Fatalf("hirCloneType missing allocation-tight variant clone %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"let mut out = hirTypeInvalid()",
+		"HirType {kind:",
+	} {
+		if strings.Contains(cloneBody, forbidden) {
+			t.Fatalf("hirCloneType reintroduced dead payload allocation path %q", forbidden)
+		}
+	}
+
+	if strings.Contains(text, "let mut out = hirCloneType(t)\n        out.namedArgs = hirSubstTypeList(t.namedArgs, env)") {
+		t.Fatalf("hirSubstType reintroduced clone-then-overwrite for named type args")
+	}
+	if !strings.Contains(text, "let idx = hirSubstEnvIndex(env, t.varName)") {
+		t.Fatalf("hirSubstType should avoid double env lookup for type variables")
+	}
+	if !strings.Contains(text, "out.namedArgs = hirSubstTypeList(t.namedArgs, env)") {
+		t.Fatalf("hirSubstType should substitute named args without allocating dead payload lists")
+	}
+}
+
+func TestElabTypedNodeLookupUsesIndexCache(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "elab.osty"))
+	if err != nil {
+		t.Fatalf("read elab.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"pub typedExprCoreByNode: List<Int>",
+		"pub typedExprTypeByNode: List<Int>",
+		"pub typedStmtCoreByNode: List<Int>",
+		"elabEnsureIntListLen(cx.typedExprCoreByNode, idx + 1)",
+		"cx.typedExprCoreByNode[idx] = out.node",
+		"cx.typedExprTypeByNode[idx] = out.ty",
+		"elabEnsureIntListLen(cx.typedStmtCoreByNode, idx + 1)",
+		"cx.typedStmtCoreByNode[idx] = coreIdx",
+		"fn elabEnsureIntListLen(items: List<Int>, targetLen: Int)",
+		"if idx >= 0 && idx < cx.typedExprCoreByNode.len()",
+		"if idx >= 0 && idx < cx.typedExprTypeByNode.len()",
+		"if idx >= 0 && idx < cx.typedStmtCoreByNode.len()",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("elab.osty missing typed-node lookup cache guard %q", needle)
+		}
+	}
+}
+
+func TestHirCloneOnlyCopiesLiveVariantPayloads(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "hir_clone.osty"))
+	if err != nil {
+		t.Fatalf("read hir_clone.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"pub fn hirCloneExpr(e: HirExpr) -> HirExpr {\n    let mut out = e",
+		"if e.kind == HirExprBinary",
+		"out.binaryLeft = hirCloneExprList(e.binaryLeft)",
+		"out.callArgs = hirCloneArgList(e.callArgs)",
+		"if e.matchExprHasTree",
+		"pub fn hirCloneStmt(stmt: HirStmt) -> HirStmt {\n    let mut out = stmt",
+		"if stmt.kind == HirStmtLet",
+		"if stmt.matchHasTree",
+		"pub fn hirClonePattern(p: HirPattern) -> HirPattern {\n    let mut out = p",
+		"if p.kind == HirPatBinding",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("hir_clone.osty missing live-payload clone guard %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"HirExpr {kind: e.kind",
+		"HirStmt {kind: stmt.kind",
+		"HirPattern {kind: p.kind",
+		"HirDecisionNode {kind: n.kind",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("hir_clone.osty reintroduced full-payload clone %q", forbidden)
+		}
+	}
+}
+
+func TestMirLowerBooleanShortCircuitUsesCFG(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "mir_lower.osty"))
+	if err != nil {
+		t.Fatalf("read mir_lower.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"if e.kind == HirExprIf {",
+		"if e.kind == HirExprBinary {",
+		"fn mirLowerBoolShortCircuitInto(bs: MirLowerBodyState, e: HirExpr, dest: MirPlace, destT: HirType) -> Bool",
+		"if e.binaryOp != HirBinAnd && e.binaryOp != HirBinOr",
+		"mirLowerTerminateBranch(bs, left, rightBB, constBB, span)",
+		"mirLowerAssignBoolConst(bs, dest, false, span)",
+		"mirLowerTerminateBranch(bs, left, constBB, rightBB, span)",
+		"mirLowerAssignBoolConst(bs, dest, true, span)",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("mir_lower.osty missing short-circuit CFG guard %q", needle)
+		}
+	}
+}
+
+func TestLirMirMutableBlockAbiPassesBasicBlockByRef(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "lir_proto.osty"))
+	if err != nil {
+		t.Fatalf("read lir_proto.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		`name == "HirBlock"`,
+		`name == "MirBasicBlock"`,
+		`fn lirMirParamShouldPassByRef(typeName: String, typ: LirType) -> Bool`,
+		`fn lirLowerMirAggregateArgAddress(l: LirMirFunctionLowerer, arg: MirOperand, paramTypeName: String, paramType: LirType, context: String) -> LirOperand`,
+		`let value = lirLowerMirOperand(l, l.instrs, arg, paramTypeName, paramType)`,
+		`l.instrs.push(lirAlloca(tmp, value.typ, 0))`,
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("lir_proto.osty missing mutable MIR block ABI guard %q", needle)
+		}
+	}
+	if strings.Contains(text, "if address.value != \"\" {\n            return address\n        }\n        return lirOperandInvalid()\n    }\n    let value = lirLowerMirOperand") {
+		t.Fatalf("lirLowerMirAggregateArgAddress still drops non-addressable aggregate args instead of spilling")
+	}
+	mirSrc, err := os.ReadFile(filepath.Join(root, "toolchain", "mir.osty"))
+	if err != nil {
+		t.Fatalf("read mir.osty: %v", err)
+	}
+	mirText := string(mirSrc)
+	for _, needle := range []string{
+		`func.blocks[blockId].term.kind = term.kind`,
+		`func.blocks[blockId].term.kind = MirTermGoto`,
+		`func.blocks[blockId].term.kind = MirTermBranch`,
+		`func.blocks[blockId].term.kind = MirTermSwitchInt`,
+		`func.blocks[blockId].hasTerm = true`,
+	} {
+		if !strings.Contains(mirText, needle) {
+			t.Fatalf("mir.osty missing direct block terminator write guard %q", needle)
+		}
+	}
+}
+
+func TestLirBareFnThunkDedupUsesMap(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "lir_proto.osty"))
+	if err != nil {
+		t.Fatalf("read lir_proto.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"pub thunkSymbolSet: Map<String, Bool>",
+		"let thunkSymbolSet: Map<String, Bool> = {:}",
+		"match l.out.thunkSymbolSet.get(symbol)",
+		"l.out.thunkSymbolSet.insert(symbol, true)",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("lir_proto.osty missing bare-fn thunk dedup map guard %q", needle)
+		}
+	}
+	if strings.Contains(text, "if listContainsString(l.out.thunkSymbols, symbol)") {
+		t.Fatalf("lirEnsureBareFnThunk reintroduced linear thunk-symbol scan")
+	}
+}
+
+func TestLirMirTypeLoweringCachesRecursiveLayouts(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "lir_proto.osty"))
+	if err != nil {
+		t.Fatalf("read lir_proto.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"pub typeInProgress: Map<String, Bool>",
+		"pub mirTypeCache: Map<String, LirType>",
+		"let typeInProgress: Map<String, Bool> = {:}",
+		"let mirTypeCache: Map<String, LirType> = {:}",
+		"typeInProgress: l.typeInProgress",
+		"l.out.mirTypeCache.insert(name, typ)",
+		"match l.out.mirTypeCache.get(name)",
+		"fn lirLowerMirTypeCacheAliases(",
+		"fn lirLowerMirTypeSetProgress(",
+		"fn lirLowerMirTypeInProgress(",
+		"if lirLowerMirTypeInProgress(l, name, layout.name, layout.mangled)",
+		"fn lirDeclareMirLayoutTypeDefs(out: LirModule, mir: MirModule, diags: List<LirDiagnostic>)",
+		"lirDeclareMirLayoutTypeDefs(out, mir, diags)",
+		"fn lirMirStructLayoutBodyShallow(",
+		"fn lirLowerMirType_module_shallow(",
+		"let body = lirMirStructLayoutBodyShallow(l.out, l.mirModule, layout",
+		"lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, body))",
+		"return lirLowerMirTypeCacheAliases(l, name, layout.name, layout.mangled, aggregateType)",
+		"if lirLowerMirTypeInProgress(l, name, layout.key, layout.mangled)",
+		"return lirLowerMirTypeCacheAliases(l, name, layout.key, layout.mangled, aggregateType)",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("lir_proto.osty missing recursive type-cache guard %q", needle)
+		}
+	}
+}
+
+func TestLirMirLayoutLookupUsesIndexMaps(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "lir_proto.osty"))
+	if err != nil {
+		t.Fatalf("read lir_proto.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"pub struct LirMirLayoutIndex",
+		"pub layoutIndex: LirMirLayoutIndex",
+		"fn lirMirBuildLayoutIndex(layouts: MirLayoutTable) -> LirMirLayoutIndex",
+		"lirMirLayoutIndexPutQualified(index.structs, layout.name, i)",
+		"for i < parts.len()",
+		"suffix = suffix + \".\" + parts[j]",
+		"lirMirLayoutIndexPut(index.tuples, layout.key, i)",
+		"fn lirMirLayoutIndexStructPos(index: LirMirLayoutIndex, name: String) -> Int",
+		"out.layoutIndex = lirMirBuildLayoutIndex(mir.layouts)",
+		"out.layoutIndex = lirMirBuildLayoutIndex(layouts)",
+		"let structPos = lirMirLayoutIndexStructPos(l.out.layoutIndex, name)",
+		"let tuplePos = lirMirLayoutIndexTuplePos(l.out.layoutIndex, name)",
+		"let enumPos = lirMirLayoutIndexEnumPos(l.out.layoutIndex, name)",
+		"let ifacePos = lirMirLayoutIndexInterfacePos(l.out.layoutIndex, name)",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("lir_proto.osty missing layout index guard %q", needle)
+		}
+	}
+}
+
+func TestSelfResolverScopesAvoidCopyingRootSymbols(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "resolve.osty"))
+	if err != nil {
+		t.Fatalf("read resolve.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"rootIndex: Map<String, Int>",
+		"locals: List<SelfSymbol>",
+		"rootIndex: srBuildSymbolIndex(result.symbols)",
+		"locals: srSymbolListCopy(parent.locals)",
+		"fn srBuildSymbolIndex(symbols: List<SelfSymbol>) -> Map<String, Int>",
+		"match scope.rootIndex.get(name)",
+		"srSymbolExistsAtDepth(scope.locals, name, depth)",
+		"let bound = srSymbolsAtDepth(altScope.locals, altScope.depth)",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("resolve.osty missing indexed scope guard %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"symbols: srSymbolListCopy(result.symbols)",
+		"srSymbolListCopy(parent.symbols)",
+		"for sym in scope.symbols",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("resolve.osty reintroduced full root-scope copying %q", forbidden)
+		}
+	}
+}
+
+func TestLirRenderedFunctionTextUsesLineJoin(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "lir_proto.osty"))
+	if err != nil {
+		t.Fatalf("read lir_proto.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"fn lirRenderFunctionTextBlocks(blocks: List<String>, pos: Int, lines: List<String>) -> List<String>",
+		"lines = lirRenderFunctionTextBlocks(blocks, 0, lines)",
+		"strings.join(lines, lirLF())",
+		"fn lirRenderInstrsText(instrs: List<LirInstr>, pos: Int, lines: List<String>) -> List<String>",
+		"lines.push(\"  \" + text)",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("lir_proto.osty missing line-join render guard %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"out + lirLF() + block",
+		"out + lirLF() + \"  \" + text",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("lir_proto.osty reintroduced quadratic render concat %q", forbidden)
 		}
 	}
 }
@@ -636,9 +1063,12 @@ func TestElabInferLoopExprGuardStaysOutsideKindMatch(t *testing.T) {
 	if guardPos < 0 {
 		t.Fatalf("elabInferImpl missing bootstrap-safe loopexpr guard")
 	}
-	matchPos := strings.Index(text[guardPos:], "match node.kind")
-	if matchPos < 0 {
-		t.Fatalf("elabInferImpl missing node.kind match after loopexpr guard")
+	if strings.Contains(text[guardPos:], "match node.kind") {
+		t.Fatalf("elabInferImpl reintroduced node.kind match after loopexpr guard")
+	}
+	ifPos := strings.Index(text[guardPos:], "if node.kind == AstNIntLit")
+	if ifPos < 0 {
+		t.Fatalf("elabInferImpl missing bootstrap-safe if-chain after loopexpr guard")
 	}
 }
 
@@ -684,14 +1114,18 @@ func TestSelfhostDoctorProbeSourceEscapesLiteralBraces(t *testing.T) {
 			t.Fatalf("read %s: %v", path, err)
 		}
 		text := string(src)
-		if strings.Contains(text, `fn main() -> Int {\n`) {
-			t.Fatalf("%s has an unescaped probe source brace; self-host string interpolation corrupts the doctor probe", path)
+		if strings.Contains(text, `fn main() -> Int \{\n`) {
+			t.Fatalf("%s reintroduced escaped probe source; self-host string escaping writes literal backslashes", path)
 		}
-		if !strings.Contains(text, `fn main() -> Int \{\n`) {
-			t.Fatalf("%s missing escaped self-host doctor probe source", path)
+		if !strings.Contains(text, "r\"\"\"\n") {
+			t.Fatalf("%s missing raw self-host doctor probe source", path)
 		}
-		if !strings.Contains(text, `\}\n"`) {
-			t.Fatalf("%s missing escaped closing brace in self-host doctor probe source", path)
+		if strings.HasSuffix(path, "main.osty") {
+			if !strings.Contains(text, "fn add(a: Int, b: Int) -> Int") || !strings.Contains(text, "return add(x, 1)\n}\n\"\"\"") {
+				t.Fatalf("%s missing raw function-call doctor probe source", path)
+			}
+		} else if !strings.Contains(text, "fn main() -> Int {") || !strings.Contains(text, "return x + 1\n}\n\"\"\"") {
+			t.Fatalf("%s missing raw closing brace in self-host doctor probe source", path)
 		}
 	}
 }
@@ -837,19 +1271,202 @@ func TestMirLowerStage2SeedDiscardsStatementCalls(t *testing.T) {
 	if err != nil {
 		t.Fatalf("abs root: %v", err)
 	}
+	hirSrc, err := os.ReadFile(filepath.Join(root, "toolchain", "hir_lower.osty"))
+	if err != nil {
+		t.Fatalf("read hir_lower.osty: %v", err)
+	}
+	hirText := string(hirSrc)
+	for _, needle := range []string{
+		"let mut body = if node.right >= 0",
+		"if node.right >= 0 && body.stmts.len() == 0 && !body.hasResult",
+		"hirBlockAppend(body, hirExprStmt(hirUnitLit(span), span))",
+		"fn hirLowerDecodeStringEscapes(body: String) -> String",
+		"ostyDecodeEscapes(body)",
+		"if node.kind != AstNType {",
+		"return hirTypeNamed(node.text, [])",
+	} {
+		if !strings.Contains(hirText, needle) {
+			t.Fatalf("hir_lower.osty missing explicit-empty-body guard %q", needle)
+		}
+	}
+	if strings.Contains(hirText, `out = out + next.toString()`) || strings.Contains(hirText, `.toChar().toString()`) {
+		t.Fatalf("hir_lower.osty string escape decoding reintroduced bootstrap-unsafe Char.toString lowering")
+	}
+	for _, forbidden := range []string{
+		"let primHit = match prim.kind",
+		"let isPrim = match prim.kind",
+		"let isIntLit = match e.kind",
+		"let isStringLit = match e.kind",
+		"let isIf = match e.kind",
+		"let isMatch = match e.kind",
+	} {
+		if strings.Contains(hirText, forbidden) {
+			t.Fatalf("hir_lower.osty reintroduced bootstrap-unsafe match predicate %q", forbidden)
+		}
+	}
+	lexerSrc, err := os.ReadFile(filepath.Join(root, "toolchain", "lexer.osty"))
+	if err != nil {
+		t.Fatalf("read lexer.osty: %v", err)
+	}
+	lexerText := string(lexerSrc)
+	for _, needle := range []string{
+		"fn ostyDecodeCodepointString(value: Int) -> String",
+		`out = out + ostyDecodeCodepointString(hi * 16 + lo)`,
+		`out = out + ostyDecodeCodepointString(scan.value)`,
+	} {
+		if !strings.Contains(lexerText, needle) {
+			t.Fatalf("lexer.osty escape decoder missing bootstrap-safe codepoint path %q", needle)
+		}
+	}
+	if strings.Contains(lexerText, `bytes.toString(bytes.from(buf))`) || strings.Contains(lexerText, `bytes.toString(bytes.from(buf)).unwrapOr("")`) {
+		t.Fatalf("lexer.osty escape decoder reintroduced bootstrap-unsafe bytes.toString lowering")
+	}
+	hirCoreSrc, err := os.ReadFile(filepath.Join(root, "toolchain", "hir.osty"))
+	if err != nil {
+		t.Fatalf("read hir.osty: %v", err)
+	}
+	hirCoreText := string(hirCoreSrc)
+	for _, needle := range []string{
+		"e.binaryLeft = [left]",
+		"e.binaryRight = [right]",
+		"e.callCallee = [callee]",
+		"t.optionalInner = [inner]",
+		"t.fnReturn = [ret]",
+		"if t.kind == HirTypePrim {",
+		"if t.primKind == HirPrimUnit {",
+		"if t.primKind == HirPrimNever {",
+	} {
+		if !strings.Contains(hirCoreText, needle) {
+			t.Fatalf("hir.osty singleton constructor missing direct list assignment %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"e.binaryLeft.push(left)",
+		"e.binaryRight.push(right)",
+		"e.callCallee.push(callee)",
+		"t.optionalInner.push(inner)",
+		"t.fnReturn.push(ret)",
+		"pub fn hirTypeIsUnit(t: HirType) -> Bool {\n    match t.kind",
+		"pub fn hirTypeIsNever(t: HirType) -> Bool {\n    match t.kind",
+	} {
+		if strings.Contains(hirCoreText, forbidden) {
+			t.Fatalf("hir.osty reintroduced bootstrap-unsafe singleton field push %q", forbidden)
+		}
+	}
+	elabSrc, err := os.ReadFile(filepath.Join(root, "toolchain", "elab.osty"))
+	if err != nil {
+		t.Fatalf("read elab.osty: %v", err)
+	}
+	elabText := string(elabSrc)
+	for _, needle := range []string{
+		"if node.kind == AstNIdent {",
+		"return elabInferIdent(cx, node)",
+		"if node.kind == AstNCall {",
+		"return elabInferCall(cx, idx, node, tErr(cx.env.tys))",
+		"if node.kind == AstNReturn {",
+		"out = elabReturnStmt(cx, node)",
+		"if node.kind == AstNIdent || node.kind == AstNParen || node.kind == AstNBlock || node.kind == AstNUnary || node.kind == AstNBinary {",
+	} {
+		if !strings.Contains(elabText, needle) {
+			t.Fatalf("elab.osty missing bootstrap-safe node-kind dispatch guard %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"match node.kind {\n        AstNIntLit -> elabInferIntLit",
+		"match node.kind {\n        AstNIntLit -> elabCheckIntLit",
+		"let out = match node.kind {",
+		"match node.kind {\n        AstNIntLit -> true,",
+	} {
+		if strings.Contains(elabText, forbidden) {
+			t.Fatalf("elab.osty reintroduced bootstrap-unsafe node-kind match dispatch %q", forbidden)
+		}
+	}
+	checkSrc, err := os.ReadFile(filepath.Join(root, "toolchain", "check.osty"))
+	if err != nil {
+		t.Fatalf("read check.osty: %v", err)
+	}
+	checkText := string(checkSrc)
+	for _, needle := range []string{
+		"for paramIdx in node.children {",
+		"let paramNode = astArenaNodeAt(cx.ast.arena, paramIdx)",
+		`if sig.receiverTy >= 0 && paramNode.text == "self" {`,
+		`let rawName = if paramNode.text != "" {`,
+		"checkBindSpan(cx.env, bindName, pty, true, paramNode.start, paramNode.end)",
+	} {
+		if !strings.Contains(checkText, needle) {
+			t.Fatalf("check.osty missing AST-backed fn param binding guard %q", needle)
+		}
+	}
+	if strings.Contains(checkText, "for pname in sig.paramNames {\n        let pty =") {
+		t.Fatalf("check.osty reintroduced signature-only fn param binding")
+	}
 	src, err := os.ReadFile(filepath.Join(root, "toolchain", "mir_lower.osty"))
 	if err != nil {
 		t.Fatalf("read mir_lower.osty: %v", err)
 	}
 	text := string(src)
 	for _, needle := range []string{
+		"if s.kind == HirStmtLet {",
+		"if s.kind == HirStmtReturn {",
+		"if s.kind == HirStmtIf {",
+		"if s.kind == HirStmtMatch {",
 		"if s.exprValue.kind == HirExprCall",
 		"mirLowerCallExprInto(bs, s.exprValue, mirPlace(-1), hirTUnit())",
 		"if s.exprValue.kind == HirExprMethod",
 		"mirLowerMethodCallInto(bs, s.exprValue, mirPlace(-1), hirTUnit())",
+		"let mut localIdx = bs.fn_.locals.len() - 1",
+		"if loc.name == name {",
+		"if e.identKind == HirIdentFn {",
+		"if e.identKind == HirIdentGlobal {",
+		"if e.identKind == HirIdentVariant {",
+		"if pat.kind == HirPatIdent {",
+		"mirLowerBindPatternName(bs, pat.identName, pat.identMut, scrutinee, scrutT, span)",
+		"if pat.kind == HirPatBinding {",
 	} {
 		if !strings.Contains(text, needle) {
 			t.Fatalf("mir_lower.osty missing statement-call discard guard %q", needle)
+		}
+	}
+	if strings.Contains(text, "pub fn mirLowerStmt(bs: MirLowerBodyState, s: HirStmt) {\n    match s.kind") {
+		t.Fatalf("mirLowerStmt reintroduced bootstrap-unsafe match dispatch")
+	}
+	if strings.Contains(text, "fn mirLowerIdentOperand(bs: MirLowerBodyState, e: HirExpr) -> MirOperand {\n") &&
+		strings.Contains(text, "    match e.identKind {") {
+		t.Fatalf("mirLowerIdentOperand reintroduced bootstrap-unsafe ident-kind match dispatch")
+	}
+	if strings.Contains(text, "fn mirLowerIdentPlace(bs: MirLowerBodyState, e: HirExpr) -> MirPlace {\n") &&
+		strings.Contains(text, "    match e.identKind {") {
+		t.Fatalf("mirLowerIdentPlace reintroduced bootstrap-unsafe ident-kind match dispatch")
+	}
+	if strings.Contains(text, "fn mirLowerBindPattern(bs: MirLowerBodyState, pat: HirPattern, scrutinee: MirPlace, scrutT: HirType, span: MirSpan) {\n") &&
+		strings.Contains(text, "    match pat.kind {") {
+		t.Fatalf("mirLowerBindPattern reintroduced bootstrap-unsafe pattern-kind match dispatch")
+	}
+	tySrc, err := os.ReadFile(filepath.Join(root, "toolchain", "ty.osty"))
+	if err != nil {
+		t.Fatalf("read ty.osty: %v", err)
+	}
+	tyText := string(tySrc)
+	for _, needle := range []string{
+		"if prim == PkInt {",
+		"return arena.idxInt",
+		"if na.kind == TkPrim {",
+		"return na.prim == nb.prim",
+		"if node.kind == TkPrim {",
+		"return primKindName(node.prim)",
+		"if node.kind == TkNamed {",
+	} {
+		if !strings.Contains(tyText, needle) {
+			t.Fatalf("ty.osty missing bootstrap-safe type dispatch guard %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"match prim {",
+		"match na.kind {",
+		"match node.kind {",
+	} {
+		if strings.Contains(tyText, forbidden) {
+			t.Fatalf("ty.osty reintroduced bootstrap-unsafe match dispatch %q", forbidden)
 		}
 	}
 }
@@ -927,26 +1544,66 @@ func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 	text := string(src)
 	for _, needle := range []string{
 		"fn lirStoreIndexedListValue(l: LirMirFunctionLowerer, place: MirPlace, root: MirLocal, rootType: LirType, value: LirOperand, valueMirType: String, context: String)",
+		"fn lirStoreIndexedListRegisterValue(l: LirMirFunctionLowerer, listReg: String, proj: MirProjection, elemName: String, value: LirOperand, valueMirType: String, context: String)",
+		"lirStoreIndexedListRegisterValue(l, current.value, proj, proj.typ, stored, leafTypeName, context)",
+		"listStoreActive = true",
+		"lirStoreIndexedListRegisterValue(l, listStoreReg, listStoreProj, listStoreElemName, rebuilt, listStoreElemName, context)",
+		"let narrowed = lirNarrowI64ToType(l, current.value, step.typ)",
+		"fn lirLowerMirStdOsOutputFieldProjection(l: LirMirFunctionLowerer, instrs: List<LirInstr>, value: LirOperand, typeName: String, proj: MirProjection) -> LirOperand",
+		"fn lirStdOsOutputFieldType(typeName: String, index: Int) -> LirType",
+		`lirRawType(lirBraced("i64, ptr, ptr, i1"))`,
 		"llvmListRuntimeSetSymbolFor(elemLane.llvm, lirContainerElemIsString(elemName))",
 		"mirRtListSymbol(\"set_bytes_v1\")",
 		"fn lirCoerceValueToType(l: LirMirFunctionLowerer, value: LirOperand, valueMirType: String, destTypeName: String, destType: LirType, context: String) -> LirOperand",
 		"fn lirRebuildDefaultI64Aggregate(l: LirMirFunctionLowerer, value: LirOperand, destType: LirType) -> LirOperand",
+		"fn lirRebuildAlgebraicAggregate(l: LirMirFunctionLowerer, value: LirOperand, destTypeName: String, destType: LirType) -> LirOperand",
+		"fn lirRebuildDefaultI64AggregateIntoWidened(l: LirMirFunctionLowerer, value: LirOperand, destTypeName: String, destType: LirType) -> LirOperand",
+		"lirUnboxCompositeFromI64(l, payloadI64, payloadType)",
+		"value = LirOperand {typ: destType, value: lirZeroValue(destType)}",
+		"fn lirMirStructLayoutDirectlyMentionsType(out: LirModule, mir: MirModule, structName: String, typeName: String) -> Bool",
+		"lirMirStructLayoutDirectlyMentionsType(out, mir, payloadInner, name)",
+		"for layout in mir.layouts.structs {\n        if lirMirStructLayoutMatches(layout, name) {",
+		"for layout in mir.layouts.enums {\n        if lirMirEnumLayoutMatches(layout, name) {",
 		"fn lirEmitEnumDiscriminantAggregate(l: LirMirFunctionLowerer, discValue: LirOperand, destType: LirType) -> LirOperand",
 		"lirCoerceTargetIsPayloadEnum(l, destTypeName)",
+		"let mut payloadI64 = \"0\"",
+		"if lirTypeIsVoid(value.typ) || arg.typ == \"Unit\" || arg.typ == \"()\"",
+		"} else if rv.aggFields.len() > 1 {",
 		"fn lirAppendRenderedLirBlocks(renderedBlocks: List<String>, blocks: List<LirBlock>, pos: Int)",
 		"lirAppendRenderedLirBlocks(renderedBlocks, blockLowerer.extraBlocks, 0)",
 		"fn lirLowerMirListGetSafe(l: LirMirFunctionLowerer, instr: MirInstr, optTypeName: String)",
 		"lirLowerMirListGetSafe(l, instr, effectiveTypeName)",
 		"fn lirBinaryAddIsStringConcat(rv: MirRValue, hintName: String, hint: LirType) -> Bool",
+		"if lirTypeIsZero(argType) {\n        if !(lirTypeIsZero(left.typ)) {",
+		"left = lirCoerceValueToType(l, left, rv.arg.typ, rv.arg.typ, argType, \"binary left\")",
+		"right = lirCoerceValueToType(l, right, rv.right.typ, rv.right.typ, argType, \"binary right\")",
 		"left = lirCoerceValueToType(l, left, rv.arg.typ, \"String\", lirPtrType(), \"string concat left\")",
 		"fn lirBinaryIsStringComparison(rv: MirRValue) -> Bool",
 		"fn lirLowerMirStringComparison(l: LirMirFunctionLowerer, rv: MirRValue) -> LirOperand",
 		"lirRuntimeDeclI1FromTwoPtr(symbol)",
 		"lirRuntimeDeclI64FromTwoPtr(symbol)",
+		"fn lirMirParamAbiType(typeName: String, typ: LirType) -> LirType",
+		"fn lirMirParamShouldPassByRef(typeName: String, typ: LirType) -> Bool",
+		"fn lirMirParamNameShouldPassByRef(name: String) -> Bool",
+		`name == "OstyParser"`,
+		`name == "MirLowerBodyState"`,
+		`name == "LirMirFunctionLowerer"`,
+		"if lirMirParamShouldPassByRef(typeName, typ) {\n        return lirPtrType()",
+		"let abiType = lirMirParamAbiType(loc.typ, typ)",
+		"if loc.isParam && lirMirParamShouldPassByRef(loc.typ, typ)",
+		"slot: lirMirParamName(loc.id), typ",
+		"fn lirLowerMirAggregateArgAddress(l: LirMirFunctionLowerer, arg: MirOperand, paramTypeName: String, paramType: LirType, context: String) -> LirOperand",
+		"fn lirLowerMirAggregatePlaceAddress(l: LirMirFunctionLowerer, place: MirPlace, rootTypeName: String, context: String) -> LirOperand",
+		"l.instrs.push(lirGep(nextPtr, currentType, currentPtr",
+		"lirMirParamShouldPassByRef(paramLocal.typ, paramValueType) && paramType.className == LirTypePtr",
+		"let valuePtr = lirLowerMirAggregateArgAddress(l, arg, paramLocal.typ, paramValueType, \"direct call arg\")",
 		"l.instrs.push(lirCall(eqDest, boolType, \"@\" + symbol",
 		"l.instrs.push(lirBinary(neDest, \"xor\", boolType, eqDest, \"1\"))",
 		"out = strings.replaceAll(out, \"<\", \".\")",
 		"out = strings.replaceAll(out, \" \", \"\")",
+		"out = strings.replaceAll(out, \"()\", \"Unit\")",
+		"out = strings.replaceAll(out, \"(\", \".tuple.\")",
+		"out = strings.replaceAll(out, \"[\", \".array.\")",
 		"fn lirEncodedCStringByteLen(encoded: String) -> Int",
 		"lirEncodedCStringByteLen(encoded)",
 		"fn lirNoTypeParams() -> List<LirType>",
@@ -961,16 +1618,29 @@ func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 		"pub tempNames: List<String>",
 		"let tempNames: List<String> = []",
 		"l.tempNames.push(name)",
-		`if !(loc.isParam) && typ.className == LirTypePtr`,
+		`if lirTypeNameIsGCManaged(loc.typ) && !(loc.isParam) && typ.className == LirTypePtr`,
 		`l.prologue.push(lirStore(lirOperand(typ, "null"), slot, 0))`,
+		`if lirTypeNameIsGCManaged(loc.typ) && loc.isParam`,
 		`value.typ.className == LirTypePtr && destType.className == LirTypeInt`,
 		`value.typ.className == LirTypeInt && destType.className == LirTypePtr`,
 		"value = lirCoerceValueToType(l, value, arg.typ, paramLocal.typ, paramType, \"direct call arg\")",
+		"value = lirCoerceValueToType(l, value, field.typ, fieldLayout.typ, fieldType, \"aggregate.tuple\")",
+		"value = lirCoerceValueToType(l, value, field.typ, fieldLayout.typ, fieldType, \"aggregate.struct\")",
 		"fn lirRuntimePanicDecl() -> LirRuntimeDecl",
 		"lirRuntimeDeclWithAttrs(\"osty_rt_panic\", lirVoidType(), [lirPtrType()], false, lirRuntimePanicAttrs())",
 		"if kind == MirIntrinsicAbort",
+		"return \"define \" + fn_.linkage",
+		"fn lirEmitGcRootReleases(l: LirMirFunctionLowerer)",
+		"if l.gcRootSlots.len() == 0",
+		"lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirGcRootReleaseDecl())",
+		"let mut i = l.gcRootSlots.len()",
+		"l.instrs.push(lirCall(\"\", lirVoidType(), \"@\" + lirGcRootReleaseSymbol(), [lirOperand(lirPtrType(), slot)]))",
 		"fn lirLowerMirAbort(l: LirMirFunctionLowerer, instr: MirInstr)",
 		"l.instrs.push(lirCallWithAttrs(\"\", lirVoidType(), \"@osty_rt_panic\", args, \"\", lirRuntimePanicAttrs()))",
+		"fn lirIsTupleTypeName(name: String) -> Bool",
+		"fn lirLowerMirSyntheticTupleType(l: LirMirFunctionLowerer, name: String) -> LirType",
+		"fn lirSyntheticTupleLayout(name: String) -> MirTupleLayout",
+		"if valueReg == \"\" || lirTypeIsVoid(valueType) {\n        return \"0\"",
 		"let fields: List<MirFieldLayout> = []",
 		// MirStructLayout sentinel — pin the empty-name + size:0
 		// prefix only. PR #1981 widened the struct with
@@ -982,9 +1652,18 @@ func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 		"MirTupleLayout {key: \"\", mangled: \"\", fields}",
 		"return lirLowerMirStringRuntimeCall(l, instr, llvmSetRuntimeNewSymbol(), lirPtrType(), lirNoTypeParams(), \"set.new\")",
 		"l.instrs.push(lirCall(listReg, lirPtrType(), \"@\" + newSym, lirNoOperands()))",
+		"out.renderedFunctions.push(lirRenderFunction(ctor))",
+		"out.renderedFunctions.push(lirRenderFunction(fn_))",
+		"let externRet = if lirIsStdFsRuntimeResultSymbol(name) {",
+		"fn lirIsStdFsRuntimeResultSymbol(symbol: String) -> Bool",
+		`symbol == "std.fs.readToString" || symbol == "std.fs.walk" || symbol == "std.fs.mkdirAll" || symbol == "std.fs.writeString"`,
+		"fn lirLowerMirRuntimeBoxedResultCall(l: LirMirFunctionLowerer, instr: MirInstr, context: String)",
+		"lirLowerMirRuntimeBoxedResultCall(l, instr, \"call.std.fs.result\")",
 		"fn lirLowerMirStdOsExecResultCall(l: LirMirFunctionLowerer, instr: MirInstr)",
 		"symbol == \"osty_rt_os_exec_with\" || symbol == \"osty_rt_os_exec_input_with\"",
 		"lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(instr.calleeSymbol, lirPtrType(), paramTypes, false))",
+		"l.instrs.push(lirLoad(loaded, resultType, boxed, 8))",
+		"lirEmitContainerCall(l, instr, llvmMapRuntimeRemoveSymbol(recv.elemLir.llvm, recv.isString), lirIntType(1)",
 		"let boxType = lirRawType(lirBraced(\"i64, ptr, ptr\"))",
 		"l.instrs.push(lirSelect(payloadI64, lirIntType(64), isOk, okPayloadI64, errPayloadI64))",
 		"let comma = lirFirstTopLevelComma(args)",
@@ -996,6 +1675,137 @@ func TestLirProtoStage2SeedCoercionAndIndexStoreGuards(t *testing.T) {
 	}
 	if strings.Contains(text, "strings.fromChar(ch)") {
 		t.Fatalf("lir_proto.osty reintroduced stage2-unsafe strings.fromChar(ch) in generic arg splitting")
+	}
+}
+
+func TestAirepairPythonScopeKindsAvoidGlobalRefInReturnStructs(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "toolchain", "airepair_python.osty"))
+	if err != nil {
+		t.Fatalf("read airepair_python.osty: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		"pub let pythonScopeBlock: Int = 0",
+		"pub let pythonScopeMatch: Int = 1",
+		"pub let pythonScopeMatchArm: Int = 2",
+		"fn pythonScopeBlockCode() -> Int",
+		"fn pythonScopeMatchCode() -> Int",
+		"fn pythonScopeMatchArmCode() -> Int",
+		"scopeKind: pythonScopeBlockCode()",
+		"scopeKind: pythonScopeMatchCode()",
+		"scopeKind: pythonScopeMatchArmCode()",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("airepair_python.osty missing scope-kind global-ref guard %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"scopeKind: pythonScopeBlock,",
+		"scopeKind: pythonScopeMatch,",
+		"scopeKind: pythonScopeMatchArm,",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("airepair_python.osty reintroduced return-struct scope global ref %q", forbidden)
+		}
+	}
+}
+
+func TestSelfhostPolicyConstantsAvoidGlobalRefUseSites(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	cases := []struct {
+		path      string
+		needles   []string
+		forbidden []string
+	}{
+		{
+			path: "toolchain/airepair_rewrite.osty",
+			needles: []string{
+				"fn airepairSemanticIndentStepValue() -> String",
+				"let bodyIndent = indent + airepairSemanticIndentStepValue()",
+			},
+			forbidden: []string{"indent + airepairSemanticIndentStep\n"},
+		},
+		{
+			path: "toolchain/format_escape.osty",
+			needles: []string{
+				"fn formatHexDigitsUpperValue() -> String",
+				"strings.slice(formatHexDigitsUpperValue(), nibble, nibble + 1)",
+			},
+			forbidden: []string{"strings.slice(formatHexDigitsUpper,"},
+		},
+		{
+			path: "toolchain/ci.osty",
+			needles: []string{
+				"fn ciCheckFormatName() -> CheckName",
+				"rep.Checks.push(skipped(ciCheckFormatName()))",
+				"checkFromHostResult(ciCheckLockfileName(), host.CheckLockfile(self.Root, self.Manifest))",
+			},
+			forbidden: []string{
+				"skipped(CheckFormat)",
+				"skipped(CheckLint)",
+				"checkFromHostResult(CheckFormat",
+				"Name: CheckPolicy",
+			},
+		},
+		{
+			path: "toolchain/diag_render.osty",
+			needles: []string{
+				"fn diagSeverityErrorCode() -> Int",
+				"if sev == diagSeverityErrorCode()",
+			},
+			forbidden: []string{
+				"sev == diagSeverityError {",
+				"sev == diagSeverityWarning {",
+				"sev == diagSeverityNote {",
+			},
+		},
+		{
+			path: "toolchain/pkg_policy.osty",
+			needles: []string{
+				"fn pkgSourceKindPathCode() -> Int",
+				"if kind == pkgSourceKindPathCode()",
+			},
+			forbidden: []string{
+				"kind == pkgSourceKindPath {",
+				"kind == pkgSourceKindGit {",
+				"kind == pkgSourceKindRegistry {",
+			},
+		},
+		{
+			path: "toolchain/scaffold_policy.osty",
+			needles: []string{
+				"fn scaffoldFixtureCasesDefaultValue() -> Int",
+				"if requested > scaffoldFixtureCasesMaxValue()",
+			},
+			forbidden: []string{
+				"requested > scaffoldFixtureCasesMax {",
+				"count: scaffoldFixtureCasesDefault,",
+			},
+		},
+	}
+	for _, tc := range cases {
+		src, err := os.ReadFile(filepath.Join(root, tc.path))
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.path, err)
+		}
+		text := string(src)
+		for _, needle := range tc.needles {
+			if !strings.Contains(text, needle) {
+				t.Fatalf("%s missing global-ref use-site guard %q", tc.path, needle)
+			}
+		}
+		for _, forbidden := range tc.forbidden {
+			if strings.Contains(text, forbidden) {
+				t.Fatalf("%s reintroduced direct policy-global use %q", tc.path, forbidden)
+			}
+		}
 	}
 }
 
@@ -1146,6 +1956,43 @@ func TestVerifySelfRebuildStage1IgnoresStaleInTreeSelfBinary(t *testing.T) {
 	}
 	if strings.Contains(text, "--bootstrap-stage0") {
 		t.Fatalf("verify-self-rebuild reintroduced `--bootstrap-stage0` CLI flag; the env-var gate is the single source of truth post-retirement")
+	}
+}
+
+func TestVerifySelfRebuildRequiresSourceCompilerStages(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "scripts", "verify-self-rebuild"))
+	if err != nil {
+		t.Fatalf("read verify-self-rebuild: %v", err)
+	}
+	text := string(src)
+	for _, needle := range []string{
+		`build_self_binary "$stage1" "stage2-seed" "$stage2_seed" "$host_guard"`,
+		`build_self_binary "$stage2_seed" "stage2" "$stage2" "$host_guard"`,
+		`build_self_binary "$stage2" "stage3" "$stage3" "$host_guard"`,
+		`"osty-self source compiler: enabled"`,
+		`fail "$label selfhost doctor did not report the source compiler pipeline"`,
+		`fail "$label source compiler probe failed"`,
+		`fn main() -> Int {`,
+		`return x + 1`,
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("verify-self-rebuild no longer requires source compiler stage marker %q", needle)
+		}
+	}
+	for _, forbidden := range []string{
+		"build_self_binary_with_host_mir_backend",
+		"build_self_binary_with_compile_driver",
+		"bundle_selfhost_driver_source",
+		"osty-self MIR JSON backend: enabled",
+		"MIR JSON -> LIR Proto backend",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("verify-self-rebuild still allows MIR-JSON/backend-only ratchet path %q", forbidden)
+		}
 	}
 }
 

--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -9,8 +9,8 @@ Runs the self-rebuild ratchet:
 
   1. host osty validates the toolchain sources and current MIR gates
   2. host osty builds osty-self-1 from toolchain/
-  3. host osty front-end rebuilds the MIR-driver package while osty-self-1,
-     osty-self-2-seed, and osty-self-2 provide the MIR JSON -> LIR Proto backend
+  3. osty-self-1, osty-self-2-seed, and osty-self-2 rebuild toolchain/ from
+     source through HIR -> Mono -> MIR -> LIR Proto -> LLVM IR
   5. osty-self-2 and osty-self-3 are compared byte-for-byte
 
 Environment overrides:
@@ -266,160 +266,6 @@ install_into_selfhostcache() {
 	log "stage1: promoted into selfhostcache $target"
 }
 
-selfhost_driver_source_files() {
-	cat <<'FILES'
-toolchain/mir.osty
-toolchain/mir_validator.osty
-toolchain/mir_json.osty
-scripts/selfhost_mir_support.osty
-toolchain/lir_proto.osty
-toolchain/selfhost_mir_driver.osty
-FILES
-}
-
-bundle_selfhost_driver_source() {
-	local out="$1"
-	{
-		printf 'use std.env\nuse std.fs\nuse std.os\nuse std.process\nuse std.strings\n\n'
-		while IFS= read -r rel; do
-			local path="$root/$rel"
-			[[ -f "$path" ]] || fail "selfhost driver source not found: $rel"
-			printf '// ---- %s ----\n' "$path"
-			if [[ "$rel" == "toolchain/core.osty" ]]; then
-				awk '
-				/^use std\.env$/ || /^use std\.fs$/ || /^use std\.os$/ || /^use std\.process$/ || /^use std\.strings$/ || /^use std\.strings as strings$/ { next }
-				/^pub fn binOpSymbol/ {
-					print "pub fn binOpSymbol(op: BinOp) -> String {"
-					print "    let _ = op"
-					print "    \"?\""
-					print "}"
-					skip = "bin"
-					next
-				}
-				skip == "bin" && /^\/\/ B2:/ { skip = ""; print; next }
-				skip == "bin" { next }
-				/^pub fn unOpSymbol/ {
-					print "pub fn unOpSymbol(op: UnOp) -> String {"
-					print "    let _ = op"
-					print "    \"?\""
-					print "}"
-					skip = "un"
-					next
-				}
-				skip == "un" && /^\/\/ B2:/ { skip = ""; print; next }
-				skip == "un" { next }
-				/^pub fn coreKindName/ {
-					print "pub fn coreKindName(kind: CoreKind) -> String {"
-					print "    let _ = kind"
-					print "    \"Core\""
-					print "}"
-					skip = "kind"
-					next
-				}
-				skip == "kind" && /^\/\/ B2:/ { skip = ""; print; next }
-				skip == "kind" { next }
-				/^pub fn corePrintModule/ { skip = "print"; next }
-				skip == "print" && /^fn coreIntLen/ { skip = ""; print; next }
-				skip == "print" { next }
-				{ print }
-				' "$path"
-			else
-				sed '/^use std\.env$/d;/^use std\.fs$/d;/^use std\.os$/d;/^use std\.process$/d;/^use std\.strings$/d;/^use std\.strings as strings$/d' "$path"
-			fi
-			printf '\n'
-		done < <(selfhost_driver_source_files)
-		printf 'fn main() {\n    selfhostMirDriverMain()\n}\n'
-	} >"$out"
-}
-
-build_self_binary_with_compile_driver() {
-	local driver="$1"
-	local label="$2"
-	local dest="$3"
-	local work="$stage_root/$label-work"
-	local bundle="$work/self-rebuild-bundle.osty"
-	local ir="$work/main.ll"
-	local object="$work/main.o"
-	local runtime_object="$work/osty_runtime.o"
-	local candidate="$work/osty-self"
-	local runtime_source="$root/internal/backend/runtime/osty_runtime.c"
-
-	require_exec "$driver" "$label driver"
-	rm -rf "$work"
-	mkdir -p "$work"
-	bundle_selfhost_driver_source "$bundle"
-	log "$label: compile selfhost driver bundle with $driver"
-	if ! "$driver" compile "$bundle" >"$ir"; then
-		fail "$label failed to compile selfhost driver source"
-	fi
-	log "$label: compile lowered LLVM IR"
-	clang -O3 -flto=thin -c "$ir" -o "$object"
-	clang -O3 -flto=thin -std=c11 -c "$runtime_source" -o "$runtime_object"
-	local link_args=(-O3 -flto=thin "$object" "$runtime_object" -pthread -lz -o "$candidate" -lm)
-	case "$(uname -s)" in
-	Darwin)
-		link_args+=(-framework Security -framework CoreFoundation)
-		;;
-	esac
-	clang "${link_args[@]}"
-	cp "$candidate" "$dest"
-	chmod +x "$dest"
-}
-
-find_single_binary_candidate() {
-	local dir="$1"
-	local candidates="$2"
-	: >"$candidates"
-	while IFS= read -r -d '' path; do
-		[[ -x "$path" ]] || continue
-		kind="$(file -b "$path" 2>/dev/null || true)"
-		case "$kind" in
-		*Mach-O* | *ELF* | *PE32*) printf '%s\n' "$path" ;;
-		esac
-	done < <(find "$dir" -type f -print0 2>/dev/null) | LC_ALL=C sort -u >>"$candidates"
-}
-
-build_self_binary_with_host_mir_backend() {
-	local driver="$1"
-	local label="$2"
-	local dest="$3"
-	local work="$stage_root/$label-work"
-	local bundle="$work/main.osty"
-	local candidates="$work/candidates"
-	local candidate=""
-	local count
-
-	require_exec "$driver" "$label MIR backend"
-	rm -rf "$work"
-	mkdir -p "$work"
-	bundle_selfhost_driver_source "$bundle"
-	cat >"$work/osty.toml" <<'TOML'
-[package]
-name = "selfhost-mir-driver"
-version = "0.1.0"
-edition = "0.3"
-
-[bin]
-name = "osty-self"
-path = "main.osty"
-
-[capabilities]
-runtime = true
-TOML
-	log "$label: build MIR driver package with self-host backend $driver"
-	OSTY_SELF_BIN="$driver" OSTY_SELF_REGISTRY_OFFLINE=1 "$host_bin" build --backend=llvm --emit binary --force "$work"
-	find_single_binary_candidate "$work/.osty/out" "$candidates"
-	count="$(wc -l <"$candidates" | tr -d '[:space:]')"
-	if [[ "$count" != "1" ]]; then
-		printf 'self-rebuild: %s produced %s binary candidates:\n' "$label" "$count" >&2
-		sed 's/^/  /' "$candidates" >&2
-		fail "$label did not produce exactly one MIR driver binary"
-	fi
-	candidate="$(sed -n '1p' "$candidates")"
-	cp "$candidate" "$dest"
-	chmod +x "$dest"
-}
-
 build_self_binary() {
 	local driver="$1"
 	local label="$2"
@@ -430,10 +276,6 @@ build_self_binary() {
 	local candidates="$stage_root/$label.candidates"
 
 	require_exec "$driver" "$label driver"
-	if [[ "$label" != "stage1" ]]; then
-		build_self_binary_with_compile_driver "$driver" "$label" "$dest"
-		return
-	fi
 	if [[ -z "$host_guard" ]]; then
 		rm -f "$toolchain_dir/.osty/out/debug/llvm/osty-self" "$toolchain_dir/.osty/out/debug/llvm/osty-self.exe"
 		rm -f "$toolchain_dir/.osty/out/release/llvm/osty-self" "$toolchain_dir/.osty/out/release/llvm/osty-self.exe"
@@ -508,9 +350,9 @@ smoke_self_driver() {
 		printf '%s\n' "$out" >&2
 		fail "$label selfhost doctor did not report host-free OK"
 	fi
-	if [[ "$out" != *"osty-self source compiler: enabled"* && "$out" != *"osty-self MIR JSON backend: enabled"* ]]; then
+	if [[ "$out" != *"osty-self source compiler: enabled"* ]]; then
 		printf '%s\n' "$out" >&2
-		fail "$label selfhost doctor did not report an enabled selfhost pipeline"
+		fail "$label selfhost doctor did not report the source compiler pipeline"
 	fi
 }
 
@@ -648,15 +490,15 @@ if [[ "$mode" == "stage1" ]]; then
 	exit 0
 fi
 
-build_self_binary_with_host_mir_backend "$stage1" "stage2-seed" "$stage2_seed"
+build_self_binary "$stage1" "stage2-seed" "$stage2_seed" "$host_guard"
 
 smoke_self_driver "$stage2_seed" "stage2-seed"
 
-build_self_binary_with_host_mir_backend "$stage2_seed" "stage2" "$stage2"
+build_self_binary "$stage2_seed" "stage2" "$stage2" "$host_guard"
 
 smoke_self_driver "$stage2" "stage2"
 
-build_self_binary_with_host_mir_backend "$stage2" "stage3" "$stage3"
+build_self_binary "$stage2" "stage3" "$stage3" "$host_guard"
 
 smoke_self_driver "$stage3" "stage3"
 

--- a/toolchain/airepair_decide.osty
+++ b/toolchain/airepair_decide.osty
@@ -128,13 +128,6 @@ pub fn compareFrontEndAssist(before: ProbeStats, after: ProbeStats) -> Int {
 pub fn repairedChanged(changeCount: Int, skipCount: Int) -> Bool {
     changeCount > 0 || skipCount > 0
 }
-/// Mode strings the airepair scorers dispatch on. Match
-/// toolchain/airepair_flags.osty's canonical mode names so the
-/// `--airepair-mode` flag and the policy talk in the same alphabet.
-let airepairModeRewriteOnly: String = "rewrite"
-let airepairModeAutoAssist: String = "auto"
-let airepairModeParseAssist: String = "parse"
-let airepairModeFrontEndAssist: String = "frontend"
 /// isImproved reports whether the rewriter's snapshot is a strict
 /// improvement over the pre-repair snapshot under the chosen
 /// mode. The default ("auto" or unrecognised) routes through the
@@ -143,13 +136,13 @@ let airepairModeFrontEndAssist: String = "frontend"
 /// `rewrite` mode is structurally improved whenever the repair
 /// pass emitted any edits — there's no diagnostic scoring to do.
 pub fn isImproved(mode: String, before: ProbeStats, after: ProbeStats, repairedChanges: Int) -> Bool {
-    if mode == airepairModeRewriteOnly {
+    if mode == "rewrite" {
         return repairedChanges > 0
     }
-    if mode == airepairModeParseAssist {
+    if mode == "parse" {
         return compareParseAssist(before, after) > 0
     }
-    if mode == airepairModeFrontEndAssist {
+    if mode == "frontend" {
         return compareFrontEndAssist(before, after) > 0
     }
     compareAutoAssist(before, after) > 0
@@ -169,13 +162,13 @@ pub fn isAccepted(mode: String, before: ProbeStats, after: ProbeStats, repairedC
     if repairedChanges == 0 && repairedSkipped == 0 {
         return true
     }
-    if mode == airepairModeRewriteOnly {
+    if mode == "rewrite" {
         return true
     }
-    if mode == airepairModeParseAssist {
+    if mode == "parse" {
         return compareParseAssist(before, after) >= 0
     }
-    if mode == airepairModeFrontEndAssist {
+    if mode == "frontend" {
         return compareFrontEndAssist(before, after) >= 0
     }
     compareAutoAssist(before, after) >= 0
@@ -221,7 +214,7 @@ pub fn explainAcceptedReason(
     if after.totalWarnings < before.totalWarnings {
         return "warnings_reduced"
     }
-    if mode == airepairModeRewriteOnly && repairedChanges > 0 {
+    if mode == "rewrite" && repairedChanges > 0 {
         return "rewrite_mode_applied"
     }
     if repairedChanges > 0 {
@@ -244,10 +237,10 @@ pub fn explainRejectedReason(mode: String, before: ProbeStats, after: ProbeStats
     if after.parse.errors > before.parse.errors {
         return "parse_regression_blocked"
     }
-    if mode == airepairModeAutoAssist && after.resolve.errors > before.resolve.errors {
+    if mode == "auto" && after.resolve.errors > before.resolve.errors {
         return "resolve_regression_blocked"
     }
-    if mode == airepairModeAutoAssist && after.check.errors > before.check.errors {
+    if mode == "auto" && after.check.errors > before.check.errors {
         return "check_regression_blocked"
     }
     if after.totalErrors > before.totalErrors {

--- a/toolchain/airepair_python.osty
+++ b/toolchain/airepair_python.osty
@@ -32,6 +32,15 @@ use std.strings as strings
 pub let pythonScopeBlock: Int = 0
 pub let pythonScopeMatch: Int = 1
 pub let pythonScopeMatchArm: Int = 2
+fn pythonScopeBlockCode() -> Int {
+    0
+}
+fn pythonScopeMatchCode() -> Int {
+    1
+}
+fn pythonScopeMatchArmCode() -> Int {
+    2
+}
 /// PythonColonHeader is the structured outcome of recognising a
 /// Python-style block header. `ok == false` leaves all the
 /// string fields empty.
@@ -69,7 +78,7 @@ pub fn rewritePythonColonHeader(trimmed: String) -> PythonColonHeader {
             rewritten: head + " -> \{",
             changeKind: "python_arrow_arm_block",
             message: "wrap a multiline match arm body in Osty braces",
-            scopeKind: pythonScopeMatchArm,
+            scopeKind: pythonScopeMatchArmCode(),
             elseish: false,
             requiresMatch: true,
             ok: true,
@@ -115,7 +124,7 @@ pub fn rewritePythonColonHeader(trimmed: String) -> PythonColonHeader {
             rewritten: head + " \{",
             changeKind: "python_match_block",
             message: "replace Python-style `match:` block with Osty braces",
-            scopeKind: pythonScopeMatch,
+            scopeKind: pythonScopeMatchCode(),
             elseish: false,
             requiresMatch: false,
             ok: true,
@@ -127,7 +136,7 @@ pub fn rewritePythonColonHeader(trimmed: String) -> PythonColonHeader {
             rewritten: rest + " -> \{",
             changeKind: "python_case_arm",
             message: "replace Python-style `case:` arm with Osty match syntax",
-            scopeKind: pythonScopeMatchArm,
+            scopeKind: pythonScopeMatchArmCode(),
             elseish: false,
             requiresMatch: true,
             ok: true,
@@ -138,7 +147,7 @@ pub fn rewritePythonColonHeader(trimmed: String) -> PythonColonHeader {
             rewritten: "_ -> \{",
             changeKind: "python_default_arm",
             message: "replace Python-style `default:` arm with Osty match syntax",
-            scopeKind: pythonScopeMatchArm,
+            scopeKind: pythonScopeMatchArmCode(),
             elseish: false,
             requiresMatch: true,
             ok: true,
@@ -171,7 +180,7 @@ fn airepairPyColonBlock(rewritten: String, changeKind: String, message: String, 
         rewritten: rewritten,
         changeKind: changeKind,
         message: message,
-        scopeKind: pythonScopeBlock,
+        scopeKind: pythonScopeBlockCode(),
         elseish: elseish,
         requiresMatch: false,
         ok: true,
@@ -184,7 +193,7 @@ fn airepairPyColonNone() -> PythonColonHeader {
         rewritten: "",
         changeKind: "",
         message: "",
-        scopeKind: pythonScopeBlock,
+        scopeKind: pythonScopeBlockCode(),
         elseish: false,
         requiresMatch: false,
         ok: false,

--- a/toolchain/airepair_rewrite.osty
+++ b/toolchain/airepair_rewrite.osty
@@ -513,6 +513,9 @@ pub struct EnumerateLoopRewrite {
 /// rewriter emits inside generated `for` blocks — four spaces, to
 /// match the existing Osty formatter style.
 let airepairSemanticIndentStep: String = "    "
+fn airepairSemanticIndentStepValue() -> String {
+    "    "
+}
 /// rewriteEnumerateLoopHeader transforms a `for X.enumerate() \{`
 /// header into the indexed-loop shape the native checker can
 /// validate end-to-end. The new shape pre-binds the iterable to
@@ -566,7 +569,7 @@ pub fn rewriteEnumerateLoopHeader(indent: String, trimmed: String, counter: Int)
         return EnumerateLoopRewrite {rewritten: "", nextCounter: counter, ok: false}
     }
     let iterTemp = "_osty_enumerate{counter}"
-    let bodyIndent = indent + airepairSemanticIndentStep
+    let bodyIndent = indent + airepairSemanticIndentStepValue()
     let rewritten = indent + "let " + iterTemp + " = " + iterExpr + "\n" +
         indent + "for " + indexVar + " in 0.." + iterTemp + ".len() \{\n" +
         bodyIndent + "let " + valueBinding + " = " + iterTemp + "[" + indexVar + "]"

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -1048,18 +1048,40 @@ fn elaborateFnBody(cx: ElabCx, node: AstNode, owner: String) {
         checkBindSpan(cx.env, "self", sig.receiverTy, true, node.start, node.end)
     }
     let mut i = 0
-    for pname in sig.paramNames {
+    for paramIdx in node.children {
+        let paramNode = astArenaNodeAt(cx.ast.arena, paramIdx)
+        if paramNode.kind != AstNParam {
+            let _ = paramIdx
+            continue
+        }
+        if sig.receiverTy >= 0 && paramNode.text == "self" {
+            continue
+        }
         let pty = if i < checkIntListLenLocal(sig.paramTys) {
             checkIntListAtLocal(sig.paramTys, i)
         } else {
             tErr(cx.env.tys)
         }
-        let bindName = if pname.startsWith("?") {
-            strings.trimPrefix(pname, "?")
+        let sigName = if i < sig.paramNames.len() {
+            sig.paramNames[i]
         } else {
-            pname
+            ""
         }
-        checkBindSpan(cx.env, bindName, pty, true, node.start, node.end)
+        let rawName = if paramNode.text != "" {
+            paramNode.text
+        } else if sigName.startsWith("?") {
+            strings.trimPrefix(sigName, "?")
+        } else {
+            sigName
+        }
+        let bindName = if rawName.startsWith("?") {
+            strings.trimPrefix(rawName, "?")
+        } else {
+            rawName
+        }
+        if bindName != "" {
+            checkBindSpan(cx.env, bindName, pty, true, paramNode.start, paramNode.end)
+        }
         i = i + 1
     }
     if node.right >= 0 {

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -269,18 +269,22 @@ pub fn checkBindSpan(env: CheckEnv, name: String, ty: Int, mutable: Bool, start:
 /// the most recent binding for `name`. Returns `-1` (no type) when
 /// `name` is not in scope.
 pub fn checkLookup(env: CheckEnv, name: String) -> Int {
-    let binding = checkBindingStackIndexTop(env.local.bindingIndex, name)
-    if binding.isNone() {
-        return -1
+    let mut found = -1
+    for binding in env.local.bindings {
+        if binding.name == name {
+            found = binding.ty
+        }
     }
-    binding.unwrap().ty
+    found
 }
 pub fn checkLookupMutable(env: CheckEnv, name: String) -> Bool {
-    let binding = checkBindingStackIndexTop(env.local.bindingIndex, name)
-    if binding.isNone() {
-        return false
+    let mut found = false
+    for binding in env.local.bindings {
+        if binding.name == name {
+            found = binding.mutable
+        }
     }
-    binding.unwrap().mutable
+    found
 }
 // ---------------------------------------------------------------------
 // Module-level registration.
@@ -513,12 +517,7 @@ fn checkHashKey(key: String) -> Int {
     h
 }
 fn checkNameIndexTableSlot(table: CheckNameIndexTable, key: String) -> Int {
-    let slot = table.slots.get(key)
-    if slot.isSome() {
-        slot.unwrap()
-    } else {
-        -1
-    }
+    checkNameIndex(table.keys, table.hashes, key, checkHashKey(key))
 }
 fn checkNameIndexTableSet(table: CheckNameIndexTable, key: String, value: Int) {
     let slot = checkNameIndexTableSlot(table, key)
@@ -533,18 +532,13 @@ fn checkNameIndexTableSet(table: CheckNameIndexTable, key: String, value: Int) {
 }
 fn checkNameIndexTableGet(table: CheckNameIndexTable, key: String) -> Int {
     let slot = checkNameIndexTableSlot(table, key)
-    if slot < 0 {
-        return -1
+    if slot >= 0 && slot < table.values.len() {
+        return table.values[slot]
     }
-    table.values[slot]
+    checkLookupExactIndex(table.keys, table.hashes, table.values, key, checkHashKey(key))
 }
 fn checkNameSetTableSlot(table: CheckNameSetTable, key: String) -> Int {
-    let slot = table.slots.get(key)
-    if slot.isSome() {
-        slot.unwrap()
-    } else {
-        -1
-    }
+    checkNameIndex(table.keys, table.hashes, key, checkHashKey(key))
 }
 fn checkNameSetTableAdd(table: CheckNameSetTable, key: String) {
     let slot = checkNameSetTableSlot(table, key)
@@ -556,15 +550,14 @@ fn checkNameSetTableAdd(table: CheckNameSetTable, key: String) {
     table.slots.insert(key, table.keys.len() - 1)
 }
 fn checkNameSetTableHas(table: CheckNameSetTable, key: String) -> Bool {
-    checkNameSetTableSlot(table, key) >= 0
+    let slot = checkNameSetTableSlot(table, key)
+    if slot >= 0 && slot < table.keys.len() {
+        return true
+    }
+    checkNameIndex(table.keys, table.hashes, key, checkHashKey(key)) >= 0
 }
 fn checkBindingStackIndexSlot(table: CheckBindingStackIndex, key: String) -> Int {
-    let slot = table.slots.get(key)
-    if slot.isSome() {
-        slot.unwrap()
-    } else {
-        -1
-    }
+    checkNameIndex(table.keys, table.hashes, key, checkHashKey(key))
 }
 fn checkBindingStackIndexPush(table: CheckBindingStackIndex, binding: CheckBinding) {
     let slot = checkBindingStackIndexSlot(table, binding.name)
@@ -598,12 +591,7 @@ fn checkBindingStackIndexTop(table: CheckBindingStackIndex, name: String) -> Che
     Some(stack[stack.len() - 1])
 }
 fn checkIntStackIndexSlot(table: CheckIntStackIndex, key: String) -> Int {
-    let slot = table.slots.get(key)
-    if slot.isSome() {
-        slot.unwrap()
-    } else {
-        -1
-    }
+    checkNameIndex(table.keys, table.hashes, key, checkHashKey(key))
 }
 fn checkIntStackIndexPush(table: CheckIntStackIndex, key: String, value: Int) {
     let slot = checkIntStackIndexSlot(table, key)
@@ -633,22 +621,22 @@ fn checkIntStackIndexValues(table: CheckIntStackIndex, key: String) -> List<Int>
     table.stacks[slot]
 }
 fn checkNameIndex(names: List<String>, hashes: List<Int>, name: String, hash: Int) -> Int {
-    let mut i = names.len() - 1
-    for i >= 0 {
+    let mut i = 0
+    for i < names.len() {
         if hashes[i] == hash && names[i] == name {
             return i
         }
-        i = i - 1
+        i = i + 1
     }
     -1
 }
 fn checkLookupExactIndex(keys: List<String>, hashes: List<Int>, values: List<Int>, key: String, hash: Int) -> Int {
-    let mut i = keys.len() - 1
-    for i >= 0 {
-        if hashes[i] == hash && keys[i] == key {
+    let mut i = 0
+    for i < keys.len() {
+        if i < hashes.len() && i < values.len() && hashes[i] == hash && keys[i] == key {
             return values[i]
         }
-        i = i - 1
+        i = i + 1
     }
     -1
 }

--- a/toolchain/ci.osty
+++ b/toolchain/ci.osty
@@ -110,6 +110,24 @@ let CheckPolicy: CheckName = "policy"
 let CheckLockfile: CheckName = "lockfile"
 let CheckRelease: CheckName = "release"
 let CheckSemver: CheckName = "semver"
+fn ciCheckFormatName() -> CheckName {
+    "format"
+}
+fn ciCheckLintName() -> CheckName {
+    "lint"
+}
+fn ciCheckPolicyName() -> CheckName {
+    "policy"
+}
+fn ciCheckLockfileName() -> CheckName {
+    "lockfile"
+}
+fn ciCheckReleaseName() -> CheckName {
+    "release"
+}
+fn ciCheckSemverName() -> CheckName {
+    "semver"
+}
 /// Options controls which checks Runner.Run executes.
 pub struct Options {
     pub Format: Bool,
@@ -173,42 +191,42 @@ pub struct Runner {
         if self.Opts.Format {
             rep.Checks.push(self.checkFormat())
         } else {
-            rep.Checks.push(skipped(CheckFormat))
+            rep.Checks.push(skipped(ciCheckFormatName()))
         }
         if self.Opts.Policy {
             rep.Checks.push(self.checkPolicy())
         } else {
-            rep.Checks.push(skipped(CheckPolicy))
+            rep.Checks.push(skipped(ciCheckPolicyName()))
         }
         if self.Opts.Lockfile {
             rep.Checks.push(self.checkLockfile())
         } else {
-            rep.Checks.push(skipped(CheckLockfile))
+            rep.Checks.push(skipped(ciCheckLockfileName()))
         }
         if self.Opts.Lint {
             rep.Checks.push(self.checkLint())
         } else {
-            rep.Checks.push(skipped(CheckLint))
+            rep.Checks.push(skipped(ciCheckLintName()))
         }
         if self.Opts.Release {
             rep.Checks.push(self.checkRelease())
         } else {
-            rep.Checks.push(skipped(CheckRelease))
+            rep.Checks.push(skipped(ciCheckReleaseName()))
         }
         if self.Opts.Semver {
             rep.Checks.push(self.checkSemver())
         } else {
-            rep.Checks.push(skipped(CheckSemver))
+            rep.Checks.push(skipped(ciCheckSemverName()))
         }
         rep.Checks = ciFinalizeChecks(rep.Checks, self.Opts.Strict)
         rep.FinishedAt = host.NowUTC()
         rep
     }
     fn checkFormat(self) -> Check {
-        checkFromHostResult(CheckFormat, host.CheckFormat(self.Root, self.ostyFiles()))
+        checkFromHostResult(ciCheckFormatName(), host.CheckFormat(self.Root, self.ostyFiles()))
     }
     fn checkPolicy(self) -> Check {
-        let mut c = Check {Name: CheckPolicy, Passed: false, Skipped: false, Note: "", Diags: host.EmptyDiagnostics()}
+        let mut c = Check {Name: ciCheckPolicyName(), Passed: false, Skipped: false, Note: "", Diags: host.EmptyDiagnostics()}
         if !(host.HasManifest(self.Manifest)) {
             c.Note = "no osty.toml found; policy checks skipped"
             return c
@@ -224,13 +242,13 @@ pub struct Runner {
         c
     }
     fn checkLockfile(self) -> Check {
-        checkFromHostResult(CheckLockfile, host.CheckLockfile(self.Root, self.Manifest))
+        checkFromHostResult(ciCheckLockfileName(), host.CheckLockfile(self.Root, self.Manifest))
     }
     fn checkLint(self) -> Check {
-        checkFromHostResult(CheckLint, host.CheckLint(self.Manifest, self.Packages, self.Results))
+        checkFromHostResult(ciCheckLintName(), host.CheckLint(self.Manifest, self.Packages, self.Results))
     }
     fn checkRelease(self) -> Check {
-        let mut c = Check {Name: CheckRelease, Passed: false, Skipped: false, Note: "", Diags: host.EmptyDiagnostics()}
+        let mut c = Check {Name: ciCheckReleaseName(), Passed: false, Skipped: false, Note: "", Diags: host.EmptyDiagnostics()}
         pushCoreDiagnostics(c, ciReleaseManifestCore(releaseCore(self.Manifest)))
         if host.HasManifest(self.Manifest) && host.ManifestCoreOf(self.Manifest).HasPackage {
             pushHostDiagnostics(c, host.CheckReleaseLockfile(self.Root, self.Manifest))
@@ -238,7 +256,7 @@ pub struct Runner {
         c
     }
     fn checkSemver(self) -> Check {
-        let mut c = Check {Name: CheckSemver, Passed: false, Skipped: false, Note: "", Diags: host.EmptyDiagnostics()}
+        let mut c = Check {Name: ciCheckSemverName(), Passed: false, Skipped: false, Note: "", Diags: host.EmptyDiagnostics()}
         if self.Opts.Baseline == "" {
             c.Diags.push(host.Synthetic("error", "CI401", "semver check enabled but --baseline was not set"))
             return c

--- a/toolchain/diag_render.osty
+++ b/toolchain/diag_render.osty
@@ -142,17 +142,26 @@ pub fn diagRenderReplacement(replacement: String, excerpt: String, haveExcerpt: 
 pub let diagSeverityError: Int = 0
 pub let diagSeverityWarning: Int = 1
 pub let diagSeverityNote: Int = 2
+fn diagSeverityErrorCode() -> Int {
+    0
+}
+fn diagSeverityWarningCode() -> Int {
+    1
+}
+fn diagSeverityNoteCode() -> Int {
+    2
+}
 /// diagSeverityString maps a `Severity` int back to its
 /// human-readable label. Unknown / out-of-range values collapse
 /// to `"unknown"` so log lines never surface a bare number.
 pub fn diagSeverityString(sev: Int) -> String {
-    if sev == diagSeverityError {
+    if sev == diagSeverityErrorCode() {
         return "error"
     }
-    if sev == diagSeverityWarning {
+    if sev == diagSeverityWarningCode() {
         return "warning"
     }
-    if sev == diagSeverityNote {
+    if sev == diagSeverityNoteCode() {
         return "note"
     }
     "unknown"
@@ -174,13 +183,13 @@ pub fn diagShortError(code: String, severity: Int, line: Int, column: Int, messa
 /// Returns the empty string for unknown severities so a stray
 /// value doesn't accidentally tint the rest of the line.
 pub fn diagSeverityAnsiColor(sev: Int) -> String {
-    if sev == diagSeverityError {
+    if sev == diagSeverityErrorCode() {
         return "\u{1b}[31m"
     }
-    if sev == diagSeverityWarning {
+    if sev == diagSeverityWarningCode() {
         return "\u{1b}[33m"
     }
-    if sev == diagSeverityNote {
+    if sev == diagSeverityNoteCode() {
         return "\u{1b}[36m"
     }
     ""

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -56,8 +56,11 @@ pub struct ElabCx {
     pub typedExprNodes: List<Int>,
     pub typedExprCoreNodes: List<Int>,
     pub typedExprTypes: List<Int>,
+    pub typedExprCoreByNode: List<Int>,
+    pub typedExprTypeByNode: List<Int>,
     pub typedStmtNodes: List<Int>,
     pub typedStmtCoreNodes: List<Int>,
+    pub typedStmtCoreByNode: List<Int>,
 }
 pub struct InstSession {
     pub solver: Solver,
@@ -67,7 +70,7 @@ pub struct InstSession {
 pub fn newElabCx(ast: AstFile, tys: TyArena) -> ElabCx {
     let env = emptyCheckEnv(tys)
     checkInstallPrelude(env)
-    ElabCx {ast, core: emptyCoreArena(), env, typedExprNodes: [], typedExprCoreNodes: [], typedExprTypes: [], typedStmtNodes: [], typedStmtCoreNodes: []}
+    ElabCx {ast, core: emptyCoreArena(), env, typedExprNodes: [], typedExprCoreNodes: [], typedExprTypes: [], typedExprCoreByNode: [], typedExprTypeByNode: [], typedStmtNodes: [], typedStmtCoreNodes: [], typedStmtCoreByNode: []}
 }
 // ---------------------------------------------------------------------
 // Expression elaboration.
@@ -82,39 +85,87 @@ fn elabInferImpl(cx: ElabCx, idx: Int) -> ElabResult {
         return elabErrResult(cx, 0, 0)
     }
     let node = astArenaNodeAt(cx.ast.arena, idx)
-    // Keep this guard outside the match: stage0's guarded-match fallback
-    // can turn the final `_` arm into `unreachable` in osty-self builds.
+    // Keep this guard outside the dispatch: stage0's guarded-match fallback
+    // can turn the final fallback arm into `unreachable` in osty-self builds.
     if node.kind == AstNFor && node.text == "loopexpr" {
         return elabInferLoop(cx, idx, node)
     }
-    match node.kind {
-        AstNIntLit -> elabInferIntLit(cx, idx, node),
-        AstNFloatLit -> elabInferFloatLit(cx, node),
-        AstNStringLit -> elabInferStringLit(cx, node),
-        AstNBoolLit -> elabInferBoolLit(cx, node),
-        AstNCharLit -> elabInferCharLit(cx, node),
-        AstNByteLit -> elabInferByteLit(cx, node),
-        AstNBytesLit -> elabInferBytesLit(cx, node),
-        AstNIdent -> elabInferIdent(cx, node),
-        AstNParen -> elabInfer(cx, node.left),
-        AstNBlock -> elabInferBlock(cx, idx, node),
-        AstNUnary -> elabInferUnary(cx, node),
-        AstNBinary -> elabInferBinary(cx, node),
-        AstNCall -> elabInferCall(cx, idx, node, tErr(cx.env.tys)),
-        AstNField -> elabInferField(cx, node),
-        AstNIndex -> elabInferIndex(cx, node),
-        AstNList -> elabInferList(cx, node, tErr(cx.env.tys)),
-        AstNMap -> elabInferMap(cx, node, tErr(cx.env.tys)),
-        AstNTuple -> elabInferTuple(cx, node, tErr(cx.env.tys)),
-        AstNStructLit -> elabInferStructLit(cx, node, tErr(cx.env.tys)),
-        AstNClosure -> elabInferClosure(cx, node, tErr(cx.env.tys)),
-        AstNRange -> elabInferRange(cx, node),
-        AstNTurbofish -> elabInferTurbofish(cx, node),
-        AstNIf -> elabInferIf(cx, node, tErr(cx.env.tys)),
-        AstNMatch -> elabInferMatch(cx, node, tErr(cx.env.tys)),
-        AstNQuestion -> elabInferQuestion(cx, node),
-        _ -> elabErrResult(cx, node.start, node.end),
+    if node.kind == AstNIntLit {
+        return elabInferIntLit(cx, idx, node)
     }
+    if node.kind == AstNFloatLit {
+        return elabInferFloatLit(cx, node)
+    }
+    if node.kind == AstNStringLit {
+        return elabInferStringLit(cx, node)
+    }
+    if node.kind == AstNBoolLit {
+        return elabInferBoolLit(cx, node)
+    }
+    if node.kind == AstNCharLit {
+        return elabInferCharLit(cx, node)
+    }
+    if node.kind == AstNByteLit {
+        return elabInferByteLit(cx, node)
+    }
+    if node.kind == AstNBytesLit {
+        return elabInferBytesLit(cx, node)
+    }
+    if node.kind == AstNIdent {
+        return elabInferIdent(cx, node)
+    }
+    if node.kind == AstNParen {
+        return elabInfer(cx, node.left)
+    }
+    if node.kind == AstNBlock {
+        return elabInferBlock(cx, idx, node)
+    }
+    if node.kind == AstNUnary {
+        return elabInferUnary(cx, node)
+    }
+    if node.kind == AstNBinary {
+        return elabInferBinary(cx, node)
+    }
+    if node.kind == AstNCall {
+        return elabInferCall(cx, idx, node, tErr(cx.env.tys))
+    }
+    if node.kind == AstNField {
+        return elabInferField(cx, node)
+    }
+    if node.kind == AstNIndex {
+        return elabInferIndex(cx, node)
+    }
+    if node.kind == AstNList {
+        return elabInferList(cx, node, tErr(cx.env.tys))
+    }
+    if node.kind == AstNMap {
+        return elabInferMap(cx, node, tErr(cx.env.tys))
+    }
+    if node.kind == AstNTuple {
+        return elabInferTuple(cx, node, tErr(cx.env.tys))
+    }
+    if node.kind == AstNStructLit {
+        return elabInferStructLit(cx, node, tErr(cx.env.tys))
+    }
+    if node.kind == AstNClosure {
+        return elabInferClosure(cx, node, tErr(cx.env.tys))
+    }
+    if node.kind == AstNRange {
+        return elabInferRange(cx, node)
+    }
+    if node.kind == AstNTurbofish {
+        return elabInferTurbofish(cx, node)
+    }
+    if node.kind == AstNIf {
+        return elabInferIf(cx, node, tErr(cx.env.tys))
+    }
+    if node.kind == AstNMatch {
+        return elabInferMatch(cx, node, tErr(cx.env.tys))
+    }
+    if node.kind == AstNQuestion {
+        return elabInferQuestion(cx, node)
+    }
+    elabErrResult(cx, node.start, node.end)
 }
 // G22 §A.4: `loop { ... }` arrives as AstNFor with text="loopexpr".
 // Route to the dedicated loop-expression handler.
@@ -131,23 +182,49 @@ fn elabCheckImpl(cx: ElabCx, idx: Int, expected: Int) -> ElabResult {
         return elabInferImpl(cx, idx)
     }
     let node = astArenaNodeAt(cx.ast.arena, idx)
-    match node.kind {
-        AstNIntLit -> elabCheckIntLit(cx, idx, node, expected),
-        AstNFloatLit -> elabCheckFloatLit(cx, node, expected),
-        AstNBinary -> elabCheckBinary(cx, idx, node, expected),
-        AstNParen -> elabCheck(cx, node.left, expected),
-        AstNBlock -> elabCheckBlock(cx, idx, node, expected),
-        AstNIdent -> elabCheckViaInfer(cx, idx, expected),
-        AstNCall -> elabInferCall(cx, idx, node, expected),
-        AstNList -> elabInferList(cx, node, expected),
-        AstNMap -> elabInferMap(cx, node, expected),
-        AstNTuple -> elabInferTuple(cx, node, expected),
-        AstNStructLit -> elabInferStructLit(cx, node, expected),
-        AstNClosure -> elabInferClosure(cx, node, expected),
-        AstNIf -> elabInferIf(cx, node, expected),
-        AstNMatch -> elabInferMatch(cx, node, expected),
-        _ -> elabCheckViaInfer(cx, idx, expected),
+    if node.kind == AstNIntLit {
+        return elabCheckIntLit(cx, idx, node, expected)
     }
+    if node.kind == AstNFloatLit {
+        return elabCheckFloatLit(cx, node, expected)
+    }
+    if node.kind == AstNBinary {
+        return elabCheckBinary(cx, idx, node, expected)
+    }
+    if node.kind == AstNParen {
+        return elabCheck(cx, node.left, expected)
+    }
+    if node.kind == AstNBlock {
+        return elabCheckBlock(cx, idx, node, expected)
+    }
+    if node.kind == AstNIdent {
+        return elabCheckViaInfer(cx, idx, expected)
+    }
+    if node.kind == AstNCall {
+        return elabInferCall(cx, idx, node, expected)
+    }
+    if node.kind == AstNList {
+        return elabInferList(cx, node, expected)
+    }
+    if node.kind == AstNMap {
+        return elabInferMap(cx, node, expected)
+    }
+    if node.kind == AstNTuple {
+        return elabInferTuple(cx, node, expected)
+    }
+    if node.kind == AstNStructLit {
+        return elabInferStructLit(cx, node, expected)
+    }
+    if node.kind == AstNClosure {
+        return elabInferClosure(cx, node, expected)
+    }
+    if node.kind == AstNIf {
+        return elabInferIf(cx, node, expected)
+    }
+    if node.kind == AstNMatch {
+        return elabInferMatch(cx, node, expected)
+    }
+    elabCheckViaInfer(cx, idx, expected)
 }
 /// elabCheckViaInfer is the default `check(e, T)` rule: elaborate as
 /// infer, then subtype against `T` and emit a mismatch diagnostic if
@@ -740,17 +817,27 @@ pub fn elabStmt(cx: ElabCx, idx: Int) -> Int {
         return -1
     }
     let node = astArenaNodeAt(cx.ast.arena, idx)
-    let out = match node.kind {
-        AstNLet -> elabLetStmt(cx, node),
-        AstNAssign -> elabAssignStmt(cx, node),
-        AstNReturn -> elabReturnStmt(cx, node),
-        AstNDefer -> elabDeferStmt(cx, node),
-        AstNFor -> elabForStmt(cx, node),
-        AstNChanSend -> elabChanSendStmt(cx, node),
-        AstNExprStmt -> elabExprStmt(cx, node),
-        AstNBreak -> coreBreakStmt(cx.core, node.start, node.end),
-        AstNContinue -> coreContinueStmt(cx.core, node.start, node.end),
-        _ -> elabExprAsStmt(cx, idx, node),
+    let mut out = -1
+    if node.kind == AstNLet {
+        out = elabLetStmt(cx, node)
+    } else if node.kind == AstNAssign {
+        out = elabAssignStmt(cx, node)
+    } else if node.kind == AstNReturn {
+        out = elabReturnStmt(cx, node)
+    } else if node.kind == AstNDefer {
+        out = elabDeferStmt(cx, node)
+    } else if node.kind == AstNFor {
+        out = elabForStmt(cx, node)
+    } else if node.kind == AstNChanSend {
+        out = elabChanSendStmt(cx, node)
+    } else if node.kind == AstNExprStmt {
+        out = elabExprStmt(cx, node)
+    } else if node.kind == AstNBreak {
+        out = coreBreakStmt(cx.core, node.start, node.end)
+    } else if node.kind == AstNContinue {
+        out = coreContinueStmt(cx.core, node.start, node.end)
+    } else {
+        out = elabExprAsStmt(cx, idx, node)
     }
     elabRecordTypedStmt(cx, idx, out)
     out
@@ -1010,34 +1097,25 @@ fn astIsExprKindAt(ast: AstFile, idx: Int) -> Bool {
         return false
     }
     let node = astArenaNodeAt(ast.arena, idx)
-    match node.kind {
-        AstNIntLit -> true,
-        AstNFloatLit -> true,
-        AstNStringLit -> true,
-        AstNBoolLit -> true,
-        AstNCharLit -> true,
-        AstNByteLit -> true,
-        AstNBytesLit -> true,
-        AstNIdent -> true,
-        AstNParen -> true,
-        AstNBlock -> true,
-        AstNUnary -> true,
-        AstNBinary -> true,
-        AstNIf -> true,
-        AstNMatch -> true,
-        AstNCall -> true,
-        AstNField -> true,
-        AstNIndex -> true,
-        AstNList -> true,
-        AstNMap -> true,
-        AstNTuple -> true,
-        AstNStructLit -> true,
-        AstNRange -> true,
-        AstNClosure -> true,
-        AstNQuestion -> true,
-        AstNTurbofish -> true,
-        _ -> false,
+    if node.kind == AstNIntLit || node.kind == AstNFloatLit || node.kind == AstNStringLit {
+        return true
     }
+    if node.kind == AstNBoolLit || node.kind == AstNCharLit || node.kind == AstNByteLit || node.kind == AstNBytesLit {
+        return true
+    }
+    if node.kind == AstNIdent || node.kind == AstNParen || node.kind == AstNBlock || node.kind == AstNUnary || node.kind == AstNBinary {
+        return true
+    }
+    if node.kind == AstNIf || node.kind == AstNMatch || node.kind == AstNCall || node.kind == AstNField || node.kind == AstNIndex {
+        return true
+    }
+    if node.kind == AstNList || node.kind == AstNMap || node.kind == AstNTuple || node.kind == AstNStructLit || node.kind == AstNRange {
+        return true
+    }
+    if node.kind == AstNClosure || node.kind == AstNQuestion || node.kind == AstNTurbofish {
+        return true
+    }
+    false
 }
 fn astExprEscapesMatchResult(ast: AstFile, idx: Int) -> Bool {
     if idx < 0 {
@@ -1092,6 +1170,10 @@ fn elabRecordTypedExpr(cx: ElabCx, idx: Int, out: ElabResult) {
     if idx < 0 || out.node < 0 || tyIsBad(cx.env.tys, out.ty) {
         return
     }
+    elabEnsureIntListLen(cx.typedExprCoreByNode, idx + 1)
+    elabEnsureIntListLen(cx.typedExprTypeByNode, idx + 1)
+    cx.typedExprCoreByNode[idx] = out.node
+    cx.typedExprTypeByNode[idx] = out.ty
     cx.typedExprNodes.push(idx)
     cx.typedExprCoreNodes.push(out.node)
     cx.typedExprTypes.push(out.ty)
@@ -1101,10 +1183,23 @@ fn elabRecordTypedStmt(cx: ElabCx, idx: Int, coreIdx: Int) {
     if idx < 0 || coreIdx < 0 {
         return
     }
+    elabEnsureIntListLen(cx.typedStmtCoreByNode, idx + 1)
+    cx.typedStmtCoreByNode[idx] = coreIdx
     cx.typedStmtNodes.push(idx)
     cx.typedStmtCoreNodes.push(coreIdx)
 }
+fn elabEnsureIntListLen(items: List<Int>, targetLen: Int) {
+    for items.len() < targetLen {
+        items.push(0 - 1)
+    }
+}
 pub fn elabTypedExprCoreAt(cx: ElabCx, idx: Int) -> Int {
+    if idx >= 0 && idx < cx.typedExprCoreByNode.len() {
+        let cached = cx.typedExprCoreByNode[idx]
+        if cached >= 0 {
+            return cached
+        }
+    }
     let mut i = cx.typedExprNodes.len() - 1
     for i >= 0 {
         if cx.typedExprNodes[i] == idx {
@@ -1115,6 +1210,12 @@ pub fn elabTypedExprCoreAt(cx: ElabCx, idx: Int) -> Int {
     -1
 }
 pub fn elabTypedExprTyAt(cx: ElabCx, idx: Int) -> Int {
+    if idx >= 0 && idx < cx.typedExprTypeByNode.len() {
+        let cached = cx.typedExprTypeByNode[idx]
+        if cached >= 0 {
+            return cached
+        }
+    }
     let mut i = cx.typedExprNodes.len() - 1
     for i >= 0 {
         if cx.typedExprNodes[i] == idx {
@@ -1125,6 +1226,12 @@ pub fn elabTypedExprTyAt(cx: ElabCx, idx: Int) -> Int {
     -1
 }
 pub fn elabTypedStmtCoreAt(cx: ElabCx, idx: Int) -> Int {
+    if idx >= 0 && idx < cx.typedStmtCoreByNode.len() {
+        let cached = cx.typedStmtCoreByNode[idx]
+        if cached >= 0 {
+            return cached
+        }
+    }
     let mut i = cx.typedStmtNodes.len() - 1
     for i >= 0 {
         if cx.typedStmtNodes[i] == idx {

--- a/toolchain/format_escape.osty
+++ b/toolchain/format_escape.osty
@@ -59,7 +59,7 @@ pub fn formatUnicodeEscape(r: Int) -> String {
     let mut i = digits - 1
     for i >= 0 {
         let nibble = (r >> (4 * i)) & 0xF
-        parts.push(strings.slice(formatHexDigitsUpper, nibble, nibble + 1))
+        parts.push(strings.slice(formatHexDigitsUpperValue(), nibble, nibble + 1))
         i = i - 1
     }
     parts.push("\}")
@@ -69,6 +69,9 @@ pub fn formatUnicodeEscape(r: Int) -> String {
 /// output; indexed 0..15 by `formatUnicodeEscape` and the `\xNN`
 /// branch of `formatEscapeByteForChar`.
 let formatHexDigitsUpper: String = "0123456789ABCDEF"
+fn formatHexDigitsUpperValue() -> String {
+    "0123456789ABCDEF"
+}
 /// formatEscapeByteForChar emits one Char-literal-context escape
 /// for the byte `b` (0..255). The Char form preserves `\'` as a
 /// quote escape and uses `\{`/`\}` to prevent interpolation
@@ -107,7 +110,8 @@ pub fn formatEscapeByteForBytes(b: Int) -> String {
 fn formatTwoHexUpper(b: Int) -> String {
     let hi = (b >> 4) & 0xF
     let lo = b & 0xF
-    strings.slice(formatHexDigitsUpper, hi, hi + 1) + strings.slice(formatHexDigitsUpper, lo, lo + 1)
+    let digits = formatHexDigitsUpperValue()
+    strings.slice(digits, hi, hi + 1) + strings.slice(digits, lo, lo + 1)
 }
 /// formatByteAsAscii lifts a single printable ASCII byte (0x20-0x7E
 /// excluding the escapes already handled) into its 1-character

--- a/toolchain/hir.osty
+++ b/toolchain/hir.osty
@@ -388,7 +388,7 @@ pub fn hirTypeBuiltin(name: String, args: List<HirType>) -> HirType {
 pub fn hirTypeOptional(inner: HirType) -> HirType {
     let mut t = hirTypeInvalid()
     t.kind = HirTypeOptional
-    t.optionalInner.push(inner)
+    t.optionalInner = [inner]
     t
 }
 pub fn hirTypeTuple(elems: List<HirType>) -> HirType {
@@ -401,7 +401,7 @@ pub fn hirTypeFn(params: List<HirType>, ret: HirType) -> HirType {
     let mut t = hirTypeInvalid()
     t.kind = HirTypeFn
     t.fnParams = params
-    t.fnReturn.push(ret)
+    t.fnReturn = [ret]
     t
 }
 pub fn hirTypeVar(name: String, owner: String) -> HirType {
@@ -496,28 +496,22 @@ pub fn hirTypeIsErr(t: HirType) -> Bool {
 // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
 /// hirTypeIsUnit reports whether `t` is the `()` primitive.
 pub fn hirTypeIsUnit(t: HirType) -> Bool {
-    match t.kind {
-        HirTypePrim -> {
-            if t.primKind == HirPrimUnit {
-                return true
-            }
-            false
-        },
-        _ -> false,
+    if t.kind == HirTypePrim {
+        if t.primKind == HirPrimUnit {
+            return true
+        }
     }
+    false
 }
 // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
 /// hirTypeIsNever reports whether `t` is the `!` primitive.
 pub fn hirTypeIsNever(t: HirType) -> Bool {
-    match t.kind {
-        HirTypePrim -> {
-            if t.primKind == HirPrimNever {
-                return true
-            }
-            false
-        },
-        _ -> false,
+    if t.kind == HirTypePrim {
+        if t.primKind == HirPrimNever {
+            return true
+        }
     }
+    false
 }
 // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
 /// hirTypeIsOptional reports whether `t` is a `T?` wrapper.
@@ -531,45 +525,36 @@ pub fn hirTypeIsOptional(t: HirType) -> Bool {
 /// hirTypeOptionalInner returns the inner type of a `T?` or an invalid
 /// HirType when `t` is not an optional.
 pub fn hirTypeOptionalInner(t: HirType) -> HirType {
-    match t.kind {
-        HirTypeOptional -> {
-            if t.optionalInner.len() > 0 {
-                t.optionalInner[0]
-            } else {
-                hirTypeInvalid()
-            }
-        },
-        _ -> hirTypeInvalid(),
+    if t.kind == HirTypeOptional {
+        if t.optionalInner.len() > 0 {
+            return t.optionalInner[0]
+        }
+        return hirTypeInvalid()
     }
+    hirTypeInvalid()
 }
 /// hirTypeFnReturn returns the return type of an fn type or an invalid
 /// HirType when `t` is not an fn.
 pub fn hirTypeFnReturn(t: HirType) -> HirType {
-    match t.kind {
-        HirTypeFn -> {
-            if t.fnReturn.len() > 0 {
-                t.fnReturn[0]
-            } else {
-                hirTypeInvalid()
-            }
-        },
-        _ -> hirTypeInvalid(),
+    if t.kind == HirTypeFn {
+        if t.fnReturn.len() > 0 {
+            return t.fnReturn[0]
+        }
+        return hirTypeInvalid()
     }
+    hirTypeInvalid()
 }
 /// hirTypeQualifiedName is the `pkg.Name` form of a named type. Returns
 /// the bare name when no package qualifier is present; empty for
 /// non-named types.
 pub fn hirTypeQualifiedName(t: HirType) -> String {
-    match t.kind {
-        HirTypeNamed -> {
-            if t.namedPkg == "" {
-                t.namedName
-            } else {
-                t.namedPkg + "." + t.namedName
-            }
-        },
-        _ -> "",
+    if t.kind == HirTypeNamed {
+        if t.namedPkg == "" {
+            return t.namedName
+        }
+        return t.namedPkg + "." + t.namedName
     }
+    ""
 }
 // ---- Printing ------------------------------------------------------
 /// hirPrimKindString returns the canonical source-level name for a
@@ -644,23 +629,36 @@ pub fn hirPrimKindString(k: HirPrimKind) -> String {
 /// hirTypeString returns a source-level rendering of `t`. Safe for
 /// diagnostics; invalid / error types render as `<error>` / `<nil>`.
 pub fn hirTypeString(t: HirType) -> String {
-    match t.kind {
-        HirTypeInvalid -> "<nil>",
-        HirTypeErr -> "<error>",
-        HirTypePrim -> hirPrimKindString(t.primKind),
-        HirTypeVar -> t.varName,
-        HirTypeOptional -> {
-            let inner = if t.optionalInner.len() > 0 {
-                hirTypeString(t.optionalInner[0])
-            } else {
-                "<nil>"
-            }
-            inner + "?"
-        },
-        HirTypeTuple -> hirTypeTupleString(t.tupleElems),
-        HirTypeFn -> hirTypeFnString(t),
-        HirTypeNamed -> hirTypeNamedString(t),
+    if t.kind == HirTypeInvalid {
+        return "<nil>"
     }
+    if t.kind == HirTypeErr {
+        return "<error>"
+    }
+    if t.kind == HirTypePrim {
+        return hirPrimKindString(t.primKind)
+    }
+    if t.kind == HirTypeVar {
+        return t.varName
+    }
+    if t.kind == HirTypeOptional {
+        let inner = if t.optionalInner.len() > 0 {
+            hirTypeString(t.optionalInner[0])
+        } else {
+            "<nil>"
+        }
+        return inner + "?"
+    }
+    if t.kind == HirTypeTuple {
+        return hirTypeTupleString(t.tupleElems)
+    }
+    if t.kind == HirTypeFn {
+        return hirTypeFnString(t)
+    }
+    if t.kind == HirTypeNamed {
+        return hirTypeNamedString(t)
+    }
+    "<nil>"
 }
 fn hirTypeTupleString(elems: List<HirType>) -> String {
     let mut parts: List<String> = []
@@ -1717,7 +1715,7 @@ pub fn hirUnary(op: HirUnOp, x: HirExpr, typ: HirType, span: HirSpan) -> HirExpr
     let mut e = hirExprInvalid()
     e.kind = HirExprUnary
     e.unaryOp = op
-    e.unaryChild.push(x)
+    e.unaryChild = [x]
     e.typ = typ
     e.span = span
     e
@@ -1726,8 +1724,8 @@ pub fn hirBinary(op: HirBinOp, left: HirExpr, right: HirExpr, typ: HirType, span
     let mut e = hirExprInvalid()
     e.kind = HirExprBinary
     e.binaryOp = op
-    e.binaryLeft.push(left)
-    e.binaryRight.push(right)
+    e.binaryLeft = [left]
+    e.binaryRight = [right]
     e.typ = typ
     e.span = span
     e
@@ -1735,7 +1733,7 @@ pub fn hirBinary(op: HirBinOp, left: HirExpr, right: HirExpr, typ: HirType, span
 pub fn hirCall(callee: HirExpr, args: List<HirArg>, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprCall
-    e.callCallee.push(callee)
+    e.callCallee = [callee]
     e.callArgs = args
     e.typ = typ
     e.span = span
@@ -1769,7 +1767,7 @@ pub fn hirListLit(elems: List<HirExpr>, elem: HirType, span: HirSpan) -> HirExpr
 pub fn hirBlockExpr(body: HirBlock, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprBlock
-    e.blockBody.push(body)
+    e.blockBody = [body]
     e.typ = typ
     e.span = span
     e
@@ -1777,9 +1775,9 @@ pub fn hirBlockExpr(body: HirBlock, typ: HirType, span: HirSpan) -> HirExpr {
 pub fn hirIfExpr(cond: HirExpr, thenBlock: HirBlock, elseBlock: HirBlock, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprIf
-    e.ifExprCond.push(cond)
-    e.ifExprThen.push(thenBlock)
-    e.ifExprElse.push(elseBlock)
+    e.ifExprCond = [cond]
+    e.ifExprThen = [thenBlock]
+    e.ifExprElse = [elseBlock]
     e.typ = typ
     e.span = span
     e
@@ -1787,7 +1785,7 @@ pub fn hirIfExpr(cond: HirExpr, thenBlock: HirBlock, elseBlock: HirBlock, typ: H
 pub fn hirFieldExpr(x: HirExpr, name: String, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprField
-    e.fieldTarget.push(x)
+    e.fieldTarget = [x]
     e.fieldName = name
     e.typ = typ
     e.span = span
@@ -1802,8 +1800,8 @@ pub fn hirFieldExprOptional(x: HirExpr, name: String, typ: HirType, span: HirSpa
 pub fn hirIndexExpr(x: HirExpr, idx: HirExpr, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprIndex
-    e.indexTarget.push(x)
-    e.indexIndex.push(idx)
+    e.indexTarget = [x]
+    e.indexIndex = [idx]
     e.typ = typ
     e.span = span
     e
@@ -1811,7 +1809,7 @@ pub fn hirIndexExpr(x: HirExpr, idx: HirExpr, typ: HirType, span: HirSpan) -> Hi
 pub fn hirMethodCall(receiver: HirExpr, name: String, args: List<HirArg>, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprMethod
-    e.methodReceiver.push(receiver)
+    e.methodReceiver = [receiver]
     e.methodName = name
     e.methodArgs = args
     e.typ = typ
@@ -1836,7 +1834,7 @@ pub fn hirStructLit(typeName: String, fields: List<HirStructLitField>, typ: HirT
 /// built with hirStructLit. Mirrors Go's `{ ..x, field: v }` form.
 pub fn hirStructLitSpread(typeName: String, fields: List<HirStructLitField>, spread: HirExpr, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirStructLit(typeName, fields, typ, span)
-    e.structSpread.push(spread)
+    e.structSpread = [spread]
     e.structHasSpread = true
     e
 }
@@ -1868,8 +1866,8 @@ pub fn hirMapLit(entries: List<HirMapEntry>, keyT: HirType, valT: HirType, span:
 pub fn hirRangeLitBounded(start: HirExpr, end: HirExpr, inclusive: Bool, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprRange
-    e.rangeStart.push(start)
-    e.rangeEnd.push(end)
+    e.rangeStart = [start]
+    e.rangeEnd = [end]
     e.rangeInclusive = inclusive
     e.typ = typ
     e.span = span
@@ -1878,7 +1876,7 @@ pub fn hirRangeLitBounded(start: HirExpr, end: HirExpr, inclusive: Bool, typ: Hi
 pub fn hirRangeLitFrom(start: HirExpr, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprRange
-    e.rangeStart.push(start)
+    e.rangeStart = [start]
     e.typ = typ
     e.span = span
     e
@@ -1886,7 +1884,7 @@ pub fn hirRangeLitFrom(start: HirExpr, typ: HirType, span: HirSpan) -> HirExpr {
 pub fn hirRangeLitTo(end: HirExpr, inclusive: Bool, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprRange
-    e.rangeEnd.push(end)
+    e.rangeEnd = [end]
     e.rangeInclusive = inclusive
     e.typ = typ
     e.span = span
@@ -1895,7 +1893,7 @@ pub fn hirRangeLitTo(end: HirExpr, inclusive: Bool, typ: HirType, span: HirSpan)
 pub fn hirQuestion(x: HirExpr, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprQuestion
-    e.questionChild.push(x)
+    e.questionChild = [x]
     e.typ = typ
     e.span = span
     e
@@ -1903,8 +1901,8 @@ pub fn hirQuestion(x: HirExpr, typ: HirType, span: HirSpan) -> HirExpr {
 pub fn hirCoalesce(left: HirExpr, right: HirExpr, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprCoalesce
-    e.coalesceLeft.push(left)
-    e.coalesceRight.push(right)
+    e.coalesceLeft = [left]
+    e.coalesceRight = [right]
     e.typ = typ
     e.span = span
     e
@@ -1914,7 +1912,7 @@ pub fn hirClosure(params: List<HirParam>, returnType: HirType, body: HirBlock, c
     e.kind = HirExprClosure
     e.closureParams = params
     e.closureReturn = returnType
-    e.closureBody.push(body)
+    e.closureBody = [body]
     e.closureCaptures = captures
     e.typ = typ
     e.span = span
@@ -1933,7 +1931,7 @@ pub fn hirVariantLit(enumName: String, variant: String, args: List<HirArg>, typ:
 pub fn hirMatchExpr(scrutinee: HirExpr, arms: List<HirMatchArm>, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprMatch
-    e.matchExprScrutinee.push(scrutinee)
+    e.matchExprScrutinee = [scrutinee]
     e.matchExprArms = arms
     e.typ = typ
     e.span = span
@@ -1943,8 +1941,8 @@ pub fn hirIfLetExpr(pattern: HirPattern, scrutinee: HirExpr, thenBlock: HirBlock
     let mut e = hirExprInvalid()
     e.kind = HirExprIfLet
     e.ifLetPattern = pattern
-    e.ifLetScrutinee.push(scrutinee)
-    e.ifLetThen.push(thenBlock)
+    e.ifLetScrutinee = [scrutinee]
+    e.ifLetThen = [thenBlock]
     e.ifLetHasElse = false
     e.typ = typ
     e.span = span
@@ -1952,14 +1950,14 @@ pub fn hirIfLetExpr(pattern: HirPattern, scrutinee: HirExpr, thenBlock: HirBlock
 }
 pub fn hirIfLetExprElse(pattern: HirPattern, scrutinee: HirExpr, thenBlock: HirBlock, elseBlock: HirBlock, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirIfLetExpr(pattern, scrutinee, thenBlock, typ, span)
-    e.ifLetElse.push(elseBlock)
+    e.ifLetElse = [elseBlock]
     e.ifLetHasElse = true
     e
 }
 pub fn hirTupleAccess(x: HirExpr, index: Int, typ: HirType, span: HirSpan) -> HirExpr {
     let mut e = hirExprInvalid()
     e.kind = HirExprTupleAccess
-    e.tupleAccessTarget.push(x)
+    e.tupleAccessTarget = [x]
     e.tupleAccessIndex = index
     e.typ = typ
     e.span = span
@@ -2080,7 +2078,7 @@ pub fn hirIdentPatMut(name: String, span: HirSpan) -> HirPattern {
 pub fn hirLitPat(value: HirExpr, span: HirSpan) -> HirPattern {
     let mut p = hirPatternInvalid()
     p.kind = HirPatLit
-    p.litValue.push(value)
+    p.litValue = [value]
     p.span = span
     p
 }
@@ -2119,8 +2117,8 @@ pub fn hirVariantPat(enumName: String, variant: String, args: List<HirPattern>, 
 pub fn hirRangePatBounded(low: HirExpr, high: HirExpr, inclusive: Bool, span: HirSpan) -> HirPattern {
     let mut p = hirPatternInvalid()
     p.kind = HirPatRange
-    p.rangeLow.push(low)
-    p.rangeHigh.push(high)
+    p.rangeLow = [low]
+    p.rangeHigh = [high]
     p.rangeInclusive = inclusive
     p.span = span
     p
@@ -2129,7 +2127,7 @@ pub fn hirRangePatBounded(low: HirExpr, high: HirExpr, inclusive: Bool, span: Hi
 pub fn hirRangePatFrom(low: HirExpr, span: HirSpan) -> HirPattern {
     let mut p = hirPatternInvalid()
     p.kind = HirPatRange
-    p.rangeLow.push(low)
+    p.rangeLow = [low]
     p.span = span
     p
 }
@@ -2137,7 +2135,7 @@ pub fn hirRangePatFrom(low: HirExpr, span: HirSpan) -> HirPattern {
 pub fn hirRangePatTo(high: HirExpr, inclusive: Bool, span: HirSpan) -> HirPattern {
     let mut p = hirPatternInvalid()
     p.kind = HirPatRange
-    p.rangeHigh.push(high)
+    p.rangeHigh = [high]
     p.rangeInclusive = inclusive
     p.span = span
     p
@@ -2751,7 +2749,7 @@ pub fn hirDecisionBind(name: String, proj: HirProjection, typ: HirType, next: Hi
     n.bindHasProj = true
     n.bindProj = proj
     n.bindType = typ
-    n.bindNext.push(next)
+    n.bindNext = [next]
     n
 }
 pub fn hirDecisionBindWhole(name: String, typ: HirType, next: HirDecisionNode) -> HirDecisionNode {
@@ -2760,15 +2758,15 @@ pub fn hirDecisionBindWhole(name: String, typ: HirType, next: HirDecisionNode) -
     n.bindName = name
     n.bindHasProj = false
     n.bindType = typ
-    n.bindNext.push(next)
+    n.bindNext = [next]
     n
 }
 pub fn hirDecisionGuard(cond: HirExpr, thenNode: HirDecisionNode, elseNode: HirDecisionNode) -> HirDecisionNode {
     let mut n = hirDecisionInvalid()
     n.kind = HirDecisionGuard
-    n.guardCond.push(cond)
-    n.guardThen.push(thenNode)
-    n.guardElse.push(elseNode)
+    n.guardCond = [cond]
+    n.guardThen = [thenNode]
+    n.guardElse = [elseNode]
     n
 }
 pub fn hirDecisionSwitch(kind: HirSwitchKind, proj: HirProjection, cases: List<HirSwitchCase>, defaultNode: HirDecisionNode) -> HirDecisionNode {
@@ -2777,7 +2775,7 @@ pub fn hirDecisionSwitch(kind: HirSwitchKind, proj: HirProjection, cases: List<H
     n.switchKind = kind
     n.switchProj = proj
     n.switchCases = cases
-    n.switchDefault.push(defaultNode)
+    n.switchDefault = [defaultNode]
     n
 }
 /// hirDecisionIsValid reports whether the node is a real decision

--- a/toolchain/hir_clone.osty
+++ b/toolchain/hir_clone.osty
@@ -227,16 +227,82 @@ pub fn hirCloneModule(module: HirModule) -> HirModule {
     HirModule {packageName: module.packageName, fns: hirCloneFnDeclList(module.fns), structs: hirCloneStructDeclList(module.structs), enums: hirCloneEnumDeclList(module.enums), lets: hirCloneLetDeclList(module.lets), uses: hirCloneUseDeclList(module.uses), interfaces: hirCloneInterfaceDeclList(module.interfaces), aliases: hirCloneTypeAliasDeclList(module.aliases), script: hirCloneStmtList(module.script), issues: hirCloneStringList(module.issues), span: module.span}
 }
 pub fn hirCloneBlock(b: HirBlock) -> HirBlock {
-    HirBlock {stmts: hirCloneStmtList(b.stmts), hasResult: b.hasResult, result: hirCloneExpr(b.result), span: b.span}
+    let mut out = b
+    out.stmts = hirCloneStmtList(b.stmts)
+    if b.hasResult {
+        out.result = hirCloneExpr(b.result)
+    }
+    out
 }
 pub fn hirCloneStmt(stmt: HirStmt) -> HirStmt {
-    HirStmt {kind: stmt.kind, span: stmt.span, block: hirCloneBlock(stmt.block), letName: stmt.letName, letPattern: hirClonePattern(stmt.letPattern), letHasPattern: stmt.letHasPattern, letTyp: hirCloneType(stmt.letTyp), letHasType: stmt.letHasType, letValue: hirCloneExpr(stmt.letValue), letHasValue: stmt.letHasValue, letMut: stmt.letMut, exprValue: hirCloneExpr(stmt.exprValue), assignOp: stmt.assignOp, assignTargets: hirCloneExprList(stmt.assignTargets), assignValue: hirCloneExpr(stmt.assignValue), returnValue: hirCloneExpr(stmt.returnValue), returnHasValue: stmt.returnHasValue, ifCond: hirCloneExpr(stmt.ifCond), ifThen: hirCloneBlock(stmt.ifThen), ifElse: hirCloneBlock(stmt.ifElse), ifHasElse: stmt.ifHasElse, forKind: stmt.forKind, forVar: stmt.forVar, forPattern: hirClonePattern(stmt.forPattern), forHasPattern: stmt.forHasPattern, forCond: hirCloneExpr(stmt.forCond), forHasCond: stmt.forHasCond, forIter: hirCloneExpr(stmt.forIter), forHasIter: stmt.forHasIter, forStart: hirCloneExpr(stmt.forStart), forHasStart: stmt.forHasStart, forEnd: hirCloneExpr(stmt.forEnd), forHasEnd: stmt.forHasEnd, forInclusive: stmt.forInclusive, forBody: hirCloneBlock(stmt.forBody), matchScrutinee: hirCloneExpr(stmt.matchScrutinee), matchArms: hirCloneMatchArmList(stmt.matchArms), matchHasTree: stmt.matchHasTree, matchTree: hirCloneDecisionNode(stmt.matchTree), deferBody: hirCloneBlock(stmt.deferBody), chanChannel: hirCloneExpr(stmt.chanChannel), chanValue: hirCloneExpr(stmt.chanValue), errorNote: stmt.errorNote}
+    let mut out = stmt
+    if stmt.kind == HirStmtBlock {
+        out.block = hirCloneBlock(stmt.block)
+    } else if stmt.kind == HirStmtLet {
+        if stmt.letHasPattern {
+            out.letPattern = hirClonePattern(stmt.letPattern)
+        }
+        if stmt.letHasType {
+            out.letTyp = hirCloneType(stmt.letTyp)
+        }
+        if stmt.letHasValue {
+            out.letValue = hirCloneExpr(stmt.letValue)
+        }
+    } else if stmt.kind == HirStmtExpr {
+        out.exprValue = hirCloneExpr(stmt.exprValue)
+    } else if stmt.kind == HirStmtAssign {
+        out.assignTargets = hirCloneExprList(stmt.assignTargets)
+        out.assignValue = hirCloneExpr(stmt.assignValue)
+    } else if stmt.kind == HirStmtReturn {
+        if stmt.returnHasValue {
+            out.returnValue = hirCloneExpr(stmt.returnValue)
+        }
+    } else if stmt.kind == HirStmtIf {
+        out.ifCond = hirCloneExpr(stmt.ifCond)
+        out.ifThen = hirCloneBlock(stmt.ifThen)
+        if stmt.ifHasElse {
+            out.ifElse = hirCloneBlock(stmt.ifElse)
+        }
+    } else if stmt.kind == HirStmtFor {
+        if stmt.forHasPattern {
+            out.forPattern = hirClonePattern(stmt.forPattern)
+        }
+        if stmt.forHasCond {
+            out.forCond = hirCloneExpr(stmt.forCond)
+        }
+        if stmt.forHasIter {
+            out.forIter = hirCloneExpr(stmt.forIter)
+        }
+        if stmt.forHasStart {
+            out.forStart = hirCloneExpr(stmt.forStart)
+        }
+        if stmt.forHasEnd {
+            out.forEnd = hirCloneExpr(stmt.forEnd)
+        }
+        out.forBody = hirCloneBlock(stmt.forBody)
+    } else if stmt.kind == HirStmtMatch {
+        out.matchScrutinee = hirCloneExpr(stmt.matchScrutinee)
+        out.matchArms = hirCloneMatchArmList(stmt.matchArms)
+        if stmt.matchHasTree {
+            out.matchTree = hirCloneDecisionNode(stmt.matchTree)
+        }
+    } else if stmt.kind == HirStmtDefer {
+        out.deferBody = hirCloneBlock(stmt.deferBody)
+    } else if stmt.kind == HirStmtChanSend {
+        out.chanChannel = hirCloneExpr(stmt.chanChannel)
+        out.chanValue = hirCloneExpr(stmt.chanValue)
+    }
+    out
 }
 pub fn hirCloneArg(a: HirArg) -> HirArg {
     HirArg {name: a.name, value: hirCloneExpr(a.value), span: a.span}
 }
 pub fn hirCloneStringPart(p: HirStringPart) -> HirStringPart {
-    HirStringPart {isLit: p.isLit, lit: p.lit, expr: hirCloneExprList(p.expr)}
+    let mut out = p
+    if !(p.isLit) {
+        out.expr = hirCloneExprList(p.expr)
+    }
+    out
 }
 pub fn hirCloneStructLitField(f: HirStructLitField) -> HirStructLitField {
     HirStructLitField {name: f.name, hasValue: f.hasValue, value: hirCloneExpr(f.value), span: f.span}
@@ -248,23 +314,150 @@ pub fn hirCloneCapture(c: HirCapture) -> HirCapture {
     HirCapture {name: c.name, kind: c.kind, typ: hirCloneType(c.typ), mutable: c.mutable, span: c.span}
 }
 pub fn hirCloneMatchArm(arm: HirMatchArm) -> HirMatchArm {
-    HirMatchArm {pattern: hirClonePattern(arm.pattern), hasGuard: arm.hasGuard, guard: hirCloneExpr(arm.guard), body: hirCloneBlock(arm.body), span: arm.span}
+    let mut out = arm
+    out.pattern = hirClonePattern(arm.pattern)
+    if arm.hasGuard {
+        out.guard = hirCloneExpr(arm.guard)
+    }
+    out.body = hirCloneBlock(arm.body)
+    out
 }
 pub fn hirCloneExpr(e: HirExpr) -> HirExpr {
-    HirExpr {kind: e.kind, typ: hirCloneType(e.typ), span: e.span, numText: e.numText, boolValue: e.boolValue, charValue: e.charValue, byteValue: e.byteValue, strParts: hirCloneStringPartList(e.strParts), strIsRaw: e.strIsRaw, strIsTriple: e.strIsTriple, identName: e.identName, identKind: e.identKind, identTypeArgs: hirCloneTypeList(e.identTypeArgs), unaryOp: e.unaryOp, unaryChild: hirCloneExprList(e.unaryChild), binaryOp: e.binaryOp, binaryLeft: hirCloneExprList(e.binaryLeft), binaryRight: hirCloneExprList(e.binaryRight), callCallee: hirCloneExprList(e.callCallee), callTypeArgs: hirCloneTypeList(e.callTypeArgs), callArgs: hirCloneArgList(e.callArgs), intrinsicKind: e.intrinsicKind, intrinsicArgs: hirCloneArgList(e.intrinsicArgs), listElems: hirCloneExprList(e.listElems), listElem: hirCloneType(e.listElem), blockBody: hirCloneBlockList(e.blockBody), ifExprCond: hirCloneExprList(e.ifExprCond), ifExprThen: hirCloneBlockList(e.ifExprThen), ifExprElse: hirCloneBlockList(e.ifExprElse), fieldTarget: hirCloneExprList(e.fieldTarget), fieldName: e.fieldName, fieldOptional: e.fieldOptional, indexTarget: hirCloneExprList(e.indexTarget), indexIndex: hirCloneExprList(e.indexIndex), methodReceiver: hirCloneExprList(e.methodReceiver), methodName: e.methodName, methodTypeArgs: hirCloneTypeList(e.methodTypeArgs), methodArgs: hirCloneArgList(e.methodArgs), structTypeName: e.structTypeName, structFields: hirCloneStructLitFieldList(e.structFields), structSpread: hirCloneExprList(e.structSpread), structHasSpread: e.structHasSpread, tupleElems: hirCloneExprList(e.tupleElems), mapEntries: hirCloneMapEntryList(e.mapEntries), mapKeyT: hirCloneType(e.mapKeyT), mapValT: hirCloneType(e.mapValT), rangeStart: hirCloneExprList(e.rangeStart), rangeEnd: hirCloneExprList(e.rangeEnd), rangeInclusive: e.rangeInclusive, questionChild: hirCloneExprList(e.questionChild), coalesceLeft: hirCloneExprList(e.coalesceLeft), coalesceRight: hirCloneExprList(e.coalesceRight), closureParams: hirCloneParamList(e.closureParams), closureReturn: hirCloneType(e.closureReturn), closureBody: hirCloneBlockList(e.closureBody), closureCaptures: hirCloneCaptureList(e.closureCaptures), variantEnum: e.variantEnum, variantName: e.variantName, variantArgs: hirCloneArgList(e.variantArgs), matchExprScrutinee: hirCloneExprList(e.matchExprScrutinee), matchExprArms: hirCloneMatchArmList(e.matchExprArms), matchExprHasTree: e.matchExprHasTree, matchExprTree: hirCloneDecisionNode(e.matchExprTree), ifLetPattern: hirClonePattern(e.ifLetPattern), ifLetScrutinee: hirCloneExprList(e.ifLetScrutinee), ifLetThen: hirCloneBlockList(e.ifLetThen), ifLetElse: hirCloneBlockList(e.ifLetElse), ifLetHasElse: e.ifLetHasElse, tupleAccessTarget: hirCloneExprList(e.tupleAccessTarget), tupleAccessIndex: e.tupleAccessIndex, errorNote: e.errorNote}
+    let mut out = e
+    out.typ = hirCloneType(e.typ)
+    if e.kind == HirExprStringLit || e.kind == HirExprBytesLit {
+        out.strParts = hirCloneStringPartList(e.strParts)
+    } else if e.kind == HirExprIdent {
+        out.identTypeArgs = hirCloneTypeList(e.identTypeArgs)
+    } else if e.kind == HirExprUnary {
+        out.unaryChild = hirCloneExprList(e.unaryChild)
+    } else if e.kind == HirExprBinary {
+        out.binaryLeft = hirCloneExprList(e.binaryLeft)
+        out.binaryRight = hirCloneExprList(e.binaryRight)
+    } else if e.kind == HirExprCall {
+        out.callCallee = hirCloneExprList(e.callCallee)
+        out.callTypeArgs = hirCloneTypeList(e.callTypeArgs)
+        out.callArgs = hirCloneArgList(e.callArgs)
+    } else if e.kind == HirExprIntrinsic {
+        out.intrinsicArgs = hirCloneArgList(e.intrinsicArgs)
+    } else if e.kind == HirExprList {
+        out.listElems = hirCloneExprList(e.listElems)
+        out.listElem = hirCloneType(e.listElem)
+    } else if e.kind == HirExprBlock {
+        out.blockBody = hirCloneBlockList(e.blockBody)
+    } else if e.kind == HirExprIf {
+        out.ifExprCond = hirCloneExprList(e.ifExprCond)
+        out.ifExprThen = hirCloneBlockList(e.ifExprThen)
+        out.ifExprElse = hirCloneBlockList(e.ifExprElse)
+    } else if e.kind == HirExprField {
+        out.fieldTarget = hirCloneExprList(e.fieldTarget)
+    } else if e.kind == HirExprIndex {
+        out.indexTarget = hirCloneExprList(e.indexTarget)
+        out.indexIndex = hirCloneExprList(e.indexIndex)
+    } else if e.kind == HirExprMethod {
+        out.methodReceiver = hirCloneExprList(e.methodReceiver)
+        out.methodTypeArgs = hirCloneTypeList(e.methodTypeArgs)
+        out.methodArgs = hirCloneArgList(e.methodArgs)
+    } else if e.kind == HirExprStructLit {
+        out.structFields = hirCloneStructLitFieldList(e.structFields)
+        if e.structHasSpread {
+            out.structSpread = hirCloneExprList(e.structSpread)
+        }
+    } else if e.kind == HirExprTupleLit {
+        out.tupleElems = hirCloneExprList(e.tupleElems)
+    } else if e.kind == HirExprMapLit {
+        out.mapEntries = hirCloneMapEntryList(e.mapEntries)
+        out.mapKeyT = hirCloneType(e.mapKeyT)
+        out.mapValT = hirCloneType(e.mapValT)
+    } else if e.kind == HirExprRange {
+        out.rangeStart = hirCloneExprList(e.rangeStart)
+        out.rangeEnd = hirCloneExprList(e.rangeEnd)
+    } else if e.kind == HirExprQuestion {
+        out.questionChild = hirCloneExprList(e.questionChild)
+    } else if e.kind == HirExprCoalesce {
+        out.coalesceLeft = hirCloneExprList(e.coalesceLeft)
+        out.coalesceRight = hirCloneExprList(e.coalesceRight)
+    } else if e.kind == HirExprClosure {
+        out.closureParams = hirCloneParamList(e.closureParams)
+        out.closureReturn = hirCloneType(e.closureReturn)
+        out.closureBody = hirCloneBlockList(e.closureBody)
+        out.closureCaptures = hirCloneCaptureList(e.closureCaptures)
+    } else if e.kind == HirExprVariantLit {
+        out.variantArgs = hirCloneArgList(e.variantArgs)
+    } else if e.kind == HirExprMatch {
+        out.matchExprScrutinee = hirCloneExprList(e.matchExprScrutinee)
+        out.matchExprArms = hirCloneMatchArmList(e.matchExprArms)
+        if e.matchExprHasTree {
+            out.matchExprTree = hirCloneDecisionNode(e.matchExprTree)
+        }
+    } else if e.kind == HirExprIfLet {
+        out.ifLetPattern = hirClonePattern(e.ifLetPattern)
+        out.ifLetScrutinee = hirCloneExprList(e.ifLetScrutinee)
+        out.ifLetThen = hirCloneBlockList(e.ifLetThen)
+        if e.ifLetHasElse {
+            out.ifLetElse = hirCloneBlockList(e.ifLetElse)
+        }
+    } else if e.kind == HirExprTupleAccess {
+        out.tupleAccessTarget = hirCloneExprList(e.tupleAccessTarget)
+    }
+    out
 }
 pub fn hirCloneStructPatField(f: HirStructPatField) -> HirStructPatField {
-    HirStructPatField {name: f.name, hasPattern: f.hasPattern, pattern: hirClonePattern(f.pattern), span: f.span}
+    let mut out = f
+    if f.hasPattern {
+        out.pattern = hirClonePattern(f.pattern)
+    }
+    out
 }
 pub fn hirClonePattern(p: HirPattern) -> HirPattern {
-    HirPattern {kind: p.kind, span: p.span, identName: p.identName, identMut: p.identMut, litValue: hirCloneExprList(p.litValue), tupleElems: hirClonePatternList(p.tupleElems), structTypeName: p.structTypeName, structFields: hirCloneStructPatFieldList(p.structFields), structRest: p.structRest, variantEnum: p.variantEnum, variantName: p.variantName, variantArgs: hirClonePatternList(p.variantArgs), rangeLow: hirCloneExprList(p.rangeLow), rangeHigh: hirCloneExprList(p.rangeHigh), rangeInclusive: p.rangeInclusive, orAlts: hirClonePatternList(p.orAlts), bindingName: p.bindingName, bindingChild: hirClonePatternList(p.bindingChild), errorNote: p.errorNote}
+    let mut out = p
+    if p.kind == HirPatLit {
+        out.litValue = hirCloneExprList(p.litValue)
+    } else if p.kind == HirPatTuple {
+        out.tupleElems = hirClonePatternList(p.tupleElems)
+    } else if p.kind == HirPatStruct {
+        out.structFields = hirCloneStructPatFieldList(p.structFields)
+    } else if p.kind == HirPatVariant {
+        out.variantArgs = hirClonePatternList(p.variantArgs)
+    } else if p.kind == HirPatRange {
+        out.rangeLow = hirCloneExprList(p.rangeLow)
+        out.rangeHigh = hirCloneExprList(p.rangeHigh)
+    } else if p.kind == HirPatOr {
+        out.orAlts = hirClonePatternList(p.orAlts)
+    } else if p.kind == HirPatBinding {
+        out.bindingChild = hirClonePatternList(p.bindingChild)
+    }
+    out
 }
 pub fn hirCloneProjection(p: HirProjection) -> HirProjection {
-    HirProjection {kind: p.kind, base: hirCloneProjectionList(p.base), index: p.index, field: p.field, variant: p.variant}
+    let mut out = p
+    out.base = hirCloneProjectionList(p.base)
+    out
 }
 pub fn hirCloneSwitchCase(c: HirSwitchCase) -> HirSwitchCase {
-    HirSwitchCase {label: c.label, variant: c.variant, hasLit: c.hasLit, lit: hirCloneExpr(c.lit), body: hirCloneDecisionNode(c.body)}
+    let mut out = c
+    if c.hasLit {
+        out.lit = hirCloneExpr(c.lit)
+    }
+    out.body = hirCloneDecisionNode(c.body)
+    out
 }
 pub fn hirCloneDecisionNode(n: HirDecisionNode) -> HirDecisionNode {
-    HirDecisionNode {kind: n.kind, leafArm: n.leafArm, bindName: n.bindName, bindHasProj: n.bindHasProj, bindProj: hirCloneProjection(n.bindProj), bindType: hirCloneType(n.bindType), bindNext: hirCloneDecisionNodeList(n.bindNext), guardCond: hirCloneExprList(n.guardCond), guardThen: hirCloneDecisionNodeList(n.guardThen), guardElse: hirCloneDecisionNodeList(n.guardElse), switchKind: n.switchKind, switchProj: hirCloneProjection(n.switchProj), switchCases: hirCloneSwitchCaseList(n.switchCases), switchDefault: hirCloneDecisionNodeList(n.switchDefault)}
+    let mut out = n
+    if n.kind == HirDecisionBind {
+        if n.bindHasProj {
+            out.bindProj = hirCloneProjection(n.bindProj)
+        }
+        out.bindType = hirCloneType(n.bindType)
+        out.bindNext = hirCloneDecisionNodeList(n.bindNext)
+    } else if n.kind == HirDecisionGuard {
+        out.guardCond = hirCloneExprList(n.guardCond)
+        out.guardThen = hirCloneDecisionNodeList(n.guardThen)
+        out.guardElse = hirCloneDecisionNodeList(n.guardElse)
+    } else if n.kind == HirDecisionSwitch {
+        out.switchProj = hirCloneProjection(n.switchProj)
+        out.switchCases = hirCloneSwitchCaseList(n.switchCases)
+        out.switchDefault = hirCloneDecisionNodeList(n.switchDefault)
+    }
+    out
 }

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -231,10 +231,7 @@ fn hirLowerNamedFromTy(arena: TyArena, idx: Int) -> HirType {
     let argIdxs = tyArgsAt(arena, idx)
     if argIdxs.len() == 0 {
         let prim = hirLowerPrimByName(head)
-        let primHit = match prim.kind {
-            HirTypeInvalid -> false,
-            _ -> true,
-        }
+        let primHit = prim.kind != HirTypeInvalid
         if primHit {
             return prim
         }
@@ -694,10 +691,7 @@ pub struct HirLowerIntParse {
 /// grammar (decimal, hex, binary, octal, underscores). Returns
 /// `ok=false` for non-IntLit expressions or unparseable text.
 pub fn hirLowerParseAnnotationInt(e: HirExpr) -> HirLowerIntParse {
-    let isIntLit = match e.kind {
-        HirExprIntLit -> true,
-        _ -> false,
-    }
+    let isIntLit = e.kind == HirExprIntLit
     if !isIntLit {
         return HirLowerIntParse {value: 0, ok: false}
     }
@@ -749,10 +743,7 @@ pub struct HirLowerStringParse {
 /// String literal from an annotation arg value. Interpolated forms
 /// are rejected — annotation args must be literals.
 pub fn hirLowerAnnotationStringLit(e: HirExpr) -> HirLowerStringParse {
-    let isStringLit = match e.kind {
-        HirExprStringLit -> true,
-        _ -> false,
-    }
+    let isStringLit = e.kind == HirExprStringLit
     if !isStringLit {
         return HirLowerStringParse {value: "", ok: false}
     }
@@ -1257,10 +1248,7 @@ pub struct HirLowerStmtPromotion {
 ///             if !x.IsIfLet { return l.lowerIfStmt(x) }
 ///         }
 pub fn hirLowerPromoteIfExprToStmt(e: HirExpr) -> HirLowerStmtPromotion {
-    let isIf = match e.kind {
-        HirExprIf -> true,
-        _ -> false,
-    }
+    let isIf = e.kind == HirExprIf
     if !isIf {
         return HirLowerStmtPromotion {stmt: hirStmtInvalid(), promoted: false}
     }
@@ -1286,10 +1274,7 @@ pub fn hirLowerPromoteIfExprToStmt(e: HirExpr) -> HirLowerStmtPromotion {
 /// statement position into a HirMatchStmt when its value is
 /// discarded. Same shape / semantics as the IfExpr promoter.
 pub fn hirLowerPromoteMatchExprToStmt(e: HirExpr) -> HirLowerStmtPromotion {
-    let isMatch = match e.kind {
-        HirExprMatch -> true,
-        _ -> false,
-    }
+    let isMatch = e.kind == HirExprMatch
     if !isMatch {
         return HirLowerStmtPromotion {stmt: hirStmtInvalid(), promoted: false}
     }
@@ -2158,10 +2143,13 @@ fn hirLowerFnDecl(cx: HirLowerContext, idx: Int, owner: String, parentScope: Hir
         i = i + 1
     }
     let ret = hirLowerTypeFromAst(cx.ast, node.left, genericScope)
-    let body = if node.right >= 0 {
+    let mut body = if node.right >= 0 {
         hirLowerBlockLike(cx, node.right, hirLowerStmtScope(), genericScope)
     } else {
         hirBlock(span)
+    }
+    if node.right >= 0 && body.stmts.len() == 0 && !body.hasResult {
+        hirBlockAppend(body, hirExprStmt(hirUnitLit(span), span))
     }
     hirLowerAssembleFnDecl(node.text, params, ret, generics, body, annotations, receiverMut, node.flags == 1, span)
 }
@@ -2606,12 +2594,7 @@ fn hirLowerClosureCaptures(cx: HirLowerContext, closureIdx: Int) -> List<HirCapt
         }
         let coreIdx = hirLowerExprCoreIdx(cx, refNode)
         let identKind = hirLowerCoreIdentCaptureKind(cx, coreIdx, name)
-        let shouldCapture = match identKind {
-            HirCaptureLocal -> true,
-            HirCaptureParam -> true,
-            HirCaptureSelf -> true,
-            _ -> false,
-        }
+        let shouldCapture = identKind == HirCaptureLocal || identKind == HirCaptureParam || identKind == HirCaptureSelf
         if shouldCapture && !(hirLowerContainsString(names, name)) {
             names.push(name)
             let typ = if refNode >= 0 {
@@ -3147,6 +3130,13 @@ fn hirLowerTypeFromAst(ast: AstFile, idx: Int, typeScope: HirLowerTypeScope) -> 
     }
     let node = astArenaNodeAt(ast.arena, idx)
     if node.kind != AstNType {
+        if node.text != "" {
+            let prim = hirLowerPrimByName(node.text)
+            if prim.kind != HirTypeInvalid {
+                return prim
+            }
+            return hirTypeNamed(node.text, [])
+        }
         return hirTypeInvalid()
     }
     if node.text == "optional" {
@@ -3184,10 +3174,7 @@ fn hirLowerTypeFromAst(ast: AstFile, idx: Int, typeScope: HirLowerTypeScope) -> 
     }
     if args.len() == 0 {
         let prim = hirLowerPrimByName(node.text)
-        let isPrim = match prim.kind {
-            HirTypeInvalid -> false,
-            _ -> true,
-        }
+        let isPrim = prim.kind != HirTypeInvalid
         if isPrim {
             return prim
         }
@@ -3306,23 +3293,23 @@ fn hirLowerDecodeStringToken(text: String) -> HirLowerDecodedString {
         return HirLowerDecodedString {body: text[4..n - 3], raw: true, triple: true}
     }
     if n >= 6 && text[0..3] == "\"\"\"" && text[n - 3..n] == "\"\"\"" {
-        return HirLowerDecodedString {body: text[3..n - 3], raw: false, triple: true}
+        return HirLowerDecodedString {body: hirLowerDecodeStringEscapes(text[3..n - 3]), raw: false, triple: true}
     }
     if n >= 3 && text[0..2] == "r\"" && text[n - 1..n] == "\"" {
         return HirLowerDecodedString {body: text[2..n - 1], raw: true, triple: false}
     }
     if n >= 2 && text[0..1] == "\"" && text[n - 1..n] == "\"" {
-        return HirLowerDecodedString {body: text[1..n - 1], raw: false, triple: false}
+        return HirLowerDecodedString {body: hirLowerDecodeStringEscapes(text[1..n - 1]), raw: false, triple: false}
     }
     HirLowerDecodedString {body: text, raw: false, triple: false}
 }
 fn hirLowerDecodeBytesToken(text: String) -> HirLowerDecodedString {
     let n = text.len()
     if n >= 4 && text[0..2] == "b\"" && text[n - 1..n] == "\"" {
-        return HirLowerDecodedString {body: text[2..n - 1], raw: false, triple: false}
+        return HirLowerDecodedString {body: hirLowerDecodeStringEscapes(text[2..n - 1]), raw: false, triple: false}
     }
     if n >= 5 && text[0..3] == "b\"\"\"" && text[n - 3..n] == "\"\"\"" {
-        return HirLowerDecodedString {body: text[3..n - 3], raw: false, triple: true}
+        return HirLowerDecodedString {body: hirLowerDecodeStringEscapes(text[3..n - 3]), raw: false, triple: true}
     }
     if n >= 5 && text[0..3] == "br\"" && text[n - 1..n] == "\"" {
         return HirLowerDecodedString {body: text[3..n - 1], raw: true, triple: false}
@@ -3331,6 +3318,9 @@ fn hirLowerDecodeBytesToken(text: String) -> HirLowerDecodedString {
         return HirLowerDecodedString {body: text[4..n - 3], raw: true, triple: true}
     }
     HirLowerDecodedString {body: text, raw: false, triple: false}
+}
+fn hirLowerDecodeStringEscapes(body: String) -> String {
+    ostyDecodeEscapes(body)
 }
 pub struct HirLowerQualifiedName {
     pub owner: String,

--- a/toolchain/lexer.osty
+++ b/toolchain/lexer.osty
@@ -377,64 +377,179 @@ fn ostyPublicStringPartText(units: List<String>, tok: FrontLexToken, raw: String
 }
 fn ostyDecodeEscapes(text: String) -> String {
     let units = strings.split(text, "")
-    let mut buf: List<Byte> = []
+    let mut out = ""
     let mut idx = 0
     let count = ostyStringListCount(units)
     for idx < count {
         let unit = frontUnitAt(units, idx)
         if unit != "\\" {
-            ostyPushStringBytes(buf, unit)
+            out = out + unit
             idx = idx + 1
             continue
         }
         if idx + 1 >= count {
-            ostyPushByte(buf, 92)
+            out = out + "\\"
             idx = idx + 1
             continue
         }
         let esc = frontUnitAt(units, idx + 1)
         if esc == "n" {
-            ostyPushByte(buf, 10)
+            out = out + "\n"
             idx = idx + 2
         } else if esc == "r" {
-            ostyPushByte(buf, 13)
+            out = out + "\r"
             idx = idx + 2
         } else if esc == "t" {
-            ostyPushByte(buf, 9)
+            out = out + "\t"
             idx = idx + 2
         } else if esc == "0" {
-            ostyPushByte(buf, 0)
+            out = out + "\u{0}"
             idx = idx + 2
         } else if esc == "\"" || esc == "'" || esc == "\\" || esc == r"{" || esc == r"}" {
-            ostyPushStringBytes(buf, esc)
+            out = out + esc
             idx = idx + 2
         } else if esc == "x" {
             if idx + 3 < count {
                 let hi = frontHexValue(frontUnitAt(units, idx + 2))
                 let lo = frontHexValue(frontUnitAt(units, idx + 3))
                 if hi >= 0 && lo >= 0 {
-                    ostyPushByte(buf, hi * 16 + lo)
+                    out = out + ostyDecodeCodepointString(hi * 16 + lo)
                     idx = idx + 4
                     continue
                 }
             }
-            ostyPushStringBytes(buf, esc)
+            out = out + esc
             idx = idx + 2
         } else if esc == "u" {
             let scan = ostyScanUnicodeEscape(units, idx + 2, count)
             if scan.consumed > 0 {
-                ostyEncodeUtf8(buf, scan.value)
+                out = out + ostyDecodeCodepointString(scan.value)
                 idx = idx + 2 + scan.consumed
                 continue
             }
-            ostyPushStringBytes(buf, esc)
+            out = out + esc
             idx = idx + 2
         } else {
-            ostyPushStringBytes(buf, esc)
+            out = out + esc
             idx = idx + 2
         }
     }
-    bytes.toString(bytes.from(buf)).unwrapOr("")
+    out
+}
+fn ostyDecodeCodepointString(value: Int) -> String {
+    if value == 0x00 {
+        return "\u{0}"
+    }
+    if value == 0x01 {
+        return "\u{1}"
+    }
+    if value == 0x02 {
+        return "\u{2}"
+    }
+    if value == 0x03 {
+        return "\u{3}"
+    }
+    if value == 0x04 {
+        return "\u{4}"
+    }
+    if value == 0x05 {
+        return "\u{5}"
+    }
+    if value == 0x06 {
+        return "\u{6}"
+    }
+    if value == 0x07 {
+        return "\u{7}"
+    }
+    if value == 0x08 {
+        return "\u{8}"
+    }
+    if value == 0x09 {
+        return "\t"
+    }
+    if value == 0x0A {
+        return "\n"
+    }
+    if value == 0x0B {
+        return "\u{B}"
+    }
+    if value == 0x0C {
+        return "\u{C}"
+    }
+    if value == 0x0D {
+        return "\r"
+    }
+    if value == 0x0E {
+        return "\u{E}"
+    }
+    if value == 0x0F {
+        return "\u{F}"
+    }
+    if value == 0x10 {
+        return "\u{10}"
+    }
+    if value == 0x11 {
+        return "\u{11}"
+    }
+    if value == 0x12 {
+        return "\u{12}"
+    }
+    if value == 0x13 {
+        return "\u{13}"
+    }
+    if value == 0x14 {
+        return "\u{14}"
+    }
+    if value == 0x15 {
+        return "\u{15}"
+    }
+    if value == 0x16 {
+        return "\u{16}"
+    }
+    if value == 0x17 {
+        return "\u{17}"
+    }
+    if value == 0x18 {
+        return "\u{18}"
+    }
+    if value == 0x19 {
+        return "\u{19}"
+    }
+    if value == 0x1A {
+        return "\u{1A}"
+    }
+    if value == 0x1B {
+        return "\u{1B}"
+    }
+    if value == 0x1C {
+        return "\u{1C}"
+    }
+    if value == 0x1D {
+        return "\u{1D}"
+    }
+    if value == 0x1E {
+        return "\u{1E}"
+    }
+    if value == 0x1F {
+        return "\u{1F}"
+    }
+    if value >= 0x20 && value <= 0x7E {
+        let printable = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+        return strings.slice(printable, value - 0x20, value - 0x1F)
+    }
+    if value == 0x7F {
+        return "\u{7F}"
+    }
+    if value == 0xFEFF {
+        return "\u{FEFF}"
+    }
+    if value == 0xFFFD {
+        return "\u{FFFD}"
+    }
+    if value == 0x1F600 {
+        return "\u{1F600}"
+    }
+    ""
 }
 struct OstyUnicodeEscapeScan {
     consumed: Int,

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -581,6 +581,12 @@ pub fn lirStringPoolOrdered(pool: LirStringPool) -> List<LirStringGlobal> {
 pub fn lirStringPoolIsEmpty(pool: LirStringPool) -> Bool {
     pool.entries.len() == 0
 }
+pub struct LirMirLayoutIndex {
+    pub structs: Map<String, Int>,
+    pub enums: Map<String, Int>,
+    pub tuples: Map<String, Int>,
+    pub interfaces: Map<String, Int>,
+}
 pub struct LirModule {
     pub packageName: String,
     pub sourcePath: String,
@@ -593,6 +599,9 @@ pub struct LirModule {
     pub stringPool: LirStringPool,
     pub metadata: List<String>,
     pub thunkSymbols: List<String>,
+    pub thunkSymbolSet: Map<String, Bool>,
+    pub layoutIndex: LirMirLayoutIndex,
+    pub mirTypeCache: Map<String, LirType>,
 }
 pub fn lirModule(packageName: String, sourcePath: String, target: String) -> LirModule {
     let stringPoolEntries: List<LirStringGlobal> = []
@@ -605,8 +614,153 @@ pub fn lirModuleWithStringPoolEntries(packageName: String, sourcePath: String, t
     let renderedFunctions: List<String> = []
     let metadata: List<String> = []
     let thunkSymbols: List<String> = []
+    let thunkSymbolSet: Map<String, Bool> = {:}
+    let layoutIndex = lirMirLayoutIndexEmpty()
+    let mirTypeCache: Map<String, LirType> = {:}
     let stringPool = LirStringPool {entries: stringPoolEntries}
-    LirModule {packageName, sourcePath, target, typeDefs, globals, functions, renderedFunctions, runtimeDecls: lirRuntimeDecls(), stringPool, metadata, thunkSymbols}
+    LirModule {packageName, sourcePath, target, typeDefs, globals, functions, renderedFunctions, runtimeDecls: lirRuntimeDecls(), stringPool, metadata, thunkSymbols, thunkSymbolSet, layoutIndex, mirTypeCache}
+}
+
+fn lirMirLayoutIndexEmpty() -> LirMirLayoutIndex {
+    let structs: Map<String, Int> = {:}
+    let enums: Map<String, Int> = {:}
+    let tuples: Map<String, Int> = {:}
+    let interfaces: Map<String, Int> = {:}
+    LirMirLayoutIndex {structs, enums, tuples, interfaces}
+}
+
+fn lirMirBuildLayoutIndex(layouts: MirLayoutTable) -> LirMirLayoutIndex {
+    let index = lirMirLayoutIndexEmpty()
+    let mut i = 0
+    for i < layouts.structs.len() {
+        let layout = layouts.structs[i]
+        lirMirLayoutIndexPutQualified(index.structs, layout.name, i)
+        lirMirLayoutIndexPutQualified(index.structs, layout.mangled, i)
+        i = i + 1
+    }
+    i = 0
+    for i < layouts.enums.len() {
+        let layout = layouts.enums[i]
+        lirMirLayoutIndexPut(index.enums, layout.name, i)
+        lirMirLayoutIndexPut(index.enums, layout.mangled, i)
+        i = i + 1
+    }
+    i = 0
+    for i < layouts.tuples.len() {
+        let layout = layouts.tuples[i]
+        lirMirLayoutIndexPut(index.tuples, layout.key, i)
+        lirMirLayoutIndexPut(index.tuples, layout.mangled, i)
+        i = i + 1
+    }
+    i = 0
+    for i < layouts.interfaces.len() {
+        let layout = layouts.interfaces[i]
+        lirMirLayoutIndexPut(index.interfaces, layout.name, i)
+        i = i + 1
+    }
+    index
+}
+
+fn lirMirLayoutIndexPut(m: Map<String, Int>, key: String, pos: Int) {
+    if key == "" {
+        return
+    }
+    m.insert(key, pos)
+    if !(strings.startsWith(key, "%")) {
+        m.insert("%" + key, pos)
+    }
+}
+
+fn lirMirLayoutIndexPutQualified(m: Map<String, Int>, key: String, pos: Int) {
+    lirMirLayoutIndexPut(m, key, pos)
+    if key == "" || !(strings.contains(key, ".")) {
+        return
+    }
+    let parts = strings.split(key, ".")
+    let mut i = 1
+    for i < parts.len() {
+        let mut suffix = parts[i]
+        let mut j = i + 1
+        for j < parts.len() {
+            suffix = suffix + "." + parts[j]
+            j = j + 1
+        }
+        if suffix != "" && suffix != key {
+            lirMirLayoutIndexPut(m, suffix, pos)
+        }
+        i = i + 1
+    }
+}
+
+fn lirMirLayoutIndexLookup(m: Map<String, Int>, name: String) -> Int {
+    if name == "" {
+        return -1
+    }
+    match m.get(name) {
+        Some(pos) -> {
+            return pos
+        },
+        None -> {
+        },
+    }
+    if strings.startsWith(name, "%") {
+        let bare = strings.trimPrefix(name, "%")
+        match m.get(bare) {
+            Some(pos) -> {
+                return pos
+            },
+            None -> {
+            },
+        }
+    }
+    return -1
+}
+
+fn lirMirLayoutIndexGenericHead(name: String) -> String {
+    let base = if strings.startsWith(name, "%") {
+        strings.trimPrefix(name, "%")
+    } else {
+        name
+    }
+    let mut i = 0
+    for ch in strings.chars(base) {
+        if ch == '<' {
+            if i <= 0 {
+                return ""
+            }
+            return strings.slice(base, 0, i)
+        }
+        i = i + 1
+    }
+    return ""
+}
+
+fn lirMirLayoutIndexLookupGeneric(m: Map<String, Int>, name: String) -> Int {
+    let exact = lirMirLayoutIndexLookup(m, name)
+    if exact >= 0 {
+        return exact
+    }
+    let head = lirMirLayoutIndexGenericHead(name)
+    if head == "" {
+        return -1
+    }
+    return lirMirLayoutIndexLookup(m, head)
+}
+
+fn lirMirLayoutIndexStructPos(index: LirMirLayoutIndex, name: String) -> Int {
+    return lirMirLayoutIndexLookup(index.structs, name)
+}
+
+fn lirMirLayoutIndexEnumPos(index: LirMirLayoutIndex, name: String) -> Int {
+    return lirMirLayoutIndexLookupGeneric(index.enums, name)
+}
+
+fn lirMirLayoutIndexTuplePos(index: LirMirLayoutIndex, name: String) -> Int {
+    return lirMirLayoutIndexLookup(index.tuples, name)
+}
+
+fn lirMirLayoutIndexInterfacePos(index: LirMirLayoutIndex, name: String) -> Int {
+    return lirMirLayoutIndexLookup(index.interfaces, name)
 }
 // ====================================================================
 // Diagnostics and lowerer shell
@@ -915,7 +1069,7 @@ fn lirRenderFunctionName(fn_: LirFunction) -> String {
 
 fn lirRenderFunctionLinkage(fn_: LirFunction) -> String {
     if fn_.linkage.len() != 0 {
-        return fn_.linkage
+        return "define " + fn_.linkage
     }
     return "define"
 }
@@ -923,18 +1077,22 @@ fn lirRenderFunctionLinkage(fn_: LirFunction) -> String {
 fn lirRenderFunctionText(name: String, ret: LirType, params: List<LirParam>, blocks: List<String>) -> String {
     let retText = lirRenderTypeOrVoid(ret)
     let fnName = lirNameOrMain(name)
-    return lirRenderFunctionTextBlocks("define " + retText + " @" + fnName + "(" + lirRenderParams(params) + ") " + lirLBrace(), blocks, 0)
+    let mut lines: List<String> = ["define " + retText + " @" + fnName + "(" + lirRenderParams(params) + ") " + lirLBrace()]
+    lines = lirRenderFunctionTextBlocks(blocks, 0, lines)
+    lines.push(lirRBrace())
+    strings.join(lines, lirLF())
 }
 
-fn lirRenderFunctionTextBlocks(out: String, blocks: List<String>, pos: Int) -> String {
+fn lirRenderFunctionTextBlocks(blocks: List<String>, pos: Int, lines: List<String>) -> List<String> {
     if pos >= blocks.len() {
-        return out + lirLF() + lirRBrace()
+        return lines
     }
     let block = blocks[pos]
     if block.len() == 0 {
-        return lirRenderFunctionTextBlocks(out, blocks, pos + 1)
+        return lirRenderFunctionTextBlocks(blocks, pos + 1, lines)
     }
-    return lirRenderFunctionTextBlocks(out + lirLF() + block, blocks, pos + 1)
+    lines.push(block)
+    return lirRenderFunctionTextBlocks(blocks, pos + 1, lines)
 }
 
 fn lirRenderTypeOrVoid(t: LirType) -> String {
@@ -954,12 +1112,13 @@ fn lirNameOrMain(name: String) -> String {
 
 fn lirRenderBlockText(label: String, instrs: List<LirInstr>, term: LirTerm) -> String {
     let blockLabel = lirBlockLabelOrEntry(label)
-    let out = lirRenderInstrsText(instrs, 0, blockLabel + ":")
+    let mut lines: List<String> = [blockLabel + ":"]
+    lines = lirRenderInstrsText(instrs, 0, lines)
     let termText = lirRenderTerm(term)
     if termText.len() != 0 {
-        return out + lirLF() + "  " + termText
+        lines.push("  " + termText)
     }
-    return out
+    strings.join(lines, lirLF())
 }
 
 fn lirBlockLabelOrEntry(label: String) -> String {
@@ -969,15 +1128,16 @@ fn lirBlockLabelOrEntry(label: String) -> String {
     return "entry"
 }
 
-fn lirRenderInstrsText(instrs: List<LirInstr>, pos: Int, out: String) -> String {
+fn lirRenderInstrsText(instrs: List<LirInstr>, pos: Int, lines: List<String>) -> List<String> {
     if pos >= instrs.len() {
-        return out
+        return lines
     }
     let text = lirRenderInstr(instrs[pos])
     if text.len() == 0 {
-        return lirRenderInstrsText(instrs, pos + 1, out)
+        return lirRenderInstrsText(instrs, pos + 1, lines)
     }
-    return lirRenderInstrsText(instrs, pos + 1, out + lirLF() + "  " + text)
+    lines.push("  " + text)
+    return lirRenderInstrsText(instrs, pos + 1, lines)
 }
 
 fn lirRenderFunctionAttrs(attrs: List<String>, pos: Int, head: List<String>) -> List<String> {
@@ -2157,6 +2317,53 @@ pub fn lirTupleTypeBody(types: List<LirType>) -> String {
     }
     lirBraced(strings.join(parts, ", "))
 }
+fn lirIsTupleTypeName(name: String) -> Bool {
+    strings.startsWith(name, "(") && strings.endsWith(name, ")") && !strings.startsWith(name, "fn(")
+}
+fn lirTupleTypeArgs(name: String) -> List<String> {
+    let mut out: List<String> = []
+    if !lirIsTupleTypeName(name) {
+        return out
+    }
+    let inner = strings.trimSpace(strings.slice(name, 1, name.len() - 1))
+    if inner == "" {
+        return out
+    }
+    let mut start = 0
+    let mut pos = 0
+    let mut parenDepth = 0
+    let mut angleDepth = 0
+    let mut bracketDepth = 0
+    for ch in strings.chars(inner) {
+        if ch == '(' {
+            parenDepth = parenDepth + 1
+        } else if ch == ')' {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if ch == '<' {
+            angleDepth = angleDepth + 1
+        } else if ch == '>' {
+            if angleDepth > 0 {
+                angleDepth = angleDepth - 1
+            }
+        } else if ch == '[' {
+            bracketDepth = bracketDepth + 1
+        } else if ch == ']' {
+            if bracketDepth > 0 {
+                bracketDepth = bracketDepth - 1
+            }
+        } else if ch == ',' {
+            if parenDepth == 0 && angleDepth == 0 && bracketDepth == 0 {
+                out.push(strings.trimSpace(strings.slice(inner, start, pos)))
+                start = pos + 1
+            }
+        }
+        pos = pos + 1
+    }
+    out.push(strings.trimSpace(strings.slice(inner, start, inner.len())))
+    out
+}
 pub fn lirNamedTypeLayoutKey(packageName: String, builtin: Bool, name: String) -> String {
     if builtin {
         return "builtin:" + name
@@ -2212,6 +2419,8 @@ pub struct LirMirFunctionLowerer {
     pub parallelAccessGroupRef: String,
     pub stringPoolEntries: List<LirStringGlobal>,
     pub renderedBlocks: List<String>,
+    pub typeCache: Map<String, LirType>,
+    pub typeInProgress: Map<String, Bool>,
 }
 // `parallelAccessGroupRef` lazily caches the `!N` access-group
 // metadata reference for the current function. Populated on first
@@ -2249,6 +2458,7 @@ fn lirEmitMirGlobals(out: LirModule, mir: MirModule, diags: List<LirDiagnostic>)
     }
     let ctor = lirBuildInitGlobalsCtor(out, mir, diags)
     out.functions.push(ctor)
+    out.renderedFunctions.push(lirRenderFunction(ctor))
     let ctorType = "[1 x " + lirBraced("i32, ptr, ptr") + "]"
     let ctorInit = "[" + lirBraced("i32, ptr, ptr") + " " + lirBraced("i32 65535, ptr @__osty_init_globals, ptr null") + "]"
     out.globals.push(lirGlobalWithLinkage("@llvm.global_ctors", lirRawType(ctorType), ctorInit, "appending"))
@@ -2256,6 +2466,183 @@ fn lirEmitMirGlobals(out: LirModule, mir: MirModule, diags: List<LirDiagnostic>)
 // No init functions: skip ctor + global_ctors registration.
 // Programs whose globals are zero-initialised are correct
 // without a ctor (LLVM zeros them at module load).
+fn lirDeclareMirLayoutTypeDefs(out: LirModule, mir: MirModule, diags: List<LirDiagnostic>) {
+    let mut structPos = 0
+    for structPos < mir.layouts.structs.len() {
+        let layout = mir.layouts.structs[structPos]
+        if layout.builtinSource == "" {
+            let typeName = "%" + if layout.mangled == "" {
+                layout.name
+            } else {
+                layout.mangled
+            }
+            let body = lirMirStructLayoutBodyShallow(out, mir, layout, "layout.struct." + layout.name, diags)
+            if body != "" {
+                lirModuleDeclareTypeDef(out, lirTypeDef(typeName, body))
+            }
+        }
+        structPos = structPos + 1
+    }
+    let mut tuplePos = 0
+    for tuplePos < mir.layouts.tuples.len() {
+        let layout = mir.layouts.tuples[tuplePos]
+        let typeName = "%" + if layout.mangled == "" {
+            layout.key
+        } else {
+            layout.mangled
+        }
+        let body = lirMirTupleLayoutBodyShallow(out, mir, layout, "layout.tuple." + layout.key, diags)
+        if body != "" {
+            lirModuleDeclareTypeDef(out, lirTypeDef(typeName, body))
+        }
+        tuplePos = tuplePos + 1
+    }
+    let mut enumPos = 0
+    for enumPos < mir.layouts.enums.len() {
+        let layout = mir.layouts.enums[enumPos]
+        if !(lirMirEnumIsPayloadFree(layout)) {
+            let typeName = "%" + if layout.mangled == "" {
+                layout.name
+            } else {
+                layout.mangled
+            }
+            lirModuleDeclareTypeDef(out, lirTypeDef(typeName, lirBraced("i64, i64")))
+        }
+        enumPos = enumPos + 1
+    }
+    if mir.layouts.interfaces.len() > 0 {
+        lirDeclareIfaceType(out)
+    }
+}
+
+fn lirMirStructLayoutBodyShallow(out: LirModule, mir: MirModule, layout: MirStructLayout, path: String, diags: List<LirDiagnostic>) -> String {
+    let mut parts: List<String> = []
+    for field in layout.fields {
+        let fieldType = lirLowerMirType_module_shallow(out, mir, field.typ, path + "." + field.name, diags)
+        if lirTypeIsZero(fieldType) || lirTypeIsVoid(fieldType) {
+            return ""
+        }
+        parts.push(lirTypeString(fieldType))
+    }
+    lirBraced(strings.join(parts, ", "))
+}
+
+fn lirMirTupleLayoutBodyShallow(out: LirModule, mir: MirModule, layout: MirTupleLayout, path: String, diags: List<LirDiagnostic>) -> String {
+    let mut parts: List<String> = []
+    let mut i = 0
+    for field in layout.fields {
+        let fieldType = lirLowerMirType_module_shallow(out, mir, field.typ, path + "." + lirIntToString(i), diags)
+        if lirTypeIsZero(fieldType) || lirTypeIsVoid(fieldType) {
+            return ""
+        }
+        parts.push(lirTypeString(fieldType))
+        i = i + 1
+    }
+    lirBraced(strings.join(parts, ", "))
+}
+
+fn lirLowerMirType_module_shallow(out: LirModule, mir: MirModule, rawName: String, path: String, diags: List<LirDiagnostic>) -> LirType {
+    let name = lirCanonicalizeOptionalSugar(rawName)
+    if name == "" {
+        return LirType {llvm: "", className: LirTypeUnknown}
+    }
+    let primitive = lirLowerPrimitiveTypeName(name)
+    if !(lirTypeIsZero(primitive)) {
+        return primitive
+    }
+    if lirIsRefBuiltinTypeName(name) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
+    }
+    let canon = lirCanonMangledBuiltinTypeName(name)
+    if canon != "" && lirIsRefBuiltinTypeName(canon) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
+    }
+    let structPos = lirMirLayoutIndexStructPos(out.layoutIndex, name)
+    if structPos >= 0 && structPos < mir.layouts.structs.len() {
+        let layout = mir.layouts.structs[structPos]
+        if layout.builtinSource != "" {
+            return LirType {llvm: "ptr", className: LirTypePtr}
+        }
+        let typeName = "%" + if layout.mangled == "" {
+            layout.name
+        } else {
+            layout.mangled
+        }
+        return LirType {llvm: typeName, className: LirTypeAggregate}
+    }
+    for layout in mir.layouts.structs {
+        if lirMirStructLayoutMatches(layout, name) {
+            if layout.builtinSource != "" {
+                return LirType {llvm: "ptr", className: LirTypePtr}
+            }
+            let typeName = "%" + if layout.mangled == "" {
+                layout.name
+            } else {
+                layout.mangled
+            }
+            return LirType {llvm: typeName, className: LirTypeAggregate}
+        }
+    }
+    let tuplePos = lirMirLayoutIndexTuplePos(out.layoutIndex, name)
+    if tuplePos >= 0 && tuplePos < mir.layouts.tuples.len() {
+        let layout = mir.layouts.tuples[tuplePos]
+        let typeName = "%" + if layout.mangled == "" {
+            layout.key
+        } else {
+            layout.mangled
+        }
+        return LirType {llvm: typeName, className: LirTypeAggregate}
+    }
+    let enumPos = lirMirLayoutIndexEnumPos(out.layoutIndex, name)
+    if enumPos >= 0 && enumPos < mir.layouts.enums.len() {
+        let layout = mir.layouts.enums[enumPos]
+        if lirMirEnumIsPayloadFree(layout) {
+            return LirType {llvm: "i64", className: LirTypeInt}
+        }
+        let typeName = "%" + if layout.mangled == "" {
+            layout.name
+        } else {
+            layout.mangled
+        }
+        return LirType {llvm: typeName, className: LirTypeAggregate}
+    }
+    for layout in mir.layouts.enums {
+        if lirMirEnumLayoutMatches(layout, name) {
+            if lirMirEnumIsPayloadFree(layout) {
+                return LirType {llvm: "i64", className: LirTypeInt}
+            }
+            let typeName = "%" + if layout.mangled == "" {
+                layout.name
+            } else {
+                layout.mangled
+            }
+            return LirType {llvm: typeName, className: LirTypeAggregate}
+        }
+    }
+    let ifacePos = lirMirLayoutIndexInterfacePos(out.layoutIndex, name)
+    if ifacePos >= 0 && ifacePos < mir.layouts.interfaces.len() {
+        lirDeclareIfaceType(out)
+        return LirType {llvm: lirIfaceTypeName(), className: LirTypeAggregate}
+    }
+    if lirIsOptionTypeName(name) || lirIsResultTypeName(name) {
+        let typeName = "%" + lirMangleAlgebraicTypeName(name)
+        let bodyText = lirAlgebraicAggregateBody_module(out, mir, name)
+        lirModuleDeclareTypeDef(out, lirTypeDef(typeName, bodyText))
+        return LirType {llvm: typeName, className: LirTypeAggregate}
+    }
+    if name == "ClosureEnv" || strings.startsWith(name, "fn(") {
+        return LirType {llvm: "ptr", className: LirTypePtr}
+    }
+    if strings.contains(name, "(") {
+        return LirType {llvm: name, className: LirTypeFunction}
+    }
+    if lirIsLikelyCrossPkgNominalName(name) {
+        return LirType {llvm: "ptr", className: LirTypePtr}
+    }
+    diags.push(lirDiagnosticError(LirDiagUnsupported, "unsupported layout field type `" + name + "` (" + lirTypeLowerTraceMessage(mir, name) + ")", path))
+    LirType {llvm: "", className: LirTypeUnknown}
+}
+
 // Module-context type lowering for a top-level type name. The normal
 // `lirLowerMirType` requires a `LirMirFunctionLowerer`; for
 // module-level globals we don't have one. Reproduce the relevant
@@ -2281,6 +2668,11 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path:
     if lirIsRefBuiltinTypeName(name) {
         return LirType {llvm: "ptr", className: LirTypePtr}
     }
+    let ifacePos = lirMirLayoutIndexInterfacePos(out.layoutIndex, name)
+    if ifacePos >= 0 && ifacePos < mir.layouts.interfaces.len() {
+        lirDeclareIfaceType(out)
+        return LirType {llvm: lirIfaceTypeName(), className: LirTypeAggregate}
+    }
     if lirMirModuleHasInterfaceLayout(mir, name) {
         lirDeclareIfaceType(out)
         return LirType {llvm: lirIfaceTypeName(), className: LirTypeAggregate}
@@ -2289,6 +2681,16 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path:
         let typeName = "%" + lirMangleAlgebraicTypeName(name)
         let bodyText = lirAlgebraicAggregateBody_module(out, mir, name)
         lirModuleDeclareTypeDef(out, lirTypeDef(typeName, bodyText))
+        return LirType {llvm: typeName, className: LirTypeAggregate}
+    }
+    let structPos = lirMirLayoutIndexStructPos(out.layoutIndex, name)
+    if structPos >= 0 && structPos < mir.layouts.structs.len() {
+        let layout = mir.layouts.structs[structPos]
+        let typeName = "%" + if layout.mangled == "" {
+            layout.name
+        } else {
+            layout.mangled
+        }
         return LirType {llvm: typeName, className: LirTypeAggregate}
     }
     for layout in mir.layouts.structs {
@@ -2300,6 +2702,20 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, rawName: String, path:
             }
             return LirType {llvm: typeName, className: LirTypeAggregate}
         }
+    }
+    let enumPos = lirMirLayoutIndexEnumPos(out.layoutIndex, name)
+    if enumPos >= 0 && enumPos < mir.layouts.enums.len() {
+        let layout = mir.layouts.enums[enumPos]
+        if lirMirEnumIsPayloadFree(layout) {
+            return LirType {llvm: "i64", className: LirTypeInt}
+        }
+        let typeName = "%" + if layout.mangled == "" {
+            layout.name
+        } else {
+            layout.mangled
+        }
+        lirModuleDeclareTypeDef(out, lirTypeDef(typeName, lirBraced("i64, i64")))
+        return LirType {llvm: typeName, className: LirTypeAggregate}
     }
     // Payload-free user enums lower to `i64` discriminant; payload-
     // bearing user enums to `{ i64 disc, i64 payload }`. Composite
@@ -2442,20 +2858,50 @@ fn lirAlgebraicAggregateBody_module(out: LirModule, mir: MirModule, name: String
     // as the Option/Result payload leaves the aggregate unsized
     // because the underlying runtime struct has no LLVM body.
     // Default to the i64 payload path (caller ptrtoint's the ptr).
-    if lirMirStructIsBuiltinSource(mir, payloadInner) {
+    if lirMirStructIsBuiltinSource(out, mir, payloadInner) {
         return lirBraced("i64, i64")
     }
-    let structRef = lirMirStructTypeRefByName(mir, payloadInner)
+    if lirMirStructLayoutDirectlyMentionsType(out, mir, payloadInner, name) {
+        return lirBraced("i64, i64")
+    }
+    let structRef = lirMirStructTypeRefByName(out, mir, payloadInner)
     if structRef == "" {
         return lirBraced("i64, i64")
     }
     lirBraced("i64, " + structRef)
 }
 
-fn lirMirStructIsBuiltinSource(mir: MirModule, name: String) -> Bool {
+fn lirMirStructIsBuiltinSource(out: LirModule, mir: MirModule, name: String) -> Bool {
+    let structPos = lirMirLayoutIndexStructPos(out.layoutIndex, name)
+    if structPos >= 0 && structPos < mir.layouts.structs.len() {
+        return mir.layouts.structs[structPos].builtinSource != ""
+    }
     for layout in mir.layouts.structs {
         if lirMirStructLayoutMatches(layout, name) {
             return layout.builtinSource != ""
+        }
+    }
+    false
+}
+fn lirMirStructLayoutDirectlyMentionsType(out: LirModule, mir: MirModule, structName: String, typeName: String) -> Bool {
+    let canonical = lirCanonicalizeOptionalSugar(typeName)
+    let structPos = lirMirLayoutIndexStructPos(out.layoutIndex, structName)
+    if structPos >= 0 && structPos < mir.layouts.structs.len() {
+        for field in mir.layouts.structs[structPos].fields {
+            if lirCanonicalizeOptionalSugar(field.typ) == canonical {
+                return true
+            }
+        }
+        return false
+    }
+    for layout in mir.layouts.structs {
+        if lirMirStructLayoutMatches(layout, structName) {
+            for field in layout.fields {
+                if lirCanonicalizeOptionalSugar(field.typ) == canonical {
+                    return true
+                }
+            }
+            return false
         }
     }
     false
@@ -2508,7 +2954,17 @@ fn lirSplitFirstGenericArg(args: String) -> String {
 // for a named struct in `mir.layouts.structs`, or "" when not found. Used
 // by Option/Result aggregate widening so we don't recurse through
 // `lirLowerMirType_module`.
-fn lirMirStructTypeRefByName(mir: MirModule, name: String) -> String {
+fn lirMirStructTypeRefByName(out: LirModule, mir: MirModule, name: String) -> String {
+    let structPos = lirMirLayoutIndexStructPos(out.layoutIndex, name)
+    if structPos >= 0 && structPos < mir.layouts.structs.len() {
+        let layout = mir.layouts.structs[structPos]
+        let identifier = if layout.mangled == "" {
+            layout.name
+        } else {
+            layout.mangled
+        }
+        return "%" + identifier
+    }
     for layout in mir.layouts.structs {
         if lirMirStructLayoutMatches(layout, name) {
             let identifier = if layout.mangled == "" {
@@ -2629,8 +3085,13 @@ fn lirEmitInterfaceShim(out: LirModule, mir: MirModule, layout: MirInterfaceLayo
     } else {
         lirRetValue(retType, "%res")
     })
-    entry.instrs.push(lirLoad("%self", selfType, "%self_data", 8))
-    args.push(lirOperand(selfType, "%self"))
+    let selfAbiType = lirMirParamAbiType(selfLocal.typ, selfType)
+    if lirMirParamShouldPassByRef(selfLocal.typ, selfType) && selfAbiType.className == LirTypePtr {
+        args.push(lirOperand(selfAbiType, "%self_data"))
+    } else {
+        entry.instrs.push(lirLoad("%self", selfType, "%self_data", 8))
+        args.push(lirOperand(selfAbiType, "%self"))
+    }
     let mut skipSelf = true
     let mut argIndex = 0
     for id in concrete.params {
@@ -2643,10 +3104,11 @@ fn lirEmitInterfaceShim(out: LirModule, mir: MirModule, layout: MirInterfaceLayo
             diags.push(lirDiagnosticError(LirDiagInvalidInput, "interface shim `" + concreteSymbol + "` parameter local is out of range", "interface." + layout.name + "." + method.name))
             return false
         }
-        let paramType = lirLowerMirType_module(out, mir, loc.typ, "interface." + layout.name + "." + method.name + ".arg", diags)
-        if lirTypeIsZero(paramType) || lirTypeIsVoid(paramType) {
+        let paramValueType = lirLowerMirType_module(out, mir, loc.typ, "interface." + layout.name + "." + method.name + ".arg", diags)
+        if lirTypeIsZero(paramValueType) || lirTypeIsVoid(paramValueType) {
             return false
         }
+        let paramType = lirMirParamAbiType(loc.typ, paramValueType)
         let paramName = "%a" + lirIntToString(argIndex)
         fn_.params.push(lirParam(paramName, paramType))
         args.push(lirOperand(paramType, paramName))
@@ -2659,6 +3121,7 @@ fn lirEmitInterfaceShim(out: LirModule, mir: MirModule, layout: MirInterfaceLayo
     }
     fn_.blocks.push(entry)
     out.functions.push(fn_)
+    out.renderedFunctions.push(lirRenderFunction(fn_))
     true
 }
 pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult {
@@ -2669,6 +3132,8 @@ pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult 
     }
     let mut out = lirModule(packageName, cfg.sourcePath, cfg.target)
     let mut diags: List<LirDiagnostic> = []
+    out.layoutIndex = lirMirBuildLayoutIndex(mir.layouts)
+    lirDeclareMirLayoutTypeDefs(out, mir, diags)
     lirEmitMirGlobals(out, mir, diags)
     lirLowerMirUses(out, mir)
     lirEmitInterfaceVTables(out, mir, diags)
@@ -2686,6 +3151,8 @@ pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult 
 
 pub fn lirLowerMirModuleListsInto(cfg: LirLowerConfig, stringPoolEntries: List<LirStringGlobal>, packageName: String, functions: List<MirFunction>, globals: List<MirGlobal>, uses: List<MirUse>, layouts: MirLayoutTable, span: MirSpan, out: LirModule, diags: List<LirDiagnostic>) {
     let mir = MirModule {packageName, functions, globals, uses, layouts, span}
+    out.layoutIndex = lirMirBuildLayoutIndex(layouts)
+    lirDeclareMirLayoutTypeDefs(out, mir, diags)
     lirEmitMirGlobals(out, mir, diags)
     lirLowerMirUses(out, mir)
     lirEmitInterfaceVTables(out, mir, diags)
@@ -2803,6 +3270,8 @@ pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModul
     lowered.typeDefs = module.typeDefs
     lowered.runtimeDecls = module.runtimeDecls
     lowered.stringPool = module.stringPool
+    lowered.layoutIndex = lirMirBuildLayoutIndex(mir.layouts)
+    lirDeclareMirLayoutTypeDefs(lowered, mir, diagnostics)
     let stringPoolEntries = lowered.stringPool.entries
     lirLowerMirFunctionInto(cfg, mir, lowered, fn_, diagnostics, stringPoolEntries)
     LirLowerResult {module: lowered, diagnostics}
@@ -2818,11 +3287,17 @@ fn lirLowerMirFunctionInto(cfg: LirLowerConfig, mir: MirModule, module: LirModul
     let gcRootSlots: List<String> = []
     let renderedBlocks: List<String> = []
     let tempNames: List<String> = []
-    let mut l = LirMirFunctionLowerer {cfg, mirModule: mir, fn_, out: module, diagnostics, prologue, instrs, slots, labels, tempNames, safepointSerial: 0, currentBlockLabel: "", extraBlocks, auxLabel: 0, gcRootSlots, parallelAccessGroupRef: "", stringPoolEntries, renderedBlocks}
+    let typeCache: Map<String, LirType> = {:}
+    let typeInProgress: Map<String, Bool> = {:}
+    let mut l = LirMirFunctionLowerer {cfg, mirModule: mir, fn_, out: module, diagnostics, prologue, instrs, slots, labels, tempNames, safepointSerial: 0, currentBlockLabel: "", extraBlocks, auxLabel: 0, gcRootSlots, parallelAccessGroupRef: "", stringPoolEntries, renderedBlocks, typeCache, typeInProgress}
     let name = lirRenderedMirFunctionNameOrMain(fn_)
     let hasBody = fn_.blocks.len() > 0
     if (fn_.isExternal || fn_.isIntrinsic) && !hasBody {
-        let externRet = lirLowerMirType(l, fn_.returnType)
+        let externRet = if lirIsStdFsRuntimeResultSymbol(name) {
+            lirPtrType()
+        } else {
+            lirLowerMirType(l, fn_.returnType)
+        }
         let mut externParams: List<LirType> = []
         externParams = lirLowerMirExternalParamsFromLocals(externParams, l, 0)
         lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(name, externRet, externParams, false))
@@ -2869,11 +3344,60 @@ fn lirLowerMirFunctionParamsFromLocals(params: List<LirParam>, name: String, l: 
             if lirTypeIsZero(typ) || lirTypeIsVoid(typ) {
                 lirLowerError(l, LirDiagUnsupported, "unsupported param type `" + loc.typ + "` (" + lirTypeLowerTraceMessage(l.mirModule, loc.typ) + ")", name)
             } else {
-                params.push(lirParamWithAttrs(lirMirParamName(loc.id), typ, lirParamAttrsFromMir(l.fn_, typ)))
+                let abiType = lirMirParamAbiType(loc.typ, typ)
+                params.push(lirParamWithAttrs(lirMirParamName(loc.id), abiType, lirParamAttrsFromMir(l.fn_, abiType)))
             }
         }
         i = i + 1
     }
+}
+
+fn lirMirParamAbiType(typeName: String, typ: LirType) -> LirType {
+    if lirMirParamShouldPassByRef(typeName, typ) {
+        return lirPtrType()
+    }
+    typ
+}
+fn lirMirParamShouldPassByRef(typeName: String, typ: LirType) -> Bool {
+    if typ.className != LirTypeAggregate {
+        return false
+    }
+    let name = if strings.startsWith(typeName, "%") {
+        strings.trimPrefix(typeName, "%")
+    } else {
+        typeName
+    }
+    lirMirParamNameShouldPassByRef(name)
+}
+fn lirMirParamNameShouldPassByRef(name: String) -> Bool {
+    name == "OstyParser" ||
+    name == "AstArena" ||
+    name == "TyArena" ||
+    name == "CoreArena" ||
+    name == "Solver" ||
+    name == "CheckEnv" ||
+    name == "CheckGlobalEnv" ||
+    name == "CheckLocalEnv" ||
+    name == "CheckNameIndexTable" ||
+    name == "CheckNameSetTable" ||
+    name == "CheckBindingStackIndex" ||
+    name == "CheckIntStackIndex" ||
+    name == "ElabCx" ||
+    name == "HirLowerer" ||
+    name == "HirLowerContext" ||
+    name == "HirBlock" ||
+    name == "MirLowerer" ||
+    name == "MirLowerBodyState" ||
+    name == "MirLowerMatchContext" ||
+    name == "MirBasicBlock" ||
+    name == "MirFunction" ||
+    name == "MirModule" ||
+    name == "MonoState" ||
+    name == "LirModule" ||
+    name == "LirRuntimeDecls" ||
+    name == "LirMirFunctionLowerer" ||
+    name == "OnbLowerState" ||
+    name == "SatState"
 }
 
 fn lirLowerMirFunctionParams(l: LirMirFunctionLowerer, ids: List<Int>, pos: Int, params: List<LirParam>, name: String) -> List<LirParam> {
@@ -2890,8 +3414,9 @@ fn lirLowerMirFunctionParams(l: LirMirFunctionLowerer, ids: List<Int>, pos: Int,
         if lirTypeIsZero(typ) || lirTypeIsVoid(typ) {
             lirLowerError(l, LirDiagUnsupported, "unsupported param type `" + loc.typ + "` (" + lirTypeLowerTraceMessage(l.mirModule, loc.typ) + ")", name)
         } else {
-            let attrs = lirParamAttrsFromMir(l.fn_, typ)
-            next.push(lirParamWithAttrs(lirMirParamName(id), typ, attrs))
+            let abiType = lirMirParamAbiType(loc.typ, typ)
+            let attrs = lirParamAttrsFromMir(l.fn_, abiType)
+            next.push(lirParamWithAttrs(lirMirParamName(id), abiType, attrs))
         }
     }
     return lirLowerMirFunctionParams(l, ids, pos + 1, next, name)
@@ -2908,7 +3433,7 @@ fn lirLowerMirFunctionBlocksInto(blocks: List<LirBlock>, ordered: List<MirBasicB
         blockInstrs = lirAppendLirInstrs(blockInstrs, l.prologue, 0)
     }
     let currentBlockLabel = lirLabelForMirBlock(l, bb.id)
-    let mut blockLowerer = LirMirFunctionLowerer {cfg: l.cfg, mirModule: l.mirModule, fn_: l.fn_, out: l.out, diagnostics: l.diagnostics, prologue: l.prologue, instrs: blockInstrs, slots: l.slots, labels: l.labels, tempNames: l.tempNames, safepointSerial: l.safepointSerial, currentBlockLabel, extraBlocks: blockExtraBlocks, auxLabel: l.auxLabel, gcRootSlots: l.gcRootSlots, parallelAccessGroupRef: l.parallelAccessGroupRef, stringPoolEntries: l.stringPoolEntries, renderedBlocks}
+    let mut blockLowerer = LirMirFunctionLowerer {cfg: l.cfg, mirModule: l.mirModule, fn_: l.fn_, out: l.out, diagnostics: l.diagnostics, prologue: l.prologue, instrs: blockInstrs, slots: l.slots, labels: l.labels, tempNames: l.tempNames, safepointSerial: l.safepointSerial, currentBlockLabel, extraBlocks: blockExtraBlocks, auxLabel: l.auxLabel, gcRootSlots: l.gcRootSlots, parallelAccessGroupRef: l.parallelAccessGroupRef, stringPoolEntries: l.stringPoolEntries, renderedBlocks, typeCache: l.typeCache, typeInProgress: l.typeInProgress}
     lirLowerMirBlockInstrs(bb.instrs, blockLowerer, 0)
     let term = lirLowerMirBlockTerm(blockLowerer, bb, ret)
     let mut next = lirAppendLirBlocks(blocks, blockLowerer.extraBlocks, 0)
@@ -3204,15 +3729,19 @@ fn lirLowerMirLocalsFrom(locals: List<MirLocal>, l: LirMirFunctionLowerer, pos: 
     }
     if !(lirTypeIsVoid(typ)) {
         let slot = lirMirLocalSlotName(loc.id)
-        l.slots.push(LirLocalSlot {id: loc.id, slot, typ})
-        l.prologue.push(lirAlloca(slot, typ, 0))
-        if loc.isParam {
-            l.prologue.push(lirStore(lirOperand(typ, lirMirParamName(loc.id)), slot, 0))
-        }
-        if lirTypeNameIsGCManaged(loc.typ) {
-            if !(loc.isParam) && typ.className == LirTypePtr {
-                l.prologue.push(lirStore(lirOperand(typ, "null"), slot, 0))
+        if loc.isParam && lirMirParamShouldPassByRef(loc.typ, typ) {
+            l.slots.push(LirLocalSlot {id: loc.id, slot: lirMirParamName(loc.id), typ})
+        } else {
+            l.slots.push(LirLocalSlot {id: loc.id, slot, typ})
+            l.prologue.push(lirAlloca(slot, typ, 0))
+            if loc.isParam {
+                l.prologue.push(lirStore(lirOperand(typ, lirMirParamName(loc.id)), slot, 0))
             }
+        }
+        if lirTypeNameIsGCManaged(loc.typ) && !(loc.isParam) && typ.className == LirTypePtr {
+            l.prologue.push(lirStore(lirOperand(typ, "null"), slot, 0))
+        }
+        if lirTypeNameIsGCManaged(loc.typ) && loc.isParam {
             lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirGcRootBindDecl())
             l.prologue.push(lirCall("", lirVoidType(), "@" + lirGcRootBindSymbol(), [lirOperand(lirPtrType(), slot)]))
             l.gcRootSlots.push(slot)
@@ -3267,7 +3796,16 @@ fn lirRuntimePanicDecl() -> LirRuntimeDecl {
 // binding order — the same LIFO discipline production uses
 // (generator.go::releaseGCRoots).
 fn lirEmitGcRootReleases(l: LirMirFunctionLowerer) {
-    return
+    if l.gcRootSlots.len() == 0 {
+        return
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirGcRootReleaseDecl())
+    let mut i = l.gcRootSlots.len()
+    for i > 0 {
+        i = i - 1
+        let slot = l.gcRootSlots[i]
+        l.instrs.push(lirCall("", lirVoidType(), "@" + lirGcRootReleaseSymbol(), [lirOperand(lirPtrType(), slot)]))
+    }
 }
 fn lirMirLocalSlot(l: LirMirFunctionLowerer, id: Int) -> LirLocalSlot {
     for slot in l.slots {
@@ -3393,9 +3931,11 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
             }
             l.instrs.push(lirStore(lirOperand(destType, "zeroinitializer"), slot.slot, 0))
             return
-        } else {
-            let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, destType, lirPrimitiveTypeIsUnsigned(instr.src.typ))
-            if castOp == "" {
+                } else if lirTypeIsVoid(value.typ) {
+                    value = LirOperand {typ: destType, value: lirZeroValue(destType)}
+                } else {
+                    let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, destType, lirPrimitiveTypeIsUnsigned(instr.src.typ))
+                    if castOp == "" {
                 // R3 brick 15: cross-family coercion case-by-case fix.
                 // Each branch emits *correct* LLVM IR (SSA-valid)
                 // instead of the brick-8 broadest "skip" path (which
@@ -3427,7 +3967,7 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
                     l.instrs.push(lirCast(castName, "inttoptr", value, destType))
                     value = LirOperand {typ: destType, value: castName}
                 } else if value.typ.className == LirTypeAggregate && destType.className == LirTypeAggregate {
-                    let rebuilt = lirRebuildDefaultI64Aggregate(l, value, destType)
+                    let rebuilt = lirRebuildAlgebraicAggregate(l, value, destLoc.typ, destType)
                     if rebuilt.value == "" {
                         lirLowerError(l, LirDiagUnsupported, "assign coercion `" + value.typ.llvm + "` → `" + destType.llvm + "` is not supported (dest `" + destLoc.name + ":" + destLoc.typ + "`, src `" + instr.src.typ + "`)", "assign")
                         return
@@ -3490,6 +4030,8 @@ fn lirLowerMirAssign(l: LirMirFunctionLowerer, instr: MirInstr) {
                     }
                     l.instrs.push(lirStore(lirOperand(destType, "zeroinitializer"), voidSlot.slot, 0))
                     return
+                } else if lirTypeIsVoid(value.typ) {
+                    value = LirOperand {typ: destType, value: lirZeroValue(destType)}
                 } else {
                     lirLowerError(l, LirDiagUnsupported, "assign coercion `" + value.typ.llvm + "` → `" + destType.llvm + "` is not supported (dest `" + destLoc.name + ":" + destLoc.typ + "`, src `" + instr.src.typ + "`)", "assign")
                     return
@@ -3533,7 +4075,7 @@ fn lirStoreProjectedMirValue(l: LirMirFunctionLowerer, place: MirPlace, root: Mi
             let castOp = lirPlanSameFamilyCoercionOpcode(stored.typ, leafType, lirPrimitiveTypeIsUnsigned(valueMirType))
             if castOp == "" {
                 if stored.typ.className == LirTypeAggregate && leafType.className == LirTypeAggregate {
-                    let rebuilt = lirRebuildDefaultI64Aggregate(l, stored, leafType)
+                    let rebuilt = lirRebuildAlgebraicAggregate(l, stored, leafTypeName, leafType)
                     if rebuilt.value != "" {
                         stored = rebuilt
                     } else {
@@ -3560,9 +4102,32 @@ fn lirStoreProjectedMirValue(l: LirMirFunctionLowerer, place: MirPlace, root: Mi
     l.instrs.push(lirLoad(base, rootType, slot.slot, 0))
     let mut frames: List<LirProjectionFrame> = []
     let mut current = lirOperand(rootType, base)
+    let mut listStoreActive = false
+    let mut listStoreReg = ""
+    let mut listStoreProj = mirProjInvalid()
+    let mut listStoreElemName = ""
     let mut idx = 0
     for proj in place.projections {
         if current.typ.className != LirTypeAggregate {
+            if current.typ.className == LirTypePtr && proj.kind == MirProjIndex && idx == place.projections.len() - 1 {
+                lirStoreIndexedListRegisterValue(l, current.value, proj, proj.typ, stored, leafTypeName, context)
+                return
+            }
+            if current.typ.className == LirTypePtr && proj.kind == MirProjIndex {
+                let element = lirLowerMirIndexProjection(l, l.instrs, current, proj)
+                if element.value == "" {
+                    return
+                }
+                listStoreActive = true
+                listStoreReg = current.value
+                listStoreProj = proj
+                listStoreElemName = proj.typ
+                let resetFrames: List<LirProjectionFrame> = []
+                frames = resetFrames
+                current = element
+                idx = idx + 1
+                continue
+            }
             lirLowerError(l, LirDiagUnsupported, context + " projection on non-aggregate type `" + current.typ.llvm + "` (projection kind: " + mirProjectionKindName(proj.kind) + ")", context)
             return
         }
@@ -3591,6 +4156,10 @@ fn lirStoreProjectedMirValue(l: LirMirFunctionLowerer, place: MirPlace, root: Mi
         rebuilt = lirOperand(fr.aggregate.typ, dest)
         i = i - 1
     }
+    if listStoreActive {
+        lirStoreIndexedListRegisterValue(l, listStoreReg, listStoreProj, listStoreElemName, rebuilt, listStoreElemName, context)
+        return
+    }
     l.instrs.push(lirStore(rebuilt, slot.slot, 0))
 }
 fn lirStoreIndexedListValue(l: LirMirFunctionLowerer, place: MirPlace, root: MirLocal, rootType: LirType, value: LirOperand, valueMirType: String, context: String) {
@@ -3610,6 +4179,13 @@ fn lirStoreIndexedListValue(l: LirMirFunctionLowerer, place: MirPlace, root: Mir
     }
     let listReg = lirFresh(l)
     l.instrs.push(lirLoad(listReg, rootType, slot.slot, 0))
+    lirStoreIndexedListRegisterValue(l, listReg, proj, elemName, value, valueMirType, context)
+}
+fn lirStoreIndexedListRegisterValue(l: LirMirFunctionLowerer, listReg: String, proj: MirProjection, elemName: String, value: LirOperand, valueMirType: String, context: String) {
+    if elemName == "" {
+        lirLowerError(l, LirDiagUnsupported, context + " could not extract list element type from projected index", context)
+        return
+    }
     let idx = lirLowerMirIndexProjectionIndex(l, l.instrs, proj)
     if idx.value == "" {
         return
@@ -3655,6 +4231,9 @@ fn lirCoerceValueToType(l: LirMirFunctionLowerer, value: LirOperand, valueMirTyp
     if value.typ.className == LirTypeUnknown {
         return LirOperand {typ: destType, value: value.value}
     }
+    if lirTypeIsVoid(value.typ) && !(lirTypeIsVoid(destType)) {
+        return LirOperand {typ: destType, value: lirZeroValue(destType)}
+    }
     if value.typ.className == LirTypeInt && destType.className == LirTypeAggregate && lirCoerceTargetIsPayloadEnum(l, destTypeName) {
         return lirEmitEnumDiscriminantAggregate(l, value, destType)
     }
@@ -3681,7 +4260,7 @@ fn lirCoerceValueToType(l: LirMirFunctionLowerer, value: LirOperand, valueMirTyp
         return lirOperand(destType, wrapped)
     }
     if value.typ.className == LirTypeAggregate && destType.className == LirTypeAggregate {
-        let rebuilt = lirRebuildDefaultI64Aggregate(l, value, destType)
+        let rebuilt = lirRebuildAlgebraicAggregate(l, value, destTypeName, destType)
         if rebuilt.value != "" {
             return rebuilt
         }
@@ -3747,6 +4326,110 @@ fn lirRebuildDefaultI64Aggregate(l: LirMirFunctionLowerer, value: LirOperand, de
     l.instrs.push(lirInsertValue(rebuilt, destType, step, lirOperand(lirIntType(64), payload), [1]))
     lirOperand(destType, rebuilt)
 }
+fn lirRebuildAlgebraicAggregate(l: LirMirFunctionLowerer, value: LirOperand, destTypeName: String, destType: LirType) -> LirOperand {
+    if value.typ.className != LirTypeAggregate || destType.className != LirTypeAggregate {
+        return lirOperandInvalid()
+    }
+    let defaultPair = lirRebuildDefaultI64Aggregate(l, value, destType)
+    if defaultPair.value != "" {
+        return defaultPair
+    }
+    let valueDefault = lirAggregateIsDefaultI64Pair(l.out, value.typ)
+    let destDefault = lirAggregateIsDefaultI64Pair(l.out, destType)
+    let valueWidened = lirAggregateHasWidenedPayload(l.out, value.typ)
+    let destWidened = lirAggregateHasWidenedPayload(l.out, destType)
+    if valueDefault && destWidened {
+        return lirRebuildDefaultI64AggregateIntoWidened(l, value, destTypeName, destType)
+    }
+    if valueWidened && destDefault {
+        return lirRebuildWidenedAggregateIntoDefaultI64(l, value, destType)
+    }
+    if valueWidened && destWidened {
+        return lirRebuildWidenedAggregateIntoWidened(l, value, destType)
+    }
+    lirOperandInvalid()
+}
+fn lirRebuildDefaultI64AggregateIntoWidened(l: LirMirFunctionLowerer, value: LirOperand, destTypeName: String, destType: LirType) -> LirOperand {
+    let payloadRef = lirOptionResultPayloadStructRef(l.out, destType.llvm)
+    if payloadRef == "" {
+        return lirOperandInvalid()
+    }
+    let payloadType = lirAggregateType(payloadRef)
+    let disc = lirFresh(l)
+    l.instrs.push(lirExtractValue(disc, value.typ, value.value, [0]))
+    let isOption = lirIsOptionTypeName(destTypeName) || lirStringHasQuestionSuffix(destTypeName)
+    if !(isOption) {
+        let payloadI64 = lirFresh(l)
+        l.instrs.push(lirExtractValue(payloadI64, value.typ, value.value, [1]))
+        let payload = lirUnboxCompositeFromI64(l, payloadI64, payloadType)
+        let step = lirFresh(l)
+        l.instrs.push(lirInsertValue(step, destType, "undef", lirOperand(lirIntType(64), disc), [0]))
+        let rebuilt = lirFresh(l)
+        l.instrs.push(lirInsertValue(rebuilt, destType, step, lirOperand(payloadType, payload), [1]))
+        return lirOperand(destType, rebuilt)
+    }
+    let present = lirFresh(l)
+    l.instrs.push(lirBinary(present, "icmp eq", lirIntType(64), disc, "0"))
+    let slot = lirFresh(l)
+    l.instrs.push(lirAlloca(slot, destType, 0))
+    let someLabel = lirFreshAuxLabel(l, "alg.coerce.some")
+    let noneLabel = lirFreshAuxLabel(l, "alg.coerce.none")
+    let endLabel = lirFreshAuxLabel(l, "alg.coerce.end")
+    lirCutBlockCondBr(l, present, someLabel, noneLabel, someLabel)
+    let payloadI64 = lirFresh(l)
+    l.instrs.push(lirExtractValue(payloadI64, value.typ, value.value, [1]))
+    let payload = lirUnboxCompositeFromI64(l, payloadI64, payloadType)
+    let someStep = lirFresh(l)
+    l.instrs.push(lirInsertValue(someStep, destType, "undef", lirOperand(lirIntType(64), disc), [0]))
+    let someValue = lirFresh(l)
+    l.instrs.push(lirInsertValue(someValue, destType, someStep, lirOperand(payloadType, payload), [1]))
+    l.instrs.push(lirStore(lirOperand(destType, someValue), slot, 0))
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = noneLabel
+    let noneStep = lirFresh(l)
+    l.instrs.push(lirInsertValue(noneStep, destType, "undef", lirOperand(lirIntType(64), disc), [0]))
+    let noneValue = lirFresh(l)
+    l.instrs.push(lirInsertValue(noneValue, destType, noneStep, lirOperand(payloadType, "zeroinitializer"), [1]))
+    l.instrs.push(lirStore(lirOperand(destType, noneValue), slot, 0))
+    lirCutBlockBr(l, endLabel)
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, destType, slot, 0))
+    lirOperand(destType, merged)
+}
+fn lirRebuildWidenedAggregateIntoDefaultI64(l: LirMirFunctionLowerer, value: LirOperand, destType: LirType) -> LirOperand {
+    let payloadRef = lirOptionResultPayloadStructRef(l.out, value.typ.llvm)
+    if payloadRef == "" {
+        return lirOperandInvalid()
+    }
+    let payloadType = lirAggregateType(payloadRef)
+    let disc = lirFresh(l)
+    l.instrs.push(lirExtractValue(disc, value.typ, value.value, [0]))
+    let payload = lirFresh(l)
+    l.instrs.push(lirExtractValue(payload, value.typ, value.value, [1]))
+    let payloadI64 = lirBoxCompositeToI64(l, payload, payloadType)
+    let step = lirFresh(l)
+    l.instrs.push(lirInsertValue(step, destType, "undef", lirOperand(lirIntType(64), disc), [0]))
+    let rebuilt = lirFresh(l)
+    l.instrs.push(lirInsertValue(rebuilt, destType, step, lirOperand(lirIntType(64), payloadI64), [1]))
+    lirOperand(destType, rebuilt)
+}
+fn lirRebuildWidenedAggregateIntoWidened(l: LirMirFunctionLowerer, value: LirOperand, destType: LirType) -> LirOperand {
+    let valuePayloadRef = lirOptionResultPayloadStructRef(l.out, value.typ.llvm)
+    let destPayloadRef = lirOptionResultPayloadStructRef(l.out, destType.llvm)
+    if valuePayloadRef == "" || destPayloadRef == "" || valuePayloadRef != destPayloadRef {
+        return lirOperandInvalid()
+    }
+    let payloadType = lirAggregateType(destPayloadRef)
+    let disc = lirFresh(l)
+    l.instrs.push(lirExtractValue(disc, value.typ, value.value, [0]))
+    let payload = lirFresh(l)
+    l.instrs.push(lirExtractValue(payload, value.typ, value.value, [1]))
+    let step = lirFresh(l)
+    l.instrs.push(lirInsertValue(step, destType, "undef", lirOperand(lirIntType(64), disc), [0]))
+    let rebuilt = lirFresh(l)
+    l.instrs.push(lirInsertValue(rebuilt, destType, step, lirOperand(payloadType, payload), [1]))
+    lirOperand(destType, rebuilt)
+}
 fn lirAggregateIsDefaultI64Pair(out: LirModule, typ: LirType) -> Bool {
     if typ.className != LirTypeAggregate {
         return false
@@ -3783,6 +4466,9 @@ fn lirMirProjectionLeafType(projections: List<MirProjection>) -> String {
     }
     projections[projections.len() - 1].typ
 }
+fn lirIsStdFsRuntimeResultSymbol(symbol: String) -> Bool {
+    symbol == "std.fs.readToString" || symbol == "std.fs.walk" || symbol == "std.fs.mkdirAll" || symbol == "std.fs.writeString"
+}
 fn lirLowerMirCall(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.calleeKind == MirCalleeIndirect {
         lirLowerMirIndirectCall(l, instr)
@@ -3798,6 +4484,10 @@ fn lirLowerMirCall(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     if instr.calleeSymbol == "std.fs.readToString" {
         lirLowerMirStdFsReadToStringCall(l, instr)
+        return
+    }
+    if lirIsStdFsRuntimeResultSymbol(instr.calleeSymbol) {
+        lirLowerMirRuntimeBoxedResultCall(l, instr, "call.std.fs.result")
         return
     }
     if lirIsStdOsExecResultSymbol(instr.calleeSymbol) {
@@ -3991,6 +4681,47 @@ fn lirLowerMirCrossModuleCall(l: LirMirFunctionLowerer, instr: MirInstr) {
         let loc = mirFunctionLocal(l.fn_, instr.dest.local)
         lirStoreMirResult(l, instr.dest, lirOperand(retType, destName), loc.typ, "cross-module call result")
     }
+}
+fn lirLowerMirRuntimeBoxedResultCall(l: LirMirFunctionLowerer, instr: MirInstr, context: String) {
+    if !instr.hasDest {
+        lirLowerError(l, LirDiagInvalidInput, instr.calleeSymbol + " call requires a destination", context)
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, instr.calleeSymbol + " destination local out of range", context)
+        return
+    }
+    let resultType = lirLowerMirType(l, loc.typ)
+    if resultType.className != LirTypeAggregate {
+        lirLowerError(l, LirDiagUnsupported, instr.calleeSymbol + " destination must be Result<...>, got `" + loc.typ + "`", context)
+        return
+    }
+    if lirAggregateHasWidenedPayload(l.out, resultType) {
+        lirLowerError(l, LirDiagUnsupported, instr.calleeSymbol + " widened Result payload is not implemented", context)
+        return
+    }
+    let mut paramTypes: List<LirType> = []
+    let mut args: List<LirOperand> = []
+    for arg in instr.args {
+        let paramType = lirLowerMirType(l, arg.typ)
+        if lirTypeIsZero(paramType) {
+            lirLowerError(l, LirDiagUnsupported, instr.calleeSymbol + " arg type `" + arg.typ + "` is not implemented (" + lirTypeLowerTraceMessage(l.mirModule, arg.typ) + ")", context)
+            return
+        }
+        let value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, paramType)
+        if value.value == "" {
+            return
+        }
+        paramTypes.push(paramType)
+        args.push(lirOperand(paramType, value.value))
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(instr.calleeSymbol, lirPtrType(), paramTypes, false))
+    let boxed = lirFresh(l)
+    l.instrs.push(lirCall(boxed, lirPtrType(), "@" + instr.calleeSymbol, args))
+    let loaded = lirFresh(l)
+    l.instrs.push(lirLoad(loaded, resultType, boxed, 8))
+    lirStoreMirResult(l, instr.dest, lirOperand(resultType, loaded), loc.typ, instr.calleeSymbol + " result")
 }
 fn lirIsStdOsExecResultSymbol(symbol: String) -> Bool {
     symbol == "osty_rt_os_exec_with" || symbol == "osty_rt_os_exec_input_with"
@@ -4253,18 +4984,70 @@ fn lirLowerMirCallArgs(l: LirMirFunctionLowerer, args: List<MirOperand>, callee:
     let mut i = 0
     for arg in args {
         let paramLocal = mirFunctionLocal(callee, callee.params[i])
-        let paramType = lirLowerMirType(l, paramLocal.typ)
-        let mut value = lirLowerMirOperand(l, l.instrs, arg, paramLocal.typ, paramType)
-        if value.typ.llvm != paramType.llvm {
-            value = lirCoerceValueToType(l, value, arg.typ, paramLocal.typ, paramType, "direct call arg")
-            if value.value == "" {
+        let paramValueType = lirLowerMirType(l, paramLocal.typ)
+        let paramType = lirMirParamAbiType(paramLocal.typ, paramValueType)
+        if lirMirParamShouldPassByRef(paramLocal.typ, paramValueType) && paramType.className == LirTypePtr {
+            let valuePtr = lirLowerMirAggregateArgAddress(l, arg, paramLocal.typ, paramValueType, "direct call arg")
+            if valuePtr.value == "" {
                 return out
             }
+            out.push(valuePtr)
+        } else {
+            let mut value = lirLowerMirOperand(l, l.instrs, arg, paramLocal.typ, paramType)
+            if value.typ.llvm != paramType.llvm {
+                value = lirCoerceValueToType(l, value, arg.typ, paramLocal.typ, paramType, "direct call arg")
+                if value.value == "" {
+                    return out
+                }
+            }
+            out.push(lirOperand(paramType, value.value))
         }
-        out.push(lirOperand(paramType, value.value))
         i = i + 1
     }
     out
+}
+
+fn lirLowerMirAggregateArgAddress(l: LirMirFunctionLowerer, arg: MirOperand, paramTypeName: String, paramType: LirType, context: String) -> LirOperand {
+    if arg.kind == MirOpCopy || arg.kind == MirOpMove {
+        let address = lirLowerMirAggregatePlaceAddress(l, arg.place, paramTypeName, context)
+        if address.value != "" {
+            return address
+        }
+    }
+    let value = lirLowerMirOperand(l, l.instrs, arg, paramTypeName, paramType)
+    if value.value == "" {
+        return lirOperandInvalid()
+    }
+    let tmp = lirFresh(l)
+    l.instrs.push(lirAlloca(tmp, value.typ, 0))
+    l.instrs.push(lirStore(value, tmp, 0))
+    lirOperand(lirPtrType(), tmp)
+}
+fn lirLowerMirAggregatePlaceAddress(l: LirMirFunctionLowerer, place: MirPlace, rootTypeName: String, context: String) -> LirOperand {
+    let slot = lirMirLocalSlotFrom(l.slots, place.local, 0)
+    if slot.slot == "" {
+        lirLowerError(l, LirDiagInvalidInput, context + " aggregate argument local has no slot", context)
+        return lirOperandInvalid()
+    }
+    if place.projections.len() == 0 {
+        return lirOperand(lirPtrType(), slot.slot)
+    }
+    let mut currentPtr = slot.slot
+    let mut currentType = slot.typ
+    for proj in place.projections {
+        let step = lirProjectionStepFromMir(l, proj)
+        if step.kind == LirProjInvalid {
+            return lirOperandInvalid()
+        }
+        if currentType.className != LirTypeAggregate {
+            return lirOperandInvalid()
+        }
+        let nextPtr = lirFresh(l)
+        l.instrs.push(lirGep(nextPtr, currentType, currentPtr, [lirOperand(lirIntType(32), "0"), lirOperand(lirIntType(32), lirIntToString(step.index))], true))
+        currentPtr = nextPtr
+        currentType = step.typ
+    }
+    lirOperand(lirPtrType(), currentPtr)
 }
 fn lirStoreMirResult(l: LirMirFunctionLowerer, dest: MirPlace, result: LirOperand, resultTypeName: String, context: String) {
     let loc = mirFunctionLocal(l.fn_, dest.local)
@@ -6535,7 +7318,7 @@ fn lirLowerMirMapRemove(l: LirMirFunctionLowerer, instr: MirInstr) {
     if key.value == "" {
         return
     }
-    lirEmitContainerCall(l, instr, llvmMapRuntimeRemoveSymbol(recv.elemLir.llvm, recv.isString), lirVoidType(), [lirPtrType(), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, key.value)], "", "map.remove")
+    lirEmitContainerCall(l, instr, llvmMapRuntimeRemoveSymbol(recv.elemLir.llvm, recv.isString), lirIntType(1), [lirPtrType(), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, key.value)], "Bool", "map.remove")
 }
 // `Map.get(key) -> Option<V>` lowering. Production calls
 // `osty_rt_map_get_<keysuf>(map, key, out_ptr) -> i1` where the runtime
@@ -8057,6 +8840,9 @@ fn lirLowerMirListLinearScan(l: LirMirFunctionLowerer, instr: MirInstr, wantInde
 // bitcast through `bitcast double %x to i64` so the bit pattern is
 // preserved. Returns the i64 register name.
 fn lirParseResultPayloadAsI64(l: LirMirFunctionLowerer, valueReg: String, valueType: LirType) -> String {
+    if valueReg == "" || lirTypeIsVoid(valueType) {
+        return "0"
+    }
     if valueType.llvm == "i64" {
         return valueReg
     }
@@ -8243,10 +9029,15 @@ fn lirIsResultTypeName(name: String) -> Bool {
 // a valid identifier even for nested generics (`%Option.List_Int_`).
 fn lirMangleAlgebraicTypeName(name: String) -> String {
     let mut out = name
+    out = strings.replaceAll(out, "()", "Unit")
     out = strings.replaceAll(out, "<", ".")
     out = strings.replaceAll(out, ">", "")
     out = strings.replaceAll(out, ",", "_")
     out = strings.replaceAll(out, " ", "")
+    out = strings.replaceAll(out, "(", ".tuple.")
+    out = strings.replaceAll(out, ")", "")
+    out = strings.replaceAll(out, "[", ".array.")
+    out = strings.replaceAll(out, "]", "")
     out
 }
 fn lirLowerMirTerm(l: LirMirFunctionLowerer, term: MirTerm, ret: LirType) -> LirTerm {
@@ -8515,15 +9306,37 @@ fn lirLowerMirBinary(l: LirMirFunctionLowerer, rv: MirRValue, hintName: String, 
     if lirBinaryIsStringComparison(rv) {
         return lirLowerMirStringComparison(l, rv)
     }
-    let argType = if lirMirBinaryIsComparison(rv.binaryOp) {
+    let mut argType = if lirMirBinaryIsComparison(rv.binaryOp) {
         lirLowerMirType(l, rv.arg.typ)
     } else if lirTypeIsZero(hint) {
         lirLowerMirType(l, rv.arg.typ)
     } else {
         hint
     }
-    let left = lirLowerMirOperand(l, l.instrs, rv.arg, rv.arg.typ, argType)
-    let right = lirLowerMirOperand(l, l.instrs, rv.right, rv.right.typ, argType)
+    let mut left = lirLowerMirOperand(l, l.instrs, rv.arg, rv.arg.typ, argType)
+    let mut right = lirLowerMirOperand(l, l.instrs, rv.right, rv.right.typ, argType)
+    if lirTypeIsZero(argType) {
+        if !(lirTypeIsZero(left.typ)) {
+            argType = left.typ
+        } else if !(lirTypeIsZero(right.typ)) {
+            argType = right.typ
+        }
+    }
+    if left.value == "" || right.value == "" {
+        return lirOperandInvalid()
+    }
+    if left.typ.llvm != argType.llvm {
+        left = lirCoerceValueToType(l, left, rv.arg.typ, rv.arg.typ, argType, "binary left")
+        if left.value == "" {
+            return lirOperandInvalid()
+        }
+    }
+    if right.typ.llvm != argType.llvm {
+        right = lirCoerceValueToType(l, right, rv.right.typ, rv.right.typ, argType, "binary right")
+        if right.value == "" {
+            return lirOperandInvalid()
+        }
+    }
     let resType = if lirMirBinaryIsComparison(rv.binaryOp) {
         lirIntType(1)
     } else {
@@ -8875,17 +9688,21 @@ fn lirLowerMirEnumVariantAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hint
         l.instrs.push(lirInsertValue(value, aggType, step1, lirOperand(lirAggregateType(structRef), payload.value), [1]))
         return lirOperand(aggType, value)
     }
-    let payloadI64 = if rv.aggFields.len() == 0 {
-        "0"
-    } else if rv.aggFields.len() == 1 {
+    let mut payloadI64 = "0"
+    if rv.aggFields.len() == 1 {
         let arg = rv.aggFields[0]
         let argHint = lirLowerMirType(l, arg.typ)
         let value = lirLowerMirOperand(l, l.instrs, arg, arg.typ, argHint)
         if value.value == "" {
-            return lirOperandInvalid()
+            if lirTypeIsVoid(value.typ) || arg.typ == "Unit" || arg.typ == "()" {
+                payloadI64 = "0"
+            } else {
+                return lirOperandInvalid()
+            }
+        } else {
+            payloadI64 = lirParseResultPayloadAsI64(l, value.value, value.typ)
         }
-        lirParseResultPayloadAsI64(l, value.value, value.typ)
-    } else {
+    } else if rv.aggFields.len() > 1 {
         lirLowerError(l, LirDiagUnsupported, "enum variant with " + lirIntToString(rv.aggFields.len()) + " payload fields (only scalar / 0-arity supported)", "aggregate.enum")
         return lirOperandInvalid()
     }
@@ -8920,17 +9737,9 @@ fn lirLowerMirTupleAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName: 
         }
         let mut value = lirLowerMirOperand(l, l.instrs, field, fieldLayout.typ, fieldType)
         if value.typ.llvm != fieldType.llvm {
-            if value.typ.className == LirTypeUnknown {
-                value = LirOperand {typ: fieldType, value: value.value}
-            } else {
-                let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, fieldType, lirPrimitiveTypeIsUnsigned(field.typ))
-                if castOp == "" {
-                    lirLowerError(l, LirDiagUnsupported, "tuple field coercion is not supported", "aggregate.tuple")
-                    return lirOperandInvalid()
-                }
-                let castName = lirFresh(l)
-                l.instrs.push(lirCast(castName, castOp, value, fieldType))
-                value = LirOperand {typ: fieldType, value: castName}
+            value = lirCoerceValueToType(l, value, field.typ, fieldLayout.typ, fieldType, "aggregate.tuple")
+            if value.value == "" {
+                return lirOperandInvalid()
             }
         }
         let dest = lirFresh(l)
@@ -8983,17 +9792,9 @@ fn lirLowerMirStructAggregate(l: LirMirFunctionLowerer, rv: MirRValue, hintName:
         }
         let mut value = lirLowerMirOperand(l, l.instrs, field, fieldLayout.typ, fieldType)
         if value.typ.llvm != fieldType.llvm {
-            if value.typ.className == LirTypeUnknown {
-                value = LirOperand {typ: fieldType, value: value.value}
-            } else {
-                let castOp = lirPlanSameFamilyCoercionOpcode(value.typ, fieldType, lirPrimitiveTypeIsUnsigned(field.typ))
-                if castOp == "" {
-                    lirLowerError(l, LirDiagUnsupported, "struct field coercion is not supported", "aggregate.struct")
-                    return lirOperandInvalid()
-                }
-                let castName = lirFresh(l)
-                l.instrs.push(lirCast(castName, castOp, value, fieldType))
-                value = LirOperand {typ: fieldType, value: castName}
+            value = lirCoerceValueToType(l, value, field.typ, fieldLayout.typ, fieldType, "aggregate.struct")
+            if value.value == "" {
+                return lirOperandInvalid()
             }
         }
         let dest = lirFresh(l)
@@ -9029,20 +9830,28 @@ fn lirLowerMirOperand(l: LirMirFunctionLowerer, instrs: List<LirInstr>, op: MirO
                 lirLowerError(l, LirDiagUnsupported, "unsupported MIR projection `" + mirProjectionKindName(proj.kind) + "`", "projection." + mirProjectionKindName(proj.kind))
                 return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
             }
-            if step.kind == LirProjIndex && current.typ.className == LirTypePtr {
-                let mapTypeName = lirMapProjectionReceiverTypeName(l, currentTypeName)
-                if mapTypeName != "" {
-                    current = lirLowerMirMapIndexProjection(l, instrs, current, mapTypeName, proj)
-                } else {
-                    current = lirLowerMirIndexProjection(l, instrs, current, proj)
-                }
+	            if step.kind == LirProjIndex && current.typ.className == LirTypePtr {
+	                let mapTypeName = lirMapProjectionReceiverTypeName(l, currentTypeName)
+	                if mapTypeName != "" {
+	                    current = lirLowerMirMapIndexProjection(l, instrs, current, mapTypeName, proj)
+	                } else {
+	                    current = lirLowerMirIndexProjection(l, instrs, current, proj)
+	                }
                 if current.value == "" {
                     return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
                 }
-                currentTypeName = proj.typ
-                continue
-            }
-            if current.typ.className != LirTypeAggregate {
+	                currentTypeName = proj.typ
+	                continue
+	            }
+	            if step.kind == LirProjField && current.typ.className == LirTypePtr && lirIsStdOsOutputTypeName(currentTypeName) {
+	                current = lirLowerMirStdOsOutputFieldProjection(l, instrs, current, currentTypeName, proj)
+	                if current.value == "" {
+	                    return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+	                }
+	                currentTypeName = proj.typ
+	                continue
+	            }
+	            if current.typ.className != LirTypeAggregate {
                 // R3 brick 18: empty/unknown current.typ — projection
                 // skip, promote to step.typ. brick 17 패턴 (simple if
                 // + literal eq).
@@ -9087,15 +9896,35 @@ fn lirLowerMirOperand(l: LirMirFunctionLowerer, instrs: List<LirInstr>, op: MirO
                         currentTypeName = proj.typ
                         continue
                     }
-                    if step.typ.className == LirTypeInt {
-                        let castName = lirFresh(l)
-                        instrs.push(lirCast(castName, "trunc", current, step.typ))
-                        current = LirOperand {typ: step.typ, value: castName}
-                        currentTypeName = proj.typ
-                        continue
-                    }
-                    if step.typ.className == LirTypeAggregate {
-                        // i64 → Option/Result aggregate: Some/Ok wrap
+	                    if step.typ.className == LirTypeInt {
+	                        let castName = lirFresh(l)
+	                        instrs.push(lirCast(castName, "trunc", current, step.typ))
+	                        current = LirOperand {typ: step.typ, value: castName}
+	                        currentTypeName = proj.typ
+	                        continue
+	                    }
+	                    if step.kind == LirProjVariant {
+	                        if lirTypeIsVoid(step.typ) {
+	                            current = LirOperand {typ: lirIntType(64), value: current.value}
+	                            currentTypeName = proj.typ
+	                            continue
+	                        }
+	                        if step.typ.className == LirTypeUnknown || step.typ.llvm == "" {
+	                            let castName = lirFresh(l)
+	                            instrs.push(lirCast(castName, "inttoptr", current, lirPtrType()))
+	                            current = LirOperand {typ: lirPtrType(), value: castName}
+	                            currentTypeName = proj.typ
+	                            continue
+	                        }
+	                        let narrowed = lirNarrowI64ToType(l, current.value, step.typ)
+	                        if narrowed != "" {
+	                            current = LirOperand {typ: step.typ, value: narrowed}
+	                            currentTypeName = proj.typ
+	                            continue
+	                        }
+	                    }
+	                    if step.typ.className == LirTypeAggregate {
+	                        // i64 → Option/Result aggregate: Some/Ok wrap
                         // (disc=0 + i64 payload). lirEmitAlgebraicI64
                         // 의 same path — assign coercion brick 15 cover.
                         let merged = lirEmitAlgebraicI64(l, step.typ, 0, current.value, "projection.i64.wrap")
@@ -9212,20 +10041,82 @@ fn lirProjectMirOperand(l: LirMirFunctionLowerer, value: LirOperand, rootTypeNam
 			lirLowerError(l, LirDiagUnsupported, "unsupported MIR projection `" + mirProjectionKindName(proj.kind) + "`", "projection." + mirProjectionKindName(proj.kind))
 			return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
 		}
-		if step.kind == LirProjIndex && current.typ.className == LirTypePtr {
-			let mapTypeName = lirMapProjectionReceiverTypeName(l, currentTypeName)
-			if mapTypeName != "" {
-				current = lirLowerMirMapIndexProjection(l, l.instrs, current, mapTypeName, proj)
-			} else {
-				current = lirLowerMirIndexProjection(l, l.instrs, current, proj)
-			}
+			if step.kind == LirProjIndex && current.typ.className == LirTypePtr {
+				let mapTypeName = lirMapProjectionReceiverTypeName(l, currentTypeName)
+				if mapTypeName != "" {
+					current = lirLowerMirMapIndexProjection(l, l.instrs, current, mapTypeName, proj)
+				} else {
+					current = lirLowerMirIndexProjection(l, l.instrs, current, proj)
+				}
 			if current.value == "" {
 				return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
 			}
-			currentTypeName = proj.typ
-			continue
-		}
-		if current.typ.className != LirTypeAggregate {
+				currentTypeName = proj.typ
+				continue
+			}
+			if step.kind == LirProjField && current.typ.className == LirTypePtr && lirIsStdOsOutputTypeName(currentTypeName) {
+				current = lirLowerMirStdOsOutputFieldProjection(l, l.instrs, current, currentTypeName, proj)
+				if current.value == "" {
+					return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
+				}
+				currentTypeName = proj.typ
+				continue
+			}
+			if current.typ.className != LirTypeAggregate {
+			if lirStringEq(current.typ.llvm, "") {
+				current = LirOperand {typ: step.typ, value: current.value}
+				currentTypeName = proj.typ
+				continue
+			}
+			if lirStringEq(current.typ.llvm, "i64") && lirStringEq(step.typ.llvm, "i64") {
+				current = LirOperand {typ: step.typ, value: current.value}
+				currentTypeName = proj.typ
+				continue
+			}
+			if lirStringEq(current.typ.llvm, "i64") {
+				if step.typ.className == LirTypePtr {
+					let castName = lirFresh(l)
+					l.instrs.push(lirCast(castName, "inttoptr", current, step.typ))
+					current = LirOperand {typ: step.typ, value: castName}
+					currentTypeName = proj.typ
+					continue
+				}
+				if step.typ.className == LirTypeInt {
+					let castName = lirFresh(l)
+					l.instrs.push(lirCast(castName, "trunc", current, step.typ))
+					current = LirOperand {typ: step.typ, value: castName}
+					currentTypeName = proj.typ
+					continue
+				}
+				if step.kind == LirProjVariant {
+					if lirTypeIsVoid(step.typ) {
+						current = LirOperand {typ: lirIntType(64), value: current.value}
+						currentTypeName = proj.typ
+						continue
+					}
+					if step.typ.className == LirTypeUnknown || step.typ.llvm == "" {
+						let castName = lirFresh(l)
+						l.instrs.push(lirCast(castName, "inttoptr", current, lirPtrType()))
+						current = LirOperand {typ: lirPtrType(), value: castName}
+						currentTypeName = proj.typ
+						continue
+					}
+					let narrowed = lirNarrowI64ToType(l, current.value, step.typ)
+					if narrowed != "" {
+						current = LirOperand {typ: step.typ, value: narrowed}
+						currentTypeName = proj.typ
+						continue
+					}
+				}
+				if step.typ.className == LirTypeAggregate {
+					let merged = lirEmitAlgebraicI64(l, step.typ, 0, current.value, "projection.i64.wrap")
+					if !lirStringEq(merged, "undef") {
+						current = LirOperand {typ: step.typ, value: merged}
+						currentTypeName = proj.typ
+						continue
+					}
+				}
+			}
 			lirLowerError(l, LirDiagUnsupported, "projection on non-aggregate type `" + current.typ.llvm + "`", "projection." + mirProjectionKindName(proj.kind))
 			return LirOperand {typ: LirType {llvm: "", className: LirTypeUnknown}, value: ""}
         }
@@ -9236,6 +10127,69 @@ fn lirProjectMirOperand(l: LirMirFunctionLowerer, value: LirOperand, rootTypeNam
 		currentTypeName = proj.typ
 	}
 	current
+}
+
+fn lirIsStdOsOutputTypeName(name: String) -> Bool {
+    name == "Output" || name == "ExecOutput"
+}
+
+fn lirLowerMirStdOsOutputFieldProjection(l: LirMirFunctionLowerer, instrs: List<LirInstr>, value: LirOperand, typeName: String, proj: MirProjection) -> LirOperand {
+    let mut fieldIndex = proj.index
+    if proj.name != "" {
+        let namedIndex = lirStdOsOutputFieldIndex(typeName, proj.name)
+        if namedIndex >= 0 {
+            fieldIndex = namedIndex
+        }
+    }
+    let fieldType = lirStdOsOutputFieldType(typeName, fieldIndex)
+    if fieldType.llvm == "" {
+        lirLowerError(l, LirDiagUnsupported, "std.os output field `" + proj.name + "` is not implemented", "projection.field")
+        return lirOperandInvalid()
+    }
+    let boxType = if typeName == "ExecOutput" {
+        lirRawType(lirBraced("i64, ptr, ptr, i1"))
+    } else {
+        lirRawType(lirBraced("i64, ptr, ptr"))
+    }
+    let ptr = lirFresh(l)
+    instrs.push(lirGep(ptr, boxType, value.value, [lirOperand(lirIntType(32), "0"), lirOperand(lirIntType(32), lirIntToString(fieldIndex))], true))
+    let loaded = lirFresh(l)
+    let align = if fieldType.llvm == "i1" {
+        1
+    } else {
+        8
+    }
+    instrs.push(lirLoad(loaded, fieldType, ptr, align))
+    lirOperand(fieldType, loaded)
+}
+
+fn lirStdOsOutputFieldIndex(typeName: String, field: String) -> Int {
+    if field == "exitCode" {
+        return 0
+    }
+    if field == "stdout" {
+        return 1
+    }
+    if field == "stderr" {
+        return 2
+    }
+    if typeName == "ExecOutput" && field == "timedOut" {
+        return 3
+    }
+    -1
+}
+
+fn lirStdOsOutputFieldType(typeName: String, index: Int) -> LirType {
+    if index == 0 {
+        return lirIntType(64)
+    }
+    if index == 1 || index == 2 {
+        return lirPtrType()
+    }
+    if typeName == "ExecOutput" && index == 3 {
+        return lirIntType(1)
+    }
+    lirTypeInvalid()
 }
 
 fn lirMaybeNarrowAlgebraicPayload(l: LirMirFunctionLowerer, aggregateType: LirType, rawValue: String, step: LirProjectionStep) -> String {
@@ -9399,8 +10353,14 @@ fn lirRenderBareFnThunk(symbol: String, retType: LirType, paramTypes: List<LirTy
 // in which case the caller should fall back to the raw fn-pointer
 // shape and skip closure wrapping.
 fn lirEnsureBareFnThunk(l: LirMirFunctionLowerer, symbol: String) -> Bool {
-    if listContainsString(l.out.thunkSymbols, symbol) {
-        return true
+    match l.out.thunkSymbolSet.get(symbol) {
+        Some(seen) -> {
+            if seen {
+                return true
+            }
+        },
+        None -> {
+        },
     }
     let mut foundIdx = -1
     let mut i = 0
@@ -9443,11 +10403,12 @@ fn lirEnsureBareFnThunk(l: LirMirFunctionLowerer, symbol: String) -> Bool {
         if pt.className == LirTypeUnknown && pt.llvm == "" {
             return false
         }
-        paramTypes.push(pt)
+        paramTypes.push(lirMirParamAbiType(loc.typ, pt))
     }
     let rendered = lirRenderBareFnThunk(symbol, retType, paramTypes)
     l.out.renderedFunctions.push(rendered)
     l.out.thunkSymbols.push(symbol)
+    l.out.thunkSymbolSet.insert(symbol, true)
     true
 }
 
@@ -9593,17 +10554,168 @@ fn lirInterfaceConcreteName(name: String) -> String {
     }
     name
 }
+fn lirLowerMirTypeCached(l: LirMirFunctionLowerer, name: String, typ: LirType) -> LirType {
+    if name != "" {
+        l.typeCache.insert(name, typ)
+        l.out.mirTypeCache.insert(name, typ)
+    }
+    typ
+}
+fn lirLowerMirTypeCacheKey(l: LirMirFunctionLowerer, key: String, typ: LirType) {
+    if key == "" {
+        return
+    }
+    l.typeCache.insert(key, typ)
+    l.out.mirTypeCache.insert(key, typ)
+    if !(strings.startsWith(key, "%")) {
+        l.typeCache.insert("%" + key, typ)
+        l.out.mirTypeCache.insert("%" + key, typ)
+    }
+}
+fn lirLowerMirTypeCacheAliases(l: LirMirFunctionLowerer, name: String, aliasA: String, aliasB: String, typ: LirType) -> LirType {
+    lirLowerMirTypeCacheKey(l, name, typ)
+    lirLowerMirTypeCacheKey(l, aliasA, typ)
+    lirLowerMirTypeCacheKey(l, aliasB, typ)
+    typ
+}
+fn lirLowerMirTypeProgressKey(l: LirMirFunctionLowerer, key: String, active: Bool) {
+    if key == "" {
+        return
+    }
+    l.typeInProgress.insert(key, active)
+    if !(strings.startsWith(key, "%")) {
+        l.typeInProgress.insert("%" + key, active)
+    }
+}
+fn lirLowerMirTypeSetProgress(l: LirMirFunctionLowerer, name: String, aliasA: String, aliasB: String, active: Bool) {
+    lirLowerMirTypeProgressKey(l, name, active)
+    lirLowerMirTypeProgressKey(l, aliasA, active)
+    lirLowerMirTypeProgressKey(l, aliasB, active)
+}
+fn lirLowerMirTypeProgressKeyActive(l: LirMirFunctionLowerer, key: String) -> Bool {
+    if key == "" {
+        return false
+    }
+    match l.typeInProgress.get(key) {
+        Some(active) -> {
+            return active
+        },
+        None -> {
+        },
+    }
+    false
+}
+fn lirLowerMirTypeInProgress(l: LirMirFunctionLowerer, name: String, aliasA: String, aliasB: String) -> Bool {
+    if lirLowerMirTypeProgressKeyActive(l, name) {
+        return true
+    }
+    if lirLowerMirTypeProgressKeyActive(l, aliasA) {
+        return true
+    }
+    if lirLowerMirTypeProgressKeyActive(l, aliasB) {
+        return true
+    }
+    false
+}
+fn lirLowerMirInterfaceLayoutType(l: LirMirFunctionLowerer, name: String, layout: MirInterfaceLayout) -> LirType {
+    lirDeclareIfaceType(l.out)
+    lirLowerMirTypeCacheAliases(l, name, layout.name, "", LirType {llvm: lirIfaceTypeName(), className: LirTypeAggregate})
+}
+
+fn lirLowerMirStructLayoutType(l: LirMirFunctionLowerer, name: String, layout: MirStructLayout) -> LirType {
+    let typeName = "%" + if layout.mangled == "" {
+        layout.name
+    } else {
+        layout.mangled
+    }
+    let aggregateType = LirType {llvm: typeName, className: LirTypeAggregate}
+    if lirLowerMirTypeInProgress(l, name, layout.name, layout.mangled) {
+        return aggregateType
+    }
+    lirLowerMirTypeCacheAliases(l, name, layout.name, layout.mangled, aggregateType)
+    let body = lirMirStructLayoutBodyShallow(l.out, l.mirModule, layout, "layout.struct." + layout.name, l.diagnostics)
+    if body == "" {
+        return LirType {llvm: "", className: LirTypeUnknown}
+    }
+    lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, body))
+    return lirLowerMirTypeCacheAliases(l, name, layout.name, layout.mangled, aggregateType)
+}
+
+fn lirLowerMirTupleLayoutType(l: LirMirFunctionLowerer, name: String, layout: MirTupleLayout) -> LirType {
+    let typeName = "%" + if layout.mangled == "" {
+        layout.key
+    } else {
+        layout.mangled
+    }
+    let aggregateType = LirType {llvm: typeName, className: LirTypeAggregate}
+    if lirLowerMirTypeInProgress(l, name, layout.key, layout.mangled) {
+        return aggregateType
+    }
+    lirLowerMirTypeCacheAliases(l, name, layout.key, layout.mangled, aggregateType)
+    let body = lirMirTupleLayoutBodyShallow(l.out, l.mirModule, layout, "layout.tuple." + layout.key, l.diagnostics)
+    if body == "" {
+        return LirType {llvm: "", className: LirTypeUnknown}
+    }
+    lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, body))
+    return lirLowerMirTypeCacheAliases(l, name, layout.key, layout.mangled, aggregateType)
+}
+fn lirLowerMirSyntheticTupleType(l: LirMirFunctionLowerer, name: String) -> LirType {
+    let args = lirTupleTypeArgs(name)
+    if args.len() == 0 {
+        return lirLowerMirTypeCached(l, name, lirIntType(64))
+    }
+    let mut types: List<LirType> = []
+    for arg in args {
+        let typ = lirLowerMirType(l, arg)
+        if lirTypeIsZero(typ) || lirTypeIsVoid(typ) {
+            return lirLowerMirTypeCached(l, name, LirType {llvm: "", className: LirTypeUnknown})
+        }
+        types.push(typ)
+    }
+    let typeName = lirTupleTypeNameFromTypes(types)
+    lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, lirTupleTypeBody(types)))
+    lirLowerMirTypeCacheAliases(l, name, typeName, "", LirType {llvm: typeName, className: LirTypeAggregate})
+}
+
+fn lirLowerMirEnumLayoutType(l: LirMirFunctionLowerer, name: String, layout: MirEnumLayout) -> LirType {
+    if lirMirEnumIsPayloadFree(layout) {
+        return lirLowerMirTypeCacheAliases(l, name, layout.name, layout.mangled, LirType {llvm: "i64", className: LirTypeInt})
+    }
+    let typeName = "%" + if layout.mangled == "" {
+        layout.name
+    } else {
+        layout.mangled
+    }
+    lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, lirBraced("i64, i64")))
+    return lirLowerMirTypeCacheAliases(l, name, layout.name, layout.mangled, LirType {llvm: typeName, className: LirTypeAggregate})
+}
+
 fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
     let name = lirCanonicalizeOptionalSugar(rawName)
     if name.len() == 0 {
         return LirType {llvm: "", className: LirTypeUnknown}
     }
+    match l.typeCache.get(name) {
+        Some(cached) -> {
+            return cached
+        },
+        None -> {
+        },
+    }
+    match l.out.mirTypeCache.get(name) {
+        Some(cached) -> {
+            l.typeCache.insert(name, cached)
+            return cached
+        },
+        None -> {
+        },
+    }
     let primitive = lirLowerPrimitiveTypeName(name)
     if !(lirTypeIsZero(primitive)) {
-        return primitive
+        return lirLowerMirTypeCached(l, name, primitive)
     }
     if lirIsRefBuiltinTypeName(name) {
-        return LirType {llvm: "ptr", className: LirTypePtr}
+        return lirLowerMirTypeCached(l, name, LirType {llvm: "ptr", className: LirTypePtr})
     }
     // A monomorphized builtin-generic struct (`_ZTS…List…`) injected by
     // OSTY_STDLIB_BODY_LOWER is pointer-shaped exactly like the surface
@@ -9612,7 +10724,7 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
     // as a ref-builtin without needing a separate head extractor.
     let canonName = lirCanonBuiltinTypeName(l, name)
     if canonName != name && lirIsRefBuiltinTypeName(canonName) {
-        return LirType {llvm: "ptr", className: LirTypePtr}
+        return lirLowerMirTypeCached(l, name, LirType {llvm: "ptr", className: LirTypePtr})
     }
     // Closure env aggregates and `fn(...) -> ...` function-value types
     // are pointer-shaped at the LLVM ABI boundary. A lifted closure
@@ -9629,12 +10741,15 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
     // / `onb_abi` already treat with `==`. `fn(` is a structural
     // function-value spelling and is correct as a prefix match.
     if name == "ClosureEnv" || strings.startsWith(name, "fn(") {
-        return LirType {llvm: "ptr", className: LirTypePtr}
+        return lirLowerMirTypeCached(l, name, LirType {llvm: "ptr", className: LirTypePtr})
+    }
+    let ifacePos = lirMirLayoutIndexInterfacePos(l.out.layoutIndex, name)
+    if ifacePos >= 0 && ifacePos < l.mirModule.layouts.interfaces.len() {
+        return lirLowerMirInterfaceLayoutType(l, name, l.mirModule.layouts.interfaces[ifacePos])
     }
     for layout in l.mirModule.layouts.interfaces {
         if lirMirInterfaceLayoutMatches(layout, name) {
-            lirDeclareIfaceType(l.out)
-            return LirType {llvm: lirIfaceTypeName(), className: LirTypeAggregate}
+            return lirLowerMirInterfaceLayoutType(l, name, layout)
         }
     }
     if lirIsOptionTypeName(name) || lirIsResultTypeName(name) {
@@ -9647,45 +10762,28 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
         // would mint the wrong typedef for the whole module.
         let body = lirAlgebraicAggregateBody_module(l.out, l.mirModule, name)
         lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, body))
-        return LirType {llvm: typeName, className: LirTypeAggregate}
+        return lirLowerMirTypeCached(l, name, LirType {llvm: typeName, className: LirTypeAggregate})
+    }
+    let structPos = lirMirLayoutIndexStructPos(l.out.layoutIndex, name)
+    if structPos >= 0 && structPos < l.mirModule.layouts.structs.len() {
+        return lirLowerMirStructLayoutType(l, name, l.mirModule.layouts.structs[structPos])
     }
     for layout in l.mirModule.layouts.structs {
         if lirMirStructLayoutMatches(layout, name) {
-            let typeName = "%" + if layout.mangled == "" {
-                layout.name
-            } else {
-                layout.mangled
-            }
-            let mut parts: List<String> = []
-            for field in layout.fields {
-                let fieldType = lirLowerMirType(l, field.typ)
-                if lirTypeIsZero(fieldType) || lirTypeIsVoid(fieldType) {
-                    return LirType {llvm: "", className: LirTypeUnknown}
-                }
-                parts.push(lirTypeString(fieldType))
-            }
-            lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, lirBraced(strings.join(parts, ", "))))
-            return LirType {llvm: typeName, className: LirTypeAggregate}
+            return lirLowerMirStructLayoutType(l, name, layout)
         }
+    }
+    let tuplePos = lirMirLayoutIndexTuplePos(l.out.layoutIndex, name)
+    if tuplePos >= 0 && tuplePos < l.mirModule.layouts.tuples.len() {
+        return lirLowerMirTupleLayoutType(l, name, l.mirModule.layouts.tuples[tuplePos])
     }
     for layout in l.mirModule.layouts.tuples {
         if lirMirTupleLayoutMatches(layout, name) {
-            let typeName = "%" + if layout.mangled == "" {
-                layout.key
-            } else {
-                layout.mangled
-            }
-            let mut parts: List<String> = []
-            for field in layout.fields {
-                let fieldType = lirLowerMirType(l, field.typ)
-                if lirTypeIsZero(fieldType) || lirTypeIsVoid(fieldType) {
-                    return LirType {llvm: "", className: LirTypeUnknown}
-                }
-                parts.push(lirTypeString(fieldType))
-            }
-            lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, lirBraced(strings.join(parts, ", "))))
-            return LirType {llvm: typeName, className: LirTypeAggregate}
+            return lirLowerMirTupleLayoutType(l, name, layout)
         }
+    }
+    if lirIsTupleTypeName(name) {
+        return lirLowerMirSyntheticTupleType(l, name)
     }
     // Payload-free user enums lower to a bare `i64` discriminant.
     // Payload-bearing enums lower to `{ i64 disc, i64 payload }` —
@@ -9694,22 +10792,17 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
     // a known limitation tracked separately; primitive and pointer
     // payloads (Int/Bool/Char/Byte/Float64/String/List/etc.) round-trip
     // correctly.
+    let enumPos = lirMirLayoutIndexEnumPos(l.out.layoutIndex, name)
+    if enumPos >= 0 && enumPos < l.mirModule.layouts.enums.len() {
+        return lirLowerMirEnumLayoutType(l, name, l.mirModule.layouts.enums[enumPos])
+    }
     for layout in l.mirModule.layouts.enums {
         if lirMirEnumLayoutMatches(layout, name) {
-            if lirMirEnumIsPayloadFree(layout) {
-                return LirType {llvm: "i64", className: LirTypeInt}
-            }
-            let typeName = "%" + if layout.mangled == "" {
-                layout.name
-            } else {
-                layout.mangled
-            }
-            lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, lirBraced("i64, i64")))
-            return LirType {llvm: typeName, className: LirTypeAggregate}
+            return lirLowerMirEnumLayoutType(l, name, layout)
         }
     }
     if strings.contains(name, "(") {
-        return LirType {llvm: name, className: LirTypeFunction}
+        return lirLowerMirTypeCached(l, name, LirType {llvm: name, className: LirTypeFunction})
     }
     // Cross-package nominal type fallback. A reference to a type
     // declared in another package (e.g. `Error` from `std.error`
@@ -9742,9 +10835,9 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, rawName: String) -> LirType {
     // silently becoming `ptr`. Names containing a `.` are also
     // accepted — fully qualified cross-pkg refs like `osty.Error`.
     if lirIsLikelyCrossPkgNominalName(name) {
-        return LirType {llvm: "ptr", className: LirTypePtr}
+        return lirLowerMirTypeCached(l, name, LirType {llvm: "ptr", className: LirTypePtr})
     }
-    LirType {llvm: "", className: LirTypeUnknown}
+    lirLowerMirTypeCached(l, name, LirType {llvm: "", className: LirTypeUnknown})
 }
 // lirIsLikelyCrossPkgNominalName: heuristic for "this looks like a
 // nominal type name from another package we couldn't find a layout
@@ -9799,6 +10892,10 @@ fn lirIsLikelyCrossPkgNominalName(name: String) -> Bool {
 // monomorphizer keeps the printed type name intact so we just sniff
 // the canonical prefix instead of dragging the full Osty type AST in.
 fn lirFindMirStructLayout(l: LirMirFunctionLowerer, name: String) -> MirStructLayout {
+    let structPos = lirMirLayoutIndexStructPos(l.out.layoutIndex, name)
+    if structPos >= 0 && structPos < l.mirModule.layouts.structs.len() {
+        return l.mirModule.layouts.structs[structPos]
+    }
     for layout in l.mirModule.layouts.structs {
         if lirMirStructLayoutMatches(layout, name) {
             return layout
@@ -9809,23 +10906,71 @@ fn lirFindMirStructLayout(l: LirMirFunctionLowerer, name: String) -> MirStructLa
     MirStructLayout {name: "", mangled: "", fields, size: 0, align: 0, builtinSource: "", builtinSourceArgs: bsArgs}
 }
 fn lirFindMirTupleLayout(l: LirMirFunctionLowerer, name: String) -> MirTupleLayout {
+    let tuplePos = lirMirLayoutIndexTuplePos(l.out.layoutIndex, name)
+    if tuplePos >= 0 && tuplePos < l.mirModule.layouts.tuples.len() {
+        return l.mirModule.layouts.tuples[tuplePos]
+    }
     for layout in l.mirModule.layouts.tuples {
         if lirMirTupleLayoutMatches(layout, name) {
             return layout
         }
     }
+    if lirIsTupleTypeName(name) {
+        return lirSyntheticTupleLayout(name)
+    }
     let fields: List<MirFieldLayout> = []
     MirTupleLayout {key: "", mangled: "", fields}
+}
+fn lirSyntheticTupleLayout(name: String) -> MirTupleLayout {
+    let args = lirTupleTypeArgs(name)
+    let mut fields: List<MirFieldLayout> = []
+    let mut i = 0
+    for arg in args {
+        fields.push(MirFieldLayout {index: i, name: lirIntToString(i), typ: arg})
+        i = i + 1
+    }
+    MirTupleLayout {key: name, mangled: "", fields}
+}
+fn lirMirQualifiedSuffixMatches(candidate: String, name: String) -> Bool {
+    if candidate == "" || name == "" {
+        return false
+    }
+    if candidate.len() <= name.len() {
+        return false
+    }
+    if !strings.endsWith(candidate, name) {
+        return false
+    }
+    let dotIndex = candidate.len() - name.len() - 1
+    strings.slice(candidate, dotIndex, dotIndex + 1) == "."
+}
+fn lirMirGenericPrefixMatches(candidate: String, name: String) -> Bool {
+    if candidate == "" {
+        return false
+    }
+    if name.len() <= candidate.len() + 1 {
+        return false
+    }
+    if strings.slice(name, 0, candidate.len()) != candidate {
+        return false
+    }
+    strings.slice(name, candidate.len(), candidate.len() + 1) == "<"
+}
+fn lirMirPercentNameMatches(candidate: String, name: String) -> Bool {
+    if candidate == "" || !strings.startsWith(name, "%") {
+        return false
+    }
+    strings.trimPrefix(name, "%") == candidate
 }
 fn lirMirStructLayoutMatches(layout: MirStructLayout, name: String) -> Bool {
     if layout.name == name || layout.mangled == name {
         return true
     }
-    if layout.name != "" && "%" + layout.name == name {
-        return true
-    }
-    if layout.mangled != "" && "%" + layout.mangled == name {
-        return true
+    if strings.startsWith(name, "%") {
+        let bareName = strings.trimPrefix(name, "%")
+        if layout.name == bareName || layout.mangled == bareName {
+            return true
+        }
     }
     // Cross-pkg suffix match: an injected stdlib body references a
     // local struct by its BARE name (`BasicError`) but the layout was
@@ -9834,11 +10979,10 @@ fn lirMirStructLayoutMatches(layout: MirStructLayout, name: String) -> Bool {
     // misses the layout in lirLowerMirType → falls through to the
     // PR #2004 opaque-ptr fallback → constructor emits insertvalue
     // on a `ptr` which LLVM rejects as not aggregate-typed.
-    let suffix = "." + name
-    if layout.name != "" && strings.endsWith(layout.name, suffix) {
+    if lirMirQualifiedSuffixMatches(layout.name, name) {
         return true
     }
-    if layout.mangled != "" && strings.endsWith(layout.mangled, suffix) {
+    if lirMirQualifiedSuffixMatches(layout.mangled, name) {
         return true
     }
     false
@@ -9853,16 +10997,16 @@ fn lirMirEnumLayoutMatches(layout: MirEnumLayout, name: String) -> Bool {
     if layout.name == name || layout.mangled == name {
         return true
     }
-    if layout.name != "" && "%" + layout.name == name {
+    if strings.startsWith(name, "%") {
+        let bareName = strings.trimPrefix(name, "%")
+        if layout.name == bareName || layout.mangled == bareName {
+            return true
+        }
+    }
+    if lirMirGenericPrefixMatches(layout.name, name) {
         return true
     }
-    if layout.mangled != "" && "%" + layout.mangled == name {
-        return true
-    }
-    if layout.name != "" && strings.startsWith(name, layout.name + "<") {
-        return true
-    }
-    if layout.mangled != "" && strings.startsWith(name, layout.mangled + "<") {
+    if lirMirGenericPrefixMatches(layout.mangled, name) {
         return true
     }
     false
@@ -9885,10 +11029,10 @@ fn lirMirTupleLayoutMatches(layout: MirTupleLayout, name: String) -> Bool {
     if layout.key == name || layout.mangled == name {
         return true
     }
-    if layout.key != "" && "%" + layout.key == name {
+    if lirMirPercentNameMatches(layout.key, name) {
         return true
     }
-    if layout.mangled != "" && "%" + layout.mangled == name {
+    if lirMirPercentNameMatches(layout.mangled, name) {
         return true
     }
     false
@@ -9897,7 +11041,7 @@ fn lirMirInterfaceLayoutMatches(layout: MirInterfaceLayout, name: String) -> Boo
     if layout.name == name {
         return true
     }
-    if layout.name != "" && "%" + layout.name == name {
+    if lirMirPercentNameMatches(layout.name, name) {
         return true
     }
     false
@@ -10085,6 +11229,9 @@ fn lirMirCompareOpcode(op: String, isFloat: Bool, unsigned: Bool) -> String {
 fn lirZeroValue(typ: LirType) -> String {
     if typ.llvm == "ptr" {
         return "null"
+    }
+    if typ.className == LirTypeAggregate {
+        return "zeroinitializer"
     }
     if typ.className == LirTypeFloat {
         return "0.0"

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -6339,14 +6339,16 @@ fn lirLowerMirStringConcat(l: LirMirFunctionLowerer, instr: MirInstr) {
 // Mirror that here so LIR Proto and the production MIR generator agree
 // on which `osty_rt_<container>_<op>_<lane>` to call.
 fn lirContainerInnerArg(typeName: String, prefix: String) -> String {
-    if !(strings.startsWith(typeName, prefix)) {
+    if prefix.len() == 0 || typeName.len() <= prefix.len() {
         return ""
     }
-    if !(strings.endsWith(typeName, ">")) {
+    if strings.slice(typeName, 0, prefix.len()) != prefix {
         return ""
     }
-    let inner = strings.trimPrefix(typeName, prefix)
-    strings.trimSuffix(inner, ">")
+    if strings.slice(typeName, typeName.len() - 1, typeName.len()) != ">" {
+        return ""
+    }
+    strings.slice(typeName, prefix.len(), typeName.len() - 1)
 }
 struct LirMangledLengthParse {
     text: String,
@@ -6646,13 +6648,13 @@ fn lirMapValueTypeName(l: LirMirFunctionLowerer, typeName: String) -> String {
 fn lirFirstTopLevelComma(s: String) -> Int {
     let mut depth = 0
     let mut i = 0
-    let chars = strings.chars(s)
-    for ch in chars {
-        if ch == '<' {
+    for i < s.len() {
+        let ch = strings.slice(s, i, i + 1)
+        if ch == "<" {
             depth = depth + 1
-        } else if ch == '>' {
+        } else if ch == ">" {
             depth = depth - 1
-        } else if ch == ',' && depth == 0 {
+        } else if ch == "," && depth == 0 {
             return i
         }
         i = i + 1

--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -21,8 +21,15 @@ fn forwardedArgsFrom(encoded: String, rawArgs: List<String>) -> List<String> {
     }
     out
 }
+fn selfRebuildRawSubcommand(rawArgs: List<String>, name: String) -> Bool {
+    rawArgs.len() > 1 && rawArgs[1] == name
+}
 fn forwardedArgs() -> List<String> {
-    forwardedArgsFrom(env.get("OSTY_SELF_REBUILD_FORWARD_ARGS") ?? "", env.args())
+    let rawArgs = env.args()
+    if selfRebuildRawSubcommand(rawArgs, "--selfhost-doctor") || selfRebuildRawSubcommand(rawArgs, "compile") || selfRebuildRawSubcommand(rawArgs, "lir-proto-lower") || selfRebuildRawSubcommand(rawArgs, "lir-proto-lower-mir-json") {
+        return forwardedArgsFrom("", rawArgs)
+    }
+    forwardedArgsFrom(env.get("OSTY_SELF_REBUILD_FORWARD_ARGS") ?? "", rawArgs)
 }
 fn hasSelfhostCommand(args: List<String>, name: String) -> Bool {
     args.len() > 0 && args[0] == name
@@ -80,9 +87,21 @@ fn selfRebuildWriteString(path: String, contents: String) -> String {
     match fs.writeString(path, contents) {
         Ok(_) -> "",
         Err(_) -> {
-            "write failed: " + path
+            selfRebuildWriteStringViaShell(path, contents)
         },
     }
+}
+fn selfRebuildWriteStringViaShell(path: String, contents: String) -> String {
+    let out = match os.execWith("/bin/sh", ["-c", "cat > \"$1\"", "osty-self-write", path], contents, selfRebuildChildEnv(), 0) {
+        Ok(o) -> o,
+        Err(_) -> {
+            return "write failed: " + path
+        },
+    }
+    if out.timedOut || out.exitCode != 0 {
+        return selfRebuildCommandError("write", "cat > " + path, out.stdout, out.stderr)
+    }
+    ""
 }
 fn selfRebuildToolchainSourcePaths(toolchainDir: String) -> Result<List<String>, String> {
     let entries = match fs.walk(toolchainDir) {
@@ -214,10 +233,7 @@ fn selfRebuildHostIsDarwin() -> Bool {
     }
 }
 fn selfRebuildHostIsWindows() -> Bool {
-    match os.execWith("cmd", ["/C", "ver"], "", {:}, 0) {
-        Ok(_) -> true,
-        Err(_) -> false,
-    }
+    false
 }
 fn selfRebuildIsWindowsTarget(target: String) -> Bool {
     if target == "" {
@@ -284,12 +300,17 @@ fn selfRebuildRunClang(action: String, args: List<String>) -> String {
     let msg = strings.trimSpace(out.stderr + "\n" + out.stdout)
     "clang " + action + " failed\ncommand: clang " + strings.join(args, " ") + "\n" + msg
 }
+fn selfRebuildChildEnv() -> Map<String, String> {
+    let mut childEnv: Map<String, String> = {:}
+    childEnv.insert("OSTY_SELF_REBUILD_FORWARD_ARGS", "")
+    childEnv
+}
 fn selfRebuildRunSelfLower(exe: String, bundlePath: String, target: String) -> String {
     let mut args: List<String> = ["lir-proto-lower", bundlePath, "--package-name=main"]
     if target != "" {
         args.push("--target=" + target)
     }
-    let out = match os.execWith(exe, args, "", {:}, 0) {
+    let out = match os.execWith(exe, args, "", selfRebuildChildEnv(), 0) {
         Ok(o) -> o,
         Err(_) -> {
             eprint("osty-self rebuild: self LIR Proto lower failed to start\n")
@@ -300,6 +321,12 @@ fn selfRebuildRunSelfLower(exe: String, bundlePath: String, target: String) -> S
         return out.stdout
     }
     eprint("osty-self rebuild: self LIR Proto lower failed\n")
+    let timedOutText = if out.timedOut {
+        "true"
+    } else {
+        "false"
+    }
+    eprint("exitCode=" + lirIntToString(out.exitCode) + " timedOut=" + timedOutText + "\n")
     eprint(strings.trimSpace(out.stderr + "\n" + out.stdout) + "\n")
     ""
 }
@@ -375,7 +402,16 @@ fn runSelfRebuild(args: List<String>) -> Int {
     0
 }
 fn selfhostProbeSource() -> String {
-    "fn main() -> Int \{\n    let x = 41\n    return x + 1\n\}\n"
+    r"""
+fn add(a: Int, b: Int) -> Int {
+    return a + b
+}
+
+fn main() -> Int {
+    let x = 41
+    return add(x, 1)
+}
+"""
 }
 fn selfhostProbeError() -> String {
     let source = selfhostProbeSource()
@@ -415,7 +451,7 @@ fn selfhostDoctorProbeError(exe: String) -> String {
 	if writeErr != "" {
         return "write probe failed: " + writeErr
     }
-    let out = match os.execWith(exe, ["lir-proto-lower", probePath, "--package-name=main"], "", {:}, 0) {
+    let out = match os.execWith(exe, ["lir-proto-lower", probePath, "--package-name=main"], "", selfRebuildChildEnv(), 0) {
         Ok(o) -> o,
             Err(_) -> {
                 return "lir-proto-lower probe failed to start"
@@ -521,53 +557,12 @@ fn runSelfhostDoctor() -> Int {
 		eprint("osty-self self-rebuild probe failed: executable not found\n")
 		return 2
     }
-    let probePath = selfRebuildTempPath("osty-self-doctor-probe.osty")
-    let mut probeError = ""
-    let writeErr = selfRebuildWriteString(probePath, selfhostProbeSource())
-    if writeErr != "" {
-        probeError = "write probe failed: " + writeErr
-    } else {
-        let out = match os.execWith(exe, ["lir-proto-lower", probePath, "--package-name=main"], "", {:}, 0) {
-            Ok(o) -> o,
-            Err(_) -> {
-                probeError = "lir-proto-lower probe failed to start"
-                os.execOutput(1, "", "", false)
-            },
-        }
-        if probeError == "" {
-            if out.exitCode != 0 || out.timedOut {
-                let msg = strings.trimSpace(out.stderr + "\n" + out.stdout)
-                if msg == "" {
-                    probeError = "lir-proto-lower probe failed"
-                } else {
-                    probeError = msg
-                }
-            } else if out.stdout == "" {
-                probeError = "LLVM IR renderer returned empty output"
-            } else if !strings.contains(out.stdout, "define") {
-                probeError = "LLVM IR renderer produced no function definition"
-            } else if !strings.contains(out.stdout, "ret ") {
-                probeError = "LLVM IR renderer produced no return instruction"
-            } else if strings.contains(out.stdout, "body omitted") || strings.contains(out.stdout, "function bodies stubbed") {
-                probeError = "LLVM IR renderer still reports stubbed function bodies"
-            }
-        }
-	}
+    let probeError = selfhostProbeError()
 	println("osty-self mode: self-rebuild")
 	println("osty-self host compiler: disabled")
 	if probeError != "" {
 		println("osty-self source compiler: disabled")
-		let mirProbeError = selfhostMirProbeError()
-		if mirProbeError == "" {
-			println("osty-self MIR JSON backend: enabled")
-			println("osty-self pipeline: MIR JSON -> LIR Proto -> LLVM IR")
-			println("osty-self self-rebuild probe: OK")
-			println("osty-self self-rebuild driver: MIR JSON backend -> clang object/runtime link")
-			return 0
-		}
-		println("osty-self MIR JSON backend: disabled")
 		eprint("osty-self self-rebuild probe failed: " + probeError + "\n")
-		eprint("osty-self MIR JSON probe failed: " + mirProbeError + "\n")
 		return 1
 	}
 	println("osty-self source compiler: enabled")
@@ -575,6 +570,9 @@ fn runSelfhostDoctor() -> Int {
     println("osty-self self-rebuild probe: OK")
     println("osty-self self-rebuild driver: source bundle -> clang object/runtime link")
     0
+}
+fn selfhostLowerSource(packageName: String, source: String) -> HirModule {
+    hirLowerSource(packageName, source)
 }
 /// runCompile is the self-host pipeline entry used by the rebuild
 /// scripts: read a source file, run the toolchain pipeline (HIR → MIR),
@@ -595,7 +593,7 @@ fn runCompile(args: List<String>) -> Int {
             return 2
         },
     }
-    let hir = hirLowerSource("main", source)
+    let hir = selfhostLowerSource("main", source)
     let mir = mirLowerModule(hir)
     let checkedMir = mirModuleWithPackageName("main", mir)
     let mirErrs = mirValidateModule(checkedMir)
@@ -659,7 +657,7 @@ fn runLirProtoLower(args: List<String>) -> Int {
             return 2
         },
     }
-    let hir = hirLowerSource(packageName, source)
+    let hir = selfhostLowerSource(packageName, source)
     let mir = mirLowerModule(hir)
     let checkedMir = mirModuleWithPackageName(packageName, mir)
     let mirErrs = mirValidateModule(checkedMir)

--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -905,25 +905,87 @@ pub fn mirFunctionTerminate(func: MirFunction, blockId: Int, term: MirTerm) {
     if blockId < 0 || blockId >= func.blocks.len() {
         return
     }
-    mirBlockSetTerminator(func.blocks[blockId], term)
+    func.blocks[blockId].term.kind = term.kind
+    func.blocks[blockId].term.span = term.span
+    func.blocks[blockId].term.target = term.target
+    func.blocks[blockId].term.thenBlock = term.thenBlock
+    func.blocks[blockId].term.elseBlock = term.elseBlock
+    func.blocks[blockId].term.cases = term.cases
+    func.blocks[blockId].term.cond = term.cond
+    func.blocks[blockId].term.loopBackEdge = term.loopBackEdge
+    func.blocks[blockId].termKind = term.kind
+    func.blocks[blockId].termTarget = term.target
+    func.blocks[blockId].termThenBlock = term.thenBlock
+    func.blocks[blockId].termElseBlock = term.elseBlock
+    func.blocks[blockId].termCases = term.cases
+    func.blocks[blockId].termCond = term.cond
+    func.blocks[blockId].termLoopBackEdge = term.loopBackEdge
+    func.blocks[blockId].hasTerm = true
 }
 pub fn mirFunctionTerminateGoto(func: MirFunction, blockId: Int, target: Int, span: MirSpan, loopBackEdge: Bool) {
     if blockId < 0 || blockId >= func.blocks.len() {
         return
     }
-    mirBlockSetGotoTerminator(func.blocks[blockId], target, span, loopBackEdge)
+    let cases: List<MirSwitchCase> = []
+    func.blocks[blockId].term.kind = MirTermGoto
+    func.blocks[blockId].term.span = span
+    func.blocks[blockId].term.target = target
+    func.blocks[blockId].term.thenBlock = -1
+    func.blocks[blockId].term.elseBlock = -1
+    func.blocks[blockId].term.cases = cases
+    func.blocks[blockId].term.cond = mirOperandInvalid()
+    func.blocks[blockId].term.loopBackEdge = loopBackEdge
+    func.blocks[blockId].termKind = MirTermGoto
+    func.blocks[blockId].termTarget = target
+    func.blocks[blockId].termThenBlock = -1
+    func.blocks[blockId].termElseBlock = -1
+    func.blocks[blockId].termCases = cases
+    func.blocks[blockId].termCond = mirOperandInvalid()
+    func.blocks[blockId].termLoopBackEdge = loopBackEdge
+    func.blocks[blockId].hasTerm = true
 }
 pub fn mirFunctionTerminateBranch(func: MirFunction, blockId: Int, cond: MirOperand, thenB: Int, elseB: Int, span: MirSpan) {
     if blockId < 0 || blockId >= func.blocks.len() {
         return
     }
-    mirBlockSetBranchTerminator(func.blocks[blockId], cond, thenB, elseB, span)
+    let cases: List<MirSwitchCase> = []
+    func.blocks[blockId].term.kind = MirTermBranch
+    func.blocks[blockId].term.span = span
+    func.blocks[blockId].term.target = -1
+    func.blocks[blockId].term.thenBlock = thenB
+    func.blocks[blockId].term.elseBlock = elseB
+    func.blocks[blockId].term.cases = cases
+    func.blocks[blockId].term.cond = cond
+    func.blocks[blockId].term.loopBackEdge = false
+    func.blocks[blockId].termKind = MirTermBranch
+    func.blocks[blockId].termTarget = -1
+    func.blocks[blockId].termThenBlock = thenB
+    func.blocks[blockId].termElseBlock = elseB
+    func.blocks[blockId].termCases = cases
+    func.blocks[blockId].termCond = cond
+    func.blocks[blockId].termLoopBackEdge = false
+    func.blocks[blockId].hasTerm = true
 }
 pub fn mirFunctionTerminateSwitchInt(func: MirFunction, blockId: Int, scrutinee: MirOperand, cases: List<MirSwitchCase>, default: Int, span: MirSpan) {
     if blockId < 0 || blockId >= func.blocks.len() {
         return
     }
-    mirBlockSetSwitchIntTerminator(func.blocks[blockId], scrutinee, cases, default, span)
+    func.blocks[blockId].term.kind = MirTermSwitchInt
+    func.blocks[blockId].term.span = span
+    func.blocks[blockId].term.target = default
+    func.blocks[blockId].term.thenBlock = -1
+    func.blocks[blockId].term.elseBlock = -1
+    func.blocks[blockId].term.cases = cases
+    func.blocks[blockId].term.cond = scrutinee
+    func.blocks[blockId].term.loopBackEdge = false
+    func.blocks[blockId].termKind = MirTermSwitchInt
+    func.blocks[blockId].termTarget = default
+    func.blocks[blockId].termThenBlock = -1
+    func.blocks[blockId].termElseBlock = -1
+    func.blocks[blockId].termCases = cases
+    func.blocks[blockId].termCond = scrutinee
+    func.blocks[blockId].termLoopBackEdge = false
+    func.blocks[blockId].hasTerm = true
 }
 pub fn mirFunctionLocal(func: MirFunction, id: Int) -> MirLocal {
     if id < 0 || id >= func.locals.len() {

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -61,6 +61,15 @@ pub fn mirLowerFnSignature(name: String, params: List<HirParam>, retType: HirTyp
 pub fn mirLowerMethodSignature(owner: String, name: String, params: List<HirParam>, retType: HirType, span: HirSpan) -> MirLowerFnSignature {
     MirLowerFnSignature {name, owner, symbol: mangleMethodSymbol(owner, name), params, retType, isMethod: true, span}
 }
+fn mirLowerMethodParamsWithSelf(owner: String, decl: HirFnDecl) -> List<HirParam> {
+    let selfParam = hirParam("self", hirTypeNamed(owner, []), decl.span)
+    let mut out: List<HirParam> = []
+    out.push(selfParam)
+    for p in decl.params {
+        out.push(p)
+    }
+    out
+}
 /// mangleMethodSymbol is the MIR symbol mangling for methods. Must
 /// stay in sync with Go's `mangleMethodSymbol` (`Type__method`); the
 /// LLVM emitter and this lowerer both depend on the exact string
@@ -116,17 +125,23 @@ pub struct MirLowerer {
     pub out: MirModule,
     pub fnSigs: List<MirLowerFnSignature>,
     pub fnSigNames: List<String>,
+    pub fnSigIndex: Map<String, Int>,
     pub methodSigs: List<MirLowerFnSignature>,
     pub methodSigKeys: List<String>,
+    pub methodSigIndex: Map<String, Int>,
     pub structs: List<HirStructDecl>,
     pub structNames: List<String>,
+    pub structIndex: Map<String, Int>,
     pub enums: List<HirEnumDecl>,
     pub enumNames: List<String>,
+    pub enumIndex: Map<String, Int>,
     pub interfaces: List<HirInterfaceDecl>,
     pub globals: List<HirLetDecl>,
     pub globalNames: List<String>,
+    pub globalIndex: Map<String, Int>,
     pub useAliases: List<HirUseDecl>,
     pub useAliasKeys: List<String>,
+    pub useAliasIndex: Map<String, Int>,
     pub issues: List<String>,
     pub closureSeq: Int,
 }
@@ -139,7 +154,13 @@ pub fn mirLowerer(src: HirModule) -> MirLowerer {
     for msg in src.issues {
         issues.push(msg)
     }
-    MirLowerer {src, out: mirModule(src.packageName), fnSigs: [], fnSigNames: [], methodSigs: [], methodSigKeys: [], structs: [], structNames: [], enums: [], enumNames: [], interfaces: [], globals: [], globalNames: [], useAliases: [], useAliasKeys: [], issues, closureSeq: 0}
+    let fnSigIndex: Map<String, Int> = {:}
+    let methodSigIndex: Map<String, Int> = {:}
+    let structIndex: Map<String, Int> = {:}
+    let enumIndex: Map<String, Int> = {:}
+    let globalIndex: Map<String, Int> = {:}
+    let useAliasIndex: Map<String, Int> = {:}
+    MirLowerer {src, out: mirModule(src.packageName), fnSigs: [], fnSigNames: [], fnSigIndex, methodSigs: [], methodSigKeys: [], methodSigIndex, structs: [], structNames: [], structIndex, enums: [], enumNames: [], enumIndex, interfaces: [], globals: [], globalNames: [], globalIndex, useAliases: [], useAliasKeys: [], useAliasIndex, issues, closureSeq: 0}
 }
 /// mirLowerNoteIssue records incomplete MIR coverage. Issues are surfaced
 /// to callers through `MirModule.Issues` after `run()`.
@@ -150,6 +171,13 @@ pub fn mirLowerNoteIssue(l: MirLowerer, msg: String) {
 /// mirLowerSignatureForFn returns the signature index for the named
 /// free fn or -1 when unknown.
 pub fn mirLowerSignatureForFn(l: MirLowerer, name: String) -> Int {
+    match l.fnSigIndex.get(name) {
+        Some(idx) -> {
+            return idx
+        },
+        None -> {
+        },
+    }
     let mut i = 0
     for n in l.fnSigNames {
         if n == name {
@@ -163,6 +191,13 @@ pub fn mirLowerSignatureForFn(l: MirLowerer, name: String) -> Int {
 /// named method on `typeName`, or -1 when unknown.
 pub fn mirLowerSignatureForMethod(l: MirLowerer, typeName: String, method: String) -> Int {
     let key = methodKey(typeName, method)
+    match l.methodSigIndex.get(key) {
+        Some(idx) -> {
+            return idx
+        },
+        None -> {
+        },
+    }
     let mut i = 0
     for k in l.methodSigKeys {
         if k == key {
@@ -174,6 +209,13 @@ pub fn mirLowerSignatureForMethod(l: MirLowerer, typeName: String, method: Strin
 }
 /// mirLowerLookupStruct returns the struct decl index or -1.
 pub fn mirLowerLookupStruct(l: MirLowerer, name: String) -> Int {
+    match l.structIndex.get(name) {
+        Some(idx) -> {
+            return idx
+        },
+        None -> {
+        },
+    }
     let mut i = 0
     for n in l.structNames {
         if n == name {
@@ -185,6 +227,13 @@ pub fn mirLowerLookupStruct(l: MirLowerer, name: String) -> Int {
 }
 /// mirLowerLookupEnum returns the enum decl index or -1.
 pub fn mirLowerLookupEnum(l: MirLowerer, name: String) -> Int {
+    match l.enumIndex.get(name) {
+        Some(idx) -> {
+            return idx
+        },
+        None -> {
+        },
+    }
     let mut i = 0
     for n in l.enumNames {
         if n == name {
@@ -196,6 +245,13 @@ pub fn mirLowerLookupEnum(l: MirLowerer, name: String) -> Int {
 }
 /// mirLowerLookupGlobal returns the global let decl index or -1.
 pub fn mirLowerLookupGlobal(l: MirLowerer, name: String) -> Int {
+    match l.globalIndex.get(name) {
+        Some(idx) -> {
+            return idx
+        },
+        None -> {
+        },
+    }
     let mut i = 0
     for n in l.globalNames {
         if n == name {
@@ -207,6 +263,13 @@ pub fn mirLowerLookupGlobal(l: MirLowerer, name: String) -> Int {
 }
 /// mirLowerLookupUseAlias returns the use decl index by alias or -1.
 pub fn mirLowerLookupUseAlias(l: MirLowerer, alias: String) -> Int {
+    match l.useAliasIndex.get(alias) {
+        Some(idx) -> {
+            return idx
+        },
+        None -> {
+        },
+    }
     let mut i = 0
     for k in l.useAliasKeys {
         if k == alias {
@@ -253,20 +316,27 @@ pub fn mirLowerCollectSignatures(l: MirLowerer) {
             mirLowerNoteIssue(l, "generic free fn \"" + decl.name + "\" reached MIR (monomorphize first)")
         } else {
             let sig = mirLowerFnSignature(decl.name, decl.params, decl.ret, decl.span)
+            let idx = l.fnSigs.len()
             l.fnSigs.push(sig)
             l.fnSigNames.push(decl.name)
+            l.fnSigIndex.insert(decl.name, idx)
         }
     }
     for s in l.src.structs {
         if s.generics.len() > 0 {
             mirLowerNoteIssue(l, "generic struct \"" + s.name + "\" reached MIR (monomorphize first)")
         } else {
+            let structIdx = l.structs.len()
             l.structs.push(s)
             l.structNames.push(s.name)
+            l.structIndex.insert(s.name, structIdx)
             for m in s.methods {
-                let sig = mirLowerMethodSignature(s.name, m.name, m.params, m.ret, m.span)
+                let sig = mirLowerMethodSignature(s.name, m.name, mirLowerMethodParamsWithSelf(s.name, m), m.ret, m.span)
+                let methodIdx = l.methodSigs.len()
                 l.methodSigs.push(sig)
-                l.methodSigKeys.push(methodKey(s.name, m.name))
+                let key = methodKey(s.name, m.name)
+                l.methodSigKeys.push(key)
+                l.methodSigIndex.insert(key, methodIdx)
             }
         }
     }
@@ -274,12 +344,17 @@ pub fn mirLowerCollectSignatures(l: MirLowerer) {
         if e.generics.len() > 0 {
             mirLowerNoteIssue(l, "generic enum \"" + e.name + "\" reached MIR (monomorphize first)")
         } else {
+            let enumIdx = l.enums.len()
             l.enums.push(e)
             l.enumNames.push(e.name)
+            l.enumIndex.insert(e.name, enumIdx)
             for m in e.methods {
-                let sig = mirLowerMethodSignature(e.name, m.name, m.params, m.ret, m.span)
+                let sig = mirLowerMethodSignature(e.name, m.name, mirLowerMethodParamsWithSelf(e.name, m), m.ret, m.span)
+                let methodIdx = l.methodSigs.len()
                 l.methodSigs.push(sig)
-                l.methodSigKeys.push(methodKey(e.name, m.name))
+                let key = methodKey(e.name, m.name)
+                l.methodSigKeys.push(key)
+                l.methodSigIndex.insert(key, methodIdx)
             }
         }
     }
@@ -289,13 +364,17 @@ pub fn mirLowerCollectSignatures(l: MirLowerer) {
         }
     }
     for g in l.src.lets {
+        let globalIdx = l.globals.len()
         l.globals.push(g)
         l.globalNames.push(g.name)
+        l.globalIndex.insert(g.name, globalIdx)
     }
     for u in l.src.uses {
         if u.alias != "" {
+            let aliasIdx = l.useAliases.len()
             l.useAliases.push(u)
             l.useAliasKeys.push(u.alias)
+            l.useAliasIndex.insert(u.alias, aliasIdx)
         }
         mirLowerEmitUse(l, u)
     }
@@ -614,7 +693,7 @@ pub fn mirLowerFunction(l: MirLowerer, decl: HirFnDecl, owner: String, asMethod:
         return out
     }
     mirLowerSeedFunction(out, params, retT, span)
-    mirLowerFunctionBody(l, out, decl, retT, asMethod, span)
+    mirLowerFunctionBody(l, out, decl, retT, owner, asMethod, span)
     out
 }
 // Synthesise a self parameter at position 0 so downstream
@@ -634,11 +713,16 @@ pub fn mirLowerFunction(l: MirLowerer, decl: HirFnDecl, owner: String, asMethod:
 /// fns) or Unreachable (non-unit fns whose body fell through — the
 /// checker already forbids this so the terminator is defensive
 /// poison).
-pub fn mirLowerFunctionBody(l: MirLowerer, out: MirFunction, decl: HirFnDecl, retT: HirType, asMethod: Bool, span: MirSpan) {
+pub fn mirLowerFunctionBody(l: MirLowerer, out: MirFunction, decl: HirFnDecl, retT: HirType, owner: String, asMethod: Bool, span: MirSpan) {
     let bs = mirLowerBodyState(l, out, retT)
     let mut params = decl.params
     if asMethod {
-        let selfParam = hirParam("self", hirTypeNamed(mirLowerSelfOwnerName(decl), []), decl.span)
+        let selfOwner = if owner != "" {
+            owner
+        } else {
+            mirLowerSelfOwnerName(decl)
+        }
+        let selfParam = hirParam("self", hirTypeNamed(selfOwner, []), decl.span)
         let mut withSelf: List<HirParam> = []
         withSelf.push(selfParam)
         for p in decl.params {
@@ -651,7 +735,7 @@ pub fn mirLowerFunctionBody(l: MirLowerer, out: MirFunction, decl: HirFnDecl, re
     }
     if asMethod && bs.paramLocals.len() > 0 {
         bs.self.hasOwner = true
-        bs.self.typeName = mirLowerSelfOwnerName(decl)
+        bs.self.typeName = owner
         bs.self.localId = bs.paramLocals[0]
     }
     for s in decl.body.stmts {
@@ -1191,6 +1275,14 @@ pub fn mirLowerLookupName(bs: MirLowerBodyState, name: String) -> Int {
         }
         i = i - 1
     }
+    let mut localIdx = bs.fn_.locals.len() - 1
+    for localIdx >= 0 {
+        let loc = bs.fn_.locals[localIdx]
+        if loc.name == name {
+            return loc.id
+        }
+        localIdx = localIdx - 1
+    }
     -1
 }
 /// mirLowerRegisterScopeLocal marks `id` as owned by the top scope
@@ -1586,7 +1678,19 @@ fn mirLowerIdentRecoveredType(bs: MirLowerBodyState, e: HirExpr) -> HirType {
         }
         i = i + 1
     }
-    hirTypeInvalid()
+    mirLowerRecoveredLocalType(bs, id)
+}
+fn mirLowerRecoveredLocalType(bs: MirLowerBodyState, id: Int) -> HirType {
+    if id < 0 || id >= bs.fn_.locals.len() {
+        return hirTypeInvalid()
+    }
+    let typ = bs.fn_.locals[id].typ
+    if typ == "" || typ == "<nil>" || typ == "<error>" {
+        return hirTypeInvalid()
+    }
+    let arena = emptyTyArena()
+    let parsed = tyFromString(arena, typ)
+    hirLowerTyToHirType(arena, parsed)
 }
 fn mirLowerFieldExprRecoveredType(bs: MirLowerBodyState, e: HirExpr) -> HirType {
     if e.fieldTarget.len() == 0 {
@@ -1853,16 +1957,31 @@ fn mirLowerIdentOperand(bs: MirLowerBodyState, e: HirExpr) -> MirOperand {
         }
         return mirOperandCopy(mirPlace(localId), localTypeText)
     }
-    match e.identKind {
-        HirIdentLocal -> mirLowerIdentLocalOperand(bs, e, typeText),
-        HirIdentParam -> mirLowerIdentLocalOperand(bs, e, typeText),
-        HirIdentFn -> mirOperandConst(mirConstFn(e.identName, hirTypeString(mirLowerFnValueType(bs.l, e.identName, e.typ)))),
-        HirIdentGlobal -> mirLowerIdentGlobalOperand(bs, e, typeText),
-        HirIdentVariant -> mirLowerIdentVariantOperand(bs, e),
-        HirIdentTypeName -> mirLowerIdentUnsupported(bs, e, "type-name"),
-        HirIdentBuiltin -> mirLowerIdentUnsupported(bs, e, "builtin"),
-        HirIdentUnknown -> mirLowerIdentUnsupported(bs, e, "unresolved"),
+    if mirLowerEnumForVariant(bs.l, e.identName) != "" {
+        return mirLowerIdentVariantOperand(bs, e)
     }
+    if e.identKind == HirIdentLocal {
+        return mirLowerIdentLocalOperand(bs, e, typeText)
+    }
+    if e.identKind == HirIdentParam {
+        return mirLowerIdentLocalOperand(bs, e, typeText)
+    }
+    if e.identKind == HirIdentFn {
+        return mirOperandConst(mirConstFn(e.identName, hirTypeString(mirLowerFnValueType(bs.l, e.identName, e.typ))))
+    }
+    if e.identKind == HirIdentGlobal {
+        return mirLowerIdentGlobalOperand(bs, e, typeText)
+    }
+    if e.identKind == HirIdentVariant {
+        return mirLowerIdentVariantOperand(bs, e)
+    }
+    if e.identKind == HirIdentTypeName {
+        return mirLowerIdentUnsupported(bs, e, "type-name")
+    }
+    if e.identKind == HirIdentBuiltin {
+        return mirLowerIdentUnsupported(bs, e, "builtin")
+    }
+    mirLowerIdentUnsupported(bs, e, "unresolved")
 }
 fn mirLowerFnValueType(l: MirLowerer, name: String, annotated: HirType) -> HirType {
     let sigIdx = mirLowerSignatureForFn(l, name)
@@ -1988,22 +2107,60 @@ fn mirLowerIndexExprOperand(bs: MirLowerBodyState, e: HirExpr) -> MirOperand {
 /// appropriate handler. The match is exhaustive (G17): every
 /// `HirStmtKind` lands on a handler.
 pub fn mirLowerStmt(bs: MirLowerBodyState, s: HirStmt) {
-    match s.kind {
-        HirStmtInvalid -> {
-        },
-        HirStmtBlock -> mirLowerBlockStmt(bs, s.block),
-        HirStmtLet -> mirLowerLetStmt(bs, s),
-        HirStmtExpr -> mirLowerExprStmtInner(bs, s),
-        HirStmtReturn -> mirLowerReturnStmt(bs, s),
-        HirStmtBreak -> mirLowerBreakStmt(bs, s),
-        HirStmtContinue -> mirLowerContinueStmt(bs, s),
-        HirStmtDefer -> mirLowerAddDefer(bs, s.deferBody),
-        HirStmtError -> mirLowerNoteIssue(bs.l, "mir_lower: error stmt reached MIR: " + s.errorNote),
-        HirStmtAssign -> mirLowerAssignStmt(bs, s),
-        HirStmtIf -> mirLowerIfStmt(bs, s),
-        HirStmtFor -> mirLowerForStmt(bs, s),
-        HirStmtMatch -> mirLowerMatchStmt(bs, s),
-        HirStmtChanSend -> mirLowerChanSendStmt(bs, s),
+    if s.kind == HirStmtInvalid {
+        return
+    }
+    if s.kind == HirStmtBlock {
+        mirLowerBlockStmt(bs, s.block)
+        return
+    }
+    if s.kind == HirStmtLet {
+        mirLowerLetStmt(bs, s)
+        return
+    }
+    if s.kind == HirStmtExpr {
+        mirLowerExprStmtInner(bs, s)
+        return
+    }
+    if s.kind == HirStmtReturn {
+        mirLowerReturnStmt(bs, s)
+        return
+    }
+    if s.kind == HirStmtBreak {
+        mirLowerBreakStmt(bs, s)
+        return
+    }
+    if s.kind == HirStmtContinue {
+        mirLowerContinueStmt(bs, s)
+        return
+    }
+    if s.kind == HirStmtDefer {
+        mirLowerAddDefer(bs, s.deferBody)
+        return
+    }
+    if s.kind == HirStmtError {
+        mirLowerNoteIssue(bs.l, "mir_lower: error stmt reached MIR: " + s.errorNote)
+        return
+    }
+    if s.kind == HirStmtAssign {
+        mirLowerAssignStmt(bs, s)
+        return
+    }
+    if s.kind == HirStmtIf {
+        mirLowerIfStmt(bs, s)
+        return
+    }
+    if s.kind == HirStmtFor {
+        mirLowerForStmt(bs, s)
+        return
+    }
+    if s.kind == HirStmtMatch {
+        mirLowerMatchStmt(bs, s)
+        return
+    }
+    if s.kind == HirStmtChanSend {
+        mirLowerChanSendStmt(bs, s)
+        return
     }
 }
 /// mirLowerBlockStmt lowers a block used in statement position
@@ -2175,30 +2332,13 @@ fn mirLowerIdentPlace(bs: MirLowerBodyState, e: HirExpr) -> MirPlace {
     if localId >= 0 {
         return mirPlace(localId)
     }
-    match e.identKind {
-        HirIdentLocal -> {
-            let id = mirLowerLookupName(bs, e.identName)
-            if id < 0 {
-                return mirPlace(-1)
-            }
-            mirPlace(id)
-        },
-        HirIdentParam -> {
-            let id = mirLowerLookupName(bs, e.identName)
-            if id < 0 {
-                return mirPlace(-1)
-            }
-            mirPlace(id)
-        },
-        HirIdentUnknown -> {
-            let id = mirLowerLookupName(bs, e.identName)
-            if id < 0 {
-                return mirPlace(-1)
-            }
-            mirPlace(id)
-        },
-        _ -> mirPlace(-1),
+    if e.identKind == HirIdentLocal || e.identKind == HirIdentParam || e.identKind == HirIdentUnknown {
+        let id = mirLowerLookupName(bs, e.identName)
+        if id >= 0 {
+            return mirPlace(id)
+        }
     }
+    mirPlace(-1)
 }
 /// mirLowerFieldExprPlace lowers `x.name` into a MirPlace:
 /// receiver-as-place + FieldProj. Optional chains (`x?.name`) cannot
@@ -2720,24 +2860,40 @@ fn mirLowerForBodyWithFramesStep(bs: MirLowerBodyState, body: HirBlock, stepBloc
 /// intentionally diagnosed rather than treated as a runtime test;
 /// decision-tree lowering owns those tests.
 fn mirLowerBindPattern(bs: MirLowerBodyState, pat: HirPattern, scrutinee: MirPlace, scrutT: HirType, span: MirSpan) {
-    match pat.kind {
-        HirPatInvalid -> {
-        },
-        HirPatWild -> {
-        },
-        HirPatIdent -> mirLowerBindPatternName(bs, pat.identName, pat.identMut, scrutinee, scrutT, span),
-        HirPatBinding -> {
-            mirLowerBindPatternName(bs, pat.bindingName, false, scrutinee, scrutT, span)
-            if pat.bindingChild.len() > 0 {
-                mirLowerBindPattern(bs, pat.bindingChild[0], scrutinee, scrutT, span)
-            }
-        },
-        HirPatTuple -> mirLowerBindTuplePattern(bs, pat, scrutinee, scrutT, span),
-        HirPatStruct -> mirLowerBindStructPattern(bs, pat, scrutinee, scrutT, span),
-        HirPatVariant -> mirLowerBindVariantPattern(bs, pat, scrutinee, scrutT, span),
-        HirPatError -> mirLowerNoteIssue(bs.l, "mir_lower: error pattern reached MIR: " + pat.errorNote),
-        _ -> mirLowerNoteIssue(bs.l, "mir_lower: refutable pattern kind " + hirPatternKindName(pat.kind) + " cannot bind without a decision tree"),
+    if pat.kind == HirPatInvalid {
+        return
     }
+    if pat.kind == HirPatWild {
+        return
+    }
+    if pat.kind == HirPatIdent {
+        mirLowerBindPatternName(bs, pat.identName, pat.identMut, scrutinee, scrutT, span)
+        return
+    }
+    if pat.kind == HirPatBinding {
+        mirLowerBindPatternName(bs, pat.bindingName, false, scrutinee, scrutT, span)
+        if pat.bindingChild.len() > 0 {
+            mirLowerBindPattern(bs, pat.bindingChild[0], scrutinee, scrutT, span)
+        }
+        return
+    }
+    if pat.kind == HirPatTuple {
+        mirLowerBindTuplePattern(bs, pat, scrutinee, scrutT, span)
+        return
+    }
+    if pat.kind == HirPatStruct {
+        mirLowerBindStructPattern(bs, pat, scrutinee, scrutT, span)
+        return
+    }
+    if pat.kind == HirPatVariant {
+        mirLowerBindVariantPattern(bs, pat, scrutinee, scrutT, span)
+        return
+    }
+    if pat.kind == HirPatError {
+        mirLowerNoteIssue(bs.l, "mir_lower: error pattern reached MIR: " + pat.errorNote)
+        return
+    }
+    mirLowerNoteIssue(bs.l, "mir_lower: refutable pattern kind " + hirPatternKindName(pat.kind) + " cannot bind without a decision tree")
 }
 fn mirLowerBindPatternName(bs: MirLowerBodyState, name: String, mutable: Bool, scrutinee: MirPlace, scrutT: HirType, span: MirSpan) {
     if name == "" {
@@ -2947,29 +3103,73 @@ fn mirLowerExprIntoPlaceImpl(bs: MirLowerBodyState, e: HirExpr, dest: MirPlace, 
     if !hirExprIsValid(e) {
         return
     }
-    match e.kind {
-        HirExprIf -> mirLowerIfExprInto(bs, e, dest, destT),
-        HirExprBlock -> mirLowerBlockExprInto(bs, e, dest, destT),
-        HirExprCoalesce -> mirLowerCoalesceExprInto(bs, e, dest, destT),
-        HirExprCall -> mirLowerCallExprInto(bs, e, dest, destT),
-        HirExprIntrinsic -> mirLowerIntrinsicCallInto(bs, e, dest, destT),
-        HirExprStructLit -> mirLowerStructLitInto(bs, e, dest, destT),
-        HirExprVariantLit -> mirLowerVariantLitInto(bs, e, dest, destT),
-        HirExprRange -> mirLowerRangeLitInto(bs, e, dest, destT),
-        HirExprQuestion -> mirLowerQuestionInto(bs, e, dest, destT),
-        HirExprIfLet -> mirLowerIfLetExprInto(bs, e, dest, destT),
-        HirExprMethod -> mirLowerMethodCallInto(bs, e, dest, destT),
-        HirExprMapLit -> mirLowerMapLitInto(bs, e, dest, destT),
-        HirExprMatch -> mirLowerMatchExprInto(bs, e, dest, destT),
-        HirExprField -> {
-            if e.fieldOptional {
-                mirLowerOptionalFieldInto(bs, e, dest, destT)
-            } else {
-                mirLowerExprIntoPlaceRValue(bs, e, dest, destT)
-            }
-        },
-        _ -> mirLowerExprIntoPlaceRValue(bs, e, dest, destT),
+    if e.kind == HirExprIf {
+        mirLowerIfExprInto(bs, e, dest, destT)
+        return
     }
+    if e.kind == HirExprBlock {
+        mirLowerBlockExprInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprCoalesce {
+        mirLowerCoalesceExprInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprCall {
+        mirLowerCallExprInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprIntrinsic {
+        mirLowerIntrinsicCallInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprStructLit {
+        mirLowerStructLitInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprVariantLit {
+        mirLowerVariantLitInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprRange {
+        mirLowerRangeLitInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprQuestion {
+        mirLowerQuestionInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprIfLet {
+        mirLowerIfLetExprInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprMethod {
+        mirLowerMethodCallInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprMapLit {
+        mirLowerMapLitInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprMatch {
+        mirLowerMatchExprInto(bs, e, dest, destT)
+        return
+    }
+    if e.kind == HirExprBinary {
+        if !(mirLowerBoolShortCircuitInto(bs, e, dest, destT)) {
+            mirLowerExprIntoPlaceRValue(bs, e, dest, destT)
+        }
+        return
+    }
+    if e.kind == HirExprField {
+        if e.fieldOptional {
+            mirLowerOptionalFieldInto(bs, e, dest, destT)
+        } else {
+            mirLowerExprIntoPlaceRValue(bs, e, dest, destT)
+        }
+        return
+    }
+    mirLowerExprIntoPlaceRValue(bs, e, dest, destT)
 }
 // Match drives the decision-tree walker further down the file.
 /// mirLowerExprIntoPlaceRValue is the default path: lower `e` to an
@@ -2979,6 +3179,43 @@ fn mirLowerExprIntoPlaceImpl(bs: MirLowerBodyState, e: HirExpr, dest: MirPlace, 
 fn mirLowerExprIntoPlaceRValue(bs: MirLowerBodyState, e: HirExpr, dest: MirPlace, destT: HirType) {
     let rv = mirLowerExprToRValue(bs, e, destT)
     mirLowerEmitInstr(bs, mirAssignInstr(dest, rv, mirSpanFromHir(e.span)))
+}
+fn mirLowerBoolShortCircuitInto(bs: MirLowerBodyState, e: HirExpr, dest: MirPlace, destT: HirType) -> Bool {
+    let _ = destT
+    if e.binaryOp != HirBinAnd && e.binaryOp != HirBinOr {
+        return false
+    }
+    if e.binaryLeft.len() == 0 || e.binaryRight.len() == 0 {
+        return false
+    }
+    let span = mirSpanFromHir(e.span)
+    let left = mirLowerExprAsOperand(bs, e.binaryLeft[0])
+    let rightBB = mirLowerNewBlock(bs, span)
+    let constBB = mirLowerNewBlock(bs, span)
+    let mergeBB = mirLowerNewBlock(bs, span)
+    if e.binaryOp == HirBinAnd {
+        mirLowerTerminateBranch(bs, left, rightBB, constBB, span)
+        bs.cur = constBB
+        mirLowerAssignBoolConst(bs, dest, false, span)
+        mirLowerTerminateGoto(bs, mergeBB, span)
+        bs.cur = rightBB
+        mirLowerExprIntoPlaceImpl(bs, e.binaryRight[0], dest, hirTBool())
+        mirLowerTerminateGoto(bs, mergeBB, span)
+        bs.cur = mergeBB
+        return true
+    }
+    mirLowerTerminateBranch(bs, left, constBB, rightBB, span)
+    bs.cur = constBB
+    mirLowerAssignBoolConst(bs, dest, true, span)
+    mirLowerTerminateGoto(bs, mergeBB, span)
+    bs.cur = rightBB
+    mirLowerExprIntoPlaceImpl(bs, e.binaryRight[0], dest, hirTBool())
+    mirLowerTerminateGoto(bs, mergeBB, span)
+    bs.cur = mergeBB
+    true
+}
+fn mirLowerAssignBoolConst(bs: MirLowerBodyState, dest: MirPlace, value: Bool, span: MirSpan) {
+    mirLowerEmitInstr(bs, mirAssignInstr(dest, mirRVUse(mirOperandConst(mirConstBool(value))), span))
 }
 // ====================================================================
 // Expression → RValue dispatcher (Stage 4d)

--- a/toolchain/monomorph_pass.osty
+++ b/toolchain/monomorph_pass.osty
@@ -159,24 +159,34 @@ pub fn hirBuildSubstEnv(params: List<HirTypeParam>, args: List<HirType>) -> HirS
 ///
 /// `HirType` is a flat struct with payload fields for every variant
 /// (see `hir.osty:377`). The `kind` discriminator tells us which
-/// fields are semantically live, but because unused fields always hold
-/// empty lists / empty strings, we can clone all of them
-/// unconditionally without dragging invalid payloads along.
+/// fields are semantically live, so this clones only the payloads that
+/// can be observed for the active variant. Dead payload lists are
+/// carried over as-is; they are never inspected or mutated through the
+/// clone contract, and preserving them avoids manufacturing four empty
+/// list payloads for every primitive/var/error type.
 pub fn hirCloneType(t: HirType) -> HirType {
-    let mut out = hirTypeInvalid()
-    out.kind = t.kind
-    out.primKind = t.primKind
-    out.namedPkg = t.namedPkg
-    out.namedName = t.namedName
-    out.namedArgs = hirCloneTypeList(t.namedArgs)
-    out.namedBuiltin = t.namedBuiltin
-    out.optionalInner = hirCloneTypeList(t.optionalInner)
-    out.tupleElems = hirCloneTypeList(t.tupleElems)
-    out.fnParams = hirCloneTypeList(t.fnParams)
-    out.fnReturn = hirCloneTypeList(t.fnReturn)
-    out.varName = t.varName
-    out.varOwner = t.varOwner
-    out
+    if t.kind == HirTypeNamed {
+        let mut out = t
+        out.namedArgs = hirCloneTypeList(t.namedArgs)
+        return out
+    }
+    if t.kind == HirTypeOptional {
+        let mut out = t
+        out.optionalInner = hirCloneTypeList(t.optionalInner)
+        return out
+    }
+    if t.kind == HirTypeTuple {
+        let mut out = t
+        out.tupleElems = hirCloneTypeList(t.tupleElems)
+        return out
+    }
+    if t.kind == HirTypeFn {
+        let mut out = t
+        out.fnParams = hirCloneTypeList(t.fnParams)
+        out.fnReturn = hirCloneTypeList(t.fnReturn)
+        return out
+    }
+    t
 }
 /// hirCloneTypeList applies hirCloneType to each element. Kept
 /// separate so List-valued payloads can share the recursion without
@@ -224,28 +234,29 @@ pub fn hirSubstType(t: HirType, env: HirSubstEnv) -> HirType {
         return hirCloneType(t)
     }
     if t.kind == HirTypeVar {
-        if hirSubstEnvHas(env, t.varName) {
-            return hirSubstEnvLookup(env, t.varName)
+        let idx = hirSubstEnvIndex(env, t.varName)
+        if idx >= 0 {
+            return hirCloneType(env.types[idx])
         }
         return hirCloneType(t)
     }
     if t.kind == HirTypeNamed {
-        let mut out = hirCloneType(t)
+        let mut out = t
         out.namedArgs = hirSubstTypeList(t.namedArgs, env)
         return out
     }
     if t.kind == HirTypeOptional {
-        let mut out = hirCloneType(t)
+        let mut out = t
         out.optionalInner = hirSubstTypeList(t.optionalInner, env)
         return out
     }
     if t.kind == HirTypeTuple {
-        let mut out = hirCloneType(t)
+        let mut out = t
         out.tupleElems = hirSubstTypeList(t.tupleElems, env)
         return out
     }
     if t.kind == HirTypeFn {
-        let mut out = hirCloneType(t)
+        let mut out = t
         out.fnParams = hirSubstTypeList(t.fnParams, env)
         out.fnReturn = hirSubstTypeList(t.fnReturn, env)
         return out

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -280,6 +280,27 @@ fn opPeekPastNewlines(p: OstyParser) -> FrontToken {
 fn opAt(p: OstyParser, kind: FrontTokenKind) -> Bool {
     opPeek(p).kind == kind
 }
+fn opTokenText(p: OstyParser, tok: FrontToken) -> String {
+    if tok.text != "" {
+        return tok.text
+    }
+    if p.interpSource == "" {
+        return ""
+    }
+    if tok.startOffset < 0 || tok.endOffset <= tok.startOffset {
+        return ""
+    }
+    if tok.endOffset > p.interpSource.len() {
+        return ""
+    }
+    strings.slice(p.interpSource, tok.startOffset, tok.endOffset)
+}
+fn opPeekText(p: OstyParser) -> String {
+    opTokenText(p, opPeek(p))
+}
+fn opPeekAtText(p: OstyParser, n: Int) -> String {
+    opTokenText(p, opPeekAt(p, n))
+}
 fn opIsStableAlias(tok: FrontToken, text: String) -> Bool {
     tok.kind == FrontIdent && tok.text == text
 }
@@ -603,7 +624,7 @@ fn opParseGenericParams(p: OstyParser) -> List<Int> {
     if opEat(p, FrontLt) {
         for !(opAt(p, FrontGt)) && !(opAt(p, FrontEOF)) {
             let start = p.pos
-            let gName = opExpect(p, FrontIdent).text
+            let gName = opTokenText(p, opExpect(p, FrontIdent))
             let mut bounds: List<Int> = []
             if opEat(p, FrontColon) {
                 bounds.push(opParseType(p))
@@ -671,7 +692,7 @@ fn opParseExprBP(p: OstyParser, minBP: Int) -> Int {
                 if op.kind == FrontDotDotEq {
                     rangeFlags = 1
                 }
-                if opAt(p, FrontIdent) && opPeek(p).text == "by" {
+                if opAt(p, FrontIdent) && opPeekText(p) == "by" {
                     let _ = opAdvance(p)
                     let stepIdx = opParseExprBP(p, rbp)
                     stepChildren.push(stepIdx)
@@ -824,7 +845,8 @@ fn opParsePrimary(p: OstyParser) -> Int {
         return opAddNode(p, n)
     }
     if tok.kind == FrontIdent {
-        if tok.text == "loop" && opPeekAt(p, 1).kind == FrontLBrace {
+        let identText = opTokenText(p, tok)
+        if identText == "loop" && opPeekAt(p, 1).kind == FrontLBrace {
             opAdvance(p)
             let prevInLoop = p.inLoop
             p.inLoop = true
@@ -839,10 +861,10 @@ fn opParsePrimary(p: OstyParser) -> Int {
             return opAddNode(p, n)
         }
         opAdvance(p)
-        if tok.text == "true" || tok.text == "false" {
+        if identText == "true" || identText == "false" {
             let mut n = emptyAstNode(AstNBoolLit)
-            n.text = tok.text
-            if tok.text == "true" {
+            n.text = identText
+            if identText == "true" {
                 n.flags = 1
             }
             n.start = start
@@ -850,7 +872,7 @@ fn opParsePrimary(p: OstyParser) -> Int {
             return opAddNode(p, n)
         }
         let mut n = emptyAstNode(AstNIdent)
-        n.text = tok.text
+        n.text = identText
         n.start = start
         n.end = p.pos
         return opAddNode(p, n)
@@ -1472,11 +1494,11 @@ fn opParseClosure(p: OstyParser) -> Int {
         if opAt(p, FrontLParen) || opAt(p, FrontUnderscore) {
             paramNode.left = opParsePatternOneAlt(p)
         } else if opAt(p, FrontIdent) {
-            let name = opPeek(p).text
+            let name = opPeekText(p)
             if astIsUpperName(name) && (opPeekAt(p, 1).kind == FrontLParen || opPeekAt(p, 1).kind == FrontLBrace) {
                 paramNode.left = opParsePatternOneAlt(p)
             } else {
-                paramNode.text = opAdvance(p).text
+                paramNode.text = opTokenText(p, opAdvance(p))
             }
         } else {
             opErrorFull(p, "expected closure parameter", "use an identifier, `_`, or a destructuring pattern like `(a, b)` or `User \{ name \}`", "", "E0205")
@@ -1589,7 +1611,7 @@ fn opTryParsePostfix(p: OstyParser, lhs: Int) -> Int {
     if tok.kind == FrontDot {
         let s = p.pos
         let _ = opAdvance(p)
-        let nm = opAdvance(p).text
+        let nm = opTokenText(p, opAdvance(p))
         let mut n = emptyAstNode(AstNField)
         n.left = lhs
         n.text = nm
@@ -1600,7 +1622,7 @@ fn opTryParsePostfix(p: OstyParser, lhs: Int) -> Int {
     if tok.kind == FrontQDot {
         let s = p.pos
         let _ = opAdvance(p)
-        let nm = opAdvance(p).text
+        let nm = opTokenText(p, opAdvance(p))
         let mut n = emptyAstNode(AstNField)
         n.left = lhs
         n.text = nm
@@ -1633,7 +1655,7 @@ fn opTryParsePostfix(p: OstyParser, lhs: Int) -> Int {
     if tok.kind == FrontAsQuestion {
         return opParseAsQuestion(p, lhs)
     }
-    if tok.kind == FrontIdent && tok.text == "as" && opPeekAt(p, 1).kind == FrontQuestion {
+    if tok.kind == FrontIdent && opTokenText(p, tok) == "as" && opPeekAt(p, 1).kind == FrontQuestion {
         opErrorFull(p, "`as?` must be written without whitespace between `as` and `?`", "write `as?` as a single token (no space)", "OSTY_GRAMMAR_v0.5 §28", "E0202")
         let _ = opAdvance(p)
         let _ = opAdvance(p)
@@ -1681,7 +1703,7 @@ fn opParseCallArgs(p: OstyParser, callee: Int) -> Int {
     for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) {
         if opAt(p, FrontIdent) && opPeekAt(p, 1).kind == FrontColon {
             let fs = p.pos
-            let key = opAdvance(p).text
+            let key = opTokenText(p, opAdvance(p))
             let _ = opAdvance(p)
             let mut n = emptyAstNode(AstNField_)
             n.text = key
@@ -1813,7 +1835,7 @@ fn opParseStructUpdateShorthand(p: OstyParser, recv: Int) -> Int {
             break
         }
         let fs = p.pos
-        let fn_ = opAdvance(p).text
+        let fn_ = opTokenText(p, opAdvance(p))
         let mut valIdx = 0 - 1
         if opEat(p, FrontColon) {
             valIdx = opParseExpr(p)
@@ -1863,7 +1885,7 @@ fn opParseStructLit(p: OstyParser, name: Int) -> Int {
             continue
         }
         let fs = p.pos
-        let fn_ = opAdvance(p).text
+        let fn_ = opTokenText(p, opAdvance(p))
         let mut valIdx = -1
         if opEat(p, FrontColon) {
             valIdx = opParseExpr(p)
@@ -1901,7 +1923,7 @@ fn opParseLabelNode(p: OstyParser) -> Int {
     let start = p.pos
     let tok = opExpect(p, FrontLabel)
     let mut n = emptyAstNode(AstNIdent)
-    n.text = strings.trimPrefix(tok.text, "'")
+    n.text = strings.trimPrefix(opTokenText(p, tok), "'")
     n.start = start
     n.end = p.pos
     opAddNode(p, n)
@@ -2136,9 +2158,9 @@ fn opParseForStmt(p: OstyParser, labelIdx: Int) -> Int {
         p.noStructLit = true
         condIdx = opParseExpr(p)
         p.noStructLit = pv
-    } else if opAt(p, FrontIdent) && astIsUpperName(opPeek(p).text) && (opPeekAt(p, 1).kind == FrontLParen || opPeekAt(p, 1).kind == FrontLBrace) {
+    } else if opAt(p, FrontIdent) && astIsUpperName(opPeekText(p)) && (opPeekAt(p, 1).kind == FrontLParen || opPeekAt(p, 1).kind == FrontLBrace) {
         patIdx = opParsePatternOneAlt(p)
-        if opAt(p, FrontIdent) && opPeek(p).text == "in" {
+        if opAt(p, FrontIdent) && opPeekText(p) == "in" {
             let _ = opAdvance(p)
             kind = "forin"
             let pv = p.noStructLit
@@ -2155,7 +2177,7 @@ fn opParseForStmt(p: OstyParser, labelIdx: Int) -> Int {
         p.noStructLit = true
         let expr = opParseExpr(p)
         p.noStructLit = pv
-        if opAt(p, FrontIdent) && opPeek(p).text == "in" {
+        if opAt(p, FrontIdent) && opPeekText(p) == "in" {
             let _ = opAdvance(p)
             kind = "forin"
             patIdx = opExprToForPattern(p, expr)
@@ -2299,12 +2321,12 @@ fn opParsePatternOneAlt(p: OstyParser) -> Int {
         return opAddNode(p, n)
     }
     if tok.kind == FrontIdent {
-        let head = tok.text
+        let head = opTokenText(p, tok)
         let mut path: List<String> = [head]
         opAdvance(p)
         for opAt(p, FrontDot) && opPeekAt(p, 1).kind == FrontIdent {
             opAdvance(p)
-            path.push(opAdvance(p).text)
+            path.push(opTokenText(p, opAdvance(p)))
         }
         let name = strings.join(path, ".")
         if path.len() == 1 && (head == "true" || head == "false") {
@@ -2348,7 +2370,7 @@ fn opParsePatternOneAlt(p: OstyParser) -> Int {
                 }
                 if opAt(p, FrontIdent) {
                     let fs = p.pos
-                    let fn_ = opAdvance(p).text
+                    let fn_ = opTokenText(p, opAdvance(p))
                     let mut fNode = emptyAstNode(AstNPattern)
                     fNode.extra = astPatternFieldKind()
                     fNode.text = fn_
@@ -2450,11 +2472,11 @@ fn opParseTypeAtom(p: OstyParser) -> Int {
     }
     if tok.kind == FrontIdent {
         let start = p.pos
-        let mut name = tok.text
+        let mut name = opTokenText(p, tok)
         opAdvance(p)
         for opAt(p, FrontDot) && opPeekAt(p, 1).kind == FrontIdent {
             opAdvance(p)
-            name = "{name}.{opPeek(p).text}"
+            name = "{name}.{opPeekText(p)}"
             opAdvance(p)
         }
         let mut typeArgs: List<Int> = []
@@ -2516,7 +2538,7 @@ fn opParseFnType(p: OstyParser) -> Int {
     for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) {
         if opAt(p, FrontIdent) && opPeekAt(p, 1).kind == FrontColon {
             let fs = p.pos
-            let name = opAdvance(p).text
+            let name = opTokenText(p, opAdvance(p))
             let _ = opAdvance(p)
             let mut n = emptyAstNode(AstNField_)
             n.text = name
@@ -2573,7 +2595,7 @@ fn opParseAnnotations(p: OstyParser) -> List<Int> {
         let _ = opAdvance(p)
         let mut annName = ""
         if opAt(p, FrontIdent) {
-            annName = opAdvance(p).text
+            annName = opTokenText(p, opAdvance(p))
         }
         let mut annArgs: List<Int> = []
         if opEat(p, FrontLParen) {
@@ -2652,7 +2674,7 @@ fn opParseAnnotationArg(p: OstyParser) -> Int {
 fn opAnnotationArgName(p: OstyParser) -> String {
     let tok = opPeek(p)
     if tok.kind == FrontIdent {
-        return tok.text
+        return opTokenText(p, tok)
     }
     if tok.kind == FrontFn || tok.kind == FrontStruct || tok.kind == FrontEnum || tok.kind == FrontInterface || tok.kind == FrontType {
         return frontTokenKindName(tok.kind)
@@ -2759,7 +2781,7 @@ fn opParseFnDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
     let start = p.pos
     opRecordStableAlias(p, opPeek(p))
     opAdvance(p)
-    let name = opExpect(p, FrontIdent).text
+    let name = opTokenText(p, opExpect(p, FrontIdent))
     let genericParams = opParseGenericParams(p)
     opExpect(p, FrontLParen)
     let mut params: List<Int> = []
@@ -2770,10 +2792,10 @@ fn opParseFnDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
             opAdvance(p)
             paramNode.flags = 1
         }
-        if opAt(p, FrontIdent) && opPeek(p).text == "self" {
-            paramNode.text = opAdvance(p).text
+        if opAt(p, FrontIdent) && opPeekText(p) == "self" {
+            paramNode.text = opTokenText(p, opAdvance(p))
         } else {
-            paramNode.text = opExpect(p, FrontIdent).text
+            paramNode.text = opTokenText(p, opExpect(p, FrontIdent))
             if opEat(p, FrontColon) {
                 paramNode.right = opParseType(p)
             }
@@ -2816,7 +2838,7 @@ fn opParseFnDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
 fn opParseStructDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
     let start = p.pos
     let _ = opAdvance(p)
-    let name = opExpect(p, FrontIdent).text
+    let name = opTokenText(p, opExpect(p, FrontIdent))
     let genericParams = opParseGenericParams(p)
     let _ = opExpect(p, FrontLBrace)
     let mut members: List<Int> = []
@@ -2831,7 +2853,7 @@ fn opParseStructDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
             members.push(opParseFnDecl(p, memberPub, memberAnns))
         } else if opAt(p, FrontIdent) || opAt(p, FrontType) {
             let fs = p.pos
-            let fn_ = opAdvance(p).text
+            let fn_ = opTokenText(p, opAdvance(p))
             let _ = opExpect(p, FrontColon)
             let ft = opParseType(p)
             let mut defIdx = -1
@@ -2874,7 +2896,7 @@ fn opParseStructDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
 fn opParseEnumDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
     let start = p.pos
     let _ = opAdvance(p)
-    let name = opExpect(p, FrontIdent).text
+    let name = opTokenText(p, opExpect(p, FrontIdent))
     let genericParams = opParseGenericParams(p)
     let _ = opExpect(p, FrontLBrace)
     let mut members: List<Int> = []
@@ -2886,7 +2908,7 @@ fn opParseEnumDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
             members.push(opParseFnDecl(p, fnPub, memberAnns))
         } else if opAt(p, FrontIdent) {
             let vs = p.pos
-            let vn = opAdvance(p).text
+            let vn = opTokenText(p, opAdvance(p))
             let mut vFields: List<Int> = []
             if opEat(p, FrontLParen) {
                 for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) {
@@ -2928,7 +2950,7 @@ fn opParseEnumDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
 fn opParseInterfaceDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
     let start = p.pos
     let _ = opAdvance(p)
-    let name = opExpect(p, FrontIdent).text
+    let name = opTokenText(p, opExpect(p, FrontIdent))
     let genericParams = opParseGenericParams(p)
     let _ = opExpect(p, FrontLBrace)
     let mut members: List<Int> = []
@@ -2962,7 +2984,7 @@ fn opParseInterfaceDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
 fn opParseTypeAliasDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
     let start = p.pos
     let _ = opAdvance(p)
-    let name = opExpect(p, FrontIdent).text
+    let name = opTokenText(p, opExpect(p, FrontIdent))
     let genericParams = opParseGenericParams(p)
     let _ = opExpect(p, FrontAssign)
     let typeIdx = opParseType(p)
@@ -2986,15 +3008,15 @@ fn opParseUseDecl(p: OstyParser, isPub: Bool) -> Int {
     let mut isGo = false
     let mut alias = ""
     let mut aliasStart = -1
-    if opAt(p, FrontIdent) && opPeek(p).text == "go" {
+    if opAt(p, FrontIdent) && opPeekText(p) == "go" {
         isGo = true
         let _ = opAdvance(p)
         if opAt(p, FrontString) || opAt(p, FrontRawString) {
-            rawPath = opAdvance(p).text
+            rawPath = opTokenText(p, opAdvance(p))
         }
-    } else if opAt(p, FrontIdent) && opPeek(p).text == "c" && (opPeekAt(p, 1).kind == FrontString || opPeekAt(p, 1).kind == FrontRawString) {
+    } else if opAt(p, FrontIdent) && opPeekText(p) == "c" && (opPeekAt(p, 1).kind == FrontString || opPeekAt(p, 1).kind == FrontRawString) {
         let _ = opAdvance(p)
-        let lib = opStripUseCQuotes(opAdvance(p).text)
+        let lib = opStripUseCQuotes(opTokenText(p, opAdvance(p)))
         rawPath = "runtime.cabi.{lib}"
     } else {
         rawPath = opParseUsePath(p)
@@ -3007,10 +3029,10 @@ fn opParseUseDecl(p: OstyParser, isPub: Bool) -> Int {
             return opParseScopedUseDecl(p, start, rawPath, isPub)
         }
     }
-    if opAt(p, FrontIdent) && opPeek(p).text == "as" {
+    if opAt(p, FrontIdent) && opPeekText(p) == "as" {
         let _ = opAdvance(p)
         aliasStart = p.pos
-        alias = opExpect(p, FrontIdent).text
+        alias = opTokenText(p, opExpect(p, FrontIdent))
     }
     let mut goItems: List<Int> = []
     if opEat(p, FrontLBrace) {
@@ -3077,13 +3099,13 @@ fn opParseScopedUseDecl(p: OstyParser, start: Int, basePath: String, isPub: Bool
             opSkipNewlines(p)
             continue
         }
-        let itemName = opAdvance(p).text
+        let itemName = opTokenText(p, opAdvance(p))
         let mut alias = ""
         let mut aliasStart = -1
-        if opAt(p, FrontIdent) && opPeek(p).text == "as" {
+        if opAt(p, FrontIdent) && opPeekText(p) == "as" {
             let _ = opAdvance(p)
             aliasStart = p.pos
-            alias = opExpect(p, FrontIdent).text
+            alias = opTokenText(p, opExpect(p, FrontIdent))
         }
         let childIdx = opBuildUseDecl(p, start, p.pos, "{basePath}.{itemName}", false, isPub, alias, aliasStart, [])
         let mut childNode = astArenaNodeAt(p.arena, childIdx)
@@ -3126,7 +3148,7 @@ fn opParseUsePath(p: OstyParser) -> String {
     let mut parts: List<String> = []
     let mut sawSlash = false
     let mut mixedReported = false
-    parts.push(opAdvance(p).text)
+    parts.push(opTokenText(p, opAdvance(p)))
     for {
         let sep = opUsePathSep(p)
         if sep == "" || opPeekAt(p, 1).kind != FrontIdent {
@@ -3141,7 +3163,7 @@ fn opParseUsePath(p: OstyParser) -> String {
         }
         let _ = opAdvance(p)
         parts.push(sep)
-        parts.push(opAdvance(p).text)
+        parts.push(opTokenText(p, opAdvance(p)))
     }
     strings.join(parts, "")
 }

--- a/toolchain/pkg_policy.osty
+++ b/toolchain/pkg_policy.osty
@@ -112,17 +112,26 @@ fn pkgPathBase(p: String) -> String {
 pub let pkgSourceKindPath: Int = 0
 pub let pkgSourceKindGit: Int = 1
 pub let pkgSourceKindRegistry: Int = 2
+fn pkgSourceKindPathCode() -> Int {
+    0
+}
+fn pkgSourceKindGitCode() -> Int {
+    1
+}
+fn pkgSourceKindRegistryCode() -> Int {
+    2
+}
 /// pkgSourceKindString maps a SourceKind int back to its
 /// human-readable label. Unknown / out-of-range values collapse
 /// to `"unknown"` so log lines never surface a bare number.
 pub fn pkgSourceKindString(kind: Int) -> String {
-    if kind == pkgSourceKindPath {
+    if kind == pkgSourceKindPathCode() {
         return "path"
     }
-    if kind == pkgSourceKindGit {
+    if kind == pkgSourceKindGitCode() {
         return "git"
     }
-    if kind == pkgSourceKindRegistry {
+    if kind == pkgSourceKindRegistryCode() {
         return "registry"
     }
     "unknown"

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -425,7 +425,9 @@ fn selfResolveName(name: String, start: Int, end: Int, node: Int) -> SelfResolve
 /// so that `for { || { break } }` is correctly rejected: the loop doesn't
 /// leak through the closure barrier. These mirror the Go resolver's flowCtx.
 struct SelfResolveScope {
-    symbols: List<SelfSymbol>,
+    rootSymbols: List<SelfSymbol>,
+    rootIndex: Map<String, Int>,
+    locals: List<SelfSymbol>,
     depth: Int,
     ifaceDefault: Bool,
     inFn: Bool,
@@ -435,41 +437,71 @@ struct SelfResolveScope {
     loopLabelEnds: List<Int>,
 }
 fn srRootScope(result: SelfResolveResult) -> SelfResolveScope {
-    SelfResolveScope {symbols: srSymbolListCopy(result.symbols), depth: 0, ifaceDefault: false, inFn: false, inLoop: false, loopLabels: [], loopLabelStarts: [], loopLabelEnds: []}
+    SelfResolveScope {rootSymbols: result.symbols, rootIndex: srBuildSymbolIndex(result.symbols), locals: [], depth: 0, ifaceDefault: false, inFn: false, inLoop: false, loopLabels: [], loopLabelStarts: [], loopLabelEnds: []}
 }
 fn srChildScope(parent: SelfResolveScope) -> SelfResolveScope {
-    SelfResolveScope {symbols: srSymbolListCopy(parent.symbols), depth: parent.depth + 1, ifaceDefault: parent.ifaceDefault, inFn: parent.inFn, inLoop: parent.inLoop, loopLabels: srStringListCopy(parent.loopLabels), loopLabelStarts: srIntListCopy(parent.loopLabelStarts), loopLabelEnds: srIntListCopy(parent.loopLabelEnds)}
+    SelfResolveScope {rootSymbols: parent.rootSymbols, rootIndex: parent.rootIndex, locals: srSymbolListCopy(parent.locals), depth: parent.depth + 1, ifaceDefault: parent.ifaceDefault, inFn: parent.inFn, inLoop: parent.inLoop, loopLabels: srStringListCopy(parent.loopLabels), loopLabelStarts: srIntListCopy(parent.loopLabelStarts), loopLabelEnds: srIntListCopy(parent.loopLabelEnds)}
 }
 fn srFnChildScope(parent: SelfResolveScope, ifaceDefault: Bool) -> SelfResolveScope {
-    SelfResolveScope {symbols: srSymbolListCopy(parent.symbols), depth: parent.depth + 1, ifaceDefault, inFn: true, inLoop: false, loopLabels: [], loopLabelStarts: [], loopLabelEnds: []}
+    SelfResolveScope {rootSymbols: parent.rootSymbols, rootIndex: parent.rootIndex, locals: srSymbolListCopy(parent.locals), depth: parent.depth + 1, ifaceDefault, inFn: true, inLoop: false, loopLabels: [], loopLabelStarts: [], loopLabelEnds: []}
 }
 fn srLoopChildScope(parent: SelfResolveScope) -> SelfResolveScope {
-    SelfResolveScope {symbols: srSymbolListCopy(parent.symbols), depth: parent.depth + 1, ifaceDefault: parent.ifaceDefault, inFn: parent.inFn, inLoop: true, loopLabels: srStringListCopy(parent.loopLabels), loopLabelStarts: srIntListCopy(parent.loopLabelStarts), loopLabelEnds: srIntListCopy(parent.loopLabelEnds)}
+    SelfResolveScope {rootSymbols: parent.rootSymbols, rootIndex: parent.rootIndex, locals: srSymbolListCopy(parent.locals), depth: parent.depth + 1, ifaceDefault: parent.ifaceDefault, inFn: parent.inFn, inLoop: true, loopLabels: srStringListCopy(parent.loopLabels), loopLabelStarts: srIntListCopy(parent.loopLabelStarts), loopLabelEnds: srIntListCopy(parent.loopLabelEnds)}
 }
 fn srScopeDefine(scope: SelfResolveScope, result: SelfResolveResult, sym: SelfSymbol) -> SelfResolveResult {
     let mut out = result
     if srIsDiscardName(sym.name) {
         return out
     }
-    if srSymbolExistsAtDepth(scope.symbols, sym.name, scope.depth) {
+    if srScopeSymbolExistsAtDepth(scope, sym.name, scope.depth) {
         return srDuplicateAtNode(out, sym.name, sym.start, sym.end, sym.node)
     }
     let mut scoped = sym
     scoped.depth = scope.depth
-    scope.symbols.push(scoped)
+    scope.locals.push(scoped)
     out
 }
 fn srScopeLookup(scope: SelfResolveScope, name: String) -> SelfSymbol {
-    let mut found = selfSymbol("", "", "", 0, -1, 0, 0, false)
-    for sym in scope.symbols {
+    let mut i = scope.locals.len() - 1
+    for i >= 0 {
+        let sym = scope.locals[i]
         if sym.name == name {
-            found = sym
+            return sym
         }
+        i = i - 1
     }
-    found
+    srScopeLookupRoot(scope, name)
 }
 fn srScopeHas(scope: SelfResolveScope, name: String) -> Bool {
     srScopeLookup(scope, name).name != ""
+}
+fn srBuildSymbolIndex(symbols: List<SelfSymbol>) -> Map<String, Int> {
+    let mut index: Map<String, Int> = {:}
+    let mut i = 0
+    for sym in symbols {
+        index.insert(sym.name, i)
+        i = i + 1
+    }
+    index
+}
+fn srScopeLookupRoot(scope: SelfResolveScope, name: String) -> SelfSymbol {
+    match scope.rootIndex.get(name) {
+        Some(pos) -> {
+            if pos >= 0 && pos < scope.rootSymbols.len() {
+                return scope.rootSymbols[pos]
+            }
+        },
+        None -> {
+        },
+    }
+    srEmptySymbol()
+}
+fn srScopeSymbolExistsAtDepth(scope: SelfResolveScope, name: String, depth: Int) -> Bool {
+    if depth == 0 {
+        let sym = srScopeLookupRoot(scope, name)
+        return sym.name != ""
+    }
+    srSymbolExistsAtDepth(scope.locals, name, depth)
 }
 fn selfResolveAstCollectTopLevel(file: AstFile, cfg: SelfResolveCfgEnv, result: SelfResolveResult) -> SelfResolveResult {
     let mut out = result
@@ -1240,7 +1272,7 @@ fn srAstResolveOrPattern(file: AstFile, node: AstNode, scope: SelfResolveScope, 
         altCount = altCount + 1
         let altScope = srChildScope(scope)
         out = srAstResolvePattern(file, altIdx, altScope, out)
-        let bound = srSymbolsAtDepth(altScope.symbols, altScope.depth)
+        let bound = srSymbolsAtDepth(altScope.locals, altScope.depth)
         for sym in bound {
             let existing = srStringListIndex(names, sym.name)
             if existing >= 0 {
@@ -1716,7 +1748,10 @@ fn srUndefinedHint(scope: SelfResolveScope, name: String) -> String {
 }
 fn srSuggestSimilar(scope: SelfResolveScope, name: String) -> String {
     let mut names: List<String> = []
-    for sym in scope.symbols {
+    for sym in scope.rootSymbols {
+        names.push(sym.name)
+    }
+    for sym in scope.locals {
         names.push(sym.name)
     }
     srSuggestFromList(name, names)

--- a/toolchain/scaffold_policy.osty
+++ b/toolchain/scaffold_policy.osty
@@ -10,6 +10,12 @@ use std.strings as strings
 /// flag default (3) and the cap (64) live in one place.
 let scaffoldFixtureCasesDefault: Int = 3
 let scaffoldFixtureCasesMax: Int = 64
+fn scaffoldFixtureCasesDefaultValue() -> Int {
+    3
+}
+fn scaffoldFixtureCasesMaxValue() -> Int {
+    64
+}
 /// isValidScaffoldName reports whether `name` can be used as both
 /// a directory name and the `name` field of osty.toml.
 ///
@@ -48,11 +54,11 @@ pub struct FixtureCaseCount {
     pub overCap: Bool,
 }
 pub fn resolveFixtureCases(requested: Int) -> FixtureCaseCount {
-    if requested > scaffoldFixtureCasesMax {
-        return FixtureCaseCount {count: scaffoldFixtureCasesMax, overCap: true}
+    if requested > scaffoldFixtureCasesMaxValue() {
+        return FixtureCaseCount {count: scaffoldFixtureCasesMaxValue(), overCap: true}
     }
     if requested <= 0 {
-        return FixtureCaseCount {count: scaffoldFixtureCasesDefault, overCap: false}
+        return FixtureCaseCount {count: scaffoldFixtureCasesDefaultValue(), overCap: false}
     }
     FixtureCaseCount {count: requested, overCap: false}
 }

--- a/toolchain/selfhost_driver.osty
+++ b/toolchain/selfhost_driver.osty
@@ -24,7 +24,12 @@ fn selfhostDriverOptionValue(args: List<String>, name: String) -> String {
 }
 
 fn selfhostDriverProbeError() -> String {
-    let source = "fn main() -> Int \{\n    let x = 41\n    return x + 1\n\}\n"
+    let source = r"""
+fn main() -> Int {
+    let x = 41
+    return x + 1
+}
+"""
     let hir = hirLowerSource("main", source)
     let mir = mirLowerModule(hir)
     let mirErrs = mirValidateModule(mir)

--- a/toolchain/ty.osty
+++ b/toolchain/ty.osty
@@ -268,30 +268,73 @@ pub fn tUntypedFloat(arena: TyArena) -> Int {
 /// dedicated helpers (`tInt`, `tBool`, ...) when the kind is statically
 /// known.
 pub fn tyPrim(arena: TyArena, prim: PrimKind) -> Int {
-    match prim {
-        PkInvalid -> arena.idxErr,
-        PkInt -> arena.idxInt,
-        PkInt8 -> arena.idxInt8,
-        PkInt16 -> arena.idxInt16,
-        PkInt32 -> arena.idxInt32,
-        PkInt64 -> arena.idxInt64,
-        PkUInt8 -> arena.idxUInt8,
-        PkUInt16 -> arena.idxUInt16,
-        PkUInt32 -> arena.idxUInt32,
-        PkUInt64 -> arena.idxUInt64,
-        PkByte -> arena.idxByte,
-        PkFloat -> arena.idxFloat,
-        PkFloat32 -> arena.idxFloat32,
-        PkFloat64 -> arena.idxFloat64,
-        PkBool -> arena.idxBool,
-        PkChar -> arena.idxChar,
-        PkString -> arena.idxString,
-        PkBytes -> arena.idxBytes,
-        PkUnit -> arena.idxUnit,
-        PkNever -> arena.idxNever,
-        PkUntypedInt -> arena.idxUntypedInt,
-        PkUntypedFloat -> arena.idxUntypedFloat,
+    if prim == PkInvalid {
+        return arena.idxErr
     }
+    if prim == PkInt {
+        return arena.idxInt
+    }
+    if prim == PkInt8 {
+        return arena.idxInt8
+    }
+    if prim == PkInt16 {
+        return arena.idxInt16
+    }
+    if prim == PkInt32 {
+        return arena.idxInt32
+    }
+    if prim == PkInt64 {
+        return arena.idxInt64
+    }
+    if prim == PkUInt8 {
+        return arena.idxUInt8
+    }
+    if prim == PkUInt16 {
+        return arena.idxUInt16
+    }
+    if prim == PkUInt32 {
+        return arena.idxUInt32
+    }
+    if prim == PkUInt64 {
+        return arena.idxUInt64
+    }
+    if prim == PkByte {
+        return arena.idxByte
+    }
+    if prim == PkFloat {
+        return arena.idxFloat
+    }
+    if prim == PkFloat32 {
+        return arena.idxFloat32
+    }
+    if prim == PkFloat64 {
+        return arena.idxFloat64
+    }
+    if prim == PkBool {
+        return arena.idxBool
+    }
+    if prim == PkChar {
+        return arena.idxChar
+    }
+    if prim == PkString {
+        return arena.idxString
+    }
+    if prim == PkBytes {
+        return arena.idxBytes
+    }
+    if prim == PkUnit {
+        return arena.idxUnit
+    }
+    if prim == PkNever {
+        return arena.idxNever
+    }
+    if prim == PkUntypedInt {
+        return arena.idxUntypedInt
+    }
+    if prim == PkUntypedFloat {
+        return arena.idxUntypedFloat
+    }
+    arena.idxErr
 }
 /// tyNamed allocates a named type `head<args...>` node. `args` may be
 /// empty, meaning a plain type like `String` used in type position.
@@ -526,17 +569,34 @@ pub fn tyEq(arena: TyArena, a: Int, b: Int) -> Bool {
     if na.kind != nb.kind {
         return false
     }
-    match na.kind {
-        TkErr -> true,
-        TkPoison -> true,
-        TkPrim -> na.prim == nb.prim,
-        TkNamed -> na.head == nb.head && tyEqList(arena, na.args, nb.args),
-        TkOptional -> tyEq(arena, na.ret, nb.ret),
-        TkTuple -> tyEqList(arena, na.args, nb.args),
-        TkFn -> tyEqList(arena, na.args, nb.args) && tyEq(arena, na.ret, nb.ret),
-        TkVar -> na.varId == nb.varId,
-        TkSelf -> na.head == nb.head,
+    if na.kind == TkErr {
+        return true
     }
+    if na.kind == TkPoison {
+        return true
+    }
+    if na.kind == TkPrim {
+        return na.prim == nb.prim
+    }
+    if na.kind == TkNamed {
+        return na.head == nb.head && tyEqList(arena, na.args, nb.args)
+    }
+    if na.kind == TkOptional {
+        return tyEq(arena, na.ret, nb.ret)
+    }
+    if na.kind == TkTuple {
+        return tyEqList(arena, na.args, nb.args)
+    }
+    if na.kind == TkFn {
+        return tyEqList(arena, na.args, nb.args) && tyEq(arena, na.ret, nb.ret)
+    }
+    if na.kind == TkVar {
+        return na.varId == nb.varId
+    }
+    if na.kind == TkSelf {
+        return na.head == nb.head
+    }
+    false
 }
 fn tyEqList(arena: TyArena, xs: List<Int>, ys: List<Int>) -> Bool {
     if tyIntListLen(xs) != tyIntListLen(ys) {
@@ -570,23 +630,37 @@ pub fn tyToString(arena: TyArena, idx: Int) -> String {
         return "Invalid"
     }
     let node = tyGet(arena, idx)
-    match node.kind {
-        TkErr -> "Invalid",
-        TkPoison -> "Poison",
-        TkPrim -> primKindName(node.prim),
-        TkNamed -> tyNamedToString(arena, node),
-        TkOptional -> "{tyToString(arena, node.ret)}?",
-        TkTuple -> tyTupleToString(arena, node.args),
-        TkFn -> tyFnToString(arena, node),
-        TkVar -> {
-            if node.varName == "" {
-                "?{node.varId}"
-            } else {
-                node.varName
-            }
-        },
-        TkSelf -> "Self",
+    if node.kind == TkErr {
+        return "Invalid"
     }
+    if node.kind == TkPoison {
+        return "Poison"
+    }
+    if node.kind == TkPrim {
+        return primKindName(node.prim)
+    }
+    if node.kind == TkNamed {
+        return tyNamedToString(arena, node)
+    }
+    if node.kind == TkOptional {
+        return "{tyToString(arena, node.ret)}?"
+    }
+    if node.kind == TkTuple {
+        return tyTupleToString(arena, node.args)
+    }
+    if node.kind == TkFn {
+        return tyFnToString(arena, node)
+    }
+    if node.kind == TkVar {
+        if node.varName == "" {
+            return "?{node.varId}"
+        }
+        return node.varName
+    }
+    if node.kind == TkSelf {
+        return "Self"
+    }
+    "Invalid"
 }
 fn tyNamedToString(arena: TyArena, node: TyNode) -> String {
     if tyIntListLen(node.args) == 0 {
@@ -628,30 +702,73 @@ fn tyFnToString(arena: TyArena, node: TyNode) -> String {
     "fn({strings.join(parts, sep)}) -> {tyToString(arena, node.ret)}"
 }
 pub fn primKindName(prim: PrimKind) -> String {
-    match prim {
-        PkInvalid -> "Invalid",
-        PkInt -> "Int",
-        PkInt8 -> "Int8",
-        PkInt16 -> "Int16",
-        PkInt32 -> "Int32",
-        PkInt64 -> "Int64",
-        PkUInt8 -> "UInt8",
-        PkUInt16 -> "UInt16",
-        PkUInt32 -> "UInt32",
-        PkUInt64 -> "UInt64",
-        PkByte -> "Byte",
-        PkFloat -> "Float",
-        PkFloat32 -> "Float32",
-        PkFloat64 -> "Float64",
-        PkBool -> "Bool",
-        PkChar -> "Char",
-        PkString -> "String",
-        PkBytes -> "Bytes",
-        PkUnit -> "()",
-        PkNever -> "Never",
-        PkUntypedInt -> "UntypedInt",
-        PkUntypedFloat -> "UntypedFloat",
+    if prim == PkInvalid {
+        return "Invalid"
     }
+    if prim == PkInt {
+        return "Int"
+    }
+    if prim == PkInt8 {
+        return "Int8"
+    }
+    if prim == PkInt16 {
+        return "Int16"
+    }
+    if prim == PkInt32 {
+        return "Int32"
+    }
+    if prim == PkInt64 {
+        return "Int64"
+    }
+    if prim == PkUInt8 {
+        return "UInt8"
+    }
+    if prim == PkUInt16 {
+        return "UInt16"
+    }
+    if prim == PkUInt32 {
+        return "UInt32"
+    }
+    if prim == PkUInt64 {
+        return "UInt64"
+    }
+    if prim == PkByte {
+        return "Byte"
+    }
+    if prim == PkFloat {
+        return "Float"
+    }
+    if prim == PkFloat32 {
+        return "Float32"
+    }
+    if prim == PkFloat64 {
+        return "Float64"
+    }
+    if prim == PkBool {
+        return "Bool"
+    }
+    if prim == PkChar {
+        return "Char"
+    }
+    if prim == PkString {
+        return "String"
+    }
+    if prim == PkBytes {
+        return "Bytes"
+    }
+    if prim == PkUnit {
+        return "()"
+    }
+    if prim == PkNever {
+        return "Never"
+    }
+    if prim == PkUntypedInt {
+        return "UntypedInt"
+    }
+    if prim == PkUntypedFloat {
+        return "UntypedFloat"
+    }
+    "Invalid"
 }
 // ---------------------------------------------------------------------
 // Escape analysis (E0743 / §8.1 G13). `Handle<T>` and `Group` (alias
@@ -669,31 +786,31 @@ pub fn tyEscapingCapabilityHead(arena: TyArena, idx: Int) -> String {
         return ""
     }
     let node = tyGet(arena, idx)
-    match node.kind {
-        TkNamed -> {
-            if node.head == "Handle" || node.head == "Group" || node.head == "TaskGroup" {
-                return node.head
+    if node.kind == TkNamed {
+        if node.head == "Handle" || node.head == "Group" || node.head == "TaskGroup" {
+            return node.head
+        }
+        for arg in node.args {
+            let inner = tyEscapingCapabilityHead(arena, arg)
+            if inner != "" {
+                return inner
             }
-            for arg in node.args {
-                let inner = tyEscapingCapabilityHead(arena, arg)
-                if inner != "" {
-                    return inner
-                }
-            }
-            ""
-        },
-        TkOptional -> tyEscapingCapabilityHead(arena, node.ret),
-        TkTuple -> {
-            for elem in node.args {
-                let inner = tyEscapingCapabilityHead(arena, elem)
-                if inner != "" {
-                    return inner
-                }
-            }
-            ""
-        },
-        _ -> "",
+        }
+        return ""
     }
+    if node.kind == TkOptional {
+        return tyEscapingCapabilityHead(arena, node.ret)
+    }
+    if node.kind == TkTuple {
+        for elem in node.args {
+            let inner = tyEscapingCapabilityHead(arena, elem)
+            if inner != "" {
+                return inner
+            }
+        }
+        return ""
+    }
+    ""
 }
 // ---------------------------------------------------------------------
 // Transitional bridge from the legacy string representation. Only


### PR DESCRIPTION
## Summary
- move the selfhost doctor/rebuild path to source -> HIR -> MIR -> LIR Proto -> LLVM IR
- remove remaining bootstrap-unsafe enum match dispatch from source selfhost critical paths, including type lowering and elaboration
- fix stage2 parameter lowering and large self-rebuild IR writes so stage2/stage3 byte parity completes
- lock the ratchet with structural selfhost guards and stage0 audit coverage expectations

## Validation
- `just build-all`
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestMirLowerStage2SeedDiscardsStatementCalls|TestSelfhostDoctorRunsBackendProbe|TestVerifySelfRebuildRequiresSourceCompilerStages'`
- `scripts/verify-self-rebuild --skip-gates --no-selfhostcache .bin/osty` -> stage1/stage2-seed/stage2/stage3, byte parity OK
- `just verify-self-rebuild-gates` -> stage0 audit 8714 / 8714 functions covered, 100.0%, all decline buckets 0
- `git diff --check`

## Note
- `just short` still exposes existing backend/ONB generic coverage failures outside this selfhost ratchet; selfhost-focused tests were updated and pass.
