### PR TITLE
[codex] Ratchet MIR JSON source compat opt-in

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -63,9 +63,9 @@ const selfLowerTimeoutEnv = "OSTY_LIRPROTO_SELF_TIMEOUT"
 // MIR JSON timeout. Use "0" to disable timeout compatibility retries.
 const selfTimeoutCompatMaxBytesEnv = "OSTY_LIRPROTO_TIMEOUT_COMPAT_MAX_BYTES"
 
-// selfSourceCompatMaxBytesEnv bounds the legacy source retry used
+// selfSourceCompatMaxBytesEnv opts into the legacy source retry used
 // only when an older osty-self cannot handle MIR JSON directly.
-// Use "0" to disable the size guard.
+// Unset or "0" disables source re-lowering; positive values bound it.
 const selfSourceCompatMaxBytesEnv = "OSTY_LIRPROTO_SOURCE_COMPAT_MAX_BYTES"
 
 func main() {
@@ -318,10 +318,25 @@ func lowerLegacyMIRJSON(req nativelirproto.Request, selfBin string) (nativelirpr
 		}
 		return nativelirproto.Response{Declined: true, Error: "legacy osty-self does not support MIR JSON requests"}, nil
 	}
-	if max := sourceCompatMaxBytes(); max > 0 && len([]byte(req.Source)) > max {
+	sourceBytes := len([]byte(req.Source))
+	max := sourceCompatMaxBytes()
+	if max <= 0 {
 		sourceResp := nativelirproto.Response{
 			Declined: true,
-			Error:    fmt.Sprintf("legacy source compat skipped: source is %d bytes, exceeds %d byte guard", len([]byte(req.Source)), max),
+			Error:    fmt.Sprintf("legacy source compat skipped: set %s to a positive byte limit to enable source re-lowering", selfSourceCompatMaxBytesEnv),
+		}
+		if !triedStage0 {
+			return sourceResp, nil
+		}
+		return nativelirproto.Response{
+			Declined: true,
+			Error:    combineDeclineErrors(stage0Resp.Error, sourceResp.Error),
+		}, nil
+	}
+	if sourceBytes > max {
+		sourceResp := nativelirproto.Response{
+			Declined: true,
+			Error:    fmt.Sprintf("legacy source compat skipped: source is %d bytes, exceeds %d byte guard", sourceBytes, max),
 		}
 		if !triedStage0 {
 			return sourceResp, nil
@@ -413,15 +428,12 @@ func combineDeclineErrors(primary, secondary string) string {
 
 func sourceCompatMaxBytes() int {
 	if raw := os.Getenv(selfSourceCompatMaxBytesEnv); raw != "" {
-		if raw == "0" {
-			return 0
-		}
 		var n int
 		if _, err := fmt.Sscanf(raw, "%d", &n); err == nil && n >= 0 {
 			return n
 		}
 	}
-	return 1 << 20
+	return 0
 }
 
 func timeoutCompatMaxBytes() int64 {

--- a/cmd/osty-native-lirproto/main_test.go
+++ b/cmd/osty-native-lirproto/main_test.go
@@ -243,13 +243,14 @@ func TestValidateSelfHostedLLVMIRCatchesUndefinedTemps(t *testing.T) {
 	}
 }
 
-func TestRunMIRPayloadRetriesSourceWhenMirJSONUnsupported(t *testing.T) {
+func TestRunMIRPayloadRetriesSourceWhenMirJSONUnsupportedAndCompatEnabled(t *testing.T) {
 	bin := buildFakeOstySelf(t)
 	captureDir := t.TempDir()
 	captureArgs := filepath.Join(captureDir, "args.json")
 	captureSource := filepath.Join(captureDir, "source.osty")
 
 	t.Setenv(SelfBinEnv, bin)
+	t.Setenv(selfSourceCompatMaxBytesEnv, "1048576")
 	t.Setenv("FAKE_OSTY_SELF_REJECT_MIR_JSON", "1")
 	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
 	t.Setenv("FAKE_OSTY_SELF_CAPTURE_SOURCE", captureSource)
@@ -287,6 +288,51 @@ func TestRunMIRPayloadRetriesSourceWhenMirJSONUnsupported(t *testing.T) {
 	}
 	if staged := readFile(t, captureSource); !strings.Contains(staged, "fn main() -> Int { 7 }") {
 		t.Fatalf("compat retry staged %q, want original source", staged)
+	}
+}
+
+func TestRunMIRPayloadSkipsLegacySourceCompatByDefault(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	captureDir := t.TempDir()
+	captureArgs := filepath.Join(captureDir, "args.json")
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_REJECT_MIR_JSON", "1")
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
+	t.Setenv("FAKE_OSTY_SELF_STDOUT", "; source compat should not run\ndefine i64 @main() {\n  ret i64 7\n}\n")
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		Source:      "fn main() -> Int { 7 }\n",
+		MIR: map[string]any{
+			"version":     1,
+			"packageName": "main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if !resp.Declined {
+		t.Fatalf("Declined = false, want default source compat skip: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, "legacy source compat skipped") || !strings.Contains(resp.Error, selfSourceCompatMaxBytesEnv) {
+		t.Fatalf("Error = %q, want source compat opt-in guard", resp.Error)
+	}
+	if strings.Contains(resp.LLVMIR, "source compat should not run") {
+		t.Fatalf("source compat unexpectedly produced IR:\n%s", resp.LLVMIR)
+	}
+	args := readCapturedArgs(t, captureArgs)
+	if len(args) < 2 || args[0] != "lir-proto-lower-mir-json" {
+		t.Fatalf("args = %v, want only MIR JSON attempt", args)
 	}
 }
 


### PR DESCRIPTION
## Summary
- disable legacy source re-lowering by default after MIR JSON fallback failures
- require a positive `OSTY_LIRPROTO_SOURCE_COMPAT_MAX_BYTES` limit to opt into source compat
- add regression coverage for default skip and explicit opt-in retry

## Validation
- `go test -count=1 -vet=off ./cmd/osty-native-lirproto`
- `just support-selfhost-fast`
- `just short`
- `git diff --check`
